### PR TITLE
fix(newsletters): address publisher feedback on the newsletters list

### DIFF
--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-assets.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-assets.php
@@ -65,6 +65,8 @@ class Admin_Shell_Assets {
 				'adminUrl'        => esc_url_raw( admin_url() ),
 				'cptSlug'         => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 				'serviceProvider' => Newspack_Newsletters::service_provider(),
+				// Object-shaped even when empty so the JS side always sees a map.
+				'viewPrefs'       => (object) Admin_Shell_Preferences::get_preferences(),
 			]
 		);
 	}

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-legacy-redirect.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-legacy-redirect.php
@@ -16,8 +16,9 @@ class Admin_Shell_Legacy_Redirect {
 	/**
 	 * Query args forwarded from the legacy URL onto the React page.
 	 *
-	 * `paged` is deliberately omitted — legacy WP_List_Table uses 20
-	 * per page vs DataView's 25, so the slice wouldn't translate.
+	 * `paged` is deliberately omitted — the DataView's per-page is a
+	 * per-user preference, so the legacy slice wouldn't reliably
+	 * translate.
 	 */
 	const FORWARDED_LEGACY_ARGS = [
 		'post_status',

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
@@ -17,12 +17,14 @@ defined( 'ABSPATH' ) || exit;
  * page), stored in user meta so they follow the user across browsers.
  * Values are bootstrapped into the localized `newspackNewslettersAdmin`
  * global (see `Admin_Shell_Assets`), so the REST route is write-only in
- * practice.
+ * practice. Each screen gets its own user-meta key so a save only ever
+ * touches that screen's value — two tabs saving different screens can't
+ * clobber each other via a shared read-modify-write.
  */
 class Admin_Shell_Preferences {
 	const API_NAMESPACE = 'newspack-newsletters/v1';
 	const ROUTE         = 'admin-shell/preferences';
-	const USER_META_KEY = 'newspack_newsletters_admin_view_prefs';
+	const USER_META_KEY_PREFIX = 'newspack_newsletters_admin_view_prefs_';
 
 	const SCREEN_KEYS = [ 'newsletters-list', 'ads-list', 'advertisers-list', 'layouts-list' ];
 
@@ -94,12 +96,10 @@ class Admin_Shell_Preferences {
 			);
 		}
 
-		$all_prefs = self::get_preferences();
+		$screen_key = $request->get_param( 'screen' );
+		update_user_meta( get_current_user_id(), self::get_user_meta_key( $screen_key ), [ 'perPage' => $per_page ] );
 
-		$all_prefs[ $request->get_param( 'screen' ) ] = [ 'perPage' => $per_page ];
-		update_user_meta( get_current_user_id(), self::USER_META_KEY, $all_prefs );
-
-		return rest_ensure_response( $all_prefs );
+		return rest_ensure_response( self::get_preferences() );
 	}
 
 	/**
@@ -108,21 +108,28 @@ class Admin_Shell_Preferences {
 	 * @return array
 	 */
 	public static function get_preferences(): array {
-		$raw = get_user_meta( get_current_user_id(), self::USER_META_KEY, true );
-		if ( ! is_array( $raw ) ) {
-			return [];
-		}
 		$prefs = [];
 		foreach ( self::SCREEN_KEYS as $screen_key ) {
-			if ( ! isset( $raw[ $screen_key ]['perPage'] ) || ! is_numeric( $raw[ $screen_key ]['perPage'] ) ) {
+			$raw = get_user_meta( get_current_user_id(), self::get_user_meta_key( $screen_key ), true );
+			if ( ! is_array( $raw ) || ! isset( $raw['perPage'] ) || ! is_numeric( $raw['perPage'] ) ) {
 				continue;
 			}
-			$per_page = (int) $raw[ $screen_key ]['perPage'];
+			$per_page = (int) $raw['perPage'];
 			if ( self::is_valid_per_page( $per_page ) ) {
 				$prefs[ $screen_key ] = [ 'perPage' => $per_page ];
 			}
 		}
 		return $prefs;
+	}
+
+	/**
+	 * The user-meta key a screen's preferences are stored under.
+	 *
+	 * @param string $screen_key Screen identifier.
+	 * @return string
+	 */
+	public static function get_user_meta_key( string $screen_key ): string {
+		return self::USER_META_KEY_PREFIX . $screen_key;
 	}
 
 	/**

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
@@ -61,8 +61,15 @@ class Admin_Shell_Preferences {
 							'required' => true,
 						],
 						'prefs'  => [
-							'type'     => 'object',
-							'required' => true,
+							'type'                 => 'object',
+							'required'             => true,
+							'additionalProperties' => false,
+							'properties'           => [
+								'perPage' => [
+									'type'     => 'integer',
+									'required' => true,
+								],
+							],
 						],
 					],
 				],
@@ -71,7 +78,10 @@ class Admin_Shell_Preferences {
 	}
 
 	/**
-	 * Capability gate — matches the list screens themselves.
+	 * Capability gate — the floor for reaching any list screen. Some
+	 * screens require more (layouts needs `edit_others_posts`), but a
+	 * preference for a screen the user can't open is never read back, so
+	 * the shared floor is enough.
 	 *
 	 * @return bool
 	 */

--- a/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/includes/admin/class-admin-shell-preferences.php
@@ -1,0 +1,137 @@
+<?php
+/**
+ * Admin shell — per-user view preferences.
+ *
+ * @package Newspack_Newsletters
+ */
+
+namespace Newspack\Newsletters\Admin;
+
+use WP_Error;
+use WP_REST_Server;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Per-user view preferences for the admin-shell list screens (items per
+ * page), stored in user meta so they follow the user across browsers.
+ * Values are bootstrapped into the localized `newspackNewslettersAdmin`
+ * global (see `Admin_Shell_Assets`), so the REST route is write-only in
+ * practice.
+ */
+class Admin_Shell_Preferences {
+	const API_NAMESPACE = 'newspack-newsletters/v1';
+	const ROUTE         = 'admin-shell/preferences';
+	const USER_META_KEY = 'newspack_newsletters_admin_view_prefs';
+
+	const SCREEN_KEYS = [ 'newsletters-list', 'ads-list', 'advertisers-list', 'layouts-list' ];
+
+	/**
+	 * Client-side sentinel for "All" — the REST API caps `per_page` at
+	 * 100, so the client fetches in chunks and concatenates.
+	 */
+	const PER_PAGE_ALL = -1;
+	const PER_PAGE_MAX = 100;
+
+	/**
+	 * Boot hooks.
+	 */
+	public static function init(): void {
+		add_action( 'rest_api_init', [ __CLASS__, 'register_routes' ] );
+	}
+
+	/**
+	 * Register the update route.
+	 */
+	public static function register_routes(): void {
+		register_rest_route(
+			self::API_NAMESPACE,
+			'/' . self::ROUTE,
+			[
+				[
+					'methods'             => WP_REST_Server::EDITABLE,
+					'callback'            => [ __CLASS__, 'update_preferences' ],
+					'permission_callback' => [ __CLASS__, 'permission_check' ],
+					'args'                => [
+						'screen' => [
+							'type'     => 'string',
+							'enum'     => self::SCREEN_KEYS,
+							'required' => true,
+						],
+						'prefs'  => [
+							'type'     => 'object',
+							'required' => true,
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Capability gate — matches the list screens themselves.
+	 *
+	 * @return bool
+	 */
+	public static function permission_check(): bool {
+		return current_user_can( 'edit_posts' );
+	}
+
+	/**
+	 * Persist a screen's preferences for the current user.
+	 *
+	 * @param \WP_REST_Request $request Incoming request.
+	 * @return \WP_REST_Response|WP_Error
+	 */
+	public static function update_preferences( $request ) {
+		$prefs    = $request->get_param( 'prefs' );
+		$per_page = is_array( $prefs ) && isset( $prefs['perPage'] ) && is_numeric( $prefs['perPage'] ) ? (int) $prefs['perPage'] : null;
+		if ( null === $per_page || ! self::is_valid_per_page( $per_page ) ) {
+			return new WP_Error(
+				'newspack_newsletters_invalid_preference',
+				__( 'Invalid preference value.', 'newspack-newsletters' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		$all_prefs = self::get_preferences();
+
+		$all_prefs[ $request->get_param( 'screen' ) ] = [ 'perPage' => $per_page ];
+		update_user_meta( get_current_user_id(), self::USER_META_KEY, $all_prefs );
+
+		return rest_ensure_response( $all_prefs );
+	}
+
+	/**
+	 * The current user's sanitized preferences, keyed by screen.
+	 *
+	 * @return array
+	 */
+	public static function get_preferences(): array {
+		$raw = get_user_meta( get_current_user_id(), self::USER_META_KEY, true );
+		if ( ! is_array( $raw ) ) {
+			return [];
+		}
+		$prefs = [];
+		foreach ( self::SCREEN_KEYS as $screen_key ) {
+			if ( ! isset( $raw[ $screen_key ]['perPage'] ) || ! is_numeric( $raw[ $screen_key ]['perPage'] ) ) {
+				continue;
+			}
+			$per_page = (int) $raw[ $screen_key ]['perPage'];
+			if ( self::is_valid_per_page( $per_page ) ) {
+				$prefs[ $screen_key ] = [ 'perPage' => $per_page ];
+			}
+		}
+		return $prefs;
+	}
+
+	/**
+	 * Whether a per-page value is storable.
+	 *
+	 * @param int $value Candidate value.
+	 * @return bool
+	 */
+	private static function is_valid_per_page( int $value ): bool {
+		return self::PER_PAGE_ALL === $value || ( $value >= 1 && $value <= self::PER_PAGE_MAX );
+	}
+}

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -91,6 +91,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-newslette
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-ads-list-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-advertisers-list-rest.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-settings-rest.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-preferences.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-asset-loader.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-menu.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/admin/class-admin-shell-legacy-redirect.php';
@@ -107,3 +108,4 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/class-wizard-bridge.p
 \Newspack\Newsletters\Admin\Ads_List_REST::init();
 \Newspack\Newsletters\Admin\Advertisers_List_REST::init();
 \Newspack\Newsletters\Admin\Settings_REST::init();
+\Newspack\Newsletters\Admin\Admin_Shell_Preferences::init();

--- a/plugins/newspack-newsletters/src/admin-shell/admin-globals.js
+++ b/plugins/newspack-newsletters/src/admin-shell/admin-globals.js
@@ -30,3 +30,13 @@ export function getAdminUrl() {
 export function getCptSlug() {
 	return getGlobal()?.cptSlug || DEFAULT_CPT_SLUG;
 }
+
+/**
+ * Resolve the current user's persisted view preferences, keyed by screen.
+ *
+ * @return {Object} Preferences map (empty when none saved).
+ */
+export function getViewPrefs() {
+	const prefs = getGlobal()?.viewPrefs;
+	return prefs && typeof prefs === 'object' ? prefs : {};
+}

--- a/plugins/newspack-newsletters/src/admin-shell/components/header-count/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/header-count/index.js
@@ -11,10 +11,11 @@ import { createPortal, useEffect, useState } from '@wordpress/element';
 const CONTAINER_CLASS = 'newspack-newsletters-header-count';
 
 /**
- * @param {Object} props
- * @param {number} props.count Total items matching the current filters.
+ * @param {Object}  props
+ * @param {number}  props.count      Total items matching the current filters.
+ * @param {boolean} props.isRealized Whether `count` reflects a resolved fetch — before that it would flash "(0)".
  */
-export default function HeaderCount( { count } ) {
+export default function HeaderCount( { count, isRealized = true } ) {
 	const [ target, setTarget ] = useState( null );
 
 	useEffect( () => {
@@ -45,7 +46,7 @@ export default function HeaderCount( { count } ) {
 		};
 	}, [] );
 
-	if ( ! target || typeof count !== 'number' ) {
+	if ( ! target || ! isRealized || typeof count !== 'number' ) {
 		return null;
 	}
 

--- a/plugins/newspack-newsletters/src/admin-shell/components/header-count/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/header-count/index.js
@@ -1,0 +1,53 @@
+/**
+ * Live item count rendered next to the page title in the
+ * newspack-plugin admin-header breadcrumbs. The heading belongs to the
+ * admin-header's own React app, so the count portals into a container
+ * appended to it, re-attached if that app re-renders. Renders nothing
+ * in standalone mode (no breadcrumbs heading to attach to).
+ */
+
+import { createPortal, useEffect, useState } from '@wordpress/element';
+
+const CONTAINER_CLASS = 'newspack-newsletters-header-count';
+
+/**
+ * @param {Object} props
+ * @param {number} props.count Total items matching the current filters.
+ */
+export default function HeaderCount( { count } ) {
+	const [ target, setTarget ] = useState( null );
+
+	useEffect( () => {
+		const wrapper = document.getElementById( 'newspack-wizards-admin-header' );
+		if ( ! wrapper ) {
+			return undefined;
+		}
+		const ensureTarget = () => {
+			const heading = wrapper.querySelector( 'h1.newspack-breadcrumbs__current' );
+			if ( ! heading ) {
+				setTarget( null );
+				return;
+			}
+			if ( heading.querySelector( `.${ CONTAINER_CLASS }` ) ) {
+				return;
+			}
+			const container = document.createElement( 'span' );
+			container.className = CONTAINER_CLASS;
+			heading.appendChild( container );
+			setTarget( container );
+		};
+		ensureTarget();
+		const observer = new MutationObserver( ensureTarget );
+		observer.observe( wrapper, { childList: true, subtree: true } );
+		return () => {
+			observer.disconnect();
+			wrapper.querySelector( `.${ CONTAINER_CLASS }` )?.remove();
+		};
+	}, [] );
+
+	if ( ! target || typeof count !== 'number' ) {
+		return null;
+	}
+
+	return createPortal( ` (${ count.toLocaleString() })`, target );
+}

--- a/plugins/newspack-newsletters/src/admin-shell/components/header-count/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/header-count/index.js
@@ -11,11 +11,10 @@ import { createPortal, useEffect, useState } from '@wordpress/element';
 const CONTAINER_CLASS = 'newspack-newsletters-header-count';
 
 /**
- * @param {Object}  props
- * @param {number}  props.count      Total items matching the current filters.
- * @param {boolean} props.isRealized Whether `count` reflects a resolved fetch — before that it would flash "(0)".
+ * @param {Object} props
+ * @param {number} props.count Total items matching the current filters.
  */
-export default function HeaderCount( { count, isRealized = true } ) {
+export default function HeaderCount( { count } ) {
 	const [ target, setTarget ] = useState( null );
 
 	useEffect( () => {
@@ -46,7 +45,8 @@ export default function HeaderCount( { count, isRealized = true } ) {
 		};
 	}, [] );
 
-	if ( ! target || ! isRealized || typeof count !== 'number' ) {
+	// Hidden at zero: an empty list says so itself, and the pre-load count is 0.
+	if ( ! target || typeof count !== 'number' || count === 0 ) {
 		return null;
 	}
 

--- a/plugins/newspack-newsletters/src/admin-shell/components/header-count/index.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/header-count/index.test.js
@@ -30,6 +30,11 @@ describe( 'HeaderCount', () => {
 		expect( getHeading().querySelector( '.newspack-newsletters-header-count' ).textContent ).toBe( '' );
 	} );
 
+	it( 'renders nothing when the count is zero', () => {
+		render( <HeaderCount count={ 0 } /> );
+		expect( getHeading().querySelector( '.newspack-newsletters-header-count' ).textContent ).toBe( '' );
+	} );
+
 	it( 'removes its container on unmount', () => {
 		const { unmount } = render( <HeaderCount count={ 112 } /> );
 		unmount();

--- a/plugins/newspack-newsletters/src/admin-shell/components/header-count/index.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/header-count/index.test.js
@@ -1,0 +1,44 @@
+import { render } from '@testing-library/react';
+
+import HeaderCount from './index';
+
+describe( 'HeaderCount', () => {
+	beforeEach( () => {
+		document.body.innerHTML =
+			'<div id="newspack-wizards-admin-header"><nav><h1 class="newspack-breadcrumbs__current">All Newsletters</h1></nav></div>';
+	} );
+
+	afterEach( () => {
+		document.body.innerHTML = '';
+	} );
+
+	const getHeading = () => document.querySelector( 'h1.newspack-breadcrumbs__current' );
+
+	it( 'portals the parenthesised count into the breadcrumbs heading', () => {
+		render( <HeaderCount count={ 112 } /> );
+		expect( getHeading().textContent ).toBe( 'All Newsletters (112)' );
+	} );
+
+	it( 'updates in place when the count changes', () => {
+		const { rerender } = render( <HeaderCount count={ 112 } /> );
+		rerender( <HeaderCount count={ 3 } /> );
+		expect( getHeading().textContent ).toBe( 'All Newsletters (3)' );
+	} );
+
+	it( 'renders nothing without a numeric count', () => {
+		render( <HeaderCount count={ null } /> );
+		expect( getHeading().querySelector( '.newspack-newsletters-header-count' ).textContent ).toBe( '' );
+	} );
+
+	it( 'removes its container on unmount', () => {
+		const { unmount } = render( <HeaderCount count={ 112 } /> );
+		unmount();
+		expect( getHeading().querySelector( '.newspack-newsletters-header-count' ) ).toBeNull();
+	} );
+
+	it( 'renders nothing when the admin header is absent (standalone mode)', () => {
+		document.body.innerHTML = '<div id="root"></div>';
+		expect( () => render( <HeaderCount count={ 112 } /> ) ).not.toThrow();
+		expect( document.querySelector( '.newspack-newsletters-header-count' ) ).toBeNull();
+	} );
+} );

--- a/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.js
@@ -14,6 +14,7 @@
  * closed during a walk, and the header offers no room for it).
  */
 
+import { speak } from '@wordpress/a11y';
 import {
 	Spinner,
 	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -21,7 +22,7 @@ import {
 	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { createPortal, useEffect, useState } from '@wordpress/element';
+import { createPortal, useEffect, useRef, useState } from '@wordpress/element';
 import { __, sprintf } from '@wordpress/i18n';
 
 import { DEFAULT_PER_PAGE_OPTIONS, PER_PAGE_ALL } from '../../utils/per-page';
@@ -33,6 +34,11 @@ const optionLabel = option => ( option === PER_PAGE_ALL ? __( 'All', 'newspack-n
 // Watch for the "View options" popover and hand back a container placed
 // where the built-in items-per-page control renders: inside
 // `.dataviews-view-config`, before the Properties block.
+//
+// The popover renders in a `Popover` slot outside the DataViews root, so
+// the observer has to sit on `body` — it's scoped to `childList` only
+// (no attribute or character-data churn) and the callback is a pair of
+// querySelectors that bail on the first one when the popover is closed.
 function usePopoverSlot() {
 	const [ slot, setSlot ] = useState( null );
 
@@ -76,6 +82,24 @@ function usePopoverSlot() {
  */
 export default function ItemsPerPage( { value, onChange, options = DEFAULT_PER_PAGE_OPTIONS, progress = null } ) {
 	const slot = usePopoverSlot();
+	const isLoadingAll = !! progress;
+
+	// The visible message updates once per batch — up to ~100 times on a
+	// full walk — so it is not a live region. Announce the two moments
+	// that matter instead.
+	const wasLoadingAllRef = useRef( false );
+	useEffect( () => {
+		if ( isLoadingAll === wasLoadingAllRef.current ) {
+			return;
+		}
+		wasLoadingAllRef.current = isLoadingAll;
+		speak(
+			isLoadingAll
+				? __( 'Loading all items. This may take a moment.', 'newspack-newsletters' )
+				: __( 'Finished loading items.', 'newspack-newsletters' ),
+			'polite'
+		);
+	}, [ isLoadingAll ] );
 
 	// Center on the admin content area, not the viewport — otherwise the
 	// admin menu skews the overlay off-center.
@@ -89,7 +113,6 @@ export default function ItemsPerPage( { value, onChange, options = DEFAULT_PER_P
 						className="newspack-newsletters-fetch-all-progress"
 						spacing={ 3 }
 						alignment="center"
-						aria-live="polite"
 						style={ wpbodyRect ? { left: wpbodyRect.left + wpbodyRect.width / 2 } : undefined }
 					>
 						<Spinner />
@@ -97,8 +120,8 @@ export default function ItemsPerPage( { value, onChange, options = DEFAULT_PER_P
 							{ sprintf(
 								/* translators: 1: number of items loaded so far, 2: total number of items. */
 								__( 'Loading %1$s of %2$s…', 'newspack-newsletters' ),
-								progress.loaded,
-								progress.total
+								progress.loaded.toLocaleString(),
+								progress.total.toLocaleString()
 							) }
 						</Text>
 					</VStack>,

--- a/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.js
@@ -1,0 +1,125 @@
+/**
+ * Items-per-page control, rendered inside the DataViews "View options"
+ * popover in the slot the built-in control occupies.
+ *
+ * The built-in `ItemsPerPageControl` is suppressed via
+ * `config={ { perPageSizes: [] } }` because it can't express "All" —
+ * its option labels are the raw numbers, so the `PER_PAGE_ALL`
+ * sentinel would render as "-1". DataViews offers no slot inside the
+ * popover, so this component portals a look-alike ToggleGroupControl
+ * into the popover when it opens (anchored on the same class names the
+ * package styles against). This component itself is mounted in the
+ * DataViews `header` slot; while a fetch-all walk runs it overlays a
+ * centered spinner + progress message on the list (the popover is
+ * closed during a walk, and the header offers no room for it).
+ */
+
+import {
+	Spinner,
+	__experimentalText as Text, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControl as ToggleGroupControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToggleGroupControlOption as ToggleGroupControlOption, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { createPortal, useEffect, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
+
+import { DEFAULT_PER_PAGE_OPTIONS, PER_PAGE_ALL } from '../../utils/per-page';
+
+const CONTAINER_CLASS = 'newspack-newsletters-items-per-page';
+
+const optionLabel = option => ( option === PER_PAGE_ALL ? __( 'All', 'newspack-newsletters' ) : String( option ) );
+
+// Watch for the "View options" popover and hand back a container placed
+// where the built-in items-per-page control renders: inside
+// `.dataviews-view-config`, before the Properties block.
+function usePopoverSlot() {
+	const [ slot, setSlot ] = useState( null );
+
+	useEffect( () => {
+		const ensureSlot = () => {
+			const popover = document.querySelector( '.dataviews-view-config' );
+			if ( ! popover ) {
+				setSlot( null );
+				return;
+			}
+			const existing = popover.querySelector( `.${ CONTAINER_CLASS }` );
+			if ( existing ) {
+				return;
+			}
+			const container = document.createElement( 'div' );
+			container.className = CONTAINER_CLASS;
+			const properties = popover.querySelector( '.dataviews-field-control' );
+			if ( properties && properties.parentElement ) {
+				properties.parentElement.insertBefore( container, properties );
+			} else {
+				popover.appendChild( container );
+			}
+			setSlot( container );
+		};
+
+		ensureSlot();
+		const observer = new MutationObserver( ensureSlot );
+		observer.observe( document.body, { childList: true, subtree: true } );
+		return () => observer.disconnect();
+	}, [] );
+
+	return slot;
+}
+
+/**
+ * @param {Object}        props
+ * @param {number}        props.value      Current `view.perPage`.
+ * @param {Function}      props.onChange   Receives the new perPage value.
+ * @param {Array<number>} [props.options]  Selectable values; `PER_PAGE_ALL` renders as "All".
+ * @param {Object|null}   [props.progress] Fetch-all progress (`{ loaded, total }`) or null.
+ */
+export default function ItemsPerPage( { value, onChange, options = DEFAULT_PER_PAGE_OPTIONS, progress = null } ) {
+	const slot = usePopoverSlot();
+
+	// Center on the admin content area, not the viewport — otherwise the
+	// admin menu skews the overlay off-center.
+	const wpbodyRect = progress ? document.getElementById( 'wpbody' )?.getBoundingClientRect() : null;
+
+	return (
+		<>
+			{ progress &&
+				createPortal(
+					<VStack
+						className="newspack-newsletters-fetch-all-progress"
+						spacing={ 3 }
+						alignment="center"
+						aria-live="polite"
+						style={ wpbodyRect ? { left: wpbodyRect.left + wpbodyRect.width / 2 } : undefined }
+					>
+						<Spinner />
+						<Text weight={ 600 }>
+							{ sprintf(
+								/* translators: 1: number of items loaded so far, 2: total number of items. */
+								__( 'Loading %1$s of %2$s…', 'newspack-newsletters' ),
+								progress.loaded,
+								progress.total
+							) }
+						</Text>
+					</VStack>,
+					document.body
+				) }
+			{ slot &&
+				createPortal(
+					<ToggleGroupControl
+						__next40pxDefaultSize
+						__nextHasNoMarginBottom
+						isBlock
+						label={ __( 'Items per page', 'newspack-newsletters' ) }
+						value={ value }
+						onChange={ next => onChange( typeof next === 'number' ? next : parseInt( next, 10 ) ) }
+					>
+						{ options.map( option => (
+							<ToggleGroupControlOption key={ option } value={ option } label={ optionLabel( option ) } />
+						) ) }
+					</ToggleGroupControl>,
+					slot
+				) }
+		</>
+	);
+}

--- a/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/items-per-page/index.test.js
@@ -1,0 +1,65 @@
+/**
+ * Guards the DataViews coupling: this control portals into markup owned
+ * by `@wordpress/dataviews` (`.dataviews-view-config`, placed before
+ * `.dataviews-field-control`). A package bump that renames either class
+ * would otherwise silently drop the control from the popover.
+ */
+
+import { act, render, screen, waitFor } from '@testing-library/react';
+import { speak } from '@wordpress/a11y';
+
+import ItemsPerPage from './index';
+import { PER_PAGE_ALL } from '../../utils/per-page';
+
+jest.mock( '@wordpress/a11y', () => ( { speak: jest.fn() } ) );
+
+const openPopover = () => {
+	const popover = document.createElement( 'div' );
+	popover.className = 'dataviews-view-config';
+	popover.innerHTML = '<div class="dataviews-field-control"></div>';
+	document.body.appendChild( popover );
+	return popover;
+};
+
+describe( 'ItemsPerPage', () => {
+	beforeEach( () => {
+		speak.mockClear();
+		document.body.innerHTML = '';
+	} );
+
+	it( 'renders nothing until the View options popover opens', () => {
+		render( <ItemsPerPage value={ 20 } onChange={ jest.fn() } /> );
+		expect( screen.queryByText( 'Items per page' ) ).toBeNull();
+	} );
+
+	it( 'portals into the popover, above the Properties block', async () => {
+		render( <ItemsPerPage value={ 20 } onChange={ jest.fn() } /> );
+		const popover = await act( async () => openPopover() );
+
+		await waitFor( () => expect( popover.querySelector( '.newspack-newsletters-items-per-page' ) ).not.toBeNull() );
+		const container = popover.querySelector( '.newspack-newsletters-items-per-page' );
+		expect( container.nextElementSibling ).toBe( popover.querySelector( '.dataviews-field-control' ) );
+		expect( screen.getByText( 'Items per page' ) ).toBeInTheDocument();
+	} );
+
+	it( 'labels the All sentinel rather than showing -1', async () => {
+		render( <ItemsPerPage value={ PER_PAGE_ALL } onChange={ jest.fn() } /> );
+		await act( async () => openPopover() );
+
+		await waitFor( () => expect( screen.getByRole( 'radio', { name: 'All' } ) ).toBeChecked() );
+		expect( screen.queryByRole( 'radio', { name: '-1' } ) ).toBeNull();
+		[ '10', '20', '50', '100' ].forEach( label => expect( screen.getByRole( 'radio', { name: label } ) ).toBeInTheDocument() );
+	} );
+
+	it( 'announces the start and end of a fetch-all walk, not each batch', () => {
+		const { rerender } = render( <ItemsPerPage value={ PER_PAGE_ALL } onChange={ jest.fn() } progress={ { loaded: 100, total: 1200 } } /> );
+		expect( speak ).toHaveBeenCalledTimes( 1 );
+
+		rerender( <ItemsPerPage value={ PER_PAGE_ALL } onChange={ jest.fn() } progress={ { loaded: 200, total: 1200 } } /> );
+		expect( speak ).toHaveBeenCalledTimes( 1 );
+		expect( screen.getByText( 'Loading 200 of 1,200…' ) ).toBeInTheDocument();
+
+		rerender( <ItemsPerPage value={ PER_PAGE_ALL } onChange={ jest.fn() } progress={ null } /> );
+		expect( speak ).toHaveBeenCalledTimes( 2 );
+	} );
+} );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
@@ -1,8 +1,10 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useState } from '@wordpress/element';
+import { __, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
-import { notifyError } from '../notices';
+import { notifyError, notifyInfo } from '../notices';
+import { FETCH_ALL_CHUNK_SIZE, FETCH_ALL_MAX_ITEMS } from '../utils/per-page';
 
 // Modest parallelism for fetch-all walks — enough to hide latency
 // without hammering the server.
@@ -92,13 +94,37 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 					return;
 				}
 
+				// Caps the walk so a very large site can't hand DataViews tens of
+				// thousands of non-virtualised rows.
+				const maxPage = Math.min( pagination.totalPages, Math.ceil( FETCH_ALL_MAX_ITEMS / FETCH_ALL_CHUNK_SIZE ) );
+
 				setProgress( { loaded: all.length, total: pagination.totalItems } );
-				for ( let page = 2; page <= pagination.totalPages && ! cancelled; page += FETCH_ALL_CONCURRENCY ) {
-					const batch = [];
-					for ( let p = page; p <= Math.min( page + FETCH_ALL_CONCURRENCY - 1, pagination.totalPages ); p++ ) {
-						batch.push( apiFetch( { path: addQueryArgs( path, { page: p } ), parse: false } ).then( r => r.json() ) );
+				for ( let page = 2; page <= maxPage && ! cancelled; page += FETCH_ALL_CONCURRENCY ) {
+					const lastPage = Math.min( page + FETCH_ALL_CONCURRENCY - 1, maxPage );
+					const fetchBatch = () => {
+						const batch = [];
+						for ( let p = page; p <= lastPage; p++ ) {
+							batch.push( apiFetch( { path: addQueryArgs( path, { page: p } ), parse: false } ).then( r => r.json() ) );
+						}
+						return Promise.all( batch );
+					};
+
+					let pages;
+					try {
+						pages = await fetchBatch();
+					} catch {
+						try {
+							pages = await fetchBatch();
+						} catch {
+							if ( ! cancelled ) {
+								notifyError(
+									__( 'Only some items could be loaded. Reload the page to try again.', 'newspack-newsletters' ),
+									errorNoticeId ? { id: errorNoticeId } : undefined
+								);
+							}
+							return;
+						}
 					}
-					const pages = await Promise.all( batch );
 					if ( cancelled ) {
 						return;
 					}
@@ -109,6 +135,16 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 					} );
 					setData( all.slice() );
 					setProgress( { loaded: all.length, total: pagination.totalItems } );
+				}
+
+				if ( maxPage < pagination.totalPages && ! cancelled ) {
+					notifyInfo(
+						sprintf(
+							/* translators: %s: number of items shown */
+							__( 'Showing the first %s items. Use search or filters to narrow the list.', 'newspack-newsletters' ),
+							all.length.toLocaleString()
+						)
+					);
 				}
 			} )
 			.catch( () => {

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
@@ -22,16 +22,12 @@ function readPaginationInfo( response ) {
 	};
 }
 
-// A page can go out of range mid-walk if items are trashed/filtered away by
-// someone else — the collection got shorter, retrying won't help.
+// The collection got shorter mid-walk — retrying won't help. Any other 400 is
+// a real failure.
+const OUT_OF_RANGE_PAGE_CODES = [ 'rest_post_invalid_page_number', 'rest_term_invalid_page_number' ];
+
 function isOutOfRangePageError( error ) {
-	if ( ! error ) {
-		return false;
-	}
-	if ( error.code === 'rest_post_invalid_page_number' ) {
-		return true;
-	}
-	return error.status === 400 || error.data?.status === 400;
+	return OUT_OF_RANGE_PAGE_CODES.includes( error?.code );
 }
 
 /**
@@ -113,9 +109,8 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 				setProgress( { loaded: all.length, total: pagination.totalItems } );
 				let endedEarly = false;
 				let cappedByMax = false;
-				// Settled rather than all-or-nothing: one bad page must not discard
-				// its siblings. Only the run before the first failure is kept, so
-				// the collection stays contiguous.
+				// Settled, not all-or-nothing: one bad page must not discard its
+				// siblings. Keeping only the run before it stays contiguous.
 				const fetchPages = ( from, to ) => {
 					const batch = [];
 					for ( let p = from; p <= to; p++ ) {

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
@@ -22,8 +22,7 @@ function readPaginationInfo( response ) {
 	};
 }
 
-// The collection got shorter mid-walk — retrying won't help. Any other 400 is
-// a real failure.
+// The collection got shorter mid-walk — retrying won't help.
 const OUT_OF_RANGE_PAGE_CODES = [ 'rest_post_invalid_page_number', 'rest_term_invalid_page_number' ];
 
 function isOutOfRangePageError( error ) {
@@ -102,19 +101,17 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 					return;
 				}
 
-				// Caps the walk so a very large site can't hand DataViews tens of
-				// thousands of non-virtualised rows.
 				const maxPage = Math.min( pagination.totalPages, Math.ceil( FETCH_ALL_MAX_ITEMS / FETCH_ALL_CHUNK_SIZE ) );
 
 				setProgress( { loaded: all.length, total: pagination.totalItems } );
 				let endedEarly = false;
 				let cappedByMax = false;
-				// Settled, not all-or-nothing: one bad page must not discard its
-				// siblings. Keeping only the run before it stays contiguous.
+				// Settled, so one bad page doesn't discard its siblings.
 				const fetchPages = ( from, to ) => {
 					const batch = [];
 					for ( let p = from; p <= to; p++ ) {
-						batch.push( apiFetch( { path: addQueryArgs( path, { page: p } ), parse: false } ).then( r => r.json() ) );
+						// Parsed — an unparsed rejection is a bare `Response`, no error code.
+						batch.push( apiFetch( { path: addQueryArgs( path, { page: p } ) } ) );
 					}
 					return Promise.allSettled( batch );
 				};

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
@@ -113,50 +113,56 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 				setProgress( { loaded: all.length, total: pagination.totalItems } );
 				let endedEarly = false;
 				let cappedByMax = false;
-				for ( let page = 2; page <= maxPage && ! cancelled; page += FETCH_ALL_CONCURRENCY ) {
-					const lastPage = Math.min( page + FETCH_ALL_CONCURRENCY - 1, maxPage );
-					const fetchBatch = () => {
-						const batch = [];
-						for ( let p = page; p <= lastPage; p++ ) {
-							batch.push( apiFetch( { path: addQueryArgs( path, { page: p } ), parse: false } ).then( r => r.json() ) );
-						}
-						return Promise.all( batch );
-					};
-
-					let pages;
-					try {
-						pages = await fetchBatch();
-					} catch ( error ) {
-						if ( isOutOfRangePageError( error ) ) {
-							endedEarly = true;
+				// Settled rather than all-or-nothing: one bad page must not discard
+				// its siblings. Only the run before the first failure is kept, so
+				// the collection stays contiguous.
+				const fetchPages = ( from, to ) => {
+					const batch = [];
+					for ( let p = from; p <= to; p++ ) {
+						batch.push( apiFetch( { path: addQueryArgs( path, { page: p } ), parse: false } ).then( r => r.json() ) );
+					}
+					return Promise.allSettled( batch );
+				};
+				const keepFulfilledPrefix = results => {
+					for ( const result of results ) {
+						if ( result.status !== 'fulfilled' ) {
 							break;
 						}
-						try {
-							pages = await fetchBatch();
-						} catch ( retryError ) {
-							if ( isOutOfRangePageError( retryError ) ) {
-								endedEarly = true;
-								break;
-							}
-							if ( ! cancelled ) {
-								notifyError(
-									__( 'Only some items could be loaded. Reload the page to try again.', 'newspack-newsletters' ),
-									errorNoticeId ? { id: errorNoticeId } : undefined
-								);
-							}
-							endedEarly = true;
-							break;
+						if ( Array.isArray( result.value ) ) {
+							all.push( ...result.value );
 						}
 					}
+					return results.findIndex( result => result.status === 'rejected' );
+				};
+
+				for ( let page = 2; page <= maxPage && ! cancelled; page += FETCH_ALL_CONCURRENCY ) {
+					const lastPage = Math.min( page + FETCH_ALL_CONCURRENCY - 1, maxPage );
+
+					let results = await fetchPages( page, lastPage );
 					if ( cancelled ) {
 						return;
 					}
-					pages.forEach( pageItems => {
-						if ( Array.isArray( pageItems ) ) {
-							all.push( ...pageItems );
+					let failedAt = keepFulfilledPrefix( results );
+
+					if ( failedAt !== -1 && ! isOutOfRangePageError( results[ failedAt ].reason ) ) {
+						results = await fetchPages( page + failedAt, lastPage );
+						if ( cancelled ) {
+							return;
 						}
-					} );
+						failedAt = keepFulfilledPrefix( results );
+						if ( failedAt !== -1 && ! isOutOfRangePageError( results[ failedAt ].reason ) ) {
+							notifyError(
+								__( 'Only some items could be loaded. Reload the page to try again.', 'newspack-newsletters' ),
+								errorNoticeId ? { id: errorNoticeId } : undefined
+							);
+						}
+					}
+
 					setProgress( { loaded: all.length, total: pagination.totalItems } );
+					if ( failedAt !== -1 ) {
+						endedEarly = true;
+						break;
+					}
 				}
 
 				if ( cancelled ) {

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
@@ -1,7 +1,12 @@
 import apiFetch from '@wordpress/api-fetch';
 import { useCallback, useEffect, useState } from '@wordpress/element';
+import { addQueryArgs } from '@wordpress/url';
 
 import { notifyError } from '../notices';
+
+// Modest parallelism for fetch-all walks — enough to hide latency
+// without hammering the server.
+const FETCH_ALL_CONCURRENCY = 3;
 
 function parseHeaderInt( value ) {
 	const parsed = parseInt( value, 10 );
@@ -22,15 +27,22 @@ function readPaginationInfo( response ) {
  * parent's `view === null` latch). A falsy `trashCountPath` skips the
  * trash sub-fetch — `hasResolved` flips solely on the main resolution.
  *
- * @param {Object} options
- * @param {string} options.path             Pre-computed REST path. Falsy ⇒ defer.
- * @param {string} [options.trashCountPath] When set, sub-fetch for the trash banner.
- * @param {number} [options.mutationKey]    Bump externally to refetch (alongside internal refresh).
- * @param {string} [options.errorMessage]   notifyError message on fetch failure.
- * @param {string} [options.errorNoticeId]  notifyError dedupe id.
- * @return {{ data: Array, paginationInfo: Object, isLoading: boolean, hasResolved: boolean, hasLoadedOnce: boolean, trashCount: number|null, refresh: () => void }} Hook state.
+ * When `fetchAll` is set, the first response's `X-WP-TotalPages` drives
+ * a walk over the remaining pages (the REST API caps `per_page` at 100).
+ * Items render incrementally as pages land; `progress` reports the walk
+ * (`{ loaded, total }`, `null` outside a walk) and `totalPages` is
+ * clamped to 1 so the footer doesn't offer pagination.
+ *
+ * @param {Object}  options
+ * @param {string}  options.path             Pre-computed REST path. Falsy ⇒ defer.
+ * @param {string}  [options.trashCountPath] When set, sub-fetch for the trash banner.
+ * @param {number}  [options.mutationKey]    Bump externally to refetch (alongside internal refresh).
+ * @param {string}  [options.errorMessage]   notifyError message on fetch failure.
+ * @param {string}  [options.errorNoticeId]  notifyError dedupe id.
+ * @param {boolean} [options.fetchAll]       Walk every page of the collection.
+ * @return {{ data: Array, paginationInfo: Object, isLoading: boolean, hasResolved: boolean, hasLoadedOnce: boolean, trashCount: number|null, progress: Object|null, refresh: () => void }} Hook state.
  */
-export default function useCollectionData( { path, trashCountPath = null, mutationKey = 0, errorMessage, errorNoticeId } ) {
+export default function useCollectionData( { path, trashCountPath = null, mutationKey = 0, errorMessage, errorNoticeId, fetchAll = false } ) {
 	const [ data, setData ] = useState( [] );
 	const [ paginationInfo, setPaginationInfo ] = useState( { totalItems: 0, totalPages: 0 } );
 	const [ isLoading, setIsLoading ] = useState( true );
@@ -40,6 +52,7 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 	const [ hasLoadedOnce, setHasLoadedOnce ] = useState( false );
 	// `null` ⇒ unknown; failed trash fetch stays `null` so `=== 0` stays false and the banner stays hidden.
 	const [ trashCount, setTrashCount ] = useState( null );
+	const [ progress, setProgress ] = useState( null );
 
 	const refresh = useCallback( () => setRefreshKey( key => key + 1 ), [] );
 
@@ -52,6 +65,7 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 		}
 		let cancelled = false;
 		setIsLoading( true );
+		setProgress( null );
 
 		apiFetch( { path, parse: false } )
 			.then( async response => {
@@ -59,9 +73,43 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 				if ( cancelled ) {
 					return;
 				}
-				setData( Array.isArray( items ) ? items : [] );
-				setPaginationInfo( readPaginationInfo( response ) );
+				const pagination = readPaginationInfo( response );
+				const firstPage = Array.isArray( items ) ? items : [];
+
+				if ( ! fetchAll ) {
+					setData( firstPage );
+					setPaginationInfo( pagination );
+					setHasLoadedOnce( true );
+					return;
+				}
+
+				const all = [ ...firstPage ];
+				setData( all.slice() );
+				setPaginationInfo( { totalItems: pagination.totalItems, totalPages: 1 } );
 				setHasLoadedOnce( true );
+
+				if ( pagination.totalPages <= 1 ) {
+					return;
+				}
+
+				setProgress( { loaded: all.length, total: pagination.totalItems } );
+				for ( let page = 2; page <= pagination.totalPages && ! cancelled; page += FETCH_ALL_CONCURRENCY ) {
+					const batch = [];
+					for ( let p = page; p <= Math.min( page + FETCH_ALL_CONCURRENCY - 1, pagination.totalPages ); p++ ) {
+						batch.push( apiFetch( { path: addQueryArgs( path, { page: p } ), parse: false } ).then( r => r.json() ) );
+					}
+					const pages = await Promise.all( batch );
+					if ( cancelled ) {
+						return;
+					}
+					pages.forEach( pageItems => {
+						if ( Array.isArray( pageItems ) ) {
+							all.push( ...pageItems );
+						}
+					} );
+					setData( all.slice() );
+					setProgress( { loaded: all.length, total: pagination.totalItems } );
+				}
 			} )
 			.catch( () => {
 				if ( cancelled || ! errorMessage ) {
@@ -74,13 +122,14 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 				if ( ! cancelled ) {
 					setIsLoading( false );
 					setMainResolved( true );
+					setProgress( null );
 				}
 			} );
 
 		return () => {
 			cancelled = true;
 		};
-	}, [ path, mutationKey, refreshKey, errorMessage, errorNoticeId ] );
+	}, [ path, mutationKey, refreshKey, errorMessage, errorNoticeId, fetchAll ] );
 
 	useEffect( () => {
 		if ( ! trashCountPath ) {
@@ -108,5 +157,5 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 
 	const hasResolved = mainResolved && trashResolved;
 
-	return { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, refresh };
+	return { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, progress, refresh };
 }

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.js
@@ -22,6 +22,18 @@ function readPaginationInfo( response ) {
 	};
 }
 
+// A page can go out of range mid-walk if items are trashed/filtered away by
+// someone else — the collection got shorter, retrying won't help.
+function isOutOfRangePageError( error ) {
+	if ( ! error ) {
+		return false;
+	}
+	if ( error.code === 'rest_post_invalid_page_number' ) {
+		return true;
+	}
+	return error.status === 400 || error.data?.status === 400;
+}
+
 /**
  * Server-side paginated fetch hook for DataView list screens.
  *
@@ -31,9 +43,9 @@ function readPaginationInfo( response ) {
  *
  * When `fetchAll` is set, the first response's `X-WP-TotalPages` drives
  * a walk over the remaining pages (the REST API caps `per_page` at 100).
- * Items render incrementally as pages land; `progress` reports the walk
- * (`{ loaded, total }`, `null` outside a walk) and `totalPages` is
- * clamped to 1 so the footer doesn't offer pagination.
+ * `data` commits once the walk finishes (or aborts); `progress` reports
+ * the walk meanwhile (`{ loaded, total }`, `null` outside a walk) and
+ * `totalPages` is clamped to 1 so the footer doesn't offer pagination.
  *
  * @param {Object}  options
  * @param {string}  options.path             Pre-computed REST path. Falsy ⇒ defer.
@@ -86,11 +98,11 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 				}
 
 				const all = [ ...firstPage ];
-				setData( all.slice() );
 				setPaginationInfo( { totalItems: pagination.totalItems, totalPages: 1 } );
 				setHasLoadedOnce( true );
 
 				if ( pagination.totalPages <= 1 ) {
+					setData( all );
 					return;
 				}
 
@@ -99,6 +111,8 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 				const maxPage = Math.min( pagination.totalPages, Math.ceil( FETCH_ALL_MAX_ITEMS / FETCH_ALL_CHUNK_SIZE ) );
 
 				setProgress( { loaded: all.length, total: pagination.totalItems } );
+				let endedEarly = false;
+				let cappedByMax = false;
 				for ( let page = 2; page <= maxPage && ! cancelled; page += FETCH_ALL_CONCURRENCY ) {
 					const lastPage = Math.min( page + FETCH_ALL_CONCURRENCY - 1, maxPage );
 					const fetchBatch = () => {
@@ -112,17 +126,26 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 					let pages;
 					try {
 						pages = await fetchBatch();
-					} catch {
+					} catch ( error ) {
+						if ( isOutOfRangePageError( error ) ) {
+							endedEarly = true;
+							break;
+						}
 						try {
 							pages = await fetchBatch();
-						} catch {
+						} catch ( retryError ) {
+							if ( isOutOfRangePageError( retryError ) ) {
+								endedEarly = true;
+								break;
+							}
 							if ( ! cancelled ) {
 								notifyError(
 									__( 'Only some items could be loaded. Reload the page to try again.', 'newspack-newsletters' ),
 									errorNoticeId ? { id: errorNoticeId } : undefined
 								);
 							}
-							return;
+							endedEarly = true;
+							break;
 						}
 					}
 					if ( cancelled ) {
@@ -133,11 +156,25 @@ export default function useCollectionData( { path, trashCountPath = null, mutati
 							all.push( ...pageItems );
 						}
 					} );
-					setData( all.slice() );
 					setProgress( { loaded: all.length, total: pagination.totalItems } );
 				}
 
-				if ( maxPage < pagination.totalPages && ! cancelled ) {
+				if ( cancelled ) {
+					return;
+				}
+
+				if ( ! endedEarly && maxPage < pagination.totalPages ) {
+					endedEarly = true;
+					cappedByMax = true;
+				}
+
+				setData( all );
+
+				if ( endedEarly ) {
+					setPaginationInfo( { totalItems: all.length, totalPages: 1 } );
+				}
+
+				if ( cappedByMax ) {
 					notifyInfo(
 						sprintf(
 							/* translators: %s: number of items shown */

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
@@ -2,9 +2,11 @@ import { renderHook, waitFor } from '@testing-library/react';
 import apiFetch from '@wordpress/api-fetch';
 
 import useCollectionData from './use-collection-data';
+import { notifyError, notifyInfo } from '../notices';
+import { FETCH_ALL_MAX_ITEMS } from '../utils/per-page';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
-jest.mock( '../notices', () => ( { notifyError: jest.fn() } ) );
+jest.mock( '../notices', () => ( { notifyError: jest.fn(), notifyInfo: jest.fn() } ) );
 
 const makeResponse = ( items, { total = items.length, totalPages = 1 } = {} ) => ( {
 	headers: {
@@ -16,6 +18,8 @@ const makeResponse = ( items, { total = items.length, totalPages = 1 } = {} ) =>
 describe( 'useCollectionData', () => {
 	beforeEach( () => {
 		apiFetch.mockReset();
+		notifyError.mockClear();
+		notifyInfo.mockClear();
 	} );
 
 	it( 'fetches a single page and reports header-driven pagination', async () => {
@@ -60,6 +64,46 @@ describe( 'useCollectionData', () => {
 			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
 			expect( result.current.data ).toHaveLength( 1 );
 			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		} );
+
+		it( 'keeps already-loaded items and notifies once a page fails on both the initial attempt and the retry', async () => {
+			let page2Attempts = 0;
+			apiFetch.mockImplementation( ( { path } ) => {
+				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
+				if ( page === 1 ) {
+					return Promise.resolve( makeResponse( [ { id: 1 }, { id: 2 } ], { total: 3, totalPages: 2 } ) );
+				}
+				page2Attempts += 1;
+				return Promise.reject( new Error( 'network error' ) );
+			} );
+
+			const { result } = renderHook( () =>
+				useCollectionData( { path: '/wp/v2/test?per_page=2&page=1', fetchAll: true, errorNoticeId: 'test-id' } )
+			);
+
+			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+			expect( result.current.data.map( item => item.id ) ).toEqual( [ 1, 2 ] );
+			expect( page2Attempts ).toBe( 2 );
+			expect( notifyError ).toHaveBeenCalledWith( 'Only some items could be loaded. Reload the page to try again.', {
+				id: 'test-id',
+			} );
+		} );
+
+		it( 'stops at the fetch-all cap and notifies the list was truncated', async () => {
+			apiFetch.mockImplementation( ( { path } ) => {
+				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
+				const items = Array.from( { length: 100 }, ( unused, i ) => ( { id: page * 100 + i } ) );
+				return Promise.resolve( makeResponse( items, { total: 50000, totalPages: 500 } ) );
+			} );
+
+			const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?per_page=100&page=1', fetchAll: true } ) );
+
+			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+			expect( result.current.data ).toHaveLength( FETCH_ALL_MAX_ITEMS );
+			expect( apiFetch ).toHaveBeenCalledTimes( FETCH_ALL_MAX_ITEMS / 100 );
+			expect( notifyInfo ).toHaveBeenCalledWith(
+				`Showing the first ${ FETCH_ALL_MAX_ITEMS.toLocaleString() } items. Use search or filters to narrow the list.`
+			);
 		} );
 	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
@@ -131,7 +131,7 @@ describe( 'useCollectionData', () => {
 		} );
 
 		it( 'keeps pages that succeeded alongside a failing sibling in the same batch', async () => {
-			// Pages 2 and 3 land; page 4 went out of range because the collection shrank.
+			// Page 4 went out of range because the collection shrank.
 			apiFetch.mockImplementation( ( { path } ) => {
 				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
 				if ( page === 4 ) {
@@ -148,20 +148,22 @@ describe( 'useCollectionData', () => {
 			expect( notifyError ).not.toHaveBeenCalled();
 		} );
 
-		it( 'also treats a bare 400 status (no error code) as an out-of-range page', async () => {
+		it( 'retries and reports a 400 that is not an invalid-page error', async () => {
+			let page2Attempts = 0;
 			apiFetch.mockImplementation( ( { path } ) => {
 				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
 				if ( page === 1 ) {
 					return Promise.resolve( makeResponse( [ { id: 1 }, { id: 2 } ], { total: 3, totalPages: 2 } ) );
 				}
-				return Promise.reject( { status: 400 } );
+				page2Attempts += 1;
+				return Promise.reject( { code: 'rest_invalid_param', data: { status: 400 } } );
 			} );
 
 			const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?per_page=2&page=1', fetchAll: true } ) );
 
 			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
-			expect( result.current.data.map( item => item.id ) ).toEqual( [ 1, 2 ] );
-			expect( notifyError ).not.toHaveBeenCalled();
+			expect( page2Attempts ).toBe( 2 );
+			expect( notifyError ).toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
@@ -41,9 +41,9 @@ describe( 'useCollectionData', () => {
 				2: [ { id: 3 }, { id: 4 } ],
 				3: [ { id: 5 } ],
 			};
-			apiFetch.mockImplementation( ( { path } ) => {
+			apiFetch.mockImplementation( ( { path, parse } ) => {
 				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
-				return Promise.resolve( makeResponse( pages[ page ], { total: 5, totalPages: 3 } ) );
+				return Promise.resolve( parse === false ? makeResponse( pages[ page ], { total: 5, totalPages: 3 } ) : pages[ page ] );
 			} );
 
 			const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?per_page=2&page=1', fetchAll: true } ) );
@@ -87,15 +87,14 @@ describe( 'useCollectionData', () => {
 			expect( notifyError ).toHaveBeenCalledWith( 'Only some items could be loaded. Reload the page to try again.', {
 				id: 'test-id',
 			} );
-			// The footer/header count must match what's actually on screen, not the server's original total.
 			expect( result.current.paginationInfo ).toEqual( { totalItems: result.current.data.length, totalPages: 1 } );
 		} );
 
 		it( 'stops at the fetch-all cap and notifies the list was truncated', async () => {
-			apiFetch.mockImplementation( ( { path } ) => {
+			apiFetch.mockImplementation( ( { path, parse } ) => {
 				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
 				const items = Array.from( { length: 100 }, ( unused, i ) => ( { id: page * 100 + i } ) );
-				return Promise.resolve( makeResponse( items, { total: 50000, totalPages: 500 } ) );
+				return Promise.resolve( parse === false ? makeResponse( items, { total: 50000, totalPages: 500 } ) : items );
 			} );
 
 			const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?per_page=100&page=1', fetchAll: true } ) );
@@ -131,13 +130,12 @@ describe( 'useCollectionData', () => {
 		} );
 
 		it( 'keeps pages that succeeded alongside a failing sibling in the same batch', async () => {
-			// Page 4 went out of range because the collection shrank.
-			apiFetch.mockImplementation( ( { path } ) => {
+			apiFetch.mockImplementation( ( { path, parse } ) => {
 				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
 				if ( page === 4 ) {
 					return Promise.reject( { code: 'rest_post_invalid_page_number', data: { status: 400 } } );
 				}
-				return Promise.resolve( makeResponse( [ { id: page } ], { total: 8, totalPages: 4 } ) );
+				return Promise.resolve( parse === false ? makeResponse( [ { id: page } ], { total: 8, totalPages: 4 } ) : [ { id: page } ] );
 			} );
 
 			const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?per_page=2&page=1', fetchAll: true } ) );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
@@ -130,6 +130,24 @@ describe( 'useCollectionData', () => {
 			expect( result.current.paginationInfo ).toEqual( { totalItems: 2, totalPages: 1 } );
 		} );
 
+		it( 'keeps pages that succeeded alongside a failing sibling in the same batch', async () => {
+			// Pages 2 and 3 land; page 4 went out of range because the collection shrank.
+			apiFetch.mockImplementation( ( { path } ) => {
+				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
+				if ( page === 4 ) {
+					return Promise.reject( { code: 'rest_post_invalid_page_number', data: { status: 400 } } );
+				}
+				return Promise.resolve( makeResponse( [ { id: page } ], { total: 8, totalPages: 4 } ) );
+			} );
+
+			const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?per_page=2&page=1', fetchAll: true } ) );
+
+			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+			expect( result.current.data.map( item => item.id ) ).toEqual( [ 1, 2, 3 ] );
+			expect( result.current.paginationInfo ).toEqual( { totalItems: 3, totalPages: 1 } );
+			expect( notifyError ).not.toHaveBeenCalled();
+		} );
+
 		it( 'also treats a bare 400 status (no error code) as an out-of-range page', async () => {
 			apiFetch.mockImplementation( ( { path } ) => {
 				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
@@ -87,6 +87,8 @@ describe( 'useCollectionData', () => {
 			expect( notifyError ).toHaveBeenCalledWith( 'Only some items could be loaded. Reload the page to try again.', {
 				id: 'test-id',
 			} );
+			// The footer/header count must match what's actually on screen, not the server's original total.
+			expect( result.current.paginationInfo ).toEqual( { totalItems: result.current.data.length, totalPages: 1 } );
 		} );
 
 		it( 'stops at the fetch-all cap and notifies the list was truncated', async () => {
@@ -104,6 +106,44 @@ describe( 'useCollectionData', () => {
 			expect( notifyInfo ).toHaveBeenCalledWith(
 				`Showing the first ${ FETCH_ALL_MAX_ITEMS.toLocaleString() } items. Use search or filters to narrow the list.`
 			);
+			expect( result.current.paginationInfo ).toEqual( { totalItems: result.current.data.length, totalPages: 1 } );
+		} );
+
+		it( 'stops quietly on a deterministic out-of-range page — no retry, no error notice', async () => {
+			let page2Attempts = 0;
+			apiFetch.mockImplementation( ( { path } ) => {
+				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
+				if ( page === 1 ) {
+					return Promise.resolve( makeResponse( [ { id: 1 }, { id: 2 } ], { total: 3, totalPages: 2 } ) );
+				}
+				page2Attempts += 1;
+				return Promise.reject( { code: 'rest_post_invalid_page_number', data: { status: 400 } } );
+			} );
+
+			const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?per_page=2&page=1', fetchAll: true } ) );
+
+			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+			expect( result.current.data.map( item => item.id ) ).toEqual( [ 1, 2 ] );
+			expect( page2Attempts ).toBe( 1 );
+			expect( notifyError ).not.toHaveBeenCalled();
+			expect( notifyInfo ).not.toHaveBeenCalled();
+			expect( result.current.paginationInfo ).toEqual( { totalItems: 2, totalPages: 1 } );
+		} );
+
+		it( 'also treats a bare 400 status (no error code) as an out-of-range page', async () => {
+			apiFetch.mockImplementation( ( { path } ) => {
+				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
+				if ( page === 1 ) {
+					return Promise.resolve( makeResponse( [ { id: 1 }, { id: 2 } ], { total: 3, totalPages: 2 } ) );
+				}
+				return Promise.reject( { status: 400 } );
+			} );
+
+			const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?per_page=2&page=1', fetchAll: true } ) );
+
+			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+			expect( result.current.data.map( item => item.id ) ).toEqual( [ 1, 2 ] );
+			expect( notifyError ).not.toHaveBeenCalled();
 		} );
 	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-collection-data.test.js
@@ -1,0 +1,65 @@
+import { renderHook, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+
+import useCollectionData from './use-collection-data';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+jest.mock( '../notices', () => ( { notifyError: jest.fn() } ) );
+
+const makeResponse = ( items, { total = items.length, totalPages = 1 } = {} ) => ( {
+	headers: {
+		get: name => ( name === 'X-WP-Total' ? String( total ) : String( totalPages ) ),
+	},
+	json: async () => items,
+} );
+
+describe( 'useCollectionData', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+	} );
+
+	it( 'fetches a single page and reports header-driven pagination', async () => {
+		apiFetch.mockResolvedValue( makeResponse( [ { id: 1 }, { id: 2 } ], { total: 60, totalPages: 3 } ) );
+
+		const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?page=1' } ) );
+
+		await waitFor( () => expect( result.current.hasResolved ).toBe( true ) );
+		expect( result.current.data ).toHaveLength( 2 );
+		expect( result.current.paginationInfo ).toEqual( { totalItems: 60, totalPages: 3 } );
+		expect( result.current.progress ).toBeNull();
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	describe( 'fetchAll', () => {
+		it( 'walks every page, concatenates in page order, and clamps totalPages to 1', async () => {
+			const pages = {
+				1: [ { id: 1 }, { id: 2 } ],
+				2: [ { id: 3 }, { id: 4 } ],
+				3: [ { id: 5 } ],
+			};
+			apiFetch.mockImplementation( ( { path } ) => {
+				const page = Number( ( path.match( /[?&]page=(\d+)/ ) || [] )[ 1 ] || 1 );
+				return Promise.resolve( makeResponse( pages[ page ], { total: 5, totalPages: 3 } ) );
+			} );
+
+			const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?per_page=2&page=1', fetchAll: true } ) );
+
+			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+			expect( result.current.data.map( item => item.id ) ).toEqual( [ 1, 2, 3, 4, 5 ] );
+			expect( result.current.paginationInfo ).toEqual( { totalItems: 5, totalPages: 1 } );
+			// Walk finished — progress resets so the control label recovers.
+			expect( result.current.progress ).toBeNull();
+			expect( apiFetch ).toHaveBeenCalledTimes( 3 );
+		} );
+
+		it( 'skips the walk when the collection fits in one chunk', async () => {
+			apiFetch.mockResolvedValue( makeResponse( [ { id: 1 } ], { total: 1, totalPages: 1 } ) );
+
+			const { result } = renderHook( () => useCollectionData( { path: '/wp/v2/test?page=1', fetchAll: true } ) );
+
+			await waitFor( () => expect( result.current.isLoading ).toBe( false ) );
+			expect( result.current.data ).toHaveLength( 1 );
+			expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		} );
+	} );
+} );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -39,8 +39,9 @@ export default function usePersistedView( screenKey, defaultView ) {
 			return;
 		}
 		// One at a time — concurrent writes could land out of order.
-		const save = perPage => {
+		const save = ( perPage, attempt = 0 ) => {
 			inFlightRef.current = true;
+			let failed = false;
 			apiFetch( {
 				path: PREFERENCES_PATH,
 				method: 'POST',
@@ -49,11 +50,18 @@ export default function usePersistedView( screenKey, defaultView ) {
 				.then( () => {
 					lastSavedRef.current = perPage;
 				} )
-				.catch( () => {} )
+				.catch( () => {
+					failed = true;
+				} )
 				.finally( () => {
 					inFlightRef.current = false;
 					if ( desiredRef.current !== perPage && isValidPerPage( desiredRef.current ) ) {
 						save( desiredRef.current );
+						return;
+					}
+					// Nothing else will retrigger the effect, so retry once.
+					if ( failed && attempt < 1 ) {
+						save( perPage, attempt + 1 );
 					}
 				} );
 		};

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -33,34 +33,34 @@ export default function usePersistedView( screenKey, defaultView ) {
 	// The value the user last chose — may differ from `lastSavedRef` while a
 	// save for an older value is still in flight.
 	const desiredRef = useRef( view.perPage );
-	const requestSeqRef = useRef( 0 );
+	const inFlightRef = useRef( false );
 
 	useEffect( () => {
 		desiredRef.current = view.perPage;
-		if ( view.perPage === lastSavedRef.current || ! isValidPerPage( view.perPage ) ) {
+		if ( view.perPage === lastSavedRef.current || ! isValidPerPage( view.perPage ) || inFlightRef.current ) {
 			return;
 		}
+		// One request at a time: concurrent writes could otherwise reach the
+		// server out of order and leave the older value stored.
 		const save = perPage => {
-			const seq = ++requestSeqRef.current;
+			inFlightRef.current = true;
 			apiFetch( {
 				path: PREFERENCES_PATH,
 				method: 'POST',
 				data: { screen: screenKey, prefs: { perPage } },
 			} )
 				.then( () => {
-					// A newer save was issued while this one was in flight — it
-					// owns the state now.
-					if ( seq !== requestSeqRef.current ) {
-						return;
-					}
 					lastSavedRef.current = perPage;
-					// Reverting mid-flight leaves the effect's guard satisfied, so
-					// nothing else would correct the stored value.
-					if ( perPage !== desiredRef.current ) {
+				} )
+				.catch( () => {} )
+				.finally( () => {
+					inFlightRef.current = false;
+					// The user changed their mind mid-flight; the effect's guard
+					// stopped it scheduling anything, so chain the correction here.
+					if ( desiredRef.current !== perPage && isValidPerPage( desiredRef.current ) ) {
 						save( desiredRef.current );
 					}
-				} )
-				.catch( () => {} );
+				} );
 		};
 		save( view.perPage );
 	}, [ view.perPage, screenKey ] );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -28,21 +28,51 @@ export default function usePersistedView( screenKey, defaultView ) {
 
 	const lastSavedRef = useRef( view.perPage );
 	const timerRef = useRef( null );
+	const requestSeqRef = useRef( 0 );
+	const isUnmountingRef = useRef( false );
+
+	// Cleans up before the effect below on unmount (effects clean up in
+	// declaration order), so that effect can tell a true unmount apart from
+	// a routine dependency change.
+	useEffect(
+		() => () => {
+			isUnmountingRef.current = true;
+		},
+		[]
+	);
 
 	useEffect( () => {
 		if ( view.perPage === lastSavedRef.current || ! isValidPerPage( view.perPage ) ) {
 			return undefined;
 		}
 		const { perPage } = view;
-		timerRef.current = setTimeout( () => {
-			lastSavedRef.current = perPage;
+		const save = () => {
+			timerRef.current = null;
+			const seq = ++requestSeqRef.current;
 			apiFetch( {
 				path: PREFERENCES_PATH,
 				method: 'POST',
 				data: { screen: screenKey, prefs: { perPage } },
-			} ).catch( () => {} );
-		}, SAVE_DEBOUNCE_MS );
-		return () => clearTimeout( timerRef.current );
+			} )
+				.then( () => {
+					// A newer save may have been issued (and even settled) while
+					// this one was in flight — don't let it clobber that state.
+					if ( seq === requestSeqRef.current ) {
+						lastSavedRef.current = perPage;
+					}
+				} )
+				.catch( () => {} );
+		};
+		timerRef.current = setTimeout( save, SAVE_DEBOUNCE_MS );
+		return () => {
+			if ( timerRef.current ) {
+				clearTimeout( timerRef.current );
+				timerRef.current = null;
+				if ( isUnmountingRef.current ) {
+					save();
+				}
+			}
+		};
 	}, [ view.perPage, screenKey ] ); // eslint-disable-line react-hooks/exhaustive-deps
 
 	return [ view, setView ];

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -4,6 +4,10 @@
  * `Admin_Shell_Preferences`). Only `perPage` is persisted for now —
  * the saved value follows the user across browsers, matching classic
  * Screen Options behaviour.
+ *
+ * The save is not debounced: `perPage` is a discrete control, so a change
+ * costs at most one request per click, and firing immediately means a
+ * navigation right after the click can't drop the preference.
  */
 
 import apiFetch from '@wordpress/api-fetch';
@@ -13,7 +17,6 @@ import { getViewPrefs } from '../admin-globals';
 import { isValidPerPage } from '../utils/per-page';
 
 const PREFERENCES_PATH = '/newspack-newsletters/v1/admin-shell/preferences';
-const SAVE_DEBOUNCE_MS = 500;
 
 /**
  * @param {string} screenKey   Screen identifier (allowlisted server-side).
@@ -27,27 +30,17 @@ export default function usePersistedView( screenKey, defaultView ) {
 	} );
 
 	const lastSavedRef = useRef( view.perPage );
-	const timerRef = useRef( null );
+	// The value the user last chose — may differ from `lastSavedRef` while a
+	// save for an older value is still in flight.
+	const desiredRef = useRef( view.perPage );
 	const requestSeqRef = useRef( 0 );
-	const isUnmountingRef = useRef( false );
-
-	// Cleans up before the effect below on unmount (effects clean up in
-	// declaration order), so that effect can tell a true unmount apart from
-	// a routine dependency change.
-	useEffect(
-		() => () => {
-			isUnmountingRef.current = true;
-		},
-		[]
-	);
 
 	useEffect( () => {
+		desiredRef.current = view.perPage;
 		if ( view.perPage === lastSavedRef.current || ! isValidPerPage( view.perPage ) ) {
-			return undefined;
+			return;
 		}
-		const { perPage } = view;
-		const save = () => {
-			timerRef.current = null;
+		const save = perPage => {
 			const seq = ++requestSeqRef.current;
 			apiFetch( {
 				path: PREFERENCES_PATH,
@@ -55,25 +48,22 @@ export default function usePersistedView( screenKey, defaultView ) {
 				data: { screen: screenKey, prefs: { perPage } },
 			} )
 				.then( () => {
-					// A newer save may have been issued (and even settled) while
-					// this one was in flight — don't let it clobber that state.
-					if ( seq === requestSeqRef.current ) {
-						lastSavedRef.current = perPage;
+					// A newer save was issued while this one was in flight — it
+					// owns the state now.
+					if ( seq !== requestSeqRef.current ) {
+						return;
+					}
+					lastSavedRef.current = perPage;
+					// Reverting mid-flight leaves the effect's guard satisfied, so
+					// nothing else would correct the stored value.
+					if ( perPage !== desiredRef.current ) {
+						save( desiredRef.current );
 					}
 				} )
 				.catch( () => {} );
 		};
-		timerRef.current = setTimeout( save, SAVE_DEBOUNCE_MS );
-		return () => {
-			if ( timerRef.current ) {
-				clearTimeout( timerRef.current );
-				timerRef.current = null;
-				if ( isUnmountingRef.current ) {
-					save();
-				}
-			}
-		};
-	}, [ view.perPage, screenKey ] ); // eslint-disable-line react-hooks/exhaustive-deps
+		save( view.perPage );
+	}, [ view.perPage, screenKey ] );
 
 	return [ view, setView ];
 }

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -14,19 +14,24 @@ import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useRef, useState } from '@wordpress/element';
 
 import { getViewPrefs } from '../admin-globals';
-import { isValidPerPage } from '../utils/per-page';
+import { DEFAULT_PER_PAGE_OPTIONS, isValidPerPage } from '../utils/per-page';
 
 const PREFERENCES_PATH = '/newspack-newsletters/v1/admin-shell/preferences';
 
 /**
- * @param {string} screenKey   Screen identifier (allowlisted server-side).
- * @param {Object} defaultView Default view state.
+ * @param {string}        screenKey        Screen identifier (allowlisted server-side).
+ * @param {Object}        defaultView      Default view state.
+ * @param {Array<number>} [perPageOptions] Values this screen's control offers.
  * @return {[Object, Function]} `[ view, setView ]` pair.
  */
-export default function usePersistedView( screenKey, defaultView ) {
+export default function usePersistedView( screenKey, defaultView, perPageOptions = DEFAULT_PER_PAGE_OPTIONS ) {
 	const [ view, setView ] = useState( () => {
 		const perPage = getViewPrefs()[ screenKey ]?.perPage;
-		return isValidPerPage( perPage ) ? { ...defaultView, perPage } : defaultView;
+		// The server validates a range, not a per-screen set — a stored
+		// value this screen doesn't offer (a legacy value, or one saved
+		// on a screen with different steps) would leave the control with
+		// nothing highlighted, so fall back to the default.
+		return isValidPerPage( perPage ) && perPageOptions.includes( perPage ) ? { ...defaultView, perPage } : defaultView;
 	} );
 
 	const lastSavedRef = useRef( view.perPage );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -40,8 +40,7 @@ export default function usePersistedView( screenKey, defaultView ) {
 		if ( view.perPage === lastSavedRef.current || ! isValidPerPage( view.perPage ) || inFlightRef.current ) {
 			return;
 		}
-		// One request at a time: concurrent writes could otherwise reach the
-		// server out of order and leave the older value stored.
+		// One at a time — concurrent writes could land out of order.
 		const save = perPage => {
 			inFlightRef.current = true;
 			apiFetch( {
@@ -55,8 +54,7 @@ export default function usePersistedView( screenKey, defaultView ) {
 				.catch( () => {} )
 				.finally( () => {
 					inFlightRef.current = false;
-					// The user changed their mind mid-flight; the effect's guard
-					// stopped it scheduling anything, so chain the correction here.
+					// Changed mid-flight: the effect's guard skipped it, so correct here.
 					if ( desiredRef.current !== perPage && isValidPerPage( desiredRef.current ) ) {
 						save( desiredRef.current );
 					}

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -1,0 +1,49 @@
+/**
+ * `useState` for a DataViews `view`, seeded from and persisted to the
+ * current user's saved preferences (user meta via
+ * `Admin_Shell_Preferences`). Only `perPage` is persisted for now —
+ * the saved value follows the user across browsers, matching classic
+ * Screen Options behaviour.
+ */
+
+import apiFetch from '@wordpress/api-fetch';
+import { useEffect, useRef, useState } from '@wordpress/element';
+
+import { getViewPrefs } from '../admin-globals';
+import { isValidPerPage } from '../utils/per-page';
+
+const PREFERENCES_PATH = '/newspack-newsletters/v1/admin-shell/preferences';
+const SAVE_DEBOUNCE_MS = 500;
+
+/**
+ * @param {string} screenKey   Screen identifier (allowlisted server-side).
+ * @param {Object} defaultView Default view state.
+ * @return {[Object, Function]} `[ view, setView ]` pair.
+ */
+export default function usePersistedView( screenKey, defaultView ) {
+	const [ view, setView ] = useState( () => {
+		const perPage = getViewPrefs()[ screenKey ]?.perPage;
+		return isValidPerPage( perPage ) ? { ...defaultView, perPage } : defaultView;
+	} );
+
+	const lastSavedRef = useRef( view.perPage );
+	const timerRef = useRef( null );
+
+	useEffect( () => {
+		if ( view.perPage === lastSavedRef.current || ! isValidPerPage( view.perPage ) ) {
+			return undefined;
+		}
+		const { perPage } = view;
+		timerRef.current = setTimeout( () => {
+			lastSavedRef.current = perPage;
+			apiFetch( {
+				path: PREFERENCES_PATH,
+				method: 'POST',
+				data: { screen: screenKey, prefs: { perPage } },
+			} ).catch( () => {} );
+		}, SAVE_DEBOUNCE_MS );
+		return () => clearTimeout( timerRef.current );
+	}, [ view.perPage, screenKey ] ); // eslint-disable-line react-hooks/exhaustive-deps
+
+	return [ view, setView ];
+}

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.js
@@ -30,8 +30,6 @@ export default function usePersistedView( screenKey, defaultView ) {
 	} );
 
 	const lastSavedRef = useRef( view.perPage );
-	// The value the user last chose — may differ from `lastSavedRef` while a
-	// save for an older value is still in flight.
 	const desiredRef = useRef( view.perPage );
 	const inFlightRef = useRef( false );
 
@@ -54,7 +52,6 @@ export default function usePersistedView( screenKey, defaultView ) {
 				.catch( () => {} )
 				.finally( () => {
 					inFlightRef.current = false;
-					// Changed mid-flight: the effect's guard skipped it, so correct here.
 					if ( desiredRef.current !== perPage && isValidPerPage( desiredRef.current ) ) {
 						save( desiredRef.current );
 					}

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -62,7 +62,6 @@ describe( 'usePersistedView', () => {
 		} );
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 
-		// Back to the seeded value: still unsaved, so nothing to send.
 		act( () => {
 			result.current[ 1 ]( current => ( { ...current, perPage: 25 } ) );
 		} );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -61,4 +61,54 @@ describe( 'usePersistedView', () => {
 		} );
 		expect( apiFetch ).not.toHaveBeenCalled();
 	} );
+
+	it( 'retries a rejected save on a subsequent identical change', async () => {
+		apiFetch.mockRejectedValueOnce( new Error( 'save failed' ) );
+
+		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+		act( () => {
+			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+		} );
+		await act( async () => {
+			jest.runAllTimers();
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+		act( () => {
+			result.current[ 1 ]( current => ( { ...current, perPage: 25 } ) );
+		} );
+		act( () => {
+			jest.runAllTimers();
+		} );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+		act( () => {
+			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+		} );
+		await act( async () => {
+			jest.runAllTimers();
+			await Promise.resolve();
+		} );
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'flushes a pending debounced save immediately on unmount', () => {
+		const { result, unmount } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+		act( () => {
+			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+		} );
+		expect( apiFetch ).not.toHaveBeenCalled();
+
+		unmount();
+
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/newspack-newsletters/v1/admin-shell/preferences',
+			method: 'POST',
+			data: { screen: 'newsletters-list', prefs: { perPage: 50 } },
+		} );
+	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -51,7 +51,7 @@ describe( 'usePersistedView', () => {
 		expect( apiFetch ).not.toHaveBeenCalled();
 	} );
 
-	it( 'retries a rejected save on a subsequent identical change', async () => {
+	it( 'retries once when a save fails and nothing else would retrigger it', async () => {
 		apiFetch.mockRejectedValueOnce( new Error( 'save failed' ) );
 
 		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
@@ -59,19 +59,15 @@ describe( 'usePersistedView', () => {
 		await act( async () => {
 			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
 			await Promise.resolve();
-		} );
-		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
-
-		act( () => {
-			result.current[ 1 ]( current => ( { ...current, perPage: 25 } ) );
-		} );
-		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
-
-		await act( async () => {
-			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
 			await Promise.resolve();
 		} );
+
 		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/newspack-newsletters/v1/admin-shell/preferences',
+			method: 'POST',
+			data: { screen: 'newsletters-list', prefs: { perPage: 50 } },
+		} );
 	} );
 
 	it( 'never has two saves in flight, so writes cannot reach the server out of order', async () => {

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -10,14 +10,9 @@ const DEFAULT_VIEW = { type: 'table', page: 1, perPage: 25 };
 
 describe( 'usePersistedView', () => {
 	beforeEach( () => {
-		jest.useFakeTimers();
 		apiFetch.mockReset();
 		apiFetch.mockResolvedValue( {} );
 		delete window.newspackNewslettersAdmin;
-	} );
-
-	afterEach( () => {
-		jest.useRealTimers();
 	} );
 
 	it( 'seeds perPage from the bootstrapped preferences', () => {
@@ -32,17 +27,13 @@ describe( 'usePersistedView', () => {
 		expect( result.current[ 0 ].perPage ).toBe( 25 );
 	} );
 
-	it( 'persists a perPage change (debounced), including the All sentinel', () => {
+	it( 'persists a perPage change, including the All sentinel', () => {
 		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
 
 		act( () => {
 			result.current[ 1 ]( current => ( { ...current, perPage: PER_PAGE_ALL, page: 1 } ) );
 		} );
-		expect( apiFetch ).not.toHaveBeenCalled();
 
-		act( () => {
-			jest.runAllTimers();
-		} );
 		expect( apiFetch ).toHaveBeenCalledWith( {
 			path: '/newspack-newsletters/v1/admin-shell/preferences',
 			method: 'POST',
@@ -56,9 +47,7 @@ describe( 'usePersistedView', () => {
 		act( () => {
 			result.current[ 1 ]( current => ( { ...current, page: 3, search: 'digest' } ) );
 		} );
-		act( () => {
-			jest.runAllTimers();
-		} );
+
 		expect( apiFetch ).not.toHaveBeenCalled();
 	} );
 
@@ -67,48 +56,57 @@ describe( 'usePersistedView', () => {
 
 		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
 
-		act( () => {
-			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
-		} );
 		await act( async () => {
-			jest.runAllTimers();
-			await Promise.resolve();
+			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
 			await Promise.resolve();
 		} );
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 
+		// Back to the seeded value: still unsaved, so nothing to send.
 		act( () => {
 			result.current[ 1 ]( current => ( { ...current, perPage: 25 } ) );
 		} );
-		act( () => {
-			jest.runAllTimers();
-		} );
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 
-		act( () => {
-			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
-		} );
 		await act( async () => {
-			jest.runAllTimers();
+			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
 			await Promise.resolve();
 		} );
 		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
 	} );
 
-	it( 'flushes a pending debounced save immediately on unmount', () => {
-		const { result, unmount } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+	it( 'converges on the last chosen value when reverted while a save is in flight', async () => {
+		const DEFAULT_20 = { type: 'table', page: 1, perPage: 20 };
+		const deferred = {};
+		apiFetch.mockImplementationOnce( () => new Promise( resolve => ( deferred.resolve = resolve ) ) );
+		apiFetch.mockResolvedValue( {} );
+
+		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_20 ) );
 
 		act( () => {
 			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
 		} );
-		expect( apiFetch ).not.toHaveBeenCalled();
-
-		unmount();
-
-		expect( apiFetch ).toHaveBeenCalledWith( {
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
 			path: '/newspack-newsletters/v1/admin-shell/preferences',
 			method: 'POST',
 			data: { screen: 'newsletters-list', prefs: { perPage: 50 } },
+		} );
+
+		act( () => {
+			result.current[ 1 ]( current => ( { ...current, perPage: 20 } ) );
+		} );
+
+		await act( async () => {
+			deferred.resolve( {} );
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/newspack-newsletters/v1/admin-shell/preferences',
+			method: 'POST',
+			data: { screen: 'newsletters-list', prefs: { perPage: 20 } },
 		} );
 	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -1,0 +1,64 @@
+import { act, renderHook } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+
+import usePersistedView from './use-persisted-view';
+import { PER_PAGE_ALL } from '../utils/per-page';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+const DEFAULT_VIEW = { type: 'table', page: 1, perPage: 25 };
+
+describe( 'usePersistedView', () => {
+	beforeEach( () => {
+		jest.useFakeTimers();
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( {} );
+		delete window.newspackNewslettersAdmin;
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 'seeds perPage from the bootstrapped preferences', () => {
+		window.newspackNewslettersAdmin = { viewPrefs: { 'newsletters-list': { perPage: 100 } } };
+		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+		expect( result.current[ 0 ].perPage ).toBe( 100 );
+	} );
+
+	it( 'ignores invalid stored values and other screens', () => {
+		window.newspackNewslettersAdmin = { viewPrefs: { 'newsletters-list': { perPage: 9999 }, 'ads-list': { perPage: 50 } } };
+		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+		expect( result.current[ 0 ].perPage ).toBe( 25 );
+	} );
+
+	it( 'persists a perPage change (debounced), including the All sentinel', () => {
+		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+		act( () => {
+			result.current[ 1 ]( current => ( { ...current, perPage: PER_PAGE_ALL, page: 1 } ) );
+		} );
+		expect( apiFetch ).not.toHaveBeenCalled();
+
+		act( () => {
+			jest.runAllTimers();
+		} );
+		expect( apiFetch ).toHaveBeenCalledWith( {
+			path: '/newspack-newsletters/v1/admin-shell/preferences',
+			method: 'POST',
+			data: { screen: 'newsletters-list', prefs: { perPage: PER_PAGE_ALL } },
+		} );
+	} );
+
+	it( 'does not persist non-perPage view changes', () => {
+		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+		act( () => {
+			result.current[ 1 ]( current => ( { ...current, page: 3, search: 'digest' } ) );
+		} );
+		act( () => {
+			jest.runAllTimers();
+		} );
+		expect( apiFetch ).not.toHaveBeenCalled();
+	} );
+} );

--- a/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/hooks/use-persisted-view.test.js
@@ -75,6 +75,35 @@ describe( 'usePersistedView', () => {
 		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
 	} );
 
+	it( 'never has two saves in flight, so writes cannot reach the server out of order', async () => {
+		const deferred = {};
+		apiFetch.mockImplementationOnce( () => new Promise( resolve => ( deferred.resolve = resolve ) ) );
+		apiFetch.mockResolvedValue( {} );
+
+		const { result } = renderHook( () => usePersistedView( 'newsletters-list', DEFAULT_VIEW ) );
+
+		act( () => {
+			result.current[ 1 ]( current => ( { ...current, perPage: 50 } ) );
+		} );
+		act( () => {
+			result.current[ 1 ]( current => ( { ...current, perPage: 100 } ) );
+		} );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+		await act( async () => {
+			deferred.resolve( {} );
+			await Promise.resolve();
+			await Promise.resolve();
+		} );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+		expect( apiFetch ).toHaveBeenLastCalledWith( {
+			path: '/newspack-newsletters/v1/admin-shell/preferences',
+			method: 'POST',
+			data: { screen: 'newsletters-list', prefs: { perPage: 100 } },
+		} );
+	} );
+
 	it( 'converges on the last chosen value when reverted while a save is in flight', async () => {
 		const DEFAULT_20 = { type: 'table', page: 1, perPage: 20 };
 		const deferred = {};

--- a/plugins/newspack-newsletters/src/admin-shell/notices.js
+++ b/plugins/newspack-newsletters/src/admin-shell/notices.js
@@ -8,6 +8,10 @@ export function notifySuccess( message, options = {} ) {
 	dispatch( noticesStore ).createSuccessNotice( message, { ...options, type: 'snackbar' } );
 }
 
+export function notifyInfo( message, options = {} ) {
+	dispatch( noticesStore ).createInfoNotice( message, { ...options, type: 'snackbar' } );
+}
+
 export function notifyError( message, options = {} ) {
 	dispatch( noticesStore ).createErrorNotice( message, { ...options, type: 'snackbar' } );
 }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/actions.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/actions.js
@@ -82,7 +82,6 @@ export function getActions( { refresh, openQuickEdit } ) {
 	const trashAction = {
 		id: 'trash',
 		label: __( 'Trash', 'newspack-newsletters' ),
-		isPrimary: true,
 		icon: trash,
 		modalHeader: __( 'Move to trash', 'newspack-newsletters' ),
 		isDestructive: true,

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/actions.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/actions.test.js
@@ -24,14 +24,14 @@ describe( 'ads list actions', () => {
 		expect( ids ).toEqual( [ 'quick-edit', 'trash', 'edit', 'rename', 'restore', 'delete-permanently' ] );
 	} );
 
-	it( 'marks Quick Edit and Trash as primary actions', () => {
+	it( 'marks Quick Edit as the only primary action', () => {
 		expect( byId( 'quick-edit' ).isPrimary ).toBe( true );
-		expect( byId( 'trash' ).isPrimary ).toBe( true );
 	} );
 
-	it( 'does not mark Edit or Rename as primary actions', () => {
+	it( 'does not mark Edit, Rename, or Trash as primary actions', () => {
 		expect( byId( 'edit' ).isPrimary ).toBeFalsy();
 		expect( byId( 'rename' ).isPrimary ).toBeFalsy();
+		expect( byId( 'trash' ).isPrimary ).toBeFalsy();
 	} );
 
 	it( 'Quick Edit is eligible on non-trashed rows only', () => {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
@@ -48,7 +48,14 @@ export function buildQueryParams( view = {} ) {
 		// Active kind filter → custom REST param; no filter → wide post_status default.
 		statusFilterParam: 'newspack_newsletters_ad_status',
 		defaultStatusParam: 'status',
-		extraParams: { _embed: 'wp:term' },
+		// `_fields` short-circuits `content.rendered` / `excerpt.rendered`
+		// and the unused editor REST fields (see newsletters-list note).
+		// `_links` stays in the list — `_embed` only expands links that
+		// survive the `_fields` filter.
+		extraParams: {
+			_embed: 'wp:term',
+			_fields: 'id,status,title,date,meta,newspack_newsletters_ad_status,_links',
+		},
 	} );
 }
 

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.js
@@ -53,6 +53,10 @@ export function buildQueryParams( view = {} ) {
 		// `_links` stays in the list — `_embed` only expands links that
 		// survive the `_fields` filter.
 		extraParams: {
+			// Unconditional, unlike the newsletters list: Quick Edit here
+			// hydrates advertiser and placement from the embedded terms
+			// alone and sends both taxonomies on every save, so dropping
+			// the embed when those columns are hidden would clear them.
 			_embed: 'wp:term',
 			_fields: 'id,status,title,date,meta,newspack_newsletters_ad_status,_links',
 		},

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/build-query.test.js
@@ -1,12 +1,26 @@
 import { buildQueryParams, toQueryString } from './build-query';
+import { PER_PAGE_ALL } from '../../utils/per-page';
 
 describe( 'ads buildQueryParams', () => {
-	it( 'sets page and per_page from the view, defaulting to 1 and 25', () => {
-		expect( buildQueryParams( {} ) ).toMatchObject( { page: 1, per_page: 25 } );
+	it( 'sets page and per_page from the view, defaulting to 1 and 20', () => {
+		expect( buildQueryParams( {} ) ).toMatchObject( { page: 1, per_page: 20 } );
 		expect( buildQueryParams( { page: 2, perPage: 50 } ) ).toMatchObject( {
 			page: 2,
 			per_page: 50,
 		} );
+	} );
+
+	it( 'maps the All sentinel to max-size chunks starting at page 1', () => {
+		expect( buildQueryParams( { perPage: PER_PAGE_ALL, page: 4 } ) ).toMatchObject( { page: 1, per_page: 100 } );
+	} );
+
+	it( 'restricts fields so content/excerpt are never rendered server-side', () => {
+		const { _fields } = buildQueryParams( {} );
+		expect( _fields ).not.toContain( 'content' );
+		expect( _fields ).not.toContain( 'excerpt' );
+		expect( _fields.split( ',' ) ).toEqual( expect.arrayContaining( [ 'id', 'meta', 'newspack_newsletters_ad_status' ] ) );
+		// Without `_links`, `_embed` expands nothing and the terms columns go blank.
+		expect( _fields.split( ',' ) ).toContain( '_links' );
 	} );
 
 	it( 'requests context=edit so meta and private fields are returned', () => {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/index.js
@@ -10,7 +10,9 @@ import { emailAd } from 'newspack-icons';
 
 import { getAdminUrl } from '../../admin-globals';
 import EmptyState from '../../components/empty-state';
+import ItemsPerPage from '../../components/items-per-page';
 import { useHeaderActions } from '../../header-actions-context';
+import usePersistedView from '../../hooks/use-persisted-view';
 import { fetchAllTerms } from '../../utils/terms';
 import useAdsData from './use-ads-data';
 import { getFields } from './fields';
@@ -21,7 +23,7 @@ import AdsQuickEditPanel from './quick-edit-panel';
 const DEFAULT_VIEW = {
 	type: 'table',
 	page: 1,
-	perPage: 25,
+	perPage: 20,
 	sort: { field: 'date', direction: 'desc' },
 	search: '',
 	filters: [],
@@ -31,6 +33,10 @@ const DEFAULT_VIEW = {
 };
 
 const DEFAULT_LAYOUTS = { table: {} };
+
+// Suppress the built-in ViewConfig per-page control — the custom
+// `ItemsPerPage` renders in its place inside the View options popover.
+const DATAVIEWS_CONFIG = { perPageSizes: [] };
 
 const ADS_CPT = 'newspack_nl_ads_cpt';
 
@@ -62,9 +68,9 @@ function useFilterTerms() {
 }
 
 export default function AdsListScreen() {
-	const [ view, setView ] = useState( DEFAULT_VIEW );
+	const [ view, setView ] = usePersistedView( 'ads-list', DEFAULT_VIEW );
 	const [ quickEditItem, setQuickEditItem ] = useState( null );
-	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, refresh } = useAdsData( view );
+	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, progress, refresh } = useAdsData( view );
 	const filterTerms = useFilterTerms();
 
 	const addNewHref = `${ getAdminUrl() }post-new.php?post_type=${ ADS_CPT }`;
@@ -133,6 +139,14 @@ export default function AdsListScreen() {
 				isLoading={ isLoading }
 				getItemId={ item => String( item.id ) }
 				search
+				config={ DATAVIEWS_CONFIG }
+				header={
+					<ItemsPerPage
+						value={ view.perPage }
+						progress={ progress }
+						onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) }
+					/>
+				}
 			/>
 			{ quickEditItem && (
 				<AdsQuickEditPanel

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/index.js
@@ -10,6 +10,7 @@ import { emailAd } from 'newspack-icons';
 
 import { getAdminUrl } from '../../admin-globals';
 import EmptyState from '../../components/empty-state';
+import HeaderCount from '../../components/header-count';
 import ItemsPerPage from '../../components/items-per-page';
 import { useHeaderActions } from '../../header-actions-context';
 import usePersistedView from '../../hooks/use-persisted-view';
@@ -127,6 +128,7 @@ export default function AdsListScreen() {
 
 	return (
 		<>
+			<HeaderCount count={ paginationInfo.totalItems } />
 			<DataViews
 				className="newspack-newsletters-list newspack-newsletters-ads-list"
 				data={ data }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/use-ads-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/use-ads-data.js
@@ -1,15 +1,18 @@
 import { __ } from '@wordpress/i18n';
 
 import useCollectionData from '../../hooks/use-collection-data';
+import { isFetchAllPerPage } from '../../utils/per-page';
 import { buildQueryParams, toQueryString } from './build-query';
 
 const POSTS_PATH = '/wp/v2/newspack_nl_ads_cpt';
-const TRASH_COUNT_PATH = `${ POSTS_PATH }?status=trash&per_page=1&context=edit`;
+// Only the `X-WP-Total` header is read, so skip rendering the item body.
+const TRASH_COUNT_PATH = `${ POSTS_PATH }?status=trash&per_page=1&context=edit&_fields=id`;
 
 export default function useAdsData( view ) {
 	return useCollectionData( {
 		path: `${ POSTS_PATH }${ toQueryString( buildQueryParams( view ) ) }`,
 		trashCountPath: TRASH_COUNT_PATH,
+		fetchAll: isFetchAllPerPage( view?.perPage ),
 		errorMessage: __( 'Failed to load ads. Please refresh the page.', 'newspack-newsletters' ),
 		errorNoticeId: 'newspack-newsletters-ads-list-fetch-error',
 	} );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/advertisers-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/advertisers-list/index.js
@@ -14,6 +14,7 @@ import { __ } from '@wordpress/i18n';
 import { store } from '@wordpress/icons';
 
 import EmptyState from '../../components/empty-state';
+import HeaderCount from '../../components/header-count';
 import ItemsPerPage from '../../components/items-per-page';
 import { useHeaderActions } from '../../header-actions-context';
 import usePersistedView from '../../hooks/use-persisted-view';
@@ -98,6 +99,7 @@ export default function AdvertisersListScreen() {
 
 	return (
 		<>
+			<HeaderCount count={ paginationInfo.totalItems } />
 			{ isStrictEmpty ? (
 				<EmptyState
 					icon={ store }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/advertisers-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/advertisers-list/index.js
@@ -14,7 +14,9 @@ import { __ } from '@wordpress/i18n';
 import { store } from '@wordpress/icons';
 
 import EmptyState from '../../components/empty-state';
+import ItemsPerPage from '../../components/items-per-page';
 import { useHeaderActions } from '../../header-actions-context';
+import usePersistedView from '../../hooks/use-persisted-view';
 import AdvertiserModal from './modal';
 import useAdvertisersData from './use-advertisers-data';
 import useAllAdvertisers from './use-all-advertisers';
@@ -25,7 +27,7 @@ import { getActions } from './actions';
 const DEFAULT_VIEW = {
 	type: 'table',
 	page: 1,
-	perPage: 25,
+	perPage: 20,
 	sort: { field: 'name', direction: 'asc' },
 	search: '',
 	filters: [],
@@ -36,8 +38,12 @@ const DEFAULT_VIEW = {
 
 const DEFAULT_LAYOUTS = { table: {} };
 
+// Suppress the built-in ViewConfig per-page control — the custom
+// `ItemsPerPage` renders in its place inside the View options popover.
+const DATAVIEWS_CONFIG = { perPageSizes: [] };
+
 export default function AdvertisersListScreen() {
-	const [ view, setView ] = useState( DEFAULT_VIEW );
+	const [ view, setView ] = usePersistedView( 'advertisers-list', DEFAULT_VIEW );
 	const [ modalState, setModalState ] = useState( null ); // null | { mode: 'add' | 'edit', advertiser?: Object }
 	// Single mutation trigger shared by every write path (Modal save,
 	// per-row Delete, bulk Delete). Bumping it refetches both the
@@ -47,7 +53,7 @@ export default function AdvertisersListScreen() {
 	// created one appears immediately on the next modal open.
 	const [ mutationKey, setMutationKey ] = useState( 0 );
 
-	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce } = useAdvertisersData( view, mutationKey );
+	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, progress } = useAdvertisersData( view, mutationKey );
 	const allAdvertisers = useAllAdvertisers( mutationKey );
 
 	// `setModalState` (a `useState` setter) is itself stable, but wrapping
@@ -116,6 +122,14 @@ export default function AdvertisersListScreen() {
 					isLoading={ isLoading }
 					getItemId={ item => String( item.id ) }
 					search
+					config={ DATAVIEWS_CONFIG }
+					header={
+						<ItemsPerPage
+							value={ view.perPage }
+							progress={ progress }
+							onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) }
+						/>
+					}
 				/>
 			) }
 

--- a/plugins/newspack-newsletters/src/admin-shell/screens/advertisers-list/use-advertisers-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/advertisers-list/use-advertisers-data.js
@@ -2,6 +2,7 @@ import { __ } from '@wordpress/i18n';
 
 import useCollectionData from '../../hooks/use-collection-data';
 import { buildQueryParams, toQueryString } from '../../utils/build-query';
+import { isFetchAllPerPage } from '../../utils/per-page';
 
 const TAXONOMY_PATH = '/wp/v2/newspack_nl_advertiser';
 
@@ -13,8 +14,11 @@ const TAXONOMY_PATH = '/wp/v2/newspack_nl_advertiser';
  */
 export default function useAdvertisersData( view, mutationKey = 0 ) {
 	return useCollectionData( {
-		path: `${ TAXONOMY_PATH }${ toQueryString( buildQueryParams( view ) ) }`,
+		path: `${ TAXONOMY_PATH }${ toQueryString(
+			buildQueryParams( view, { extraParams: { _fields: 'id,name,description,slug,count,parent' } } )
+		) }`,
 		mutationKey,
+		fetchAll: isFetchAllPerPage( view?.perPage ),
 		errorMessage: __( 'Failed to load advertisers. Please refresh the page.', 'newspack-newsletters' ),
 		errorNoticeId: 'newspack-newsletters-advertisers-list-fetch-error',
 	} );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
@@ -79,7 +79,7 @@ export default function LayoutsListScreen() {
 		ensureCoreBlocksRegistered();
 	}, [] );
 
-	const [ view, setView ] = usePersistedView( 'layouts-list', DEFAULT_VIEW );
+	const [ view, setView ] = usePersistedView( 'layouts-list', DEFAULT_VIEW, PER_PAGE_OPTIONS );
 	const [ renamingId, setRenamingId ] = useState( null );
 	// Bumping this forces every write path to refetch the saved data.
 	const [ mutationKey, setMutationKey ] = useState( 0 );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
@@ -12,6 +12,7 @@ import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import { getAdminUrl } from '../../admin-globals';
+import HeaderCount from '../../components/header-count';
 import ItemsPerPage from '../../components/items-per-page';
 import { useHeaderActions } from '../../header-actions-context';
 import usePersistedView from '../../hooks/use-persisted-view';
@@ -286,27 +287,30 @@ export default function LayoutsListScreen() {
 	}
 
 	return (
-		<DataViews
-			className="newspack-newsletters-list newspack-newsletters-layouts-list"
-			data={ data }
-			fields={ fields }
-			view={ view }
-			onChangeView={ onChangeView }
-			actions={ actions }
-			paginationInfo={ paginationInfo }
-			defaultLayouts={ DEFAULT_LAYOUTS }
-			isLoading={ isLoading || isPrebuiltLoading }
-			getItemId={ item => String( item.id ) }
-			search
-			config={ DATAVIEWS_CONFIG }
-			header={
-				<ItemsPerPage
-					value={ view.perPage }
-					options={ PER_PAGE_OPTIONS }
-					progress={ progress }
-					onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) }
-				/>
-			}
-		/>
+		<>
+			<HeaderCount count={ paginationInfo.totalItems } />
+			<DataViews
+				className="newspack-newsletters-list newspack-newsletters-layouts-list"
+				data={ data }
+				fields={ fields }
+				view={ view }
+				onChangeView={ onChangeView }
+				actions={ actions }
+				paginationInfo={ paginationInfo }
+				defaultLayouts={ DEFAULT_LAYOUTS }
+				isLoading={ isLoading || isPrebuiltLoading }
+				getItemId={ item => String( item.id ) }
+				search
+				config={ DATAVIEWS_CONFIG }
+				header={
+					<ItemsPerPage
+						value={ view.perPage }
+						options={ PER_PAGE_OPTIONS }
+						progress={ progress }
+						onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) }
+					/>
+				}
+			/>
+		</>
 	);
 }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/index.js
@@ -12,8 +12,11 @@ import { useCallback, useEffect, useMemo, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 import { getAdminUrl } from '../../admin-globals';
+import ItemsPerPage from '../../components/items-per-page';
 import { useHeaderActions } from '../../header-actions-context';
+import usePersistedView from '../../hooks/use-persisted-view';
 import { notifyError, notifySuccess } from '../../notices';
+import { isFetchAllPerPage, PER_PAGE_ALL } from '../../utils/per-page';
 import { LAYOUT_CPT_SLUG } from '../../../utils/consts';
 import useLayoutsData from './use-layouts-data';
 import usePrebuiltLayouts from './use-prebuilt-layouts';
@@ -63,12 +66,19 @@ const DEFAULT_LAYOUTS = {
 	table: {},
 };
 
+// Suppress the built-in ViewConfig per-page control — the custom
+// `ItemsPerPage` renders in its place inside the View options popover.
+// Options are multiples of the grid default rather than the shared
+// 10/20/50/100.
+const DATAVIEWS_CONFIG = { perPageSizes: [] };
+const PER_PAGE_OPTIONS = [ 12, 24, 48, 96, PER_PAGE_ALL ];
+
 export default function LayoutsListScreen() {
 	useEffect( () => {
 		ensureCoreBlocksRegistered();
 	}, [] );
 
-	const [ view, setView ] = useState( DEFAULT_VIEW );
+	const [ view, setView ] = usePersistedView( 'layouts-list', DEFAULT_VIEW );
 	const [ renamingId, setRenamingId ] = useState( null );
 	// Bumping this forces every write path to refetch the saved data.
 	const [ mutationKey, setMutationKey ] = useState( 0 );
@@ -106,6 +116,11 @@ export default function LayoutsListScreen() {
 	const { showPrebuilts: authorShowPrebuilts, restrictedAuthorIds, savedFetchAllAuthors } = authorFilterResolution;
 	const showSaved = savedFetchAllAuthors || restrictedAuthorIds.length > 0;
 
+	// "All" collapses everything onto a single page, so the slot
+	// arithmetic that rations page 1 between prebuilts and saved rows
+	// doesn't apply — both sets simply concatenate.
+	const fetchingAll = isFetchAllPerPage( view.perPage );
+
 	// Prebuilts pin to page 1 only; search hides them (titles aren't
 	// indexed against parsed content). Saved rows offset-paginate around
 	// the slots prebuilts reserve.
@@ -115,7 +130,7 @@ export default function LayoutsListScreen() {
 	// prebuilt count, avoiding a refetch with a smaller slot count once
 	// prebuilts arrive.
 	const couldRideAlong = authorShowPrebuilts && ! view.search;
-	const ridingAlong = couldRideAlong && prebuiltCount > 0;
+	const ridingAlong = couldRideAlong && prebuiltCount > 0 && ! fetchingAll;
 	const firstPageSavedSlots = ridingAlong ? Math.max( 1, view.perPage - prebuiltCount ) : view.perPage;
 
 	const savedView = useMemo( () => {
@@ -137,7 +152,13 @@ export default function LayoutsListScreen() {
 		return baseView;
 	}, [ view, showSaved, couldRideAlong, isPrebuiltLoading, ridingAlong, firstPageSavedSlots, restrictedAuthorIds ] );
 
-	const { data: savedData, paginationInfo: savedPagination, isLoading, hasResolved: savedHasResolved } = useLayoutsData( savedView, mutationKey );
+	const {
+		data: savedData,
+		paginationInfo: savedPagination,
+		isLoading,
+		hasResolved: savedHasResolved,
+		progress,
+	} = useLayoutsData( savedView, mutationKey );
 
 	const filteredPrebuilts = showPrebuilts ? prebuiltData : [];
 	const filteredSaved = showSaved ? savedData : [];
@@ -165,6 +186,12 @@ export default function LayoutsListScreen() {
 		if ( ! showSaved ) {
 			return { totalItems: prebuiltCount, totalPages: 1 };
 		}
+		if ( fetchingAll ) {
+			return {
+				totalItems: savedPagination.totalItems + ( authorShowPrebuilts && ! view.search ? prebuiltCount : 0 ),
+				totalPages: 1,
+			};
+		}
 		if ( ! ridingAlong ) {
 			return {
 				totalItems: savedPagination.totalItems,
@@ -181,7 +208,7 @@ export default function LayoutsListScreen() {
 			totalItems: savedPagination.totalItems + ( authorShowPrebuilts ? prebuiltCount : 0 ),
 			totalPages: Math.max( 1, totalPages ),
 		};
-	}, [ savedPagination, prebuiltCount, showSaved, authorShowPrebuilts, ridingAlong, firstPageSavedSlots, view.perPage ] );
+	}, [ savedPagination, prebuiltCount, showSaved, authorShowPrebuilts, ridingAlong, firstPageSavedSlots, view.perPage, view.search, fetchingAll ] );
 
 	// `mediaField` is grid-only — in table mode the per-row iframe blows
 	// out row heights, so strip it on layout switches.
@@ -271,6 +298,15 @@ export default function LayoutsListScreen() {
 			isLoading={ isLoading || isPrebuiltLoading }
 			getItemId={ item => String( item.id ) }
 			search
+			config={ DATAVIEWS_CONFIG }
+			header={
+				<ItemsPerPage
+					value={ view.perPage }
+					options={ PER_PAGE_OPTIONS }
+					progress={ progress }
+					onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) }
+				/>
+			}
 		/>
 	);
 }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/layouts-list/use-layouts-data.js
@@ -3,6 +3,7 @@ import { __ } from '@wordpress/i18n';
 import { LAYOUT_CPT_SLUG } from '../../../utils/consts';
 import useCollectionData from '../../hooks/use-collection-data';
 import { buildQueryParams, toQueryString } from '../../utils/build-query';
+import { isFetchAllPerPage } from '../../utils/per-page';
 
 const COLLECTION_PATH = `/wp/v2/${ LAYOUT_CPT_SLUG }`;
 // `future` is excluded — layouts don't surface scheduling. `auto-draft` keeps "Add new" + back visible.
@@ -17,7 +18,14 @@ function buildPath( view ) {
 		defaultStatuses: DEFAULT_STATUSES,
 		// `offset` overrides `page` so page 1 can reserve slots for prebuilts.
 		supportsOffset: true,
-		extraParams: { _embed: 'author,wp:term' },
+		// `content.raw` (not `.rendered`) — previews parse blocks client-side,
+		// so skip the whole `the_content` chain. Term embeds aren't consumed.
+		// `_links` stays in the list — `_embed` only expands links that
+		// survive the `_fields` filter.
+		extraParams: {
+			_embed: 'author',
+			_fields: 'id,status,title,date,modified,author,content.raw,meta,_links',
+		},
 		arrayParams: [ { viewKey: 'author', param: 'author' } ],
 	} );
 	return `${ COLLECTION_PATH }${ toQueryString( params ) }`;
@@ -32,6 +40,7 @@ export default function useLayoutsData( view, mutationKey = 0 ) {
 	return useCollectionData( {
 		path: buildPath( view ),
 		mutationKey,
+		fetchAll: isFetchAllPerPage( view?.perPage ),
 		errorMessage: __( 'Failed to load layouts. Please refresh the page.', 'newspack-newsletters' ),
 		errorNoticeId: 'newspack-newsletters-layouts-list-fetch-error',
 	} );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/actions.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/actions.js
@@ -184,7 +184,6 @@ export function getActions( { refresh, openQuickEdit } ) {
 	const trashAction = {
 		id: 'trash',
 		label: __( 'Trash', 'newspack-newsletters' ),
-		isPrimary: true,
 		icon: trash,
 		modalHeader: __( 'Move to trash', 'newspack-newsletters' ),
 		isDestructive: true,

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/actions.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/actions.test.js
@@ -39,14 +39,14 @@ describe( 'newsletters list actions', () => {
 		] );
 	} );
 
-	it( 'marks Quick Edit and Trash as primary actions', () => {
+	it( 'marks Quick Edit as the only primary action', () => {
 		expect( byId( 'quick-edit' ).isPrimary ).toBe( true );
-		expect( byId( 'trash' ).isPrimary ).toBe( true );
 	} );
 
-	it( 'does not mark Edit or Rename as primary actions', () => {
+	it( 'does not mark Edit, Rename, or Trash as primary actions', () => {
 		expect( byId( 'edit' ).isPrimary ).toBeFalsy();
 		expect( byId( 'rename' ).isPrimary ).toBeFalsy();
+		expect( byId( 'trash' ).isPrimary ).toBeFalsy();
 	} );
 
 	it( 'Quick Edit is eligible on non-trashed rows only', () => {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
@@ -33,11 +33,24 @@ const SORT_FIELD_TO_ORDERBY = {
 };
 
 export function buildQueryParams( view = {} ) {
+	// Term embeds cost ~2 internal REST dispatches per row and only the
+	// (hidden-by-default) Categories/Tags columns read them.
+	const visibleFields = Array.isArray( view.fields ) ? view.fields : null;
+	const needsTerms = ! visibleFields || visibleFields.includes( 'categories' ) || visibleFields.includes( 'tags' );
+
 	return baseBuildQueryParams( view, {
 		fieldToQueryParam: FIELD_TO_QUERY_PARAM,
 		sortFieldToOrderby: SORT_FIELD_TO_ORDERBY,
 		defaultStatuses: DEFAULT_STATUSES,
-		extraParams: { _embed: 'author,wp:term' },
+		// `_fields` short-circuits `content.rendered` / `excerpt.rendered`
+		// (the full `the_content` chain, incl. synchronous oEmbed fetches)
+		// and the unused editor REST fields — per-item cost the list never
+		// reads. `_links` must stay in the list: `_embed` only expands
+		// links that survive the `_fields` filter.
+		extraParams: {
+			_embed: needsTerms ? 'author,wp:term' : 'author',
+			_fields: 'id,status,title,date,link,meta,newspack_newsletters_status,_links',
+		},
 	} );
 }
 

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
@@ -49,7 +49,9 @@ export function buildQueryParams( view = {} ) {
 		// links that survive the `_fields` filter.
 		extraParams: {
 			_embed: needsTerms ? 'author,wp:term' : 'author',
-			_fields: 'id,status,title,date,link,meta,newspack_newsletters_status,_links',
+			// `categories`/`tags` are cheap ID arrays — Quick Edit needs the
+			// post's real terms even when the embed is skipped.
+			_fields: 'id,status,title,date,link,meta,categories,tags,newspack_newsletters_status,_links',
 		},
 	} );
 }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.js
@@ -49,8 +49,7 @@ export function buildQueryParams( view = {} ) {
 		// links that survive the `_fields` filter.
 		extraParams: {
 			_embed: needsTerms ? 'author,wp:term' : 'author',
-			// `categories`/`tags` are cheap ID arrays — Quick Edit needs the
-			// post's real terms even when the embed is skipped.
+			// `categories`/`tags`: Quick Edit needs them when the embed is skipped.
 			_fields: 'id,status,title,date,link,meta,categories,tags,newspack_newsletters_status,_links',
 		},
 	} );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.test.js
@@ -1,20 +1,42 @@
 import { buildQueryParams, toQueryString } from './build-query';
+import { PER_PAGE_ALL } from '../../utils/per-page';
 
 describe( 'buildQueryParams', () => {
-	it( 'sets page and per_page from the view, defaulting to 1 and 25', () => {
-		expect( buildQueryParams( {} ) ).toMatchObject( { page: 1, per_page: 25 } );
+	it( 'sets page and per_page from the view, defaulting to 1 and 20', () => {
+		expect( buildQueryParams( {} ) ).toMatchObject( { page: 1, per_page: 20 } );
 		expect( buildQueryParams( { page: 3, perPage: 50 } ) ).toMatchObject( {
 			page: 3,
 			per_page: 50,
 		} );
 	} );
 
+	it( 'maps the All sentinel to max-size chunks starting at page 1', () => {
+		expect( buildQueryParams( { perPage: PER_PAGE_ALL, page: 7 } ) ).toMatchObject( { page: 1, per_page: 100 } );
+	} );
+
+	it( 'restricts fields so content/excerpt are never rendered server-side', () => {
+		const { _fields } = buildQueryParams( {} );
+		expect( _fields.split( ',' ) ).toEqual(
+			expect.arrayContaining( [ 'id', 'status', 'title', 'date', 'link', 'meta', 'newspack_newsletters_status' ] )
+		);
+		expect( _fields ).not.toContain( 'content' );
+		expect( _fields ).not.toContain( 'excerpt' );
+		// Without `_links`, `_embed` expands nothing and the author/terms columns go blank.
+		expect( _fields.split( ',' ) ).toContain( '_links' );
+	} );
+
 	it( 'requests context=edit so meta and private fields are returned', () => {
 		expect( buildQueryParams( {} ).context ).toBe( 'edit' );
 	} );
 
-	it( 'includes author and wp:term embeds for the columns that need them', () => {
+	it( 'includes author and wp:term embeds when field visibility is unknown', () => {
 		expect( buildQueryParams( {} )._embed ).toBe( 'author,wp:term' );
+	} );
+
+	it( 'drops the expensive wp:term embed when the Categories/Tags columns are hidden', () => {
+		expect( buildQueryParams( { fields: [ 'status', 'date', 'author' ] } )._embed ).toBe( 'author' );
+		expect( buildQueryParams( { fields: [ 'status', 'categories' ] } )._embed ).toBe( 'author,wp:term' );
+		expect( buildQueryParams( { fields: [ 'tags' ] } )._embed ).toBe( 'author,wp:term' );
 	} );
 
 	it( 'defaults status to all common writable statuses (no trash) when no filter is set', () => {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/build-query.test.js
@@ -23,6 +23,7 @@ describe( 'buildQueryParams', () => {
 		expect( _fields ).not.toContain( 'excerpt' );
 		// Without `_links`, `_embed` expands nothing and the author/terms columns go blank.
 		expect( _fields.split( ',' ) ).toContain( '_links' );
+		expect( _fields.split( ',' ) ).toEqual( expect.arrayContaining( [ 'categories', 'tags' ] ) );
 	} );
 
 	it( 'requests context=edit so meta and private fields are returned', () => {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/fields.js
@@ -5,7 +5,7 @@
  * field so sent/scheduled is never re-derived client-side.
  */
 
-import { Icon } from '@wordpress/components';
+import { ExternalLink, Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { commentAuthorAvatar, drafts, envelope, globe, published, scheduled, trash } from '@wordpress/icons';
 import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
@@ -134,10 +134,19 @@ const renderPublicPage = ( { item } ) => {
 	const isPublic = !! item?.meta?.is_public;
 	const icon = isPublic ? globe : envelope;
 	const label = isPublic ? __( 'Email and web', 'newspack-newsletters' ) : __( 'Email only', 'newspack-newsletters' );
+	// Real anchor so the public page opens in one click and supports
+	// cmd/middle-click; mirrors the `view-public-page` action's gate.
+	const publicUrl = isPublic && 'publish' === item?.status && item?.link ? item.link : null;
 	return (
 		<span className="newspack-newsletters-list__visibility">
 			<Icon className="newspack-newsletters-list__visibility-icon" icon={ icon } size={ 24 } />
-			<span>{ label }</span>
+			{ publicUrl ? (
+				<ExternalLink href={ publicUrl } onClickCapture={ event => event.stopPropagation() }>
+					{ label }
+				</ExternalLink>
+			) : (
+				<span>{ label }</span>
+			) }
 		</span>
 	);
 };
@@ -165,7 +174,7 @@ export function getFields( { authors = [], categories = [], tags = [], sendLists
 				{ value: 'draft,pending,auto-draft', label: statusLabels.draft },
 				{ value: 'trash', label: statusLabels.trash },
 			],
-			filterBy: { operators: [ 'isAny' ] },
+			filterBy: { operators: [ 'isAny' ], isPrimary: true },
 			getValue: ( { item } ) => item?.newspack_newsletters_status?.kind || 'draft',
 			render: renderStatus,
 		},
@@ -184,7 +193,7 @@ export function getFields( { authors = [], categories = [], tags = [], sendLists
 				value: String( id ),
 				label: String( label ),
 			} ) ),
-			filterBy: { operators: [ 'isAny' ] },
+			filterBy: { operators: [ 'isAny' ], isPrimary: true },
 			enableSorting: false,
 			getValue: ( { item } ) => item?.meta?.send_list_id || '',
 			render: renderSendList,
@@ -196,7 +205,7 @@ export function getFields( { authors = [], categories = [], tags = [], sendLists
 				value: String( id ),
 				label: String( label ),
 			} ) ),
-			filterBy: { operators: [ 'isAny' ] },
+			filterBy: { operators: [ 'isAny' ], isPrimary: true },
 			enableSorting: true,
 			getValue: ( { item } ) => String( item?._embedded?.author?.[ 0 ]?.id || '' ),
 			render: renderAuthor,
@@ -208,7 +217,7 @@ export function getFields( { authors = [], categories = [], tags = [], sendLists
 				value: String( id ),
 				label: String( label ),
 			} ) ),
-			filterBy: { operators: [ 'isAny' ] },
+			filterBy: { operators: [ 'isAny' ], isPrimary: true },
 			enableSorting: false,
 			getValue: ( { item } ) =>
 				termsForTaxonomy( item, 'category' )
@@ -224,7 +233,7 @@ export function getFields( { authors = [], categories = [], tags = [], sendLists
 				value: String( id ),
 				label: String( label ),
 			} ) ),
-			filterBy: { operators: [ 'isAny' ] },
+			filterBy: { operators: [ 'isAny' ], isPrimary: true },
 			enableSorting: false,
 			getValue: ( { item } ) =>
 				termsForTaxonomy( item, 'post_tag' )
@@ -240,7 +249,7 @@ export function getFields( { authors = [], categories = [], tags = [], sendLists
 				{ value: '1', label: __( 'Email and web', 'newspack-newsletters' ) },
 				{ value: '0', label: __( 'Email only', 'newspack-newsletters' ) },
 			],
-			filterBy: { operators: [ 'is' ] },
+			filterBy: { operators: [ 'is' ], isPrimary: true },
 			getValue: ( { item } ) => ( item?.meta?.is_public ? '1' : '0' ),
 			render: renderPublicPage,
 		},

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/index.js
@@ -97,7 +97,7 @@ export default function NewslettersListScreen() {
 
 	return (
 		<>
-			<HeaderCount count={ paginationInfo.totalItems } isRealized={ hasLoadedOnce } />
+			<HeaderCount count={ paginationInfo.totalItems } />
 			<DataViews
 				className="newspack-newsletters-list"
 				data={ data }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/index.js
@@ -10,7 +10,10 @@ import { envelope } from '@wordpress/icons';
 
 import { getAdminUrl, getCptSlug } from '../../admin-globals';
 import EmptyState from '../../components/empty-state';
+import HeaderCount from '../../components/header-count';
+import ItemsPerPage from '../../components/items-per-page';
 import { useHeaderActions } from '../../header-actions-context';
+import usePersistedView from '../../hooks/use-persisted-view';
 import useNewslettersData from './use-newsletters-data';
 import useFilterElements from './use-filter-elements';
 import { getFields } from './fields';
@@ -22,7 +25,7 @@ import NewslettersQuickEditPanel from './quick-edit-panel';
 const DEFAULT_VIEW = {
 	type: 'table',
 	page: 1,
-	perPage: 25,
+	perPage: 20,
 	sort: { field: 'date', direction: 'desc' },
 	search: '',
 	filters: [],
@@ -33,10 +36,14 @@ const DEFAULT_VIEW = {
 
 const DEFAULT_LAYOUTS = { table: {} };
 
+// Suppress the built-in ViewConfig per-page control — the custom
+// `ItemsPerPage` renders in its place inside the View options popover.
+const DATAVIEWS_CONFIG = { perPageSizes: [] };
+
 export default function NewslettersListScreen() {
-	const [ view, setView ] = useState( DEFAULT_VIEW );
+	const [ view, setView ] = usePersistedView( 'newsletters-list', DEFAULT_VIEW );
 	const [ quickEditItem, setQuickEditItem ] = useState( null );
-	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, refresh } = useNewslettersData( view );
+	const { data, paginationInfo, isLoading, hasResolved, hasLoadedOnce, trashCount, progress, refresh } = useNewslettersData( view );
 	const filterElements = useFilterElements();
 
 	const addNewHref = `${ getAdminUrl() }post-new.php?post_type=${ getCptSlug() }`;
@@ -90,6 +97,7 @@ export default function NewslettersListScreen() {
 
 	return (
 		<>
+			<HeaderCount count={ paginationInfo.totalItems } />
 			<DataViews
 				className="newspack-newsletters-list"
 				data={ data }
@@ -102,6 +110,14 @@ export default function NewslettersListScreen() {
 				isLoading={ isLoading }
 				getItemId={ item => String( item.id ) }
 				search
+				config={ DATAVIEWS_CONFIG }
+				header={
+					<ItemsPerPage
+						value={ view.perPage }
+						progress={ progress }
+						onChange={ perPage => setView( current => ( { ...current, perPage, page: 1 } ) ) }
+					/>
+				}
 			/>
 			{ quickEditItem && (
 				<NewslettersQuickEditPanel

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/index.js
@@ -97,7 +97,7 @@ export default function NewslettersListScreen() {
 
 	return (
 		<>
-			<HeaderCount count={ paginationInfo.totalItems } />
+			<HeaderCount count={ paginationInfo.totalItems } isRealized={ hasLoadedOnce } />
 			<DataViews
 				className="newspack-newsletters-list"
 				data={ data }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/quick-edit-panel.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/quick-edit-panel.js
@@ -8,14 +8,14 @@
 
 import apiFetch from '@wordpress/api-fetch';
 import { FormTokenField, RadioControl } from '@wordpress/components';
-import { useEffect, useMemo, useState } from '@wordpress/element';
+import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { envelope } from '@wordpress/icons';
 
 import QuickEditPanel from '../../components/quick-edit-panel';
 import { getNewsletterVisibilityDescriptions } from '../../../utils/service-provider';
 import { notifyError, notifySuccess } from '../../notices';
-import { fetchAllTerms, initialSelectionsForTaxonomy, resolveTokens, sortedIdsEqual } from '../../utils/terms';
+import { fetchAllTerms, initialSelectionsForTaxonomy, resolveTokens, selectionsFromIds, sortedIdsEqual } from '../../utils/terms';
 
 const POSTS_PATH = '/wp/v2/newspack_nl_cpt';
 
@@ -46,19 +46,39 @@ function useQuickEditOptions() {
 export default function NewslettersQuickEditPanel( { item, onClose, onSaved } ) {
 	const { categories, tags } = useQuickEditOptions();
 
-	const initialCategorySelections = useMemo( () => initialSelectionsForTaxonomy( item, 'category' ), [ item ] );
-	const initialTagSelections = useMemo( () => initialSelectionsForTaxonomy( item, 'post_tag' ), [ item ] );
+	// Terms are only embedded when a taxonomy column is visible — otherwise
+	// resolve the post's raw IDs against the fetched options.
+	const initialCategorySelections = useMemo( () => {
+		const embedded = initialSelectionsForTaxonomy( item, 'category' );
+		return embedded.length ? embedded : selectionsFromIds( item?.categories, categories );
+	}, [ item, categories ] );
+	const initialTagSelections = useMemo( () => {
+		const embedded = initialSelectionsForTaxonomy( item, 'post_tag' );
+		return embedded.length ? embedded : selectionsFromIds( item?.tags, tags );
+	}, [ item, tags ] );
 	const initialVisibility = item?.meta?.is_public ? 'public' : 'private';
 
 	const [ categorySelections, setCategorySelections ] = useState( initialCategorySelections );
 	const [ tagSelections, setTagSelections ] = useState( initialTagSelections );
 	const [ visibility, setVisibility ] = useState( initialVisibility );
 	const [ isBusy, setIsBusy ] = useState( false );
+	const hasEditedTermsRef = useRef( false );
 
-	const isDirty =
-		visibility !== initialVisibility ||
-		! sortedIdsEqual( categorySelections, initialCategorySelections ) ||
-		! sortedIdsEqual( tagSelections, initialTagSelections );
+	// Options land after the first render, resolving ID-only terms.
+	useEffect( () => {
+		if ( ! hasEditedTermsRef.current ) {
+			setCategorySelections( initialCategorySelections );
+		}
+	}, [ initialCategorySelections ] );
+	useEffect( () => {
+		if ( ! hasEditedTermsRef.current ) {
+			setTagSelections( initialTagSelections );
+		}
+	}, [ initialTagSelections ] );
+
+	const categoriesDirty = ! sortedIdsEqual( categorySelections, initialCategorySelections );
+	const tagsDirty = ! sortedIdsEqual( tagSelections, initialTagSelections );
+	const isDirty = visibility !== initialVisibility || categoriesDirty || tagsDirty;
 
 	const categoryNames = useMemo( () => categories.map( c => String( c.name ) ), [ categories ] );
 	const tagNames = useMemo( () => tags.map( t => String( t.name ) ), [ tags ] );
@@ -75,11 +95,14 @@ export default function NewslettersQuickEditPanel( { item, onClose, onSaved } ) 
 
 	const handleSave = async () => {
 		setIsBusy( true );
-		const data = {
-			categories: categorySelections.map( s => s.id ),
-			tags: tagSelections.map( s => s.id ),
-			meta: { is_public: visibility === 'public' },
-		};
+		// An untouched taxonomy must never be overwritten with what we resolved.
+		const data = { meta: { is_public: visibility === 'public' } };
+		if ( categoriesDirty ) {
+			data.categories = categorySelections.map( s => s.id );
+		}
+		if ( tagsDirty ) {
+			data.tags = tagSelections.map( s => s.id );
+		}
 		try {
 			await apiFetch( { path: `${ POSTS_PATH }/${ item.id }`, method: 'POST', data } );
 			notifySuccess( __( 'Newsletter updated.', 'newspack-newsletters' ) );
@@ -108,7 +131,10 @@ export default function NewslettersQuickEditPanel( { item, onClose, onSaved } ) 
 				label={ __( 'Categories', 'newspack-newsletters' ) }
 				value={ categoryTokens }
 				suggestions={ categoryNames }
-				onChange={ next => setCategorySelections( resolveTokens( next, categorySelections, categories ) ) }
+				onChange={ next => {
+					hasEditedTermsRef.current = true;
+					setCategorySelections( resolveTokens( next, categorySelections, categories ) );
+				} }
 				__experimentalValidateInput={ validateCategory }
 				__experimentalShowHowTo={ false }
 				__next40pxDefaultSize
@@ -118,7 +144,10 @@ export default function NewslettersQuickEditPanel( { item, onClose, onSaved } ) 
 				label={ __( 'Tags', 'newspack-newsletters' ) }
 				value={ tagTokens }
 				suggestions={ tagNames }
-				onChange={ next => setTagSelections( resolveTokens( next, tagSelections, tags ) ) }
+				onChange={ next => {
+					hasEditedTermsRef.current = true;
+					setTagSelections( resolveTokens( next, tagSelections, tags ) );
+				} }
 				__experimentalValidateInput={ validateTag }
 				__experimentalShowHowTo={ false }
 				__next40pxDefaultSize

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/quick-edit-panel.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/quick-edit-panel.js
@@ -64,15 +64,20 @@ export default function NewslettersQuickEditPanel( { item, onClose, onSaved } ) 
 	const [ tagSelections, setTagSelections ] = useState( initialTagSelections );
 	const [ visibility, setVisibility ] = useState( initialVisibility );
 	const [ isBusy, setIsBusy ] = useState( false );
-	const hasEditedTermsRef = useRef( false );
+	// One ref per taxonomy: when a column is hidden the baselines seed
+	// asynchronously as each taxonomy's options resolve, so a shared ref
+	// would let an edit to one freeze the other at its pre-resolution
+	// (empty) value — and a later edit there would then drop real terms.
+	const hasEditedCategoriesRef = useRef( false );
+	const hasEditedTagsRef = useRef( false );
 
 	useEffect( () => {
-		if ( ! hasEditedTermsRef.current ) {
+		if ( ! hasEditedCategoriesRef.current ) {
 			setCategorySelections( initialCategorySelections );
 		}
 	}, [ initialCategorySelections ] );
 	useEffect( () => {
-		if ( ! hasEditedTermsRef.current ) {
+		if ( ! hasEditedTagsRef.current ) {
 			setTagSelections( initialTagSelections );
 		}
 	}, [ initialTagSelections ] );
@@ -132,7 +137,7 @@ export default function NewslettersQuickEditPanel( { item, onClose, onSaved } ) 
 				value={ categoryTokens }
 				suggestions={ categoryNames }
 				onChange={ next => {
-					hasEditedTermsRef.current = true;
+					hasEditedCategoriesRef.current = true;
 					setCategorySelections( resolveTokens( next, categorySelections, categories ) );
 				} }
 				__experimentalValidateInput={ validateCategory }
@@ -145,7 +150,7 @@ export default function NewslettersQuickEditPanel( { item, onClose, onSaved } ) 
 				value={ tagTokens }
 				suggestions={ tagNames }
 				onChange={ next => {
-					hasEditedTermsRef.current = true;
+					hasEditedTagsRef.current = true;
 					setTagSelections( resolveTokens( next, tagSelections, tags ) );
 				} }
 				__experimentalValidateInput={ validateTag }

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/quick-edit-panel.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/quick-edit-panel.js
@@ -15,7 +15,7 @@ import { envelope } from '@wordpress/icons';
 import QuickEditPanel from '../../components/quick-edit-panel';
 import { getNewsletterVisibilityDescriptions } from '../../../utils/service-provider';
 import { notifyError, notifySuccess } from '../../notices';
-import { fetchAllTerms, initialSelectionsForTaxonomy, resolveTokens, selectionsFromIds, sortedIdsEqual } from '../../utils/terms';
+import { fetchAllTerms, initialSelectionsForTaxonomy, resolveTokens, selectionsFromIds, sortedIdsEqual, unresolvedIds } from '../../utils/terms';
 
 const POSTS_PATH = '/wp/v2/newspack_nl_cpt';
 
@@ -46,8 +46,7 @@ function useQuickEditOptions() {
 export default function NewslettersQuickEditPanel( { item, onClose, onSaved } ) {
 	const { categories, tags } = useQuickEditOptions();
 
-	// Terms are only embedded when a taxonomy column is visible — otherwise
-	// resolve the post's raw IDs against the fetched options.
+	// Terms are only embedded when a taxonomy column is visible.
 	const initialCategorySelections = useMemo( () => {
 		const embedded = initialSelectionsForTaxonomy( item, 'category' );
 		return embedded.length ? embedded : selectionsFromIds( item?.categories, categories );
@@ -56,6 +55,9 @@ export default function NewslettersQuickEditPanel( { item, onClose, onSaved } ) 
 		const embedded = initialSelectionsForTaxonomy( item, 'post_tag' );
 		return embedded.length ? embedded : selectionsFromIds( item?.tags, tags );
 	}, [ item, tags ] );
+	// Unresolvable terms can't be shown or removed, so they ride along on save.
+	const unresolvedCategoryIds = useMemo( () => unresolvedIds( item?.categories, initialCategorySelections ), [ item, initialCategorySelections ] );
+	const unresolvedTagIds = useMemo( () => unresolvedIds( item?.tags, initialTagSelections ), [ item, initialTagSelections ] );
 	const initialVisibility = item?.meta?.is_public ? 'public' : 'private';
 
 	const [ categorySelections, setCategorySelections ] = useState( initialCategorySelections );
@@ -64,7 +66,6 @@ export default function NewslettersQuickEditPanel( { item, onClose, onSaved } ) 
 	const [ isBusy, setIsBusy ] = useState( false );
 	const hasEditedTermsRef = useRef( false );
 
-	// Options land after the first render, resolving ID-only terms.
 	useEffect( () => {
 		if ( ! hasEditedTermsRef.current ) {
 			setCategorySelections( initialCategorySelections );
@@ -95,13 +96,12 @@ export default function NewslettersQuickEditPanel( { item, onClose, onSaved } ) 
 
 	const handleSave = async () => {
 		setIsBusy( true );
-		// An untouched taxonomy must never be overwritten with what we resolved.
 		const data = { meta: { is_public: visibility === 'public' } };
 		if ( categoriesDirty ) {
-			data.categories = categorySelections.map( s => s.id );
+			data.categories = [ ...categorySelections.map( s => s.id ), ...unresolvedCategoryIds ];
 		}
 		if ( tagsDirty ) {
-			data.tags = tagSelections.map( s => s.id );
+			data.tags = [ ...tagSelections.map( s => s.id ), ...unresolvedTagIds ];
 		}
 		try {
 			await apiFetch( { path: `${ POSTS_PATH }/${ item.id }`, method: 'POST', data } );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/quick-edit-panel.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/quick-edit-panel.test.js
@@ -53,8 +53,6 @@ describe( 'NewslettersQuickEditPanel', () => {
 		} );
 	} );
 
-	// The regression this guards: with the term embed skipped, an untouched
-	// taxonomy was posted as `[]` and stripped every term from the post.
 	it( 'does not send categories or tags when only visibility changed', async () => {
 		const item = { id: 42, title: { raw: 'Friday Five' }, meta: { is_public: false }, categories: [ 5 ], tags: [ 7 ] };
 		render( <NewslettersQuickEditPanel item={ item } onClose={ jest.fn() } onSaved={ jest.fn() } /> );
@@ -66,6 +64,19 @@ describe( 'NewslettersQuickEditPanel', () => {
 
 		await waitFor( () => expect( postCall() ).toBeTruthy() );
 		expect( postCall().data ).toEqual( { meta: { is_public: true } } );
+	} );
+
+	it( 'keeps assigned term IDs that the options fetch never resolved', async () => {
+		const item = { id: 42, title: { raw: 'Friday Five' }, meta: {}, categories: [ 5, 99 ], tags: [] };
+		render( <NewslettersQuickEditPanel item={ item } onClose={ jest.fn() } onSaved={ jest.fn() } /> );
+
+		await waitFor( () => expect( screen.getByText( 'News' ) ).toBeInTheDocument() );
+
+		fireEvent.click( screen.getByRole( 'button', { name: /remove item/i } ) );
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+
+		await waitFor( () => expect( postCall() ).toBeTruthy() );
+		expect( postCall().data.categories ).toEqual( [ 99 ] );
 	} );
 
 	it( 'seeds the token fields from the raw term IDs when no embed is present', async () => {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/quick-edit-panel.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/quick-edit-panel.test.js
@@ -1,0 +1,79 @@
+// The list query only embeds terms when a taxonomy column is visible, so
+// the panel has to resolve the post's own `categories`/`tags` ID arrays —
+// and must never send a taxonomy the user didn't touch.
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: jest.fn(),
+} ) );
+
+jest.mock( '../../components/quick-edit-panel', () => ( {
+	__esModule: true,
+	default: ( { children, isDirty, isBusy, onSave } ) => (
+		<div>
+			<div data-testid="panel-dirty">{ String( isDirty ) }</div>
+			{ children }
+			<button type="button" data-testid="panel-save" onClick={ onSave } disabled={ isBusy || ! isDirty }>
+				Save
+			</button>
+		</div>
+	),
+} ) );
+
+import { fireEvent, render, screen, waitFor } from '@testing-library/react';
+import apiFetch from '@wordpress/api-fetch';
+import NewslettersQuickEditPanel from './quick-edit-panel';
+
+const CATEGORIES = [
+	{ id: 5, name: 'News' },
+	{ id: 6, name: 'Sport' },
+];
+const TAGS = [ { id: 7, name: 'weekly' } ];
+
+const makeTermsResponse = terms => ( {
+	headers: { get: name => ( name === 'X-WP-TotalPages' ? '1' : String( terms.length ) ) },
+	json: async () => terms,
+} );
+
+const postCall = () => apiFetch.mock.calls.find( call => call[ 0 ]?.method === 'POST' )?.[ 0 ];
+
+describe( 'NewslettersQuickEditPanel', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		apiFetch.mockImplementation( ( { path, method } ) => {
+			if ( method === 'POST' ) {
+				return Promise.resolve( {} );
+			}
+			if ( path.startsWith( '/wp/v2/categories' ) ) {
+				return Promise.resolve( makeTermsResponse( CATEGORIES ) );
+			}
+			if ( path.startsWith( '/wp/v2/tags' ) ) {
+				return Promise.resolve( makeTermsResponse( TAGS ) );
+			}
+			return Promise.resolve( makeTermsResponse( [] ) );
+		} );
+	} );
+
+	// The regression this guards: with the term embed skipped, an untouched
+	// taxonomy was posted as `[]` and stripped every term from the post.
+	it( 'does not send categories or tags when only visibility changed', async () => {
+		const item = { id: 42, title: { raw: 'Friday Five' }, meta: { is_public: false }, categories: [ 5 ], tags: [ 7 ] };
+		render( <NewslettersQuickEditPanel item={ item } onClose={ jest.fn() } onSaved={ jest.fn() } /> );
+
+		await waitFor( () => expect( screen.getByText( 'News' ) ).toBeInTheDocument() );
+
+		fireEvent.click( screen.getByRole( 'radio', { name: /email and web/i } ) );
+		fireEvent.click( screen.getByTestId( 'panel-save' ) );
+
+		await waitFor( () => expect( postCall() ).toBeTruthy() );
+		expect( postCall().data ).toEqual( { meta: { is_public: true } } );
+	} );
+
+	it( 'seeds the token fields from the raw term IDs when no embed is present', async () => {
+		const item = { id: 42, title: { raw: 'Friday Five' }, meta: {}, categories: [ 5, 6 ], tags: [] };
+		render( <NewslettersQuickEditPanel item={ item } onClose={ jest.fn() } onSaved={ jest.fn() } /> );
+
+		await waitFor( () => expect( screen.getByText( 'News' ) ).toBeInTheDocument() );
+		expect( screen.getByText( 'Sport' ) ).toBeInTheDocument();
+		expect( screen.getByTestId( 'panel-dirty' ) ).toHaveTextContent( 'false' );
+	} );
+} );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/use-newsletters-data.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/newsletters-list/use-newsletters-data.js
@@ -1,15 +1,18 @@
 import { __ } from '@wordpress/i18n';
 
 import useCollectionData from '../../hooks/use-collection-data';
+import { isFetchAllPerPage } from '../../utils/per-page';
 import { buildQueryParams, toQueryString } from './build-query';
 
 const POSTS_PATH = '/wp/v2/newspack_nl_cpt';
-const TRASH_COUNT_PATH = `${ POSTS_PATH }?status=trash&per_page=1&context=edit`;
+// Only the `X-WP-Total` header is read, so skip rendering the item body.
+const TRASH_COUNT_PATH = `${ POSTS_PATH }?status=trash&per_page=1&context=edit&_fields=id`;
 
 export default function useNewslettersData( view ) {
 	return useCollectionData( {
 		path: `${ POSTS_PATH }${ toQueryString( buildQueryParams( view ) ) }`,
 		trashCountPath: TRASH_COUNT_PATH,
+		fetchAll: isFetchAllPerPage( view?.perPage ),
 		errorMessage: __( 'Failed to load newsletters. Please refresh the page.', 'newspack-newsletters' ),
 		errorNoticeId: 'newspack-newsletters-list-fetch-error',
 	} );

--- a/plugins/newspack-newsletters/src/admin-shell/style.scss
+++ b/plugins/newspack-newsletters/src/admin-shell/style.scss
@@ -187,6 +187,59 @@ body.newspack-newsletters-admin-screen--bundled {
 	}
 }
 
+// Centered over the admin content while an "All" fetch walks the
+// collection (portalled to body — inside the DataViews tree every
+// ancestor stack is a positioning context, which would pin it to the
+// actions row). `left` is set inline from #wpbody's box. The delayed
+// fade keeps fast walks from flashing the overlay in and out.
+.newspack-newsletters-fetch-all-progress {
+	animation: newspack-newsletters-fetch-all-progress-in 150ms ease-in-out 300ms both;
+	left: 50%;
+	pointer-events: none;
+	position: fixed;
+	top: 50%;
+	transform: translate(-50%, -50%);
+	z-index: 10;
+
+	.components-spinner {
+		margin: 0;
+	}
+}
+
+@keyframes newspack-newsletters-fetch-all-progress-in {
+	from {
+		opacity: 0;
+	}
+
+	to {
+		opacity: 1;
+	}
+}
+
+
+body.newspack-newsletters-admin-screen .dataviews-view-table a:not(.newspack-newsletters-list__title) {
+	color: var(--wp-admin-theme-color);
+
+	&:focus,
+	&:hover {
+		color: var(--wp-admin-theme-color-darker-20);
+	}
+}
+
+// The funnel toggle is permanently disabled once a primary filter pins
+// the filter row open (core can't hide the row anymore) — drop it.
+body.newspack-newsletters-admin-screen .dataviews-filters__visibility-toggle:disabled,
+body.newspack-newsletters-admin-screen .dataviews-filters__visibility-toggle[aria-disabled="true"] {
+	display: none;
+}
+
+// Muted item count portalled next to the breadcrumbs page title.
+.newspack-newsletters-header-count {
+	color: wp-colors.$gray-700;
+	font-weight: wp-vars.$font-weight-regular;
+	white-space: pre;
+}
+
 .newspack-newsletters-list {
 	&__author,
 	&__status,

--- a/plugins/newspack-newsletters/src/admin-shell/utils/build-query.js
+++ b/plugins/newspack-newsletters/src/admin-shell/utils/build-query.js
@@ -1,3 +1,5 @@
+import { FETCH_ALL_CHUNK_SIZE, isFetchAllPerPage } from './per-page';
+
 function asArray( value ) {
 	if ( Array.isArray( value ) ) {
 		return value;
@@ -15,7 +17,7 @@ function asArray( value ) {
  * @param {Object}                                    options                      Screen-specific bindings.
  * @param {Object}                                    [options.fieldToQueryParam]  Map of non-status filter fields → REST query params.
  * @param {Object}                                    [options.sortFieldToOrderby] Map of view.sort.field → REST `orderby`. When omitted, sort is pass-through.
- * @param {number}                                    [options.defaultPerPage]     Default `per_page` when `view.perPage` is missing. Defaults to 25.
+ * @param {number}                                    [options.defaultPerPage]     Default `per_page` when `view.perPage` is missing. Defaults to 20.
  * @param {string}                                    [options.defaultStatuses]    Comma-joined statuses to use when no status filter is active.
  * @param {string}                                    [options.statusFilterParam]  REST param to receive status-filter values. When omitted, `status` is used.
  * @param {string}                                    [options.defaultStatusParam] REST param to receive `defaultStatuses`. Defaults to `'status'`.
@@ -28,7 +30,7 @@ export function buildQueryParams( view = {}, options = {} ) {
 	const {
 		fieldToQueryParam = {},
 		sortFieldToOrderby = null,
-		defaultPerPage = 25,
+		defaultPerPage = 20,
 		defaultStatuses = null,
 		statusFilterParam = null,
 		defaultStatusParam = 'status',
@@ -37,13 +39,19 @@ export function buildQueryParams( view = {}, options = {} ) {
 		arrayParams = [],
 	} = options;
 
+	// "All" walks the collection in max-size chunks starting at page 1;
+	// `use-collection-data` follows `X-WP-TotalPages` for the rest.
+	const fetchAll = isFetchAllPerPage( view.perPage );
+
 	const params = {
-		per_page: view.perPage || defaultPerPage,
+		per_page: fetchAll ? FETCH_ALL_CHUNK_SIZE : view.perPage || defaultPerPage,
 		context: 'edit',
 		...extraParams,
 	};
 
-	if ( supportsOffset && typeof view.offset === 'number' ) {
+	if ( fetchAll ) {
+		params.page = 1;
+	} else if ( supportsOffset && typeof view.offset === 'number' ) {
 		params.offset = view.offset;
 	} else {
 		params.page = view.page || 1;

--- a/plugins/newspack-newsletters/src/admin-shell/utils/per-page.js
+++ b/plugins/newspack-newsletters/src/admin-shell/utils/per-page.js
@@ -1,0 +1,18 @@
+/**
+ * Items-per-page constants shared by the DataView list screens.
+ *
+ * `PER_PAGE_ALL` is a client-side sentinel — the REST API caps
+ * `per_page` at 100, so "All" fetches `FETCH_ALL_CHUNK_SIZE` at a time
+ * and concatenates (see `use-collection-data.js`).
+ */
+
+export const PER_PAGE_ALL = -1;
+
+export const FETCH_ALL_CHUNK_SIZE = 100;
+
+// DataViews' stock `perPageSizes` plus "All".
+export const DEFAULT_PER_PAGE_OPTIONS = [ 10, 20, 50, 100, PER_PAGE_ALL ];
+
+export const isFetchAllPerPage = value => value === PER_PAGE_ALL;
+
+export const isValidPerPage = value => Number.isInteger( value ) && ( value === PER_PAGE_ALL || ( value >= 1 && value <= FETCH_ALL_CHUNK_SIZE ) );

--- a/plugins/newspack-newsletters/src/admin-shell/utils/per-page.js
+++ b/plugins/newspack-newsletters/src/admin-shell/utils/per-page.js
@@ -8,6 +8,8 @@
 
 export const PER_PAGE_ALL = -1;
 
+// Mirrors `Admin_Shell_Preferences::PER_PAGE_MAX` (the REST cap the
+// server validates stored preferences against) — change both together.
 export const FETCH_ALL_CHUNK_SIZE = 100;
 
 // Caps the "All" walk so a very large site can't lock the tab with an

--- a/plugins/newspack-newsletters/src/admin-shell/utils/per-page.js
+++ b/plugins/newspack-newsletters/src/admin-shell/utils/per-page.js
@@ -10,6 +10,10 @@ export const PER_PAGE_ALL = -1;
 
 export const FETCH_ALL_CHUNK_SIZE = 100;
 
+// Caps the "All" walk so a very large site can't lock the tab with an
+// unvirtualised table.
+export const FETCH_ALL_MAX_ITEMS = 10000;
+
 // DataViews' stock `perPageSizes` plus "All".
 export const DEFAULT_PER_PAGE_OPTIONS = [ 10, 20, 50, 100, PER_PAGE_ALL ];
 

--- a/plugins/newspack-newsletters/src/admin-shell/utils/terms.js
+++ b/plugins/newspack-newsletters/src/admin-shell/utils/terms.js
@@ -56,12 +56,16 @@ export const initialSelectionsForTaxonomy = ( item, taxonomy ) =>
 		.map( term => ( { id: term?.id, name: term?.name } ) )
 		.filter( s => typeof s.id === 'number' && s.name );
 
-// Unresolvable IDs drop out — names only exist in the fetched options.
 export const selectionsFromIds = ( ids, options ) =>
 	( Array.isArray( ids ) ? ids : [] )
 		.map( id => ( Array.isArray( options ) ? options : [] ).find( option => option?.id === id ) )
 		.filter( option => option && option.name )
 		.map( option => ( { id: option.id, name: option.name } ) );
+
+export const unresolvedIds = ( ids, selections ) => {
+	const resolved = new Set( selections.map( selection => selection.id ) );
+	return ( Array.isArray( ids ) ? ids : [] ).filter( id => typeof id === 'number' && ! resolved.has( id ) );
+};
 
 export const sortedIdsEqual = ( a, b ) => {
 	if ( a.length !== b.length ) {

--- a/plugins/newspack-newsletters/src/admin-shell/utils/terms.js
+++ b/plugins/newspack-newsletters/src/admin-shell/utils/terms.js
@@ -56,6 +56,13 @@ export const initialSelectionsForTaxonomy = ( item, taxonomy ) =>
 		.map( term => ( { id: term?.id, name: term?.name } ) )
 		.filter( s => typeof s.id === 'number' && s.name );
 
+// Unresolvable IDs drop out — names only exist in the fetched options.
+export const selectionsFromIds = ( ids, options ) =>
+	( Array.isArray( ids ) ? ids : [] )
+		.map( id => ( Array.isArray( options ) ? options : [] ).find( option => option?.id === id ) )
+		.filter( option => option && option.name )
+		.map( option => ( { id: option.id, name: option.name } ) );
+
 export const sortedIdsEqual = ( a, b ) => {
 	if ( a.length !== b.length ) {
 		return false;

--- a/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Class Test Admin Shell Preferences
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack\Newsletters\Admin\Admin_Shell_Preferences;
+
+/**
+ * Tests for the per-user admin-shell view preferences REST surface.
+ */
+class Admin_Shell_Preferences_Test extends WP_UnitTestCase {
+	/**
+	 * Editor user — has `edit_posts`, matching the list screens' gate.
+	 *
+	 * @var int
+	 */
+	private $editor_id;
+
+	/**
+	 * Set up REST server and an authenticated editor.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->editor_id = self::factory()->user->create( [ 'role' => 'editor' ] );
+		wp_set_current_user( $this->editor_id );
+
+		global $wp_rest_server;
+		$wp_rest_server = new \WP_REST_Server();
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Reset REST server.
+	 */
+	public function tear_down() {
+		global $wp_rest_server;
+		$wp_rest_server = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Build a preferences update request.
+	 *
+	 * @param string $screen Screen key.
+	 * @param mixed  $prefs  Prefs payload.
+	 * @return WP_REST_Request
+	 */
+	private function make_request( $screen, $prefs ) {
+		$request = new WP_REST_Request( 'POST', '/newspack-newsletters/v1/admin-shell/preferences' );
+		$request->set_body_params(
+			[
+				'screen' => $screen,
+				'prefs'  => $prefs,
+			]
+		);
+		return $request;
+	}
+
+	/**
+	 * A valid per-page save round-trips into user meta and the
+	 * bootstrap getter.
+	 */
+	public function test_saves_per_page_for_allowlisted_screen() {
+		$response = rest_do_request( $this->make_request( 'newsletters-list', [ 'perPage' => 50 ] ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$this->assertSame(
+			[ 'newsletters-list' => [ 'perPage' => 50 ] ],
+			Admin_Shell_Preferences::get_preferences()
+		);
+	}
+
+	/**
+	 * The All sentinel (-1) is storable.
+	 */
+	public function test_saves_all_sentinel() {
+		$response = rest_do_request( $this->make_request( 'ads-list', [ 'perPage' => Admin_Shell_Preferences::PER_PAGE_ALL ] ) );
+
+		$this->assertSame( 200, $response->get_status() );
+		$prefs = Admin_Shell_Preferences::get_preferences();
+		$this->assertSame( Admin_Shell_Preferences::PER_PAGE_ALL, $prefs['ads-list']['perPage'] );
+	}
+
+	/**
+	 * Saves are per-screen — a second screen's save doesn't clobber the
+	 * first.
+	 */
+	public function test_saves_are_scoped_per_screen() {
+		rest_do_request( $this->make_request( 'newsletters-list', [ 'perPage' => 50 ] ) );
+		rest_do_request( $this->make_request( 'layouts-list', [ 'perPage' => 96 ] ) );
+
+		$prefs = Admin_Shell_Preferences::get_preferences();
+		$this->assertSame( 50, $prefs['newsletters-list']['perPage'] );
+		$this->assertSame( 96, $prefs['layouts-list']['perPage'] );
+	}
+
+	/**
+	 * Screens outside the allowlist are rejected by the enum arg.
+	 */
+	public function test_rejects_unknown_screen() {
+		$response = rest_do_request( $this->make_request( 'evil-screen', [ 'perPage' => 50 ] ) );
+		$this->assertSame( 400, $response->get_status() );
+	}
+
+	/**
+	 * Out-of-range and non-numeric per-page values are rejected.
+	 */
+	public function test_rejects_invalid_per_page_values() {
+		foreach ( [ 0, -2, 101, 'lots' ] as $invalid ) {
+			$response = rest_do_request( $this->make_request( 'newsletters-list', [ 'perPage' => $invalid ] ) );
+			$this->assertSame( 400, $response->get_status(), 'Expected rejection for: ' . var_export( $invalid, true ) ); // phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_var_export
+		}
+		$this->assertSame( [], Admin_Shell_Preferences::get_preferences() );
+	}
+
+	/**
+	 * Users without `edit_posts` cannot write preferences.
+	 */
+	public function test_requires_edit_posts() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+
+		$response = rest_do_request( $this->make_request( 'newsletters-list', [ 'perPage' => 50 ] ) );
+		$this->assertSame( 403, $response->get_status() );
+	}
+
+	/**
+	 * Corrupted stored meta is filtered out on read rather than
+	 * shipped to the client.
+	 */
+	public function test_get_preferences_sanitizes_stored_meta() {
+		update_user_meta(
+			$this->editor_id,
+			Admin_Shell_Preferences::USER_META_KEY,
+			[
+				'newsletters-list' => [ 'perPage' => 25 ],
+				'evil-screen'      => [ 'perPage' => 25 ],
+				'ads-list'         => [ 'perPage' => 9999 ],
+				'layouts-list'     => 'not-an-array',
+			]
+		);
+
+		$this->assertSame(
+			[ 'newsletters-list' => [ 'perPage' => 25 ] ],
+			Admin_Shell_Preferences::get_preferences()
+		);
+	}
+}

--- a/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
+++ b/plugins/newspack-newsletters/tests/test-admin-shell-preferences.php
@@ -131,20 +131,33 @@ class Admin_Shell_Preferences_Test extends WP_UnitTestCase {
 	 * shipped to the client.
 	 */
 	public function test_get_preferences_sanitizes_stored_meta() {
-		update_user_meta(
-			$this->editor_id,
-			Admin_Shell_Preferences::USER_META_KEY,
-			[
-				'newsletters-list' => [ 'perPage' => 25 ],
-				'evil-screen'      => [ 'perPage' => 25 ],
-				'ads-list'         => [ 'perPage' => 9999 ],
-				'layouts-list'     => 'not-an-array',
-			]
-		);
+		update_user_meta( $this->editor_id, Admin_Shell_Preferences::get_user_meta_key( 'newsletters-list' ), [ 'perPage' => 25 ] );
+		update_user_meta( $this->editor_id, Admin_Shell_Preferences::get_user_meta_key( 'ads-list' ), [ 'perPage' => 9999 ] );
+		update_user_meta( $this->editor_id, Admin_Shell_Preferences::get_user_meta_key( 'layouts-list' ), 'not-an-array' );
 
 		$this->assertSame(
 			[ 'newsletters-list' => [ 'perPage' => 25 ] ],
 			Admin_Shell_Preferences::get_preferences()
 		);
+	}
+
+	/**
+	 * Each screen is stored under its own user-meta key, so a save for
+	 * one screen never reads or rewrites another's — the fix for the
+	 * shared-array race where concurrent saves from different screens
+	 * could clobber one another.
+	 */
+	public function test_save_does_not_touch_other_screens_meta_key() {
+		update_user_meta( $this->editor_id, Admin_Shell_Preferences::get_user_meta_key( 'ads-list' ), [ 'perPage' => 20 ] );
+
+		rest_do_request( $this->make_request( 'newsletters-list', [ 'perPage' => 50 ] ) );
+
+		$this->assertSame(
+			[ 'perPage' => 20 ],
+			get_user_meta( $this->editor_id, Admin_Shell_Preferences::get_user_meta_key( 'ads-list' ), true )
+		);
+		$prefs = Admin_Shell_Preferences::get_preferences();
+		$this->assertSame( 50, $prefs['newsletters-list']['perPage'] );
+		$this->assertSame( 20, $prefs['ads-list']['perPage'] );
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Addresses the four regressions Dan at Outlier Media reported against the new Newsletters admin screen.

**Items per page, persisted.** The per-page control now offers 10 / 20 / 50 / 100 / **All**, and the choice is saved per user (user meta, via a new `admin-shell/preferences` REST endpoint) so it survives page loads and sessions. "All" walks the REST collection in batches of 100 behind a progress overlay ("Loading 40 of 112…"), so a publisher can keep the whole archive on screen and use the browser's find-in-page. The control lives inside the View options popover next to the other display settings, since the bundled DataViews control cannot represent an "All" option. Default page size drops from 25 to 20. Applies to all four admin-shell screens (newsletters, ads, advertisers, layouts).

**Load times.** Every list request now sends an explicit `_fields` allowlist, so the REST response no longer carries `content.rendered` and `excerpt.rendered`. Those are the expensive part: rendering post content server-side triggers synchronous, uncached oEmbed fetches, which is what turned a 100-item page into a 60–120 second wait. On the newsletters list specifically, term embeds are also now requested only when a taxonomy column is actually showing. The ads list keeps its embed unconditionally: its Quick Edit hydrates advertiser and placement from the embedded terms alone and sends both taxonomies on every save, so dropping the embed there would clear them. Locally (100 rows of near-empty drafts, so a best case for the old code) this takes the newsletters list from ~3.0s / 873KB to ~1.1s / 586KB; on real content with embeds the difference is far larger.

**Status filters.** All filters (Status, Send list, Author, Categories, Tags, Public page) are now pinned as primary chips, so filtering by status is a single click instead of three.

**View links.** The Visibility column renders a real link to the public newsletter page when one exists, so viewing a newsletter is one click again. The action stays in the menu as well.

**Along the way:** the admin header shows the current result count on all four list screens ("All Newsletters (112)", following filters and search, hidden when the list is empty), Trash is no longer an inline row action on newsletters or ads, table links pick up the admin theme colour, and the permanently-disabled filter funnel icon is hidden.

Closes DSGNEWS-200.

### How to test the changes in this Pull Request:

1. Go to **Newsletters → All Newsletters**. Confirm the list loads and the header reads "All Newsletters (N)" with N matching the total.
2. Open **View options** (the settings icon above the table). Confirm the items-per-page control sits inside the popover with options 10 / 20 / 50 / 100 / All, and that 20 is selected on a fresh install.
3. Switch to 50, then reload the page. The list should come back at 50 — the preference persists per user. Log in as a second user and confirm they still see their own setting, not yours.
4. On a site with 100+ newsletters, choose **All**. A centred overlay should fade in reading "Loading X of Y…", then the full list appears in one page with pagination showing a single page. Use the browser's find-in-page to confirm every newsletter is in the DOM.
5. With a small number of newsletters (a fast fetch), choose **All** again — the overlay should not flash on screen, as it only appears after a 300ms delay.
6. Repeat steps 2–4 on **Ads**, **Advertisers** and **Layouts**. Layouts defaults to 24 with options 12 / 24 / 48 / 96 / All; note that in All mode its prebuilt layouts are still appended to the saved ones.
7. Open DevTools → Network and compare the `newspack-newsletters/v1/newsletters` request before and after this branch. Confirm the response no longer contains `content` or `excerpt`, and that it is meaningfully smaller and faster.
8. Hide the Categories and Tags columns via View options, then reload. Confirm the request drops `wp:term` from `_embed` (author stays). Show a taxonomy column again and confirm `wp:term` returns and the category/tag cells still render correctly.
9. Confirm the filter chips (Status, Send list, Author, Categories, Tags, Public page) are all visible above the table by default, that clicking one filters immediately, and that there is no "Add filter" button or greyed-out funnel icon left over.
10. Find a published newsletter with a public page enabled. In the **Visibility** column, confirm the value is a link that opens the public page in a new tab, and that clicking it does not also select the row or open the editor. Confirm drafts and non-public newsletters show plain text instead.
11. Open a newsletter's row actions menu. Confirm Trash is there but is no longer an inline button in the row, and that Quick Edit still is. Same on the Ads screen.
12. Confirm the header count appears on Ads, Advertisers and Layouts too, and that it disappears entirely when a list (or a filtered/searched result) is empty.
13. Try to break the preferences endpoint: as a subscriber-level user, `POST` to `newspack-newsletters/v1/admin-shell/preferences` and confirm it is rejected; as an editor, post an invalid screen name or a per-page value like `0`, `500` or `"abc"` and confirm it is rejected without corrupting the stored preference.
14. Because the list no longer embeds terms by default, check Quick Edit carefully: open it on a newsletter that has categories and tags, with those columns hidden. The Categories and Tags fields must show the newsletter's real terms. Change only the visibility radio, save, and confirm the categories and tags are still intact afterwards. Then change a category, save, and confirm only that changed.
15. Run the tests: `pnpm --filter newspack-newsletters run test` (27 suites / 242 tests) and `n test-php` from `plugins/newspack-newsletters` (518 tests).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

**Worth a close look:** dropping the term embed initially left Quick Edit seeding empty Categories/Tags fields, so saving a visibility change would have stripped every term from the newsletter. Quick Edit now hydrates from the post's raw term IDs and only sends a taxonomy the user actually touched (step 14 covers this). "All" also has a 10,000-item ceiling with a notice, keeps pages that succeeded when a sibling request fails, and reports the count it actually loaded rather than the server's total.

