### PR TITLE
fix(newsletters): map AC listbox fields as multi-value

### DIFF
--- a/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -2475,9 +2475,11 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * but not promoted by default.
 	 *
 	 * Matching function depends on selection cardinality. Per AC's Contact Custom Fields API
-	 * Guide, dropdown / radio / listbox are single-selection types (their stored value is the
-	 * raw chosen option), so 'default' (strict equality) matching is correct. Checkbox and
-	 * multiselect are multi-selection types: AC stores the chosen options with a `||` delimiter
+	 * Guide, dropdown / radio are single-selection types (their stored value is the raw chosen
+	 * option), so 'default' (strict equality) matching is correct. Checkbox, listbox and
+	 * multiselect are multi-selection types — AC's "Checkbox" is a multi-select checkbox group
+	 * (not a boolean toggle) and its "List Box" is a multi-select list, so a contact can hold
+	 * several values for either. AC stores the chosen options with a `||` delimiter
 	 * (e.g. `||Option A||Option C||`), which `default` matching cannot resolve — those types
 	 * use 'list__in', and the consumer's parse_list_value() recognizes the delimiter.
 	 *
@@ -2491,8 +2493,8 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 
 		$type                       = isset( $field['type'] ) ? $field['type'] : 'text';
-		$single_select_enum_types   = [ 'dropdown', 'radio', 'listbox' ];
-		$multi_select_enum_types    = [ 'checkbox', 'multiselect' ];
+		$single_select_enum_types   = [ 'dropdown', 'radio' ];
+		$multi_select_enum_types    = [ 'checkbox', 'listbox', 'multiselect' ];
 		$enumerated_types           = array_merge( $single_select_enum_types, $multi_select_enum_types );
 		$eligible_types             = array_merge( [ 'text', 'textarea', 'date', 'datetime' ], $enumerated_types );
 		$is_promoted_by_default     = in_array( $type, $eligible_types, true );

--- a/plugins/newspack-newsletters/tests/test-active-campaign-integrations-schema.php
+++ b/plugins/newspack-newsletters/tests/test-active-campaign-integrations-schema.php
@@ -46,10 +46,10 @@ class ActiveCampaignIntegrationsSchemaTest extends WP_UnitTestCase {
 	/**
 	 * Single-selection enumerated types use 'default' matching (strict equality
 	 * against the chosen option). Per AC's Contact Custom Fields API Guide:
-	 * dropdown / radio / listbox are single selection.
+	 * dropdown / radio are single selection.
 	 */
 	public function test_single_select_types_use_default_matching() {
-		foreach ( [ 'dropdown', 'radio', 'listbox' ] as $type ) {
+		foreach ( [ 'dropdown', 'radio' ] as $type ) {
 			$mapped = $this->map_field(
 				[
 					'perstag' => 'X',
@@ -64,9 +64,13 @@ class ActiveCampaignIntegrationsSchemaTest extends WP_UnitTestCase {
 	 * Multi-selection enumerated types use 'list__in'. AC stores their value
 	 * with `||` delimiters; the consumer's parse_list_value() recognizes that
 	 * format. Strict equality cannot match `||A||B||` against `'A'`.
+	 *
+	 * AC's "Checkbox" type is a multi-select checkbox group (not a boolean
+	 * toggle) and its "List Box" is a multi-select list — per AC's docs a
+	 * contact can hold several ||-delimited values for either.
 	 */
 	public function test_multi_select_types_use_list_in_matching() {
-		foreach ( [ 'checkbox', 'multiselect' ] as $type ) {
+		foreach ( [ 'checkbox', 'listbox', 'multiselect' ] as $type ) {
 			$mapped = $this->map_field(
 				[
 					'perstag' => 'X',
@@ -89,7 +93,7 @@ class ActiveCampaignIntegrationsSchemaTest extends WP_UnitTestCase {
 			'hidden'      => 'string',
 			'dropdown'    => 'select',
 			'radio'       => 'select',
-			'listbox'     => 'select',
+			'listbox'     => 'multiselect',
 			'checkbox'    => 'multiselect',
 			'multiselect' => 'multiselect',
 			'date'        => 'date',


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`Newspack_Newsletters_Active_Campaign::map_contact_field_to_integration_schema()` treats ActiveCampaign's `listbox` field type as a single-selection enumeration (`value_type: select`, `matching_function: default`), and the docblock claims dropdown / radio / listbox are all single-selection. Per ActiveCampaign's own documentation that's wrong: a List Box field ["supports multiple selections"](https://developers.activecampaign.com/reference/contact-custom-fields-api-guide), stored `||`-delimited (`||Option A||Option C||`), and the [help center](https://help.activecampaign.com/hc/en-us/articles/221433307-Custom-contact-field-overview) describes it as a shift/ctrl-click multi-select control. Consequently, segments and access rules built on a List Box field match by whole-string equality and under-match contacts holding several values.

This moves `listbox` from the single-select group to the multi-select group, so it now maps to `value_type: multiselect` + `matching_function: list__in` (which the consumer's `parse_list_value()` resolves against the `||` delimiter), corrects the docblock, and updates the schema tests.

Mirrors the identical fix in newspack-manager's AC integration: Automattic/newspack-manager#657 (commit `a5f2532`), so both AC integrations type the same field identically.

### How to test the changes in this Pull Request:

1. From `plugins/newspack-newsletters`, run `n test-php --filter ActiveCampaignIntegrationsSchemaTest` — 7 tests pass. On `main`, the updated tests fail on the two flipped `listbox` assertions (`matching_function` and `value_type`).
2. Optionally, with ActiveCampaign connected and a "List Box" custom contact field in the account: load the integrations field schema and confirm the field now reports `value_type: multiselect` / `matching_function: list__in` (previously `select` / `default`), and that a segment criterion on one of its options matches a contact holding multiple values.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
