### PR TITLE
fix(components): render routed content when no tab owns the route

### DIFF
--- a/packages/components/src/page/index.js
+++ b/packages/components/src/page/index.js
@@ -36,7 +36,8 @@ import './style.scss';
  * @param {*}      [props.actions]
  * @param {*}      [props.tabbedNavigation] A `TabbedNavigation` element; its bar renders inside
  *                                          the sticky header block and the page children render
- *                                          inside its active tab panel.
+ *                                          inside its active tab panel — or, when no visible tab
+ *                                          owns the route, as a sibling of the panels.
  * @param {string} [props.className]
  * @param {*}      props.children
  * @return {JSX.Element} Page component.

--- a/packages/components/src/tabbed-navigation/index.js
+++ b/packages/components/src/tabbed-navigation/index.js
@@ -118,9 +118,23 @@ const RoutedTabbedNavigation = ( { items, className, disableUpcoming, content = 
 		);
 	} );
 
+	// A route no visible tab owns — a hidden sub-view (an edit screen), or a path
+	// with no matching tab at all — still has to render its content, outside the
+	// panels: with no active tab there is no panel entitled to hold it. Without
+	// this the page body is blank, and because the router's own fallback (the
+	// wizard's trailing `<Redirect>`) lives inside that content, it never mounts
+	// to correct the route either.
+	const unownedContent = null === activeValue ? content : null;
+
 	return (
 		<Tabs.Root value={ activeValue } className="newspack-tabbed-navigation__root">
-			{ renderShell( bar, panels ) }
+			{ renderShell(
+				bar,
+				<>
+					{ panels }
+					{ unownedContent }
+				</>
+			) }
 		</Tabs.Root>
 	);
 };

