### PR TITLE
ci(release): skip husky pre-commit hooks on generated release commits

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,13 +20,15 @@ permissions:
 
 env:
   PNPM_VERSION: 10.33.0
-  # This workflow only ever commits generated version/changelog stamps (the
-  # @semantic-release/git prepare commit and the package.json version sync).
-  # Skip the husky pre-commit lint for those: the PHPCS wrapper hard-fails
-  # here (no root composer install provisions vendor/bin/phpcs), and a lint
-  # gate on generated release commits could block an already-published
-  # release anyway. Every PR is fully linted by CI before merge, so nothing
-  # is lost. HUSKY=0 is the documented bypass (see AGENTS.md).
+  # Every commit this workflow makes is automation-generated: the
+  # @semantic-release/git prepare commit, the package.json version sync, and
+  # the post-release branch-sync work (merge commits + the "restore
+  # workspace:*" commit in post-release.sh). Skip the husky pre-commit lint
+  # for all of them: the PHPCS wrapper hard-fails here (no root composer
+  # install provisions vendor/bin/phpcs), and a lint gate on generated
+  # release commits could block an already-published release anyway. Every PR
+  # is fully linted by CI before merge, so nothing is lost. HUSKY=0 is the
+  # documented bypass (see AGENTS.md).
   HUSKY: '0'
 
 jobs:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,6 +20,14 @@ permissions:
 
 env:
   PNPM_VERSION: 10.33.0
+  # This workflow only ever commits generated version/changelog stamps (the
+  # @semantic-release/git prepare commit and the package.json version sync).
+  # Skip the husky pre-commit lint for those: the PHPCS wrapper hard-fails
+  # here (no root composer install provisions vendor/bin/phpcs), and a lint
+  # gate on generated release commits could block an already-published
+  # release anyway. Every PR is fully linted by CI before merge, so nothing
+  # is lost. HUSKY=0 is the documented bypass (see AGENTS.md).
+  HUSKY: '0'
 
 jobs:
   release:


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Today's stable release run ([failed job](https://github.com/Automattic/newspack-workspace/actions/runs/29766512804/job/88438669824)) broke when `@semantic-release/git` tried to commit the generated `chore(release): 2.3.1 [skip ci]` version stamp: the alpha→release promotion (#664) carried the husky pre-commit enforcement (#299) onto the `release` branch for the first time, and the PHPCS wrapper hard-fails in the release job because nothing provisions `vendor/bin/phpcs` at the workspace root there.

This sets `HUSKY: '0'` (the bypass documented in AGENTS.md) at the workflow level in `release.yml`. The Release workflow only ever commits generated version/changelog stamps, so a lint gate adds no value there — and worse, it could block a release after packages have already been published. Every PR is still fully linted by CI before merge, so no lint coverage is lost.

Why previous runs never hit this:
- Jul 13–15 `release` runs: hook files not yet promoted to the branch.
- `alpha`/hotfix/epic runs: prerelease channels never commit version stamps (see `config/release-helpers.js`), so the hook never fires.

No packages were published by the failed runs (the failure occurred in the first `prepare` commit, before any tag/npm/GitHub publish), so merging this PR triggers the Release workflow with the fixed file and cleanly releases everything pending from #664. The post-release sync then carries this change back to `main`/`alpha`.

### How to test the changes in this Pull Request:

1. Confirm the [failed job log](https://github.com/Automattic/newspack-workspace/actions/runs/29766512804/job/88438669824) shows `husky - pre-commit script failed` → `bin/precommit-phpcs.sh` → "PHP_CodeSniffer + the WP coding standards aren't installed at the workspace root" during the `git commit` of the release stamp.
2. Verify no tags were created by today's failed runs (e.g. `newspack-components@4.5.0` does not exist; npm still has 4.4.0).
3. Merge this PR into `release`; the push triggers the Release workflow using the updated file.
4. Verify the Release job passes the `prepare` step (version-stamp commits succeed) and the pending packages from #664 are tagged and published.
5. Verify the post-release branch sync flows this commit back into `main` and `alpha`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
