### PR TITLE
style(build): fix prettier formatting in webpack.config.js

### DIFF
--- a/plugins/newspack-plugin/webpack.config.js
+++ b/plugins/newspack-plugin/webpack.config.js
@@ -98,9 +98,7 @@ webpackConfig.output.chunkFilename = '[name].[contenthash].js';
 // otherwise keep a bare, unversioned name and get served stale by CDNs/proxies
 // after a deploy (they're loaded by webpack's runtime, not wp_enqueue_style, so
 // they never pick up a ?ver). Hashing matches the JS chunks' cache-busting.
-const miniCssExtractPlugin = webpackConfig.plugins.find(
-	plugin => plugin.constructor && plugin.constructor.name === 'MiniCssExtractPlugin'
-);
+const miniCssExtractPlugin = webpackConfig.plugins.find( plugin => plugin.constructor && plugin.constructor.name === 'MiniCssExtractPlugin' );
 if ( miniCssExtractPlugin && miniCssExtractPlugin.options ) {
 	miniCssExtractPlugin.options.chunkFilename = '[name].[contenthash].css';
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Formatting-only fix: joins the wrapped `miniCssExtractPlugin` lookup in `plugins/newspack-plugin/webpack.config.js` (added in #420) back onto a single line, as required by the shared wp-prettier config (`printWidth: 150`). No functional change.

Why it matters: the plugin's `lint:js` script only globs `**/{src,includes,packages}/**/*.{js,jsx,ts,tsx}`, so CI never lints this plugin-root file and the violation went unnoticed — but the workspace-root `.lintstagedrc.json` matches bare `*.{js,jsx,ts,tsx}`, so the local pre-commit hook fails for anyone who stages any change to `webpack.config.js` (even an unrelated one-liner), forcing `git commit --no-verify`. Whether plugin-root config files should be added to the `lint:js` glob so CI catches this class of drift is deliberately left out of scope as a separate discussion.

### How to test the changes in this Pull Request:

1. On `main`, run `node_modules/.bin/eslint --no-ignore plugins/newspack-plugin/webpack.config.js` from the workspace root — it reports a `prettier/prettier` error at line 101. On this branch, the same command exits clean with no problems.
2. Stage any trivial change to `plugins/newspack-plugin/webpack.config.js` and run `git commit` — on `main` the pre-commit hook (lint-staged → `bin/precommit-eslint.sh`) blocks the commit with that same error; on this branch it passes. (Discard the trivial change afterwards.)
3. Confirm the change is formatting-only: `git diff main -- plugins/newspack-plugin/webpack.config.js` shows the three wrapped lines joined into one, with no token changes — so the built output is unaffected (CI's Build ZIP job exercises this config).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