--- a/packages/components/src/tabbed-navigation/index.js
+++ b/packages/components/src/tabbed-navigation/index.js
@@ -43,7 +43,8 @@ const defaultRenderShell = ( bar, content ) => (
 /**
  * Router-driven tabs: a real WAI-ARIA tabs widget. The routed page content
  * renders inside the active tab's `Tabs.Panel`, so each tab's `aria-controls`
- * points at the panel that actually contains its content.
+ * points at the panel that actually contains its content — or, when no visible
+ * tab owns the route, as a sibling of the panels (see `unownedContent` below).
  */
 const RoutedTabbedNavigation = ( { items, className, disableUpcoming, content = null, renderShell = defaultRenderShell, children = null } ) => {
 	const history = useHistory();
@@ -124,6 +125,10 @@ const RoutedTabbedNavigation = ( { items, className, disableUpcoming, content = 
 	// this the page body is blank, and because the router's own fallback (the
 	// wizard's trailing `<Redirect>`) lives inside that content, it never mounts
 	// to correct the route either.
+	//
+	// This renders without the panels' `__panel` class, which is styleless today.
+	// Keep it that way: styling `__panel` would silently indent/pad owned routes
+	// only, and the divergence would be hard to trace back to here.
 	const unownedContent = null === activeValue ? content : null;
 
 	return (
@@ -174,13 +179,21 @@ const LinkTabbedNavigation = ( { items, className, content = null, renderShell =
  * Items with router `path`s render as a real tabs widget whose active panel
  * contains `content`; href-only items render as plain navigation links.
  *
+ * When no visible tab owns the current route — a hidden sub-view, or an unknown
+ * URL — `content` renders as a sibling of the panels with no tab selected. That
+ * is a safety net, not the preferred shape: for a route that is conceptually a
+ * sub-view of a tab, give that tab an `activeTabPaths` entry (e.g.
+ * `activeTabPaths: [ '/edit/*' ]`) so it stays selected and its panel keeps
+ * owning the content.
+ *
  * `renderShell( bar, content )` is a layout injection point used by `Page` to
  * place the bar inside its sticky header region while the content flows below.
  *
  * @param {Object}  props
  * @param {Array}   props.items             Navigation items.
  * @param {boolean} [props.disableUpcoming] Disable tabs after the active one (setup flows).
- * @param {*}       [props.content]         Page content, rendered inside the active tab's panel.
+ * @param {*}       [props.content]         Page content, rendered inside the active tab's panel — or
+ *                                          as a sibling of the panels when no visible tab owns the route.
  * @param {*}       [props.renderShell]     Layout callback `( bar, content ) => element`.
  * @param {string}  [props.className]
  * @param {*}       [props.children]        Extra elements rendered inside the bar (e.g. error notices).

--- a/packages/components/src/tabbed-navigation/index.test.js
+++ b/packages/components/src/tabbed-navigation/index.test.js
@@ -2,7 +2,7 @@
  * External dependencies.
  */
 import { act, fireEvent, render, screen } from '@testing-library/react';
-import { MemoryRouter, useHistory } from 'react-router-dom';
+import { MemoryRouter, Redirect, useHistory } from 'react-router-dom';
 
 /**
  * Internal dependencies.
@@ -149,6 +149,27 @@ describe( 'TabbedNavigation with routed items', () => {
 		ITEMS.forEach( ( { label } ) => {
 			expect( getTab( label ) ).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
+	} );
+
+	it( 'renders the content outside the panels when no tab owns the route', () => {
+		// Hidden sub-views (an edit screen) and stale URLs land here. The content
+		// must still mount — otherwise the page body is blank — but no panel may
+		// claim it, since no tab is selected.
+		renderTabs( { initialEntries: [ '/edit/123' ] } );
+
+		const content = screen.getByText( 'Routed content' );
+		expect( content ).toBeInTheDocument();
+		expect( content.closest( '[role="tabpanel"]' ) ).toBeNull();
+		ITEMS.forEach( ( { label } ) => {
+			expect( getTab( label ) ).toHaveAttribute( 'aria-selected', 'false' );
+		} );
+	} );
+
+	it( 'mounts unowned content so a router fallback inside it still runs', () => {
+		// The wizard's trailing <Redirect> lives inside this content, so dropping
+		// it would strand the route instead of correcting it.
+		renderTabs( { initialEntries: [ '/unknown' ], content: <Redirect to="/stories" /> } );
+		expect( getTab( 'Stories' ) ).toHaveAttribute( 'aria-selected', 'true' );
 	} );
 
 	it( 'navigates when the active tab changes so panels follow the route', () => {

--- a/packages/components/src/tabbed-navigation/index.test.js
+++ b/packages/components/src/tabbed-navigation/index.test.js
@@ -152,16 +152,46 @@ describe( 'TabbedNavigation with routed items', () => {
 	} );
 
 	it( 'renders the content outside the panels when no tab owns the route', () => {
-		// Hidden sub-views (an edit screen) and stale URLs land here. The content
-		// must still mount — otherwise the page body is blank — but no panel may
-		// claim it, since no tab is selected.
+		// A route no tab matches — an edit screen registered as hidden, or a stale
+		// URL. The content must still mount, or the page body is blank.
 		renderTabs( { initialEntries: [ '/edit/123' ] } );
 
-		const content = screen.getByText( 'Routed content' );
-		expect( content ).toBeInTheDocument();
-		expect( content.closest( '[role="tabpanel"]' ) ).toBeNull();
+		// Assert positively: with nothing selected the panels unmount entirely, so
+		// a `closest( '[role=tabpanel]' )` check alone would pass even if the
+		// content rendered somewhere wrong. Exactly one copy also guards the mutual
+		// exclusivity with the in-panel render.
+		const matches = screen.getAllByText( 'Routed content' );
+		expect( matches ).toHaveLength( 1 );
+		expect( matches[ 0 ].closest( '.newspack-tabbed-navigation__root' ) ).not.toBeNull();
+		expect( matches[ 0 ].closest( '[role="tabpanel"]' ) ).toBeNull();
 		ITEMS.forEach( ( { label } ) => {
 			expect( getTab( label ) ).toHaveAttribute( 'aria-selected', 'false' );
+		} );
+	} );
+
+	it( 'renders the content when the only matching item is hidden from the bar', () => {
+		// The wizard routes hidden sections but filters them out of the bar, so the
+		// item exists and yet can never own the route.
+		render(
+			<MemoryRouter initialEntries={ [ '/edit/123' ] }>
+				<TabbedNavigation
+					items={ [ ...ITEMS, { label: 'Edit', path: '/edit/:id', isHiddenInTabbedNavigation: true } ] }
+					content={ <div>Routed content</div> }
+				/>
+			</MemoryRouter>
+		);
+		expect( screen.getAllByText( 'Routed content' ) ).toHaveLength( 1 );
+		expect( screen.queryByRole( 'tab', { name: 'Edit' } ) ).not.toBeInTheDocument();
+	} );
+
+	it( 'renders unowned content even when disableUpcoming disables every tab', () => {
+		// The setup wizard's Welcome and Completed screens are hidden from the bar
+		// AND use disableUpcoming, so `index > activeIndex` disables every tab. The
+		// content still has to render — this is the case that left onboarding blank.
+		renderTabs( { initialEntries: [ '/unowned' ], disableUpcoming: true } );
+		expect( screen.getAllByText( 'Routed content' ) ).toHaveLength( 1 );
+		ITEMS.forEach( ( { label } ) => {
+			expect( getTab( label ) ).toHaveAttribute( 'aria-disabled', 'true' );
 		} );
 	} );
 


### PR DESCRIPTION
## What

When a wizard's tab bar renders but **no visible tab owns the current route**, the routed page content is dropped entirely and the page body renders blank. This restores it.

## Root cause

#472 moved the wizard's routed content *inside* the active tab's `Tabs.Panel`: `Page` now does `cloneElement( tabbedNavigation, { renderShell, content: children } )` (`packages/components/src/page/index.js:81-83`), so the whole `<Switch>` is handed to `TabbedNavigation` and rendered only by the panel whose `value === activeValue`.

On a route no visible tab matches, `activeIndex === -1` → `activeValue === null` → **every** panel renders `null`, and the content element is never placed in the tree at all.

Two consequences, the second easy to miss:

1. Hidden sub-views (edit/add screens registered with `isHidden`) render blank — the component never mounts, so it never even fetches.
2. **The router's own fallback can't save it.** The wizard's trailing `<Redirect to={ displayedSections[0].path } />` (`wizard/index.js:207`) lives *inside* the dropped content, so an unrecognized route no longer self-heals to the first tab — it's a permanent blank screen. That's a silent behavior change for every stale bookmark and typo'd URL on a multi-tab wizard.

A wizard is only safe today if it has exactly **one** visible section, in which case `Wizard` sets `tabbedNavigation = false` and `Page` falls through to `renderShell( null, children )`.

## Blast radius — all confirmed in-browser on `main`

| Surface | Broken route(s) |
|---|---|
| **Audience → Plans** | `#/edit/:id` **and** `#/new` — can neither edit nor create a plan |
| **Setup wizard** | `#/` (Welcome) and `#/completed` — the onboarding entry point |
| **Story Budget** | the bare URL (`?page=newspack-story-budget`, no hash), which is what the admin menu links to |
| **Settings** | any URL for a conditionally-registered tab that isn't currently active (e.g. `#/additional-brands` without the multibranded plugin), plus any unrecognized hash |
| **Advertising → Display Ads** | `#/google_ad_manager` and `#/google_ad_manager/:id` — Google Ad Manager ad-unit management, on any site with GAM enabled |

The advertising case is worth spelling out, because it doesn't fit the pattern of the others: that wizard hand-rolls its own `HashRouter` and passes `tabbedNavigation={ tabs }` through `withWizardScreen` rather than registering `isHidden` sections on `Wizard`. Its three tabs are `/` (`exact: true`), `/placements` and `/settings`, none of which cover the two `/google_ad_manager` routes — and the Providers tab links straight to them whenever GAM is enabled (`views/providers/index.js:84-85`), as do the ad-unit save/cancel buttons.

Story Budget deserves a note: it was *latent* rather than visibly broken, because its `dist/` predated #472. It broke the moment the bundle was rebuilt — meaning the next release would have shipped a blank landing page.

Unaffected: pricing-rules, content-gates, integrations, premium-newsletters, donations, subscriptions, dashboard, newsletters (one visible section each), and the PHP-rendered admin header (href-only items → `LinkTabbedNavigation`, no panel gating).

**Latent landmine worth knowing:** content-gates carries **6** hidden routes and integrations 2 — all safe *only* because each wizard has exactly one visible tab. Adding a second tab to either would break every one of them at once, silently.

## The fix

Render `content` as a sibling of the panels when no tab is active. It goes *outside* the panels deliberately: with no active tab, no panel is entitled to hold the content, and putting it in one would break the tab↔panel `aria-controls` pairing that `@wordpress/ui` validates in development builds.

This is fixed in the shared component rather than per-wizard on purpose. A local `activeTabPaths: [ '/new', '/edit/*' ]` on the Plans wizard would have fixed the reported symptom and left Setup, Story Budget, Settings and Advertising broken — and it wouldn't restore the `<Redirect>` fallback anywhere. The advertising case makes the point concrete: it uses a different composition path entirely, so a config-level fix would have to be applied correctly at six call sites across two different wizard idioms, and any one that's missed fails silently as a blank page.

`activeTabPaths` remains the better *per-wizard* treatment for routes that are conceptually sub-views of a visible tab (the parent tab stays selected and its panel keeps owning the content). This change is what guarantees a missed `activeTabPaths` degrades to "renders, no tab selected" instead of "blank page".

Two things checked before choosing this shape:
- `Tabs.Root` already received `value={ null }` in exactly this case before the change, so no new null is introduced.
- **No CSS anywhere targets `newspack-tabbed-navigation__panel`**, so rendering outside it has no layout consequence.

## Testing

**Automated.** Two regression tests added, covering the blank body and the swallowed `<Redirect>` (using a real `<Redirect>` as content, mirroring the wizard's actual structure). `packages/components` had **no** coverage for "pathname matches no tab" before this.

Verified they're not vacuous: with the fix reverted, **exactly 2 tests fail — both new ones** (91 others pass). With the fix, **93/93 across 13 suites**.

**Manual**, on a dev site running `main`, all four surfaces above confirmed blank before and correct after. Also re-checked for regressions on *owned* routes: content still renders inside the correct panel with the right tab highlighted (Plans tab switching, Settings tab switching, Story Budget `#/stories` ↔ `#/budgets`).

> ⚠️ **Reviewer/tester note — how to actually get this change into a build.** `newspack-components` is consumed two different ways: `newspack-plugin` symlinks `packages/` and compiles from `src`, while other plugins import the package by name and resolve `"main": "dist/esm/index.js"` — the **built** output. So `n build <plugin>` alone will appear to fix newspack-plugin while leaving every other consumer broken. To verify Story Budget you must run `npm run build` in `packages/components` **first**, then rebuild the plugin. This cost us two false negatives while confirming the fix.

## Notes

Surfaced while reviewing #466, but unrelated to it — it reproduces on plain `main` with none of that PR's code. cc the author of #472, since this adjusts that change's content-ownership model.
