### PR TITLE
fix(content-gate): keep anonymous metering tied to registered access

### DIFF
--- a/plugins/newspack-plugin/includes/class-blocks.php
+++ b/plugins/newspack-plugin/includes/class-blocks.php
@@ -84,8 +84,10 @@ final class Blocks {
 		];
 		if ( $script_data['has_memberships'] ) {
 			$script_data['content_gate_data'] = [
-				'anonymous_metered_views' => Metering::get_total_metered_views( false ),
-				'loggedin_metered_views'  => Metering::get_total_metered_views( true ),
+				// Cast to int: the getter returns false when metering is disabled or there
+				// is no gate, and the editor preview parses these as numbers.
+				'anonymous_metered_views' => absint( Metering::get_total_metered_views( false ) ),
+				'loggedin_metered_views'  => absint( Metering::get_total_metered_views( true ) ),
 				'metered_views'           => Metering::get_current_user_metered_views(),
 				'metering_period'         => Metering::get_metering_period(),
 			];

--- a/plugins/newspack-plugin/includes/content-gate/class-metering.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-metering.php
@@ -206,11 +206,17 @@ class Metering {
 	/**
 	 * Whether the registration wall is the rule that gates the current reader.
 	 *
-	 * Mirrors the gate-layout selection in
-	 * `Content_Restriction_Control::is_post_restricted()`, which restricts with the
-	 * registration layout - and skips the `custom_access` rules entirely - for both
-	 * anonymous visitors and signed-in readers who have not verified their email on a
-	 * wall that requires verification.
+	 * Follows the same registration-vs-`custom_access` split as the gate-layout
+	 * selection in `Content_Restriction_Control::is_post_restricted()`, which restricts
+	 * with the registration layout - and skips the `custom_access` rules entirely - for
+	 * both anonymous visitors and signed-in readers who have not verified their email on
+	 * a wall that requires verification.
+	 *
+	 * This assumes the reader is already known to be restricted; it is a settings
+	 * selector, not a restriction check. In particular it does not re-check the
+	 * anonymous `supports_anonymous` bypass (e.g. institutional access) that
+	 * `is_post_restricted()` applies before ever restricting an anonymous visitor - a
+	 * bypassed reader is not restricted, so no metering surface consults this for them.
 	 *
 	 * @param int  $gate_id      Gate ID.
 	 * @param bool $is_logged_in Whether to evaluate for a logged-in reader.
@@ -228,8 +234,11 @@ class Metering {
 		if ( ! $registration['require_verification'] ) {
 			return false;
 		}
-		// Non-reader users (admins, editors) are exempt, matching the same carve-out in
-		// `is_logged_in_metering_allowed()`.
+		// Exempt non-reader users (admins, editors). This reuses the reader/verified
+		// checks from `is_logged_in_metering_allowed()`'s verification bail; note that
+		// bail keys off `Content_Gate::requires_account_verification()`, which reads
+		// `require_verification` without the `active` guard applied above, so the two
+		// only fully agree while the wall is active.
 		$user = \wp_get_current_user();
 		return Reader_Activation::is_user_reader( $user ) && ! Reader_Activation::is_reader_verified( $user );
 	}
@@ -253,7 +262,7 @@ class Metering {
 	 * @param int  $gate_id      Gate ID.
 	 * @param bool $is_logged_in Whether to evaluate for a logged-in reader.
 	 *
-	 * @return array Metering settings.
+	 * @return array{enabled: bool, count: int, period: string} Metering settings.
 	 */
 	private static function get_effective_settings( $gate_id, $is_logged_in ) {
 		if ( Memberships::is_active() ) {
@@ -437,7 +446,13 @@ class Metering {
 		}
 
 		$gate_post_id = Content_Gate::get_gate_post_id();
-		$settings     = self::get_registered_settings( $gate_post_id );
+		// Read through the same helper as every reporting surface, so the enablement
+		// check here can never advertise a different allowance than they display. For
+		// every state that reaches this line the reader is either verified, a
+		// non-reader, or on a gate without a verification requirement - the verification
+		// bail above has already returned for the one state where the registration wall
+		// would govern - so this is behavior-identical to a direct paid-settings read.
+		$settings = self::get_effective_settings( $gate_post_id, true );
 
 		// Bail if metering is not enabled.
 		if ( ! $settings['enabled'] || $settings['count'] <= 0 ) {
@@ -537,7 +552,12 @@ class Metering {
 	}
 
 	/**
-	 * Get the metering period for a post.
+	 * Get the metering period for the current reader on a post.
+	 *
+	 * Resolves against the settings that govern the current reader, so the result is
+	 * auth-state dependent (via `is_user_logged_in()`, and verification state for
+	 * logged-in readers) - not a pure per-post value. Callers caching or comparing
+	 * periods across readers should key on the reader as well as the post.
 	 *
 	 * @param int|null $post_id Post ID. Default is current post.
 	 *

--- a/plugins/newspack-plugin/includes/content-gate/class-metering.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-metering.php
@@ -204,6 +204,31 @@ class Metering {
 	}
 
 	/**
+	 * Get the metering settings that govern anonymous readers.
+	 *
+	 * Beware the two senses of "registered" in this class: `get_anonymous_settings()`
+	 * reads the `registration` meta (the registration wall), while
+	 * `get_registered_settings()` reads the `custom_access` meta (the paywall).
+	 *
+	 * Anonymous readers are gated by the registration wall, so the `registration`
+	 * settings apply whenever that wall is active - including when its metering is
+	 * deliberately turned off, which means anonymous readers get no metered views at
+	 * all. Only when the registration wall is inactive do anonymous readers fall
+	 * through to the paywall, and with it the `custom_access` metering settings.
+	 *
+	 * @param int $gate_id Gate ID.
+	 *
+	 * @return array Metering settings.
+	 */
+	private static function get_effective_anonymous_settings( $gate_id ) {
+		if ( Memberships::is_active() ) {
+			return self::get_anonymous_settings( $gate_id );
+		}
+		$registration = Content_Gate::get_registration_settings( $gate_id );
+		return $registration['active'] ? self::get_anonymous_settings( $gate_id ) : self::get_registered_settings( $gate_id );
+	}
+
+	/**
 	 * Update metering settings for a gate.
 	 *
 	 * @param int   $gate_id  Gate ID.
@@ -230,7 +255,7 @@ class Metering {
 		}
 		$gate_layout_id = Content_Gate::get_gate_layout_id();
 		$gate_post_id   = Content_Gate::get_gate_post_id();
-		$handle       = 'newspack-content-gate-metering';
+		$handle         = 'newspack-content-gate-metering';
 		\wp_enqueue_script(
 			$handle,
 			Newspack::plugin_url() . '/dist/content-gate-metering.js',
@@ -239,9 +264,7 @@ class Metering {
 			true
 		);
 
-		$anonymous_settings   = self::get_anonymous_settings( $gate_post_id );
-		$registered_settings  = self::get_registered_settings( $gate_post_id );
-		$settings = $anonymous_settings['enabled'] ? $anonymous_settings : $registered_settings;
+		$settings = self::get_effective_anonymous_settings( $gate_post_id );
 		\wp_localize_script(
 			$handle,
 			'newspack_metering_settings',
@@ -329,9 +352,7 @@ class Metering {
 		}
 
 		$gate_post_id         = Content_Gate::get_gate_post_id();
-		$anonymous_settings   = self::get_anonymous_settings( $gate_post_id );
-		$registered_settings  = self::get_registered_settings( $gate_post_id );
-		$settings             = Memberships::is_active() || $anonymous_settings['enabled'] ? $anonymous_settings : $registered_settings;
+		$settings             = self::get_effective_anonymous_settings( $gate_post_id );
 		$is_frontend_metering = $settings['enabled'] && $settings['count'] > 0;
 
 		/**
@@ -490,10 +511,8 @@ class Metering {
 		if ( ! $post_id ) {
 			$post_id = get_the_ID();
 		}
-		$gate_post_id         = Content_Gate::get_gate_post_id( $post_id );
-		$anonymous_settings   = self::get_anonymous_settings( $gate_post_id );
-		$registered_settings  = self::get_registered_settings( $gate_post_id );
-		$settings = $anonymous_settings['enabled'] ? $anonymous_settings : $registered_settings;
+		$gate_post_id = Content_Gate::get_gate_post_id( $post_id );
+		$settings     = \is_user_logged_in() ? self::get_registered_settings( $gate_post_id ) : self::get_effective_anonymous_settings( $gate_post_id );
 		return $settings['period'];
 	}
 
@@ -528,12 +547,11 @@ class Metering {
 		if ( ! $gate_post_id ) {
 			return false;
 		}
-		$anonymous_settings   = self::get_anonymous_settings( $gate_post_id );
-		$registered_settings  = self::get_registered_settings( $gate_post_id );
-		if ( ! $is_logged_in && $anonymous_settings['enabled'] ) {
-			return $anonymous_settings['count'];
+		$settings = $is_logged_in ? self::get_registered_settings( $gate_post_id ) : self::get_effective_anonymous_settings( $gate_post_id );
+		if ( ! $settings['enabled'] ) {
+			return false;
 		}
-		return $registered_settings['count'];
+		return $settings['count'];
 	}
 }
 Metering::init();

--- a/plugins/newspack-plugin/includes/content-gate/class-metering.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-metering.php
@@ -216,6 +216,10 @@ class Metering {
 	 * all. Only when the registration wall is inactive do anonymous readers fall
 	 * through to the paywall, and with it the `custom_access` metering settings.
 	 *
+	 * Legacy Woo Memberships gates are exempt: they have no `registration` meta at all
+	 * and read both meters from the shared `metering` meta, so they short-circuit past
+	 * the `active` check.
+	 *
 	 * @param int $gate_id Gate ID.
 	 *
 	 * @return array Metering settings.

--- a/plugins/newspack-plugin/includes/content-gate/class-metering.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-metering.php
@@ -204,32 +204,64 @@ class Metering {
 	}
 
 	/**
-	 * Get the metering settings that govern anonymous readers.
+	 * Whether the registration wall is the rule that gates the current reader.
+	 *
+	 * Mirrors the gate-layout selection in
+	 * `Content_Restriction_Control::is_post_restricted()`, which restricts with the
+	 * registration layout - and skips the `custom_access` rules entirely - for both
+	 * anonymous visitors and signed-in readers who have not verified their email on a
+	 * wall that requires verification.
+	 *
+	 * @param int  $gate_id      Gate ID.
+	 * @param bool $is_logged_in Whether to evaluate for a logged-in reader.
+	 *
+	 * @return bool Whether the registration wall governs the reader.
+	 */
+	private static function is_gated_by_registration( $gate_id, $is_logged_in ) {
+		$registration = Content_Gate::get_registration_settings( $gate_id );
+		if ( ! $registration['active'] ) {
+			return false;
+		}
+		if ( ! $is_logged_in ) {
+			return true;
+		}
+		if ( ! $registration['require_verification'] ) {
+			return false;
+		}
+		// Non-reader users (admins, editors) are exempt, matching the same carve-out in
+		// `is_logged_in_metering_allowed()`.
+		$user = \wp_get_current_user();
+		return Reader_Activation::is_user_reader( $user ) && ! Reader_Activation::is_reader_verified( $user );
+	}
+
+	/**
+	 * Get the metering settings that govern the current reader.
 	 *
 	 * Beware the two senses of "registered" in this class: `get_anonymous_settings()`
 	 * reads the `registration` meta (the registration wall), while
 	 * `get_registered_settings()` reads the `custom_access` meta (the paywall).
 	 *
-	 * Anonymous readers are gated by the registration wall, so the `registration`
-	 * settings apply whenever that wall is active - including when its metering is
-	 * deliberately turned off, which means anonymous readers get no metered views at
-	 * all. Only when the registration wall is inactive do anonymous readers fall
-	 * through to the paywall, and with it the `custom_access` metering settings.
+	 * A reader gated by the registration wall is metered by the wall's own settings -
+	 * including when its metering is deliberately turned off, which means no metered
+	 * views at all. Only readers who are past (or not subject to) the wall fall through
+	 * to the paywall, and with it the `custom_access` metering settings.
 	 *
 	 * Legacy Woo Memberships gates are exempt: they have no `registration` meta at all
-	 * and read both meters from the shared `metering` meta, so they short-circuit past
-	 * the `active` check.
+	 * and read both meters from the shared `metering` meta, so they keep the plain
+	 * anonymous/registered split.
 	 *
-	 * @param int $gate_id Gate ID.
+	 * @param int  $gate_id      Gate ID.
+	 * @param bool $is_logged_in Whether to evaluate for a logged-in reader.
 	 *
 	 * @return array Metering settings.
 	 */
-	private static function get_effective_anonymous_settings( $gate_id ) {
+	private static function get_effective_settings( $gate_id, $is_logged_in ) {
 		if ( Memberships::is_active() ) {
-			return self::get_anonymous_settings( $gate_id );
+			return $is_logged_in ? self::get_registered_settings( $gate_id ) : self::get_anonymous_settings( $gate_id );
 		}
-		$registration = Content_Gate::get_registration_settings( $gate_id );
-		return $registration['active'] ? self::get_anonymous_settings( $gate_id ) : self::get_registered_settings( $gate_id );
+		return self::is_gated_by_registration( $gate_id, $is_logged_in )
+			? self::get_anonymous_settings( $gate_id )
+			: self::get_registered_settings( $gate_id );
 	}
 
 	/**
@@ -268,7 +300,7 @@ class Metering {
 			true
 		);
 
-		$settings = self::get_effective_anonymous_settings( $gate_post_id );
+		$settings = self::get_effective_settings( $gate_post_id, false );
 		\wp_localize_script(
 			$handle,
 			'newspack_metering_settings',
@@ -356,7 +388,7 @@ class Metering {
 		}
 
 		$gate_post_id         = Content_Gate::get_gate_post_id();
-		$settings             = self::get_effective_anonymous_settings( $gate_post_id );
+		$settings             = self::get_effective_settings( $gate_post_id, false );
 		$is_frontend_metering = $settings['enabled'] && $settings['count'] > 0;
 
 		/**
@@ -516,7 +548,7 @@ class Metering {
 			$post_id = get_the_ID();
 		}
 		$gate_post_id = Content_Gate::get_gate_post_id( $post_id );
-		$settings     = \is_user_logged_in() ? self::get_registered_settings( $gate_post_id ) : self::get_effective_anonymous_settings( $gate_post_id );
+		$settings     = self::get_effective_settings( $gate_post_id, \is_user_logged_in() );
 		return $settings['period'];
 	}
 
@@ -551,7 +583,7 @@ class Metering {
 		if ( ! $gate_post_id ) {
 			return false;
 		}
-		$settings = $is_logged_in ? self::get_registered_settings( $gate_post_id ) : self::get_effective_anonymous_settings( $gate_post_id );
+		$settings = self::get_effective_settings( $gate_post_id, $is_logged_in );
 		if ( ! $settings['enabled'] ) {
 			return false;
 		}

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/metering.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/metering.php
@@ -780,4 +780,123 @@ class Test_Metering extends \WP_UnitTestCase {
 		$this->assertEquals( 'month', Metering::get_metering_period( $post_id ), 'Logged-in readers should get the paid access period' );
 		$this->assertEquals( 3, Metering::get_total_metered_views( true ), 'Logged-in readers should get the paid access count' );
 	}
+
+	/**
+	 * Test that a logged-in reader who has not verified their email is governed by the
+	 * registered access settings, not the paid access ones.
+	 *
+	 * Such a reader is shown the registered access gate layout, so the paid access
+	 * allowance must not leak into the metering surfaces they see.
+	 */
+	public function test_unverified_reader_uses_registration_settings() {
+		// Registered access active, verification required, metering OFF. Paid access
+		// active with metering ON — the allowance that must not be borrowed.
+		$gate_id = $this->create_gate_with_settings(
+			[
+				'registration'  => [
+					'active'               => true,
+					'require_verification' => true,
+					'metering'             => [
+						'enabled' => false,
+						'count'   => 2,
+						'period'  => 'week',
+					],
+				],
+				'custom_access' => [
+					'active'   => true,
+					'metering' => [
+						'enabled' => true,
+						'count'   => 3,
+						'period'  => 'month',
+					],
+				],
+			]
+		);
+
+		// Create a post.
+		$post_id = $this->factory->post->create();
+		$this->post_ids[] = $post_id;
+
+		// Set query to current post.
+		global $wp_query;
+		$wp_query = new \WP_Query( [ 'p' => $post_id ] );
+		add_filter( 'newspack_is_post_restricted', '__return_true' );
+
+		// Apply the filter to control the gate context for testing.
+		add_filter(
+			'newspack_content_gate_post_id',
+			function() use ( $gate_id ) {
+				return $gate_id;
+			}
+		);
+
+		// Register a reader but leave them unverified.
+		$user_id = $this->register_reader( 'unverified-reader@metering-test.com' );
+		wp_set_current_user( $user_id );
+		$user = wp_get_current_user();
+		$this->assertTrue( Reader_Activation::is_user_reader( $user ), 'User should be a reader' );
+		$this->assertFalse( Reader_Activation::is_reader_verified( $user ), 'Reader should not be verified' );
+
+		// The reader sees the registered access gate immediately - no metered views.
+		$this->assertFalse( Metering::is_logged_in_metering_allowed( $post_id ), 'Unverified readers should not be metered' );
+
+		// The metering surfaces must report the registered access settings, not the paid ones.
+		$this->assertFalse( Metering::get_total_metered_views( true ), 'Unverified readers should not be offered the paid access allowance' );
+		$this->assertEquals( 'week', Metering::get_metering_period( $post_id ), 'Unverified readers should get the registered access period' );
+	}
+
+	/**
+	 * Test that a logged-in reader who HAS verified their email is still governed by the
+	 * paid access settings on a gate that requires verification.
+	 */
+	public function test_verified_reader_uses_paid_settings() {
+		$gate_id = $this->create_gate_with_settings(
+			[
+				'registration'  => [
+					'active'               => true,
+					'require_verification' => true,
+					'metering'             => [
+						'enabled' => false,
+						'count'   => 2,
+						'period'  => 'week',
+					],
+				],
+				'custom_access' => [
+					'active'   => true,
+					'metering' => [
+						'enabled' => true,
+						'count'   => 3,
+						'period'  => 'month',
+					],
+				],
+			]
+		);
+
+		// Create a post.
+		$post_id = $this->factory->post->create();
+		$this->post_ids[] = $post_id;
+
+		// Set query to current post.
+		global $wp_query;
+		$wp_query = new \WP_Query( [ 'p' => $post_id ] );
+		add_filter( 'newspack_is_post_restricted', '__return_true' );
+
+		// Apply the filter to control the gate context for testing.
+		add_filter(
+			'newspack_content_gate_post_id',
+			function() use ( $gate_id ) {
+				return $gate_id;
+			}
+		);
+
+		// Register and verify the reader.
+		$user_id = $this->register_reader( 'verified-reader@metering-test.com' );
+		\update_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true );
+		wp_set_current_user( $user_id );
+		$this->assertTrue( Reader_Activation::is_reader_verified( wp_get_current_user() ), 'Reader should be verified' );
+
+		// Past the registration wall, so the paid access settings govern.
+		$this->assertEquals( 3, Metering::get_total_metered_views( true ), 'Verified readers should get the paid access count' );
+		$this->assertEquals( 'month', Metering::get_metering_period( $post_id ), 'Verified readers should get the paid access period' );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/metering.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/metering.php
@@ -613,4 +613,168 @@ class Test_Metering extends \WP_UnitTestCase {
 		$this->assertTrue( Metering::is_frontend_metering(), 'Front-end metering should fall back to registered settings if anonymous settings are not enabled' );
 		$this->assertEquals( $registered_settings['count'], Metering::get_total_metered_views(), 'Total metered views should be the same as registered settings' );
 	}
+
+	/**
+	 * Test that front-end metering does not fall back to registered settings when
+	 * registered access is active but has metering disabled.
+	 */
+	public function test_metering_settings_do_not_fall_back_when_registration_is_active() {
+		// Registered access active with metering OFF, paid access active with metering ON.
+		$gate_id = $this->create_gate_with_settings(
+			[
+				'registration'  => [
+					'active'   => true,
+					'metering' => [
+						// Metering is off, but a stale count remains stored from when it was on.
+						'enabled' => false,
+						'count'   => 2,
+						'period'  => 'month',
+					],
+				],
+				'custom_access' => [
+					'active'   => true,
+					'metering' => [
+						'enabled' => true,
+						'count'   => 3,
+						'period'  => 'month',
+					],
+				],
+			]
+		);
+
+		// Create a post.
+		$post_id = $this->factory->post->create();
+		$this->post_ids[] = $post_id;
+
+		// Set query to current post.
+		global $wp_query;
+		$wp_query = new \WP_Query( [ 'p' => $post_id ] );
+		add_filter( 'newspack_is_post_restricted', '__return_true' );
+
+		// Ensure no user is logged in.
+		wp_set_current_user( 0 );
+
+		// Apply the filter to control the gate context for testing.
+		add_filter(
+			'newspack_content_gate_post_id',
+			function() use ( $gate_id ) {
+				return $gate_id;
+			}
+		);
+
+		// Anonymous metering is not enabled, because registered access has metering off.
+		$anonymous_settings = Metering::get_anonymous_settings( $gate_id );
+		$this->assertFalse( $anonymous_settings['enabled'], 'Anonymous settings should not be enabled' );
+
+		// Anonymous readers should hit the registered access gate immediately, without
+		// borrowing the paid access metering allowance.
+		$this->assertFalse( Metering::is_frontend_metering(), 'Front-end metering should not fall back to registered settings while registered access is active' );
+		$this->assertFalse( Metering::get_total_metered_views(), 'Anonymous readers should have no metered views' );
+	}
+
+	/**
+	 * Test that anonymous readers are still metered by registered access settings when
+	 * registered access is active and its metering is enabled.
+	 */
+	public function test_anonymous_metering_uses_registration_settings_when_enabled() {
+		// Both access rules active, each metering with a distinct count and period.
+		$gate_id = $this->create_gate_with_settings(
+			[
+				'registration'  => [
+					'active'   => true,
+					'metering' => [
+						'enabled' => true,
+						'count'   => 1,
+						'period'  => 'week',
+					],
+				],
+				'custom_access' => [
+					'active'   => true,
+					'metering' => [
+						'enabled' => true,
+						'count'   => 3,
+						'period'  => 'month',
+					],
+				],
+			]
+		);
+
+		// Create a post.
+		$post_id = $this->factory->post->create();
+		$this->post_ids[] = $post_id;
+
+		// Set query to current post.
+		global $wp_query;
+		$wp_query = new \WP_Query( [ 'p' => $post_id ] );
+		add_filter( 'newspack_is_post_restricted', '__return_true' );
+
+		// Ensure no user is logged in.
+		wp_set_current_user( 0 );
+
+		// Apply the filter to control the gate context for testing.
+		add_filter(
+			'newspack_content_gate_post_id',
+			function() use ( $gate_id ) {
+				return $gate_id;
+			}
+		);
+
+		// Anonymous readers get the registered access allowance, not the paid access one.
+		$this->assertTrue( Metering::is_frontend_metering(), 'Front-end metering should be enabled' );
+		$this->assertEquals( 1, Metering::get_total_metered_views(), 'Anonymous readers should get the registered access count' );
+		$this->assertEquals( 'week', Metering::get_metering_period( $post_id ), 'Anonymous readers should get the registered access period' );
+	}
+
+	/**
+	 * Test that the metering period for logged-in readers comes from the paid access
+	 * settings, which are what governs their metered views.
+	 */
+	public function test_metering_period_for_logged_in_readers_uses_paid_settings() {
+		// Both access rules active, each metering with a distinct period.
+		$gate_id = $this->create_gate_with_settings(
+			[
+				'registration'  => [
+					'active'   => true,
+					'metering' => [
+						'enabled' => true,
+						'count'   => 1,
+						'period'  => 'week',
+					],
+				],
+				'custom_access' => [
+					'active'   => true,
+					'metering' => [
+						'enabled' => true,
+						'count'   => 3,
+						'period'  => 'month',
+					],
+				],
+			]
+		);
+
+		// Create a post.
+		$post_id = $this->factory->post->create();
+		$this->post_ids[] = $post_id;
+
+		// Set query to current post.
+		global $wp_query;
+		$wp_query = new \WP_Query( [ 'p' => $post_id ] );
+		add_filter( 'newspack_is_post_restricted', '__return_true' );
+
+		// Apply the filter to control the gate context for testing.
+		add_filter(
+			'newspack_content_gate_post_id',
+			function() use ( $gate_id ) {
+				return $gate_id;
+			}
+		);
+
+		// Log in a reader.
+		$user_id = $this->register_reader();
+		wp_set_current_user( $user_id );
+
+		// The period must match the one the logged-in metering expiration is computed from.
+		$this->assertEquals( 'month', Metering::get_metering_period( $post_id ), 'Logged-in readers should get the paid access period' );
+		$this->assertEquals( 3, Metering::get_total_metered_views( true ), 'Logged-in readers should get the paid access count' );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/metering.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/metering.php
@@ -891,7 +891,7 @@ class Test_Metering extends \WP_UnitTestCase {
 
 		// Register and verify the reader.
 		$user_id = $this->register_reader( 'verified-reader@metering-test.com' );
-		\update_user_meta( $user_id, Reader_Activation::EMAIL_VERIFIED, true );
+		Reader_Activation::set_reader_verified( $user_id );
 		wp_set_current_user( $user_id );
 		$this->assertTrue( Reader_Activation::is_reader_verified( wp_get_current_user() ), 'Reader should be verified' );
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/metering.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/metering.php
@@ -631,6 +631,9 @@ class Test_Metering extends \WP_UnitTestCase {
 						'period'  => 'month',
 					],
 				],
+				// Load-bearing: paid access must stay active with metering ON, since it is
+				// the allowance the pre-fix code wrongly handed to anonymous readers.
+				// Disabling either would make this test pass with the bug present.
 				'custom_access' => [
 					'active'   => true,
 					'metering' => [


### PR DESCRIPTION
Fixes [NEWS-2785](https://linear.app/a8c/issue/NEWS-2785/access-control-registered-access-enabled-w-metering-off-paid-access)

## Changes proposed

### The bug

A content gate has two access rules: **registered access** (the registration wall, which governs anonymous readers) and **paid access** (the paywall). Each has its own optional metering.

#4571 added a fallback so that when registered access is switched off entirely, anonymous readers fall through to the paywall and use *its* metering settings. It keyed that fallback on `$anonymous_settings['enabled']`:

```php
$settings = Memberships::is_active() || $anonymous_settings['enabled'] ? $anonymous_settings : $registered_settings;
```

But `get_anonymous_settings()` returns `enabled = $registration['active'] && $registration['metering']['enabled']`. So a publisher with registered access **active** and its metering deliberately **off** is indistinguishable from one with registered access **disabled** — and hits the fallback too. Anonymous readers borrow the paywall's meter (3 free articles) and then see the paywall, instead of hitting the registration wall immediately. The registration gate layout is never shown.

The same predicate was copy-pasted at four call sites, so they could drift apart independently.

### The fix

A private helper `Metering::get_effective_anonymous_settings()` keyed on `$registration['active']` — the question #4571 meant to ask. All four call sites route through it.

Two adjacent corrections the change surfaced:

- **`get_metering_period()`** is now logged-in-aware. It previously returned the *registration* period to logged-in readers, whose metering expiry is computed from the *paid* period (`is_logged_in_metering_allowed()` uses `get_registered_settings()['period']`) — so the countdown banner could say "free articles this week" against a monthly reset.
- **`get_total_metered_views()`** now returns `false` when metering is disabled, as its docblock already promised and as `print_cta()` already handles. It previously returned whatever count was still stored; since `get_registration_settings()` defaults `count` to `1`, a gate whose meter was toggled off in the UI would report one free view.

### Unverified logged-in readers

The same misalignment existed one step over. `Content_Restriction_Control::is_post_restricted()` restricts a signed-in reader who has **not verified their email** on a wall that requires verification using the *registration* layout, and skips the `custom_access` rules entirely — yet the metering surfaces still reported the paywall's allowance for that reader. On a gate with registered access requiring verification and metering off, plus paid access metering on, `get_total_metered_views( true )` returned the paid count for a reader who actually gets zero, so the countdown could advertise a paid allowance on the registration wall.

So the helper is generalized: `get_effective_settings( $gate_id, $is_logged_in )`, backed by `is_gated_by_registration()`, which mirrors that layout selection — the registration wall governs anonymous visitors *and* unverified signed-in readers. Non-reader users (admins, editors) stay exempt, matching the existing carve-out in `is_logged_in_metering_allowed()`.

Access behavior for these readers was already correct (`is_logged_in_metering_allowed()` already hard-bailed on unverified readers, so they already saw the wall immediately); what this corrects is which settings the metering surfaces report. Unchanged: an unverified reader still gets no metered views at all, even where registration metering is on — granting them the registration allowance would be a loosening of access and is a separate decision.

`get_total_metered_views()` returning `false` reaches the block editor via `class-blocks.php`, which localizes it for the countdown block's preview (`parseInt( false )` is `NaN`), so those two values are now cast with `absint()` at the localization boundary. Both PHP consumers already guarded on `false === $total_views`, and a grep of the standalone repos (including `newspack-manager`) found no external callers of the changed methods.

## How to test

Automated (both new regression tests fail on `release` and pass here):

```
n test-php   # from plugins/newspack-plugin
```

Manually, on a gated post:

1. Create a content gate with **registered access active, metering OFF** and **paid access active, metering ON, count 3**.
2. Visit a gated post logged out. **Expected:** the registration gate immediately, no metered articles. (Before: 3 free articles, then the paywall.)
3. Log in as a reader with no paid access. **Expected:** 3 metered articles, then the paywall.
4. Turn on **Require verification** under registered access, then load a gated post as a signed-in reader whose email is not verified. **Expected:** the registration gate immediately, and no countdown advertising the paid allowance.
5. Flip registered access to **inactive** and reload logged out. **Expected:** 3 metered articles, then the paywall — #4571's behavior, unchanged.

Note when testing: `enqueue_scripts()` bakes the metering count and period into the cached HTML, so give the page cache a chance to turn over between config changes.

## Rollout note: this is a tightening

Exactly one gate configuration changes reader-facing behavior: **registration wall active + its metering off + paywall metering on**. On those sites, anonymous readers who have been getting free articles through this bug will start hitting the registration wall on the first article as soon as the release lands. That is the intended correction, but it is visible on day one and can read as a regression to anyone unaware of the old leak — and because campaign prompts and article-view activity are keyed off the same metering check, engagement and campaign reporting move at the same time.

Worth giving affected publishers advance notice. The remedy for anyone who wants to keep the free views is one toggle: enable Metering under the Registration rule and set a count there.

Every other configuration is unchanged, including all legacy WooCommerce Memberships gates and every signed-in reader path.

When validating after deploy, let the page cache turn over first — anonymous metered pages are cacheable, so pre-fix HTML keeps serving until expiry and a stale page looks like the fix did not land.

## Follow-ups (not in scope here)

- `Metering_Countdown::print_cta()` picks the "Create an account" vs "Sign in" link for anonymous readers from `get_registered_settings()` — the *paid* meter. `Content_Gifting_CTA` has the same shape via `has_metering()`, which ORs both meters. These are the remaining anonymous-facing readers of the wrong settings bucket.
- `class-blocks.php` localizes `anonymous_metered_views` and `loggedin_metered_views` side by side, but a single `metering_period` resolved from the editor's own session. Harmless today (that path is memberships-gated, where both meters share one stored period), a real bug if the localization is extended.
