### PR TITLE
feat(env): report seeded asset age and add --rebuild to env up

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -277,8 +277,15 @@ n env create <name> [options]  # Create environment config
                                #   so other envs keep the base checkout.
   --domain <domain>            #   Custom domain (default: <name>.test)
   --up                         #   Start the environment immediately after creation
-n env up <name> [--build]      # Start environment (creates DB, installs WP, sets up SSL)
-n env up --all [--build]       # Start all existing environments at once
+n env up <name> [options]      # Start environment (creates DB, installs WP, sets up SSL)
+  --build                      #   Seed built assets (node_modules/vendor/dist/build) from the
+                               #   main checkout into the env's worktrees. Prints each repo's
+                               #   asset build date and warns prominently when the assets
+                               #   predate the worktree's source (stale compiled JS/CSS).
+  --rebuild                    #   Implies --build; after seeding, rebuilds stale monorepo
+                               #   worktree JS from the worktree's own source on the HOST via
+                               #   corepack pnpm (env worktrees cannot be built in-container).
+n env up --all [options]       # Start all existing environments at once
 n env down <name>              # Stop environment
 n env destroy <name>           # Remove environment, DB, worktrees, and files
 n env list                     # List environments with status, URLs, and worktrees

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -282,6 +282,9 @@ n env up <name> [options]      # Start environment (creates DB, installs WP, set
                                #   main checkout into the env's worktrees. Prints each repo's
                                #   asset build date and warns prominently when the assets
                                #   predate the worktree's source (stale compiled JS/CSS).
+                               #   Safe to re-run: existing node_modules/vendor are kept, and
+                               #   dist/build refresh only when the main checkout's copy is
+                               #   newer (a worktree's own fresher build survives).
   --rebuild                    #   Implies --build; after seeding, rebuilds stale monorepo
                                #   worktree JS from the worktree's own source on the HOST via
                                #   corepack pnpm (env worktrees cannot be built in-container).

--- a/README.md
+++ b/README.md
@@ -288,7 +288,8 @@ n worktree remove <plugin> <branch> # Remove a worktree
 ```BASH
 n env create <name> --worktree <repo>:<branch> [--worktree ...] [--port <port>]
 n env up <name> [--build]           # Start the environment (--build seeds built assets
-                                    #   from the main checkout and warns when they're stale)
+                                    #   from the main checkout and warns when they're stale;
+                                    #   re-runs only refresh dist/build when main's is newer)
 n env up <name> --rebuild           # --build + rebuild stale worktree JS on the host
 n env down <name>                   # Stop the environment
 n env destroy <name>                # Stop and remove the environment

--- a/README.md
+++ b/README.md
@@ -267,7 +267,8 @@ n worktree add newspack-plugin fix/my-feature
 # 2. Create an environment pointing to that worktree
 n env create my-feature --worktree newspack-plugin:fix/my-feature
 
-# 3. Start it (--build installs deps and compiles assets)
+# 3. Start it (--build seeds deps and built assets from the main checkout,
+#    warning if they're stale; --rebuild also rebuilds stale JS on the host)
 n env up my-feature --build
 
 # 4. Visit http://localhost:8081 — this site uses the worktree branch
@@ -286,7 +287,9 @@ n worktree remove <plugin> <branch> # Remove a worktree
 
 ```BASH
 n env create <name> --worktree <repo>:<branch> [--worktree ...] [--port <port>]
-n env up <name> [--build]           # Start the environment (--build installs deps)
+n env up <name> [--build]           # Start the environment (--build seeds built assets
+                                    #   from the main checkout and warns when they're stale)
+n env up <name> --rebuild           # --build + rebuild stale worktree JS on the host
 n env down <name>                   # Stop the environment
 n env destroy <name>                # Stop and remove the environment
 n env list                          # List all environments and their status

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -127,6 +127,155 @@ each_worktree_in_env() {
     done < <(grep -E '^[[:space:]]*-[[:space:]]+\./worktrees(-repos)?/[^[:space:]:]+:/newspack-(repos|plugins|themes)/[^[:space:]:]+' "$file" 2>/dev/null)
 }
 
