### PR TITLE
test(e2e): skip content-gate specs when Access Control redesign absent

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -36,10 +36,15 @@ installed plugin code, so a plugin/core update can't leave a stale fixture behin
 > channel, but specs land on `main`, which tracks `alpha`. So a spec that drives
 > UI only present in `alpha` (a feature not yet shipped to stable) will fail every
 > night until that feature reaches the release channel – even though it passes
-> locally against `main`. When adding coverage for recently-merged UI, either
-> feature-detect the new element and fall back to the older flow (see
-> `saveGateAsActive` in `tests/utils-content-gates.ts`), or gate the spec so it
-> skips when the feature is absent. Don't assume the newest UI is present.
+> locally against `main`. When adding coverage for recently-merged UI, don't
+> assume the newest UI is present: probe for a marker of the new flow and, if it
+> is absent, `test.skip()` the spec (it lifts automatically once the feature
+> reaches release). Skip the whole spec rather than patching a single step – if
+> the flow diverges at one point it usually diverges downstream too, so a
+> half-adapted spec hangs on the *next* alpha-only interaction instead of failing
+> fast. `saveGateAsActive` in `tests/utils-content-gates.ts` is the reference: it
+> detects the redesigned wizard's pre-save panel and skips the whole content-gate
+> spec when it is missing.
 
 - **`site-setup.sh`** (this repo) is the from-scratch Newspack bootstrap (DB reset +
   fresh install + posts/users/WooCommerce+donations/memberships/subscriptions/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -30,8 +30,8 @@ That staging site is pinned to the **stable release** channel, and provisioning
 rebuilds against the plugin version installed there – not the version the specs
 were merged with. A spec that drives UI which only exists in `alpha`/`main` will
 therefore fail nightly until that feature ships to stable, so new specs must
-feature-detect such UI rather than assume it is present. See `AGENTS.md` →
-"Site setup model" for details.
+feature-detect such UI and `test.skip()` when it is absent rather than assume it
+is present. See `AGENTS.md` → "Site setup model" for details.
 
 [Credentials for the Atomic site used for the e2e testing.](https://mc.a8c.com/secret-store/?secret_id=12168)
 

--- a/e2e/tests/utils-content-gates.ts
+++ b/e2e/tests/utils-content-gates.ts
@@ -1,4 +1,4 @@
-import { expect, Page } from "@playwright/test";
+import { expect, test, Page } from "@playwright/test";
 import { goToAdminMenu } from "./utils-admin";
 
 // Shared helpers for the Access Control wizard, used by the content gating
@@ -93,26 +93,35 @@ const clickHeaderSave = async (page: Page) => {
   }
 };
 
-// Save the gate being edited and leave it live (Active). Two plugin flows
-// exist and the target site may run either, so detect which one Save triggers:
-//   - Pre-save checks on: Save opens a confirmation panel ("Are you ready to
-//     save?") where the status is chosen. New gates default to Inactive there,
-//     so pick Active explicitly.
-//   - Pre-save checks off / older plugin: Save persists immediately and new
-//     gates default to Active, so there is no panel to drive.
-// Either way the wizard routes back to the gate list once the gate is saved.
+// Save the gate being edited and leave it live (Active) via the pre-save panel
+// ("Are you ready to save?"), where new gates default to Inactive so Active is
+// picked explicitly.
+//
+// The panel is part of the redesigned Access Control wizard, which ships in
+// alpha/main but not yet on the stable release channel. It is the first point
+// where the spec's flow diverges from the older wizard: the reader-facing
+// enforcement, layout editing and teardown that follow all assume the redesign
+// too. On a site without it, Save persists immediately and routes straight back
+// to the gate list, so the panel never appears -- and pressing on would hang the
+// rest of the spec against UI that isn't there. So when the panel is absent,
+// skip: the whole spec targets the redesign and can't run on this channel. The
+// skip lifts automatically once the redesign reaches the release channel. (This
+// is why the nightly runs green on release while the specs still cover alpha; see
+// AGENTS.md -> "Site setup model".)
 export const saveGateAsActive = async (page: Page) => {
   await clickHeaderSave(page);
   const saveDialog = page.getByRole("dialog");
-  const saveConfirmation = saveDialog.getByText("Are you ready to save?");
-  const hasSavePanel = await saveConfirmation
-    .waitFor({ state: "visible", timeout: 5000 })
+  const hasSavePanel = await saveDialog
+    .getByText("Are you ready to save?")
+    .waitFor({ state: "visible", timeout: 8000 })
     .then(() => true)
     .catch(() => false);
-  if (hasSavePanel) {
-    await saveDialog.getByRole("radio", { name: "Active", exact: true }).check();
-    await saveDialog.getByRole("button", { name: "Save", exact: true }).click();
-  }
+  test.skip(
+    !hasSavePanel,
+    "Access Control redesign (pre-save panel) is not on this release channel; the spec targets the alpha wizard."
+  );
+  await saveDialog.getByRole("radio", { name: "Active", exact: true }).check();
+  await saveDialog.getByRole("button", { name: "Save", exact: true }).click();
   await page.waitForURL(/#\/content-gates/);
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

The `content-gating` and `premium-newsletters` E2E specs drive the redesigned Access Control wizard (the pre-save "Are you ready to save?" panel and the flows around it), which ships in `alpha`/`main` but not yet on the stable **release** channel that the nightly TeamCity run targets (`e2e.newspackstaging.com`, currently `newspack-plugin` 6.45.3).

On a release-channel site the *whole* spec diverges from the installed wizard, not just one step. The prior fix (#661) feature-detected the save panel and fell through when it was absent, which only moved the failure downstream: with the save step no longer fast-failing, the specs ran on into reader-facing UI that isn't present on release and hung to the per-test timeout, blowing the build's 20-minute execution budget (nightly build 18574870 recorded 0 tests).

This detects the redesign at `saveGateAsActive` (its pre-save panel is the first point of divergence) and `test.skip()`s the whole spec when it is absent. Result: the nightly runs **green** on the release channel while the specs still cover `alpha`/local in full. The skip lifts automatically once the redesign reaches the release channel. `AGENTS.md` and `README.md` are updated to describe the skip-the-whole-spec pattern (and why patching a single step is the wrong altitude here).

No production code changes; test tooling only.

### How to test the changes in this Pull Request:

1. Point the suite at a release-channel site that lacks the redesign (locally: the `e2e-release` isolated env, which mounts the `release` branch), i.e. `SITE_URL=https://e2e-release.test` in `e2e/.env`.
2. `cd e2e && USE_SETUP=true npx playwright test content-gating --project="Vanilla in Desktop Chrome"` → the spec is **skipped** (not failed, not hung); run is green.
3. Repeat for `premium-newsletters` → also skipped, green.
4. On an `alpha`/`main` site (redesign present) the specs run in full as before.

Verified locally against `e2e-release`: `content-gating` → 1 skipped / 1 passed (51.5s); `premium-newsletters` → 1 skipped / 1 passed (49.0s).

### Other information:

* [x] Have you written new tests for your changes, as applicable? (test-only change)
* [x] Have you successfully run tests with your changes locally?