### PR TITLE
chore(dev-tooling): gate e2e plugin and fix sniff state leak

### DIFF
--- a/e2e/e2e-plugin.php
+++ b/e2e/e2e-plugin.php
@@ -14,6 +14,24 @@
 
 defined( 'ABSPATH' ) || exit;
 
+/*
+ * Refuse to do anything unless the site was provisioned as an e2e target.
+ *
+ * Everything below is destructive outside a throwaway site: /_email publishes
+ * every captured message — password-reset and magic links included — to
+ * unauthenticated visitors, pre_wp_mail swallows all outgoing mail while
+ * reporting success, and the logout endpoint answers without a nonce. Those are
+ * the behaviours the suite needs, so the safeguard is refusing to run anywhere
+ * else rather than softening them.
+ *
+ * e2e-setup.sh writes this constant to wp-config.php before it installs and
+ * activates this plugin, so a correctly provisioned site always has it and a
+ * stray copy onto any other site is inert.
+ */
+if ( ! defined( 'NEWSPACK_IS_E2E' ) || ! NEWSPACK_IS_E2E ) {
+	return;
+}
+
 // Prevent the admin email confirmation screen
 add_filter( 'admin_email_check_interval', '__return_false' );
 

--- a/phpcsSniffs/Sniffs/Newsletters/ForbiddenContactsMethodsSniff.php
+++ b/phpcsSniffs/Sniffs/Newsletters/ForbiddenContactsMethodsSniff.php
@@ -55,11 +55,28 @@ class ForbiddenContactsMethodsSniff implements Sniff {
 	 */
 	private $current_class = '';
 
+	/**
+	 * Path of the file $current_class was read from, used to detect when PHPCS
+	 * has moved on to the next file.
+	 *
+	 * @var string
+	 */
+	private $current_file = '';
+
 	public function register() {
 		return [ T_CLASS, T_STRING ];
 	}
 
 	public function process( File $phpcs_file, $stack_ptr ) {
+		// PHPCS reuses a single sniff instance for every file in the run, so
+		// $current_class would otherwise carry over. A file that declares no
+		// class of its own would then be judged against the previous file's
+		// class — and silently exempted whenever that class was an allowed one.
+		if ( $phpcs_file->path !== $this->current_file ) {
+			$this->current_file  = $phpcs_file->path;
+			$this->current_class = '';
+		}
+
 		// Service-provider classes legitimately call internal methods.
 		$path_parts = explode( DIRECTORY_SEPARATOR, $phpcs_file->path );
 		$count      = count( $path_parts );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Two small, independent dev-tooling fixes found while reviewing the PHPCS scope work.

**1. `e2e/e2e-plugin.php` now returns early unless `NEWSPACK_IS_E2E` is set.**

The e2e helper plugin is deliberately destructive: `/_email` publishes every captured message (password-reset and magic links included) to unauthenticated visitors, `pre_wp_mail` swallows all outgoing mail while reporting success, and the logout endpoint answers without a nonce. Those behaviours are what the suite needs, but nothing stopped the plugin working if it were ever copied onto a site that is not a throwaway e2e target.

`e2e-setup.sh` already writes `NEWSPACK_IS_E2E` to `wp-config.php` (line 120) before it installs and activates the plugin (lines 132, 150), so every correctly provisioned site has it and this is a no-op there. Verified on the nightly staging target: the constant is set and the plugin is active.

**2. `ForbiddenContactsMethodsSniff` now resets `$current_class` between files.**

PHPCS reuses one sniff instance for a whole run and the property was never reset, so a file with no class declaration of its own was judged against the previous file's class. When that class happened to be an allowed one, the sniff silently reported nothing.

### How to test the changes in this Pull Request:

1. The e2e guard: include `e2e/e2e-plugin.php` with `ABSPATH` defined but without `NEWSPACK_IS_E2E`, and confirm no hooks are registered; define the constant and confirm they are. Then run the e2e suite against a provisioned site and confirm it is unaffected.
2. The sniff: create two files under `plugins/newspack-newsletters/`, the first ending in a `Newspack_Newsletters_Contacts` class declaration, the second containing a bare `Newspack_Newsletters_Subscription::add_contact( [] )` and no class of its own. Run phpcs over the second file alone (flags), then over both in one invocation with `--parallel=1`. Before this change the second run reports nothing; after it, the violation is reported in both.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Both fixes were verified red/green locally. Confirmed the sniff fix surfaces no new violations across `newspack-newsletters` (phpcs exits 0), so it does not turn CI red.

There are no tests for the PHPCS sniffs at all today; adding a harness for them is worth doing separately rather than in this fix.