### PR TITLE
chore(block-theme): declare @rushstack/eslint-patch devDependency

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -635,6 +635,9 @@ importers:
 
   themes/newspack-block-theme:
     devDependencies:
+      '@rushstack/eslint-patch':
+        specifier: ^1.16.1
+        version: 1.16.1
       newspack-components:
         specifier: workspace:*
         version: link:../../packages/components

--- a/themes/newspack-block-theme/package.json
+++ b/themes/newspack-block-theme/package.json
@@ -44,6 +44,7 @@
 		"typescript:check": "newspack-scripts typescript-check"
 	},
 	"devDependencies": {
+		"@rushstack/eslint-patch": "^1.16.1",
 		"newspack-components": "workspace:*",
 		"newspack-scripts": "workspace:*"
 	}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`themes/newspack-block-theme/.eslintrc.js` loads `@rushstack/eslint-patch/modern-module-resolution` on its first line, but the package was never declared in the theme's `package.json` — only `packages/scripts` and `plugins/newspack-multibranded-site` declare it. Under pnpm's strict layout the theme was relying on incidental resolution, and on local installs the module can be missing entirely. When that happens, `pnpm --filter newspack-block-theme run lint:js` crashes with `Cannot find module '@rushstack/eslint-patch/modern-module-resolution'`, and the pre-commit hook (`bin/precommit-eslint.sh`) fails the same way for any staged block-theme JS file, forcing `--no-verify` commits.

This declares `@rushstack/eslint-patch@^1.16.1` in the theme's `devDependencies`, matching the version the workspace already resolves (`1.16.1`) for the other two importers. The lockfile change is only the new importer entry — no package versions change, and no shipped code is affected (dev tooling only, so `chore` avoids triggering a theme release).

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm install` at the workspace root.
2. Run `pnpm --filter newspack-block-theme run lint:js` — it completes with exit 0 instead of crashing with `Cannot find module '@rushstack/eslint-patch/modern-module-resolution'`.
3. Confirm the module resolves from the theme directory: `ls themes/newspack-block-theme/node_modules/@rushstack/eslint-patch` shows the symlink into the virtual store.
4. Optionally, stage any `.js` file under `themes/newspack-block-theme/src/` and run `git commit` — the pre-commit ESLint wrapper loads the theme's ESLint config without the module-resolution crash.
5. Verify the lockfile diff is only the new importer entry for `themes/newspack-block-theme` (`git diff main -- pnpm-lock.yaml`), resolving to the already-present `@rushstack/eslint-patch@1.16.1`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
