### PR TITLE
test(e2e): save content gates via the release-channel flow

### DIFF
--- a/e2e/AGENTS.md
+++ b/e2e/AGENTS.md
@@ -31,20 +31,16 @@ The suite provisions the site from scratch each phase rather than restoring a DB
 dump. This keeps it drift-free: the site is always rebuilt against the currently
 installed plugin code, so a plugin/core update can't leave a stale fixture behind.
 
-> **Specs run against the *installed* plugin version, not the version they were
-> merged with.** The nightly targets a site pinned to the **stable release**
-> channel, but specs land on `main`, which tracks `alpha`. So a spec that drives
-> UI only present in `alpha` (a feature not yet shipped to stable) will fail every
-> night until that feature reaches the release channel – even though it passes
-> locally against `main`. When adding coverage for recently-merged UI, don't
-> assume the newest UI is present: probe for a marker of the new flow and, if it
-> is absent, `test.skip()` the spec (it lifts automatically once the feature
-> reaches release). Skip the whole spec rather than patching a single step – if
-> the flow diverges at one point it usually diverges downstream too, so a
-> half-adapted spec hangs on the *next* alpha-only interaction instead of failing
-> fast. `saveGateAsActive` in `tests/utils-content-gates.ts` is the reference: it
-> detects the redesigned wizard's pre-save panel and skips the whole content-gate
-> spec when it is missing.
+> **Specs run against the *installed* plugin version, and the nightly's site is
+> pinned to the stable release channel. Write specs against the release-channel
+> UI, and only that.** Specs land on `main` (which tracks `alpha`), so it is
+> tempting to drive the newest UI – but a spec that drives a feature not yet
+> shipped to stable fails every night until it ships. Don't paper over the gap
+> with feature-detection, channel branching, or `test.skip()`: a spec must not
+> fork on release vs `alpha`/`main`. If a feature is alpha-only, hold its coverage
+> until it reaches the release channel; when that UI later lands on release,
+> update the spec to match. The suite's one job is to prove the release channel
+> works, so a spec that no longer matches release is a spec to fix, not to branch.
 
 - **`site-setup.sh`** (this repo) is the from-scratch Newspack bootstrap (DB reset +
   fresh install + posts/users/WooCommerce+donations/memberships/subscriptions/

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -28,10 +28,11 @@ then run `npm run test:setup` (the setup projects provision the site over SSH).
 
 That staging site is pinned to the **stable release** channel, and provisioning
 rebuilds against the plugin version installed there – not the version the specs
-were merged with. A spec that drives UI which only exists in `alpha`/`main` will
-therefore fail nightly until that feature ships to stable, so new specs must
-feature-detect such UI and `test.skip()` when it is absent rather than assume it
-is present. See `AGENTS.md` → "Site setup model" for details.
+were merged with. Write specs against the release-channel UI: a spec that drives
+UI which only exists in `alpha`/`main` will fail nightly until that feature ships
+to stable. Don't work around that with channel branching or skips – hold coverage
+for alpha-only UI until it reaches release. See `AGENTS.md` → "Site setup model"
+for details.
 
 [Credentials for the Atomic site used for the e2e testing.](https://mc.a8c.com/secret-store/?secret_id=12168)
 

--- a/e2e/tests/utils-content-gates.ts
+++ b/e2e/tests/utils-content-gates.ts
@@ -1,4 +1,4 @@
-import { expect, test, Page } from "@playwright/test";
+import { expect, Page } from "@playwright/test";
 import { goToAdminMenu } from "./utils-admin";
 
 // Shared helpers for the Access Control wizard, used by the content gating
@@ -93,35 +93,11 @@ const clickHeaderSave = async (page: Page) => {
   }
 };
 
-// Save the gate being edited and leave it live (Active) via the pre-save panel
-// ("Are you ready to save?"), where new gates default to Inactive so Active is
-// picked explicitly.
-//
-// The panel is part of the redesigned Access Control wizard, which ships in
-// alpha/main but not yet on the stable release channel. It is the first point
-// where the spec's flow diverges from the older wizard: the reader-facing
-// enforcement, layout editing and teardown that follow all assume the redesign
-// too. On a site without it, Save persists immediately and routes straight back
-// to the gate list, so the panel never appears -- and pressing on would hang the
-// rest of the spec against UI that isn't there. So when the panel is absent,
-// skip: the whole spec targets the redesign and can't run on this channel. The
-// skip lifts automatically once the redesign reaches the release channel. (This
-// is why the nightly runs green on release while the specs still cover alpha; see
-// AGENTS.md -> "Site setup model".)
+// Save the gate being edited and return to the gate list. New gates default to
+// Active, so Save persists immediately and the wizard routes back to the list --
+// there is no status to choose.
 export const saveGateAsActive = async (page: Page) => {
   await clickHeaderSave(page);
-  const saveDialog = page.getByRole("dialog");
-  const hasSavePanel = await saveDialog
-    .getByText("Are you ready to save?")
-    .waitFor({ state: "visible", timeout: 8000 })
-    .then(() => true)
-    .catch(() => false);
-  test.skip(
-    !hasSavePanel,
-    "Access Control redesign (pre-save panel) is not on this release channel; the spec targets the alpha wizard."
-  );
-  await saveDialog.getByRole("radio", { name: "Active", exact: true }).check();
-  await saveDialog.getByRole("button", { name: "Save", exact: true }).click();
   await page.waitForURL(/#\/content-gates/);
 };
 


### PR DESCRIPTION
### Changes proposed in this Pull Request:

Follow-up to #662. The E2E suite (and its nightly TeamCity run) targets the stable **release** channel, so the content-gate specs should drive the release-channel UI strictly – no release/`main` fork in a spec.

#662 made the nightly green by having `saveGateAsActive` detect the alpha-only pre-save panel and `test.skip()` when it was absent. That is a channel fork, and it drops the specs' coverage on the very channel the suite is meant to prove. This removes it.

On the release channel, saving a new gate is simpler than on the alpha redesign: new gates default to Active, so pressing Save persists immediately and routes back to the gate list – there is no "Are you ready to save?" panel and no status to choose. `saveGateAsActive` now does exactly that (click Save, wait for the list), and the specs run in full on release. `AGENTS.md`/`README.md` are updated to state the policy plainly: write specs against the release-channel UI, and don't paper over an alpha-only feature with feature-detection, channel branching, or skips – hold that coverage until the feature reaches release.

No production code changes; test tooling only.

### How to test the changes in this Pull Request:

1. Against the release channel (the nightly's `e2e.newspackstaging.com`, or a local `e2e-release`-style env): run the content-gate specs.
2. `content-gating` and `premium-newsletters` run **to completion** (no skip, no hang) and pass.

Verified against the real nightly target `e2e.newspackstaging.com` (newspack-plugin 6.45.3): both specs, in Vanilla Desktop **and** Vanilla Mobile Chrome, `4 passed (1.5m)` – the full flow including reader metering, the regwall, registration, and teardown, plus the mobile More-menu Save path.

### Other information:

* [x] Have you written new tests for your changes, as applicable? (test-only change)
* [x] Have you successfully run tests with your changes locally?