### PR TITLE
fix(modal-checkout): escape thank-you data-checkout, remove dead code

### DIFF
--- a/plugins/newspack-blocks/src/modal-checkout/modal.js
+++ b/plugins/newspack-blocks/src/modal-checkout/modal.js
@@ -165,12 +165,6 @@ domReady( () => {
 		onCheckoutPlaceOrderError( container, hideProcessingPaymentScreen );
 
 		onCheckoutReady( container, () => {
-			// Make sure the order summary renders the correct text.
-			const summaryTextNode = productDetails?.querySelector( 'strong' );
-			if ( summaryTextNode ) {
-				summaryTextNode.textContent = checkoutData.price_summary;
-			}
-
 			// Display initial errors if any.
 			if ( modalCheckout.initialErrors ) {
 				const errorContainer = document.createElement( 'div' );

--- a/plugins/newspack-blocks/src/modal-checkout/templates/thankyou.php
+++ b/plugins/newspack-blocks/src/modal-checkout/templates/thankyou.php
@@ -60,7 +60,7 @@ $checkout_data          = Checkout_Data::get_checkout_data( $order );
 				<path d="M16.7 7.1l-6.3 8.5-3.3-2.5-.9 1.2 4.5 3.4L17.9 8z"></path>
 			</svg>
 		</span>
-		<p id="modal-checkout-product-details" data-checkout='<?php echo wp_json_encode( $checkout_data ); ?>'>
+		<p id="modal-checkout-product-details" <?php Checkout_Data::print_data_checkout_attr( $checkout_data ); ?>>
 			<strong>
 				<?php
 					echo esc_html( Modal_Checkout::get_post_checkout_success_text() );

--- a/plugins/newspack-blocks/tests/test-modal-checkout-data.php
+++ b/plugins/newspack-blocks/tests/test-modal-checkout-data.php
@@ -197,5 +197,28 @@ class Newspack_Blocks_Modal_Checkout_Data_Test extends WP_UnitTestCase_Blocks {
 		$this->assertSame( [ 1407, 1408 ], $data['variation_ids'] );
 		$this->assertArrayNotHasKey( 'amount', $data );
 	}
+
+	/**
+	 * The data-checkout attribute must escape values so a product name containing
+	 * an apostrophe can't break out of the single-quoted attribute.
+	 */
+	public function test_data_checkout_attr_escapes_single_quotes() {
+		$attr = Checkout_Data::data_checkout_attr( [ 'name' => "Editor's Choice" ] );
+
+		// Single-quote delimited attribute, matching the markup that consumes it.
+		$this->assertStringStartsWith( "data-checkout='", $attr );
+		$this->assertStringEndsWith( "'", $attr );
+
+		// The apostrophe from the payload is escaped, so it can't terminate the attribute.
+		$inner = substr( $attr, strlen( "data-checkout='" ), -1 );
+		$this->assertStringNotContainsString( "'", $inner );
+		$this->assertStringContainsString( '&#039;', $inner );
+
+		// The escaped value still round-trips back to the original payload.
+		$this->assertSame(
+			[ 'name' => "Editor's Choice" ],
+			json_decode( html_entity_decode( $inner, ENT_QUOTES ), true )
+		);
+	}
 }
 // phpcs:enable Generic.Files.OneObjectStructurePerFile.MultipleFound


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Follow-ups to the non-blocking review feedback on #453 (modal checkout order details).

- **Escape the thank-you page `data-checkout` attribute.** The order-received template emitted `data-checkout` via raw `wp_json_encode()`, so a product name containing an apostrophe would break out of the single-quoted attribute (malformed markup / broken analytics payload). It now uses the same `Checkout_Data::print_data_checkout_attr()` helper (adds `esc_attr`) that #453 introduced for the checkout form.
- **Remove dead code in the modal script.** #453 removed the static price-summary card, leaving a checkout-ready handler that wrote `price_summary` into a `<strong>` that no longer exists. The write was already inert (guarded on an element that's never present) and is now gone.
- **Add a unit test** covering the escaping helper — asserts an apostrophe in the payload is escaped, can't terminate the attribute, and round-trips back to the original value.

Two other non-blocking items from #453 were **intentionally left as-is** because changing them would regress behavior:

- The `price_summary` / `newspack_modal_checkout_price_summary` plumbing is kept — it still feeds GA4 and the RAS `checkout_completed` payload, and the dynamic-pricing engine annotates that value to keep the analytics deal-accurate. Fully removing it is a separate, cross-module analytics change (to be coordinated with the engine side).
- The `woocommerce_checkout_before_order_review_heading` action is kept — it's the injection point for the UTM hidden inputs (`WooCommerce_Order_UTM::render_utm_inputs`), so removing it would drop UTM attribution on modal-checkout orders. The hook name is orphaned (its heading is gone), but it's a WooCommerce-standard name and the call is load-bearing.

### How to test the changes in this Pull Request:

1. On a site with WooCommerce + Newspack reader revenue, create a product whose name contains an apostrophe (e.g. `Editor's Choice`).
2. Complete a modal checkout for that product and reach the thank-you (order-received) screen.
3. Inspect the `#modal-checkout-product-details` element: confirm `data-checkout` is well-formed (the apostrophe is escaped as `&#039;`, the attribute isn't cut short) and the JSON parses.
4. Confirm the `checkout_completed` analytics event still fires with the correct product details.
5. Regression: complete a normal modal checkout (product without an apostrophe) and confirm the order completes and the thank-you screen renders as before.
6. Regression (UTM): open the checkout with `?utm_source=test&utm_medium=email`, complete the order, and confirm the UTM values are saved on the order (Edit Order screen → UTM Parameters).
7. Run the unit tests: `n test-php --filter Modal_Checkout_Data` → passes (2 tests).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally? <!-- PHPUnit (Modal_Checkout_Data) passes; PHPCS + ESLint clean on the changed files. -->