+# Newest file mtime (epoch seconds) across the given directories, skipping
+# ones that don't exist. Prints nothing when no files are found. BSD and GNU
+# stat disagree on the mtime flag, so probe which flavor is available.
+newest_mtime_in() {
+    local d dirs=()
+    for d in "$@"; do
+        [[ -d "$d" ]] && dirs+=("$d")
+    done
+    [[ ${#dirs[@]} -eq 0 ]] && return 0
+    if stat -f %m . >/dev/null 2>&1; then
+        find "${dirs[@]}" -type f -exec stat -f %m {} + 2>/dev/null | sort -rn | head -1
+    else
+        find "${dirs[@]}" -type f -exec stat -c %Y {} + 2>/dev/null | sort -rn | head -1
+    fi
+}
+
+# Format an epoch timestamp as YYYY-MM-DD (BSD date -r vs GNU date -d).
+epoch_to_date() {
+    date -r "$1" +%Y-%m-%d 2>/dev/null || date -d "@$1" +%Y-%m-%d
+}
+
+# Seed built assets (node_modules, vendor, dist, build) from the main
+# checkout's copy of each worktree-mounted repo into the env's worktrees
+# (`n env up --build`). The copy preserves mtimes, so the seeded dist/build
+# are exactly as old as the main checkout's last build — which may be much
+# older than the worktree's source. Every copy reports that build date, and
+# a prominent warning fires when the assets predate the worktree's last
+# source commit (the env would serve outdated compiled JS/CSS over current
+# PHP — easy to misdiagnose as a branch-sync problem).
+#
+# When $3 (auto_rebuild) is true, stale monorepo worktrees are rebuilt from
+# their own source after seeding. The rebuild MUST run on the host — env
+# worktrees can't be built in-container — and goes through corepack pnpm,
+# filtered by workspace PATH (package.json names don't match repo dir names,
+# e.g. newspack-plugin's package is named "newspack").
+seed_worktree_assets() {
+    local compose_file="$1"
+    local env_name="$2"
+    local auto_rebuild="$3"
+    local now_ts line wt_path container_path repo repo_host_path src dst wt_root
+    local built_ts age_days age_label src_ts dir entry rel_path
+    local stale_mono=()
+    now_ts=$(date +%s)
+    # Anchored regex (matching each_worktree_in_env / get_target_container
+    # in n) so commented-out volume lines don't false-match and trigger
+    # spurious copies.
+    while read -r line; do
+        # Parse volume line: "- ./worktrees[-repos]/…:/newspack-{plugins,themes,repos}/repo"
+        # Strip leading whitespace + dash with the same [[:space:]] class
+        # the grep above uses. `env create` only emits 6-space-indented
+        # mounts, so a tab here arises only from a hand-edited compose
+        # file — this keeps the strip in step with the grep for that case.
+        wt_path=$(echo "$line" | sed -E 's/^[[:space:]]*-[[:space:]]*//' | cut -d: -f1)
+        container_path=$(echo "$line" | cut -d: -f2)
+        repo=$(basename "$container_path")
+        # Resolve the source: monorepo layout first, else the standalone repos/ dir.
+        repo_host_path=$(get_repo_host_path "$repo")
+        [[ -z "$repo_host_path" ]] && repo_host_path=$(get_standalone_repo_host_path "$repo")
+        if [[ -z "$repo_host_path" ]]; then
+            echo "Skipping built assets for $repo (no main-checkout copy to seed from)."
+            continue
+        fi
+        src="$NABSPATH/$repo_host_path"
+        dst="$NABSPATH/${wt_path#./}"
+        # Monorepo mounts nest the repo at <worktree root>/{plugins,themes}/<repo>;
+        # that root is where host-side pnpm runs. When the suffix doesn't strip
+        # (standalone repos/ and legacy mounts), the repo isn't a pnpm workspace
+        # member and can't be rebuilt via --filter.
+        wt_root="${dst%/$repo_host_path}"
+        # The newest mtime among the seeded dist/build IS their build date
+        # (mtimes are preserved by the copy).
+        built_ts=$(newest_mtime_in "$src/dist" "$src/build")
+        if [[ -n "$built_ts" ]]; then
+            age_days=$(( (now_ts - built_ts) / 86400 ))
+            age_label="${age_days} days"
+            [[ "$age_days" -eq 1 ]] && age_label="1 day"
+            echo "Copying built assets for $repo (built $(epoch_to_date "$built_ts"), $age_label ago)..."
+        else
+            echo "Copying built assets for $repo (no dist/build in $repo_host_path)..."
+        fi
+        for dir in node_modules vendor dist build; do
+            if [[ -d "$src/$dir" ]]; then
+                cp -al "$src/$dir" "$dst/$dir" 2>/dev/null || cp -a "$src/$dir" "$dst/$dir"
+            fi
+        done
+        # Stale when the seeded dist/build predate the worktree's last source
+        # commit. Compare against the commit date, not source file mtimes — a
+        # fresh worktree checkout stamps every file with the checkout time,
+        # which would false-flag assets built moments earlier.
+        src_ts=$(git -C "$dst" log -1 --format=%ct -- . 2>/dev/null)
+        if [[ -n "$built_ts" && -n "$src_ts" && "$built_ts" -lt "$src_ts" ]]; then
+            log_warning "Seeded assets for $repo are STALE: built $(epoch_to_date "$built_ts") ($age_label ago), but the worktree's source last changed $(epoch_to_date "$src_ts")."
+            log_warning "This env would serve outdated compiled JS/CSS for $repo."
+            if [[ "$wt_root" != "$dst" ]]; then
+                if [[ "$auto_rebuild" == true ]]; then
+                    echo "  Queued for rebuild from the worktree's own source (--rebuild)."
+                    stale_mono+=("$wt_root|$repo_host_path|$repo")
+                else
+                    echo "  Rebuild on the host:"
+                    echo "    cd $wt_root \\"
+                    echo "      && COREPACK_INTEGRITY_KEYS=0 corepack pnpm install \\"
+                    echo "      && COREPACK_INTEGRITY_KEYS=0 corepack pnpm --filter ./$repo_host_path run build"
+                    echo "  Or re-run with: n env up $env_name --rebuild"
+                fi
+            else
+                echo "  This is a standalone repos/ worktree; rebuild it on the host with that"
+                echo "  repo's own tooling (e.g.: cd $dst && npm ci && npm run build)."
+            fi
+        fi
+    done < <(grep -E '^[[:space:]]*-[[:space:]]+\./worktrees(-repos)?/[^[:space:]:]+:/newspack-(repos|plugins|themes)/[^[:space:]:]+' "$compose_file" 2>/dev/null)
+    [[ "$auto_rebuild" == true ]] || return 0
+    if [[ ${#stale_mono[@]} -eq 0 ]]; then
+        echo "--rebuild: no stale monorepo worktree assets; nothing to rebuild."
+        return 0
+    fi
+    if ! command -v corepack >/dev/null 2>&1; then
+        log_error "--rebuild needs corepack on the host (bundled with Node.js >= 16.9); stale assets were left in place."
+        return 0
+    fi
+    # pnpm install once per worktree root, then rebuild each stale repo,
+    # filtered by workspace path. The seeded dist/build may be hardlinked into
+    # the main checkout, so they're removed first — a rebuild writing through
+    # a shared inode would clobber the main checkout's files.
+    local installed_roots="|"
+    local failed_roots="|"
+    for entry in "${stale_mono[@]}"; do
+        IFS='|' read -r wt_root rel_path repo <<< "$entry"
+        [[ "$failed_roots" == *"|$wt_root|"* ]] && continue
+        if [[ "$installed_roots" != *"|$wt_root|"* ]]; then
+            echo "Installing JS dependencies in ${wt_root#"$NABSPATH"/} (host-side pnpm)..."
+            if (cd "$wt_root" && COREPACK_INTEGRITY_KEYS=0 COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm install); then
+                installed_roots+="$wt_root|"
+            else
+                log_error "pnpm install failed in $wt_root; skipping rebuilds there (assets remain stale)."
+                failed_roots+="$wt_root|"
+                continue
+            fi
+        fi
+        echo "Rebuilding $repo from the worktree's source..."
+        rm -rf "$wt_root/$rel_path/dist" "$wt_root/$rel_path/build"
+        if (cd "$wt_root" && COREPACK_INTEGRITY_KEYS=0 COREPACK_ENABLE_DOWNLOAD_PROMPT=0 corepack pnpm --filter "./$rel_path" run build); then
+            log_success "Rebuilt $repo from worktree source."
+        else
+            log_error "Rebuild failed for $repo. Its stale dist/build were removed before the rebuild; re-run 'n env up $env_name --build' to re-seed, or build manually in $wt_root."
+        fi
+    done
+    return 0
+}
+
 case $1 in
     create)
         env_name="$2"
@@ -363,8 +512,8 @@ YAML
     up)
         env_name="$2"
         if [[ -z "$env_name" ]]; then
-            echo "Usage: n env up <name> [--build]"
-            echo "       n env up --all [--build]"
+            echo "Usage: n env up <name> [--build] [--rebuild]"
+            echo "       n env up --all [--build] [--rebuild]"
             exit 1
         fi
         # --all: start all existing environments.
@@ -394,9 +543,12 @@ YAML
         validate_env_name "$env_name"
         shift 2
         auto_build=false
+        auto_rebuild=false
         while [[ $# -gt 0 ]]; do
             case $1 in
                 --build) auto_build=true; shift ;;
+                # --rebuild implies --build: it acts on the assets the copy seeds.
+                --rebuild) auto_build=true; auto_rebuild=true; shift ;;
                 *) echo "Unknown option: $1"; exit 1 ;;
             esac
         done
@@ -556,32 +708,10 @@ MIGRATE
         # Reload Apache to pick up SSL config (it's running by now).
         docker exec "$container_name" apachectl graceful 2>/dev/null
         echo "Environment '$env_name' is ready at https://${domain}/"
-        # Copy built assets from main repos into worktrees.
+        # Copy built assets from main repos into worktrees, reporting their
+        # build age (and rebuilding stale ones when --rebuild was given).
         if [[ "$auto_build" == true ]]; then
-            # Anchored regex (matching each_worktree_in_env / get_target_container
-            # in n) so commented-out volume lines don't false-match and trigger
-            # spurious copies.
-            grep -E '^[[:space:]]*-[[:space:]]+\./worktrees(-repos)?/[^[:space:]:]+:/newspack-(repos|plugins|themes)/[^[:space:]:]+' "$compose_file" 2>/dev/null | while read -r line; do
-                # Parse volume line: "- ./worktrees[-repos]/…:/newspack-{plugins,themes,repos}/repo"
-                # Strip leading whitespace + dash with the same [[:space:]] class
-                # the grep above uses. `env create` only emits 6-space-indented
-                # mounts, so a tab here arises only from a hand-edited compose
-                # file — this keeps the strip in step with the grep for that case.
-                wt_path=$(echo "$line" | sed -E 's/^[[:space:]]*-[[:space:]]*//' | cut -d: -f1)
-                container_path=$(echo "$line" | cut -d: -f2)
-                repo=$(basename "$container_path")
-                # Resolve the source: monorepo layout first, else the standalone repos/ dir.
-                repo_host_path=$(get_repo_host_path "$repo")
-                [[ -z "$repo_host_path" ]] && repo_host_path=$(get_standalone_repo_host_path "$repo")
-                src="$NABSPATH/$repo_host_path"
-                dst="$NABSPATH/${wt_path#./}"
-                echo "Copying built assets for $repo..."
-                for dir in node_modules vendor dist build; do
-                    if [[ -d "$src/$dir" ]]; then
-                        cp -al "$src/$dir" "$dst/$dir" 2>/dev/null || cp -a "$src/$dir" "$dst/$dir"
-                    fi
-                done
-            done
+            seed_worktree_assets "$compose_file" "$env_name" "$auto_rebuild"
         fi
         ;;
     down)
@@ -818,9 +948,13 @@ MIGRATE
         ;;
     *)
         echo "Usage: n env <create|up|down|destroy|list|cleanup|e2e-setup>"
-        echo "  up <name> [--build]      Start an environment"
-        echo "  up --all [--build]       Start all environments"
-        echo "  cleanup [--all] [--yes]  Remove environments (--all selects everything, --yes skips confirmation)"
-        echo "  e2e-setup <name> [opts]  Build a ready-to-run local e2e-tests environment (see --help)"
+        echo "  up <name> [--build] [--rebuild]  Start an environment"
+        echo "      --build                      Seed built assets (node_modules/vendor/dist/build) from the"
+        echo "                                   main checkout into the env's worktrees, reporting their build"
+        echo "                                   date and warning when they predate the worktree's source"
+        echo "      --rebuild                    Implies --build; also rebuilds stale worktree JS on the host"
+        echo "  up --all [--build] [--rebuild]   Start all environments"
+        echo "  cleanup [--all] [--yes]          Remove environments (--all selects everything, --yes skips confirmation)"
+        echo "  e2e-setup <name> [opts]          Build a ready-to-run local e2e-tests environment (see --help)"
         ;;
 esac

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -157,6 +157,11 @@ epoch_to_date() {
 # source commit (the env would serve outdated compiled JS/CSS over current
 # PHP — easy to misdiagnose as a branch-sync problem).
 #
+# Re-runs are safe: an existing node_modules/vendor is never touched (it may
+# hold the worktree's own installs), and an existing dist/build is refreshed
+# only when the main checkout's copy is newer — a worktree's own fresher
+# build (--rebuild or a manual host build) survives.
+#
 # When $3 (auto_rebuild) is true, stale monorepo worktrees are rebuilt from
 # their own source after seeding. The rebuild MUST run on the host — env
 # worktrees can't be built in-container — and goes through corepack pnpm,
@@ -167,7 +172,7 @@ seed_worktree_assets() {
     local env_name="$2"
     local auto_rebuild="$3"
     local now_ts line wt_path container_path repo repo_host_path src dst wt_root
-    local built_ts age_days age_label src_ts dir entry rel_path
+    local built_ts age_days age_label src_ts dir entry rel_path src_dir_ts dst_dir_ts
     local stale_mono=()
     now_ts=$(date +%s)
     # Anchored regex (matching each_worktree_in_env / get_target_container
@@ -208,14 +213,50 @@ seed_worktree_assets() {
             echo "Copying built assets for $repo (no dist/build in $repo_host_path)..."
         fi
         for dir in node_modules vendor dist build; do
-            if [[ -d "$src/$dir" ]]; then
-                cp -al "$src/$dir" "$dst/$dir" 2>/dev/null || cp -a "$src/$dir" "$dst/$dir"
+            [[ -d "$src/$dir" ]] || continue
+            if [[ -d "$dst/$dir" ]]; then
+                # Re-run: the worktree already has this dir, and a bare cp
+                # into an existing directory would nest a copy inside it
+                # (dst/dist/dist) instead of refreshing it.
+                if [[ "$dir" == node_modules || "$dir" == vendor ]]; then
+                    # Dependency dirs may hold the worktree's own installs
+                    # (host-side pnpm/composer); never clobber them.
+                    echo "  $dir/: kept (seeded only when missing; delete it to re-seed)."
+                    continue
+                fi
+                # dist/build: refresh only when the main checkout's copy is
+                # newer — a worktree may carry its own fresher build
+                # (--rebuild or a manual host build) that a re-run must not
+                # roll back to the main checkout's older one.
+                src_dir_ts=$(newest_mtime_in "$src/$dir")
+                dst_dir_ts=$(newest_mtime_in "$dst/$dir")
+                if [[ -n "$src_dir_ts" && ( -z "$dst_dir_ts" || "$src_dir_ts" -gt "$dst_dir_ts" ) ]]; then
+                    echo "  $dir/: refreshing (the main checkout's copy is newer)."
+                    rm -rf "$dst/$dir"
+                else
+                    echo "  $dir/: kept (the worktree's copy is not older than the main checkout's)."
+                    continue
+                fi
             fi
+            # A failed hardlink copy (e.g. across filesystems) leaves a partial
+            # destination behind; clear it so the plain-copy fallback starts
+            # clean instead of nesting into it.
+            cp -al "$src/$dir" "$dst/$dir" 2>/dev/null \
+                || { rm -rf "$dst/$dir"; cp -a "$src/$dir" "$dst/$dir"; }
         done
-        # Stale when the seeded dist/build predate the worktree's last source
-        # commit. Compare against the commit date, not source file mtimes — a
-        # fresh worktree checkout stamps every file with the checkout time,
-        # which would false-flag assets built moments earlier.
+        # Judge staleness on what the worktree actually ends up with, not on
+        # the main checkout's copy — a kept worktree-local build may be newer
+        # than the assets offered above.
+        built_ts=$(newest_mtime_in "$dst/dist" "$dst/build")
+        if [[ -n "$built_ts" ]]; then
+            age_days=$(( (now_ts - built_ts) / 86400 ))
+            age_label="${age_days} days"
+            [[ "$age_days" -eq 1 ]] && age_label="1 day"
+        fi
+        # Stale when the resulting dist/build predate the worktree's last
+        # source commit. Compare against the commit date, not source file
+        # mtimes — a fresh worktree checkout stamps every file with the
+        # checkout time, which would false-flag assets built moments earlier.
         src_ts=$(git -C "$dst" log -1 --format=%ct -- . 2>/dev/null)
         if [[ -n "$built_ts" && -n "$src_ts" && "$built_ts" -lt "$src_ts" ]]; then
             log_warning "Seeded assets for $repo are STALE: built $(epoch_to_date "$built_ts") ($age_label ago), but the worktree's source last changed $(epoch_to_date "$src_ts")."
@@ -952,6 +993,7 @@ MIGRATE
         echo "      --build                      Seed built assets (node_modules/vendor/dist/build) from the"
         echo "                                   main checkout into the env's worktrees, reporting their build"
         echo "                                   date and warning when they predate the worktree's source"
+        echo "                                   (re-runs refresh dist/build only when the main checkout's is newer)"
         echo "      --rebuild                    Implies --build; also rebuilds stale worktree JS on the host"
         echo "  up --all [--build] [--rebuild]   Start all environments"
         echo "  cleanup [--all] [--yes]          Remove environments (--all selects everything, --yes skips confirmation)"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`n env up --build` seeds `node_modules`/`vendor`/`dist`/`build` from the main checkout into an env's worktrees — silently. When the main checkout's build is older than the worktree's source (e.g. `plugins/newspack-plugin/dist/` last built weeks ago while the worktree branch has newer commits), the isolated env serves a stale compiled admin SPA over current PHP, which is confusing and easy to misdiagnose as a branch-sync problem.

This PR makes seeded-asset age visible and fixable, and makes `--build` re-runs safe:

* Every copy now reports the assets' build date and age, e.g. `Copying built assets for newspack-plugin (built 2026-06-29, 22 days ago)...`. The date is the newest mtime under the source `dist`/`build` (the copy preserves mtimes). BSD/GNU `stat`/`date` differences are handled so it works on macOS and Linux hosts.
* When the seeded `dist`/`build` predate the worktree's last source commit, a prominent `[WARNING] … STALE` block prints both dates plus the exact host-side rebuild recipe (`COREPACK_INTEGRITY_KEYS=0 corepack pnpm install` then a **path-filtered** `pnpm --filter ./plugins/<repo> run build` — package names don't match repo dir names). Staleness compares against the commit date rather than source file mtimes, because a fresh worktree checkout stamps every file with checkout time and would false-flag assets built moments earlier. Standalone `repos/` worktrees get a manual-rebuild note instead, since they aren't pnpm workspace members.
* New opt-in `n env up <name> --rebuild` (implies `--build`): after seeding, rebuilds only the stale monorepo worktrees from their own source on the host (env worktrees can't be built in-container) — one `pnpm install` per worktree root, then a path-filtered build per stale repo. The seeded `dist`/`build` are removed before rebuilding because they may be hardlinked into the main checkout, and a rebuild writing through a shared inode would clobber the main checkout's files. Without the flag, behavior stays warn-only.
* Re-running `n env up <name> --build` on an already-seeded env is now safe and refreshes sensibly. Previously each re-run `cp`'d **into** the existing directories, nesting junk copies (`dist/dist/`, `node_modules/node_modules/`) while never refreshing anything. Now an existing `node_modules`/`vendor` is kept (it may hold the worktree's own host-side installs), and an existing `dist`/`build` is refreshed only when the main checkout's copy is newer — a worktree's own fresher build (from `--rebuild` or a manual host build) survives re-runs instead of being rolled back to main's older one. Each directory reports its outcome (`kept`/`refreshing`). The STALE warning and the `--rebuild` queue now judge the worktree's **resulting** assets rather than the main checkout's copy, so a worktree carrying its own fresh build no longer warns falsely or gets pointlessly rebuilt (previously `--rebuild` would even delete that fresh build first). The cross-filesystem `cp -a` fallback also clears the partial destination a failed hardlink copy leaves behind — that path nested even on first seed.
* Docs updated to match: `n env` help text, `AGENTS.md` env commands, and the `README.md` isolated-environments section (which previously claimed `--build` "compiles assets").

### How to test the changes in this Pull Request:

1. Create an isolated env with a worktree: `n env create staletest --worktree newspack-plugin:<branch>` (don't start it yet).
2. Ensure the seeded assets will be stale: pick a `<branch>` with commits newer than the main checkout's last `plugins/newspack-plugin/dist/` build, or force it by backdating: `find plugins/newspack-plugin/dist -type f -exec touch -t 202606291200 {} +`.
3. Run `n env up staletest --build`: each worktree repo prints `Copying built assets for … (built YYYY-MM-DD, N days ago)...`, followed by a yellow `[WARNING] … STALE` block showing the build date/age, the worktree's last source-change date, the exact `corepack pnpm` recipe, and a pointer to `--rebuild`.
4. Run `n env up staletest --rebuild`: same warning with `Queued for rebuild`, then `Installing JS dependencies in worktrees/<branch> (host-side pnpm)...` and `Rebuilding newspack-plugin from the worktree's source...`. Afterwards the worktree's `dist/` is a fresh build (current mtimes) and the env serves it.
5. Re-run behavior: run `n env up staletest --build` again after step 4 — the worktree's fresh `dist/` is kept (`dist/: kept (the worktree's copy is not older than the main checkout's).`), no STALE warning fires, no nested `dist/dist/` junk appears, and `node_modules`/`vendor` report `kept (seeded only when missing; delete it to re-seed).`. Then rebuild the main checkout (`n build newspack-plugin`) and re-run `--build`: `dist/: refreshing (the main checkout's copy is newer).` and the worktree picks up the newer build.
6. Fresh case: rebuild the main checkout's plugin (`n build newspack-plugin`), remove the worktree's previously seeded `dist/`, then `n env up staletest --build`: the copy line still prints the build date (`0 days ago`) with no warning. With `--rebuild` it prints `--rebuild: no stale monorepo worktree assets; nothing to rebuild.` and never invokes pnpm.
7. Standalone `repos/` worktree (optional): an env mounting a `repos/` checkout worktree with an old `dist` warns with a manual-rebuild note instead of the pnpm recipe.
8. Sanity: `n env` and `n env up` (no args) document `--rebuild`; `n env up staletest --bogus` still fails with `Unknown option`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

There's no shell-test infrastructure in the repo; the seeding function was verified with a 33-assertion fixture harness covering stale/fresh copies, mtime preservation, the `--rebuild` path (stubbed `corepack`: install-once-per-root dedupe, path-filtered build, env vars, pre-rebuild removal of hardlinked assets), standalone `repos/` handling, and flag parsing — plus `bash -n` and a probe against the real workspace reproducing the motivating incident (dist built 2026-06-29 vs source committed 2026-07-21).

The re-run fix was verified the same way with a second, 47-assertion fixture harness: against the pre-fix code it fails 27 assertions (nested copies, never-refreshed assets, false STALE warning, `--rebuild` deleting a fresh worktree-local build, fallback nesting); against the fixed code all 47 pass, with fresh-seed behavior, hardlinking, and stale-worktree `--rebuild` queueing guarded as regressions.

