### PR TITLE
fix(reader-data): apply newspack_reader_data_max_items filter

### DIFF
--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-data.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-data.php
@@ -294,7 +294,7 @@ final class Reader_Data {
 		 * @param string $value     Value.
 		 */
 		$max_items = apply_filters( 'newspack_reader_data_max_items', self::MAX_ITEMS, $user_id, $key, $value );
-		if ( count( $user_keys ) >= self::MAX_ITEMS ) {
+		if ( count( $user_keys ) >= $max_items ) {
 			return new \WP_Error( 'too_many_items', __( 'Too many items.', 'newspack' ), [ 'status' => 400 ] );
 		}
 

--- a/plugins/newspack-plugin/tests/unit-tests/reader-data-max-items.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-data-max-items.php
@@ -1,0 +1,78 @@
+<?php
+/**
+ * Tests for the max items cap in Reader_Data::update_item().
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Reader_Data;
+
+/**
+ * Tests for the Reader_Data max items cap and its filter.
+ *
+ * @group reader-data-max-items
+ */
+class Newspack_Test_Reader_Data_Max_Items extends WP_UnitTestCase {
+
+	/**
+	 * Filter callback registered during test_filter_can_raise_max_items.
+	 *
+	 * @var callable|null
+	 */
+	private $max_items_filter = null;
+
+	/**
+	 * Tear down after each test.
+	 */
+	public function tear_down() {
+		if ( $this->max_items_filter ) {
+			remove_filter( 'newspack_reader_data_max_items', $this->max_items_filter );
+			$this->max_items_filter = null;
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a user that already has MAX_ITEMS reader data keys.
+	 *
+	 * @return int User ID.
+	 */
+	private function create_user_at_cap() {
+		$user_id = self::factory()->user->create();
+		$keys    = [];
+		for ( $i = 1; $i <= Reader_Data::MAX_ITEMS; $i++ ) {
+			$keys[] = 'key_' . $i;
+		}
+		update_user_meta( $user_id, 'newspack_reader_data_keys', $keys );
+		return $user_id;
+	}
+
+	/**
+	 * Test that a new item beyond the default cap is rejected.
+	 */
+	public function test_default_cap_blocks_new_item() {
+		$user_id = $this->create_user_at_cap();
+
+		$result = Reader_Data::update_item( $user_id, 'beyond_cap', 'value' );
+
+		self::assertWPError( $result, 'Writing a new item beyond the default cap should fail.' );
+		self::assertSame( 'too_many_items', $result->get_error_code() );
+	}
+
+	/**
+	 * Test that the newspack_reader_data_max_items filter can raise the cap.
+	 */
+	public function test_filter_can_raise_max_items() {
+		$user_id = $this->create_user_at_cap();
+
+		$this->max_items_filter = function () {
+			return Reader_Data::MAX_ITEMS + 10;
+		};
+		add_filter( 'newspack_reader_data_max_items', $this->max_items_filter );
+
+		$result = Reader_Data::update_item( $user_id, 'beyond_cap', 'value' );
+
+		self::assertTrue( $result, 'Raising the cap via the filter should allow writing an item beyond MAX_ITEMS.' );
+		self::assertSame( 'value', Reader_Data::get_data( $user_id, 'beyond_cap' ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`Reader_Data::update_item()` documents a `newspack_reader_data_max_items` filter for the per-reader item cap, and applies it into `$max_items` — but the cap check still compared against the `MAX_ITEMS` constant, so the filter has never had any effect. This fixes the check to use the filtered value, so sites can actually adjust the cap via the documented filter.

Behavior without the filter is unchanged: the cap remains `MAX_ITEMS` (100), and no code in the Newspack ecosystem currently hooks this filter.

### How to test the changes in this Pull Request:

1. Run the new tests: `cd plugins/newspack-plugin && n test-php --group reader-data-max-items` — both pass (the default cap still rejects an item beyond 100; raising the cap via the filter allows it).
2. Manually, without the filter: seed a user with 100 reader data keys (`update_user_meta( $user_id, 'newspack_reader_data_keys', $keys )`) and call `Newspack\Reader_Data::update_item( $user_id, 'new_key', 'value' )` — it returns a `too_many_items` `WP_Error`, same as before.
3. Add `add_filter( 'newspack_reader_data_max_items', function() { return 150; } );` and repeat step 2 — the write now succeeds and `Reader_Data::get_data( $user_id, 'new_key' )` returns the value.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)
