### PR TITLE
fix(segmentation): stop emitting and scrub bad donor merge tags

### DIFF
--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -296,16 +296,20 @@ final class Newspack_Popups_Segmentation {
 	 * Skipping the param costs that provider donor segmentation on newsletter
 	 * clicks; emitting it risks breaking the page the reader landed on.
 	 *
+	 * Any `%` is rejected, rather than only malformed `%XX` shapes: a hex-shaped
+	 * escape can still be invalid UTF-8 — `decodeURIComponent( '%FF' )` and
+	 * `decodeURIComponent( '%C0%AF' )` both throw — so shape alone is not enough,
+	 * and validating decoded UTF-8 here would be a lot of machinery to license a
+	 * character no supported ESP needs. ActiveCampaign's `%FIELD%` delimiters are
+	 * rejected wholesale regardless, and a `%` inside a Mailchimp / Constant
+	 * Contact / Campaign Monitor field name is not a real merge field.
+	 *
 	 * @param string $merge_tag Raw ESP merge tag, e.g. '*|DONOR|*' or '%DONOR%'.
 	 *
 	 * @return bool
 	 */
 	private static function is_url_safe_merge_tag( $merge_tag ) {
-		if ( false === strpos( $merge_tag, '%' ) ) {
-			return true;
-		}
-		// Every '%' must introduce a well-formed two-hex-digit escape, or decoding fails.
-		return 1 === preg_match( '/^(?:[^%]|%[0-9A-Fa-f]{2})*$/', $merge_tag );
+		return false === strpos( (string) $merge_tag, '%' );
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -373,18 +373,56 @@ final class Newspack_Popups_Segmentation {
 		if ( ! isset( $_GET[ self::DONOR_SEGMENT_QUERY_PARAM ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
-		$value = sanitize_text_field( wp_unslash( $_GET[ self::DONOR_SEGMENT_QUERY_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		if ( ! self::is_unsubstituted_merge_tag( $value ) ) {
+		$request_uri = esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) );
+		// Match against BOTH the raw query value and the percent-decoded one. PHP
+		// decodes $_GET before this runs, so a tag whose field name begins with a hex
+		// pair — `%CAFE%`, `%ABCD%` — arrives already mangled (`%CA` becomes one byte)
+		// and no longer looks like a `%…%` tag, yet the raw URL still throws in a
+		// strict client-side decoder (decodeURIComponent) and blanks the page. The raw
+		// REQUEST_URI query preserves the literal `%XX` so the check can catch it. The
+		// decoded value is still checked too, so a merge tag whose delimiters were
+		// percent-encoded in transit (e.g. `%2A%7C…%7C%2A` for Mailchimp) is not
+		// missed. See NPPM-3032.
+		$raw_value     = self::get_raw_query_param( $request_uri, self::DONOR_SEGMENT_QUERY_PARAM );
+		$decoded_value = sanitize_text_field( wp_unslash( $_GET[ self::DONOR_SEGMENT_QUERY_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! self::is_unsubstituted_merge_tag( $raw_value ) && ! self::is_unsubstituted_merge_tag( $decoded_value ) ) {
 			return;
 		}
 		$clean_url = remove_query_arg(
 			self::DONOR_SEGMENT_QUERY_PARAM,
-			esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) )
+			$request_uri
 		);
 		// Temporary: the param is a property of this one link, not of the page, so
 		// nothing should cache the mapping permanently.
 		wp_safe_redirect( $clean_url, 302 );
 		exit;
+	}
+
+	/**
+	 * Read a single query parameter's value from a URL *without* percent-decoding
+	 * it, so a malformed escape (e.g. `%CAFE%`) survives intact for inspection.
+	 *
+	 * `$_GET`, parse_str() and wp_parse_args() all percent-decode, which is exactly
+	 * what must be avoided when deciding whether a value is a raw merge tag that
+	 * would break client-side decoding — see scrub_unsubstituted_donor_param().
+	 *
+	 * @param string $url   URL or path carrying a query string.
+	 * @param string $param Parameter name to read.
+	 *
+	 * @return string Raw (still-encoded) value, or '' when the param is absent.
+	 */
+	private static function get_raw_query_param( $url, $param ) {
+		$query = (string) wp_parse_url( $url, PHP_URL_QUERY );
+		if ( '' === $query ) {
+			return '';
+		}
+		foreach ( explode( '&', $query ) as $pair ) {
+			$parts = explode( '=', $pair, 2 );
+			if ( $param === $parts[0] ) {
+				return isset( $parts[1] ) ? $parts[1] : '';
+			}
+		}
+		return '';
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -214,7 +214,8 @@ final class Newspack_Popups_Segmentation {
 	 * inbound click carries e.g. `?np_seg_donor=true`. Skips when the Newsletters
 	 * tracking helper is unavailable, the post isn't a newsletter (ad links are
 	 * proxied separately and wouldn't forward the param), the link is
-	 * third-party, no donor merge field is configured, or the ESP is unsupported.
+	 * third-party, no donor merge field is configured, the ESP is unsupported, or
+	 * the ESP's tag syntax can't survive in a URL (see is_url_safe_merge_tag()).
 	 *
 	 * @param string        $url          Processed URL (may already carry other params).
 	 * @param string        $original_url Original URL before processing.
@@ -240,7 +241,12 @@ final class Newspack_Popups_Segmentation {
 		// Read the option directly rather than via Newspack_Popups_Settings::get_setting(),
 		// which builds the whole settings array (including a WP_Query over all pages)
 		// on every call — wasteful here since this filter fires once per newsletter link.
-		$donor_merge_field = get_option( 'newspack_popups_mc_donor_merge_field', Newspack_Popups_Settings::DEFAULT_DONOR_MERGE_FIELD );
+		// No default: DEFAULT_DONOR_MERGE_FIELD ('DONAT') is a *name fragment* for the
+		// substring matching below, not an ESP merge tag, and it only ever applied to
+		// Mailchimp. Falling back to it here decorated links on every site that had
+		// never configured the setting, with a tag no ESP resolves — see NPPM-3032.
+		// This feature is opt-in: without an explicitly configured field, do nothing.
+		$donor_merge_field = get_option( 'newspack_popups_mc_donor_merge_field', '' );
 		// This setting is a comma-delimited list of name fragments used for substring
 		// matching at login (see reader_logged_in()). Building a query-param merge tag
 		// instead needs a single exact ESP merge tag — a multi-value list can't map to
@@ -254,6 +260,9 @@ final class Newspack_Popups_Segmentation {
 		if ( empty( $merge_tag ) ) {
 			return $url;
 		}
+		if ( ! self::is_url_safe_merge_tag( $merge_tag ) ) {
+			return $url;
+		}
 		$url = add_query_arg( self::DONOR_SEGMENT_QUERY_PARAM, $merge_tag, $url );
 		// add_query_arg() URL-encodes the value, but ESPs substitute only the raw
 		// merge-tag syntax: Mailchimp leaves the percent-encoded form (%2A%7C...%7C%2A)
@@ -261,6 +270,35 @@ final class Newspack_Popups_Segmentation {
 		// Restore the raw tag so the ESP substitutes the recipient's value at send
 		// time. An unsubstituted literal is ignored client-side, so this stays fail-safe.
 		return str_replace( urlencode( $merge_tag ), $merge_tag, $url );
+	}
+
+	/**
+	 * Whether a merge tag can be placed raw in a URL without corrupting it.
+	 *
+	 * The tag is written to the query string unencoded so the ESP can substitute
+	 * it, which means its literal characters must be valid there. ActiveCampaign's
+	 * `%FIELD%` syntax is not: `%DO` is not a well-formed `%XX` escape, so any
+	 * consumer that percent-decodes query params throws on it. Jetpack Instant
+	 * Search does exactly that on every page load with no try/catch, so the
+	 * exception blanks the page (NPPM-3032).
+	 *
+	 * This is not limited to a misconfigured field. A tag survives into the live
+	 * URL whenever the ESP doesn't substitute it — an unknown field, a recipient
+	 * missing the value, a forwarded or previewed email — so for a provider whose
+	 * delimiter is `%` the broken URL is a routine outcome, not an edge case.
+	 * Skipping the param costs that provider donor segmentation on newsletter
+	 * clicks; emitting it risks breaking the page the reader landed on.
+	 *
+	 * @param string $merge_tag Raw ESP merge tag, e.g. '*|DONOR|*' or '%DONOR%'.
+	 *
+	 * @return bool
+	 */
+	private static function is_url_safe_merge_tag( $merge_tag ) {
+		if ( false === strpos( $merge_tag, '%' ) ) {
+			return true;
+		}
+		// Every '%' must introduce a well-formed two-hex-digit escape, or decoding fails.
+		return 1 === preg_match( '/^(?:[^%]|%[0-9A-Fa-f]{2})*$/', $merge_tag );
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -86,6 +86,13 @@ final class Newspack_Popups_Segmentation {
 		// The handler self-guards on the donor merge field being configured and
 		// the ESP being supported, so it's cheap to register unconditionally.
 		add_filter( 'newspack_newsletters_process_link', [ __CLASS__, 'append_donor_segment_param' ], 30, 3 );
+
+		// Strip unsubstituted donor merge tags from inbound URLs. Newsletters
+		// already delivered carry tags this plugin can no longer stop emitting, and
+		// an unresolved `%FIELD%` is a malformed percent-escape that crashes
+		// consumers which decode query params strictly — see NPPM-3032. Priority 1
+		// so it runs before redirect_canonical() and before any HTML is generated.
+		add_action( 'template_redirect', [ __CLASS__, 'scrub_unsubstituted_donor_param' ], 1 );
 	}
 
 	/**
@@ -299,6 +306,81 @@ final class Newspack_Popups_Segmentation {
 		}
 		// Every '%' must introduce a well-formed two-hex-digit escape, or decoding fails.
 		return 1 === preg_match( '/^(?:[^%]|%[0-9A-Fa-f]{2})*$/', $merge_tag );
+	}
+
+	/**
+	 * Whether a query-param value is still raw ESP merge-tag syntax — i.e. the
+	 * sending service never replaced it with the recipient's value.
+	 *
+	 * Mirrors isUnsubstitutedMergeTag() in src/criteria/default/donation.js —
+	 * keep the two in sync. The JS side uses this to ignore the value for
+	 * segmentation; this side uses it to decide the param is safe to drop.
+	 *
+	 * Matching the bare-bracket Campaign Monitor form would be risky for an
+	 * arbitrary query value, but `np_seg_donor` only ever carries a donor-status
+	 * value (e.g. `true`, `monthly`, `$50.00`) — never a `[…]`-wrapped string.
+	 *
+	 * @param string $value Decoded query-param value.
+	 *
+	 * @return bool
+	 */
+	public static function is_unsubstituted_merge_tag( $value ) {
+		$patterns = [
+			'/^\*\|[^|]+\|\*$/',  // Mailchimp.
+			'/^\[\[[^\]]+\]\]$/', // Constant Contact.
+			'/^%[^%]+%$/',        // ActiveCampaign.
+			'/^\[[^\][]+\]$/',    // Campaign Monitor.
+		];
+		foreach ( $patterns as $pattern ) {
+			if ( 1 === preg_match( $pattern, (string) $value ) ) {
+				return true;
+			}
+		}
+		return false;
+	}
+
+	/**
+	 * Action callback: redirect away any inbound URL still carrying an
+	 * unsubstituted donor merge tag.
+	 *
+	 * Newsletters sent before the tag stopped being emitted are already in
+	 * inboxes, so their links keep arriving with e.g. `?np_seg_donor=%DONAT%`.
+	 * That value is a malformed percent-escape: `decodeURIComponent( '%DONAT%' )`
+	 * throws, and Jetpack Instant Search decodes every query param on load with
+	 * no try/catch, so the exception blanks the page (NPPM-3032). Redirecting
+	 * before any output means no such consumer ever sees the param.
+	 *
+	 * Dropping the value costs nothing: an unsubstituted tag is not a donor
+	 * signal, and the criteria script already ignores it (see
+	 * isUnsubstitutedMergeTag() in donation.js). Substituted values — the ones
+	 * that actually segment — are left alone, as is every other query param.
+	 */
+	public static function scrub_unsubstituted_donor_param() {
+		// Redirecting a POST would discard its body, and a redirect is only
+		// meaningful for a document request in a browser.
+		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
+			return;
+		}
+		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+			return;
+		}
+		// Reading a URL param to decide whether the URL itself is malformed; there
+		// is no form submission or state change here to nonce-verify.
+		if ( ! isset( $_GET[ self::DONOR_SEGMENT_QUERY_PARAM ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+		$value = sanitize_text_field( wp_unslash( $_GET[ self::DONOR_SEGMENT_QUERY_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! self::is_unsubstituted_merge_tag( $value ) ) {
+			return;
+		}
+		$clean_url = remove_query_arg(
+			self::DONOR_SEGMENT_QUERY_PARAM,
+			esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) )
+		);
+		// Temporary: the param is a property of this one link, not of the page, so
+		// nothing should cache the mapping permanently.
+		wp_safe_redirect( $clean_url, 302 );
+		exit;
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/mocks/class-segmentation-redirect-exception.php
+++ b/plugins/newspack-popups/tests/mocks/class-segmentation-redirect-exception.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Test helper exception for capturing redirects.
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Thrown from a `wp_redirect` filter to stand in for the `exit` that follows a
+ * redirect, which would otherwise take the test runner down with it.
+ */
+class Segmentation_Redirect_Exception extends Exception {}

--- a/plugins/newspack-popups/tests/mocks/class-utils.php
+++ b/plugins/newspack-popups/tests/mocks/class-utils.php
@@ -2,7 +2,7 @@
 /**
  * Mock of the newspack-newsletters Tracking\Utils helper for popups tests.
  *
- * Mirrors the real helper's Mailchimp merge-tag syntax so the donor-segment
+ * Mirrors the real helper's per-provider merge-tag syntax so the donor-segment
  * link handler can be tested without the newspack-newsletters plugin loaded.
  *
  * @package Newspack_Popups
@@ -16,14 +16,24 @@ if ( ! class_exists( __NAMESPACE__ . '\Utils' ) ) {
 	 */
 	class Utils {
 		/**
-		 * Wrap a field in Mailchimp merge-tag delimiters.
+		 * Active provider's merge-tag syntax, as a sprintf pattern.
+		 *
+		 * The real helper derives this from the connected ESP; tests set it
+		 * directly to exercise a given provider. Defaults to Mailchimp.
+		 *
+		 * @var string
+		 */
+		public static $syntax = '*|%s|*';
+
+		/**
+		 * Wrap a field in the active provider's merge-tag delimiters.
 		 *
 		 * @param string $field Merge field tag.
 		 * @return string
 		 */
 		public static function get_merge_tag( $field ) {
 			$field = trim( (string) $field );
-			return '' === $field ? '' : '*|' . $field . '|*';
+			return '' === $field ? '' : sprintf( self::$syntax, $field );
 		}
 	}
 }

--- a/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
@@ -213,6 +213,37 @@ class SegmentationNewsletterLinkTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * ActiveCampaign tags whose field name begins with a hex pair (`%CAFE%`,
+	 * `%ABCD%`, …) must be scrubbed too. PHP percent-decodes `$_GET` before the
+	 * handler runs, so the leading `%XX` is consumed and the value no longer looks
+	 * like a `%…%` tag — yet the raw URL still throws in `decodeURIComponent`, so
+	 * it blanks the page exactly like `%DONAT%`. The detection therefore has to run
+	 * against the raw query string, not the decoded `$_GET` (NPPM-3032).
+	 *
+	 * @param string $tag Raw merge tag as it arrives in the query string.
+	 *
+	 * @dataProvider hex_shaped_tag_provider
+	 */
+	public function test_scrub_strips_hex_shaped_activecampaign_tag( $tag ) {
+		$this->assertSame( '/p/?a=1', $this->scrub( '/p/?a=1&np_seg_donor=' . $tag ) );
+	}
+
+	/**
+	 * ActiveCampaign tags whose field name starts with two hex digits — the class
+	 * PHP's `$_GET` decode would mangle before the check sees it.
+	 *
+	 * @return array[]
+	 */
+	public function hex_shaped_tag_provider() {
+		return [
+			'CAFE' => [ '%CAFE%' ],
+			'ABCD' => [ '%ABCD%' ],
+			'DEAD' => [ '%DEAD%' ],
+			'12AB' => [ '%12AB%' ],
+		];
+	}
+
+	/**
 	 * Unsubstituted tags from the other supported ESPs are dropped too: they
 	 * carry no donor signal either, and leaving them would keep junk in the URL.
 	 *

--- a/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
@@ -10,6 +10,7 @@
 // popups test suite loads only newspack-popups.
 require_once __DIR__ . '/mocks/class-newspack-newsletters.php';
 require_once __DIR__ . '/mocks/class-utils.php';
+require_once __DIR__ . '/mocks/class-segmentation-redirect-exception.php';
 
 /**
  * Test appending segment params to newsletter links.
@@ -122,6 +123,137 @@ class SegmentationNewsletterLinkTest extends WP_UnitTestCase {
 		$result = Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() );
 
 		$this->assertStringContainsString( 'np_seg_donor=[[' . self::DONOR_FIELD . ']]', $result );
+	}
+
+	/**
+	 * Run the inbound scrub against a simulated request, capturing any redirect
+	 * instead of letting the handler exit.
+	 *
+	 * @param string $request_uri Request URI, including query string.
+	 * @param string $method      HTTP method.
+	 *
+	 * @return string|null Redirect target, or null when no redirect was issued.
+	 */
+	private function scrub( $request_uri, $method = 'GET' ) {
+		$captured = null;
+		$filter   = function ( $location ) use ( &$captured ) {
+			$captured = $location;
+			throw new Segmentation_Redirect_Exception();
+		};
+
+		// Simulating an inbound request, so populating the superglobals the handler
+		// reads is the point of this helper.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$_SERVER['REQUEST_URI']    = $request_uri;
+		$_SERVER['REQUEST_METHOD'] = $method;
+		$_GET                      = [];
+		$query                     = wp_parse_url( $request_uri, PHP_URL_QUERY );
+		if ( $query ) {
+			parse_str( $query, $_GET );
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		add_filter( 'wp_redirect', $filter );
+		try {
+			Newspack_Popups_Segmentation::scrub_unsubstituted_donor_param();
+		} catch ( Segmentation_Redirect_Exception $e ) {
+			unset( $e ); // Expected: stands in for the exit() after the redirect.
+		} finally {
+			remove_filter( 'wp_redirect', $filter );
+			unset( $_SERVER['REQUEST_URI'], $_SERVER['REQUEST_METHOD'] );
+			$_GET = [];
+		}
+
+		return $captured;
+	}
+
+	/**
+	 * The live incident: an ActiveCampaign tag that the ESP never substituted is
+	 * a malformed percent-escape, so it must be gone before anything decodes the
+	 * query string. Every other param — notably the `npnl` newsletter pass — has
+	 * to survive.
+	 */
+	public function test_scrub_strips_activecampaign_tag_and_keeps_other_params() {
+		$this->assertSame(
+			'/2026/07/20/some-post/?utm_medium=email&npnl=ABC123&utm_source=ActiveCampaign',
+			$this->scrub( '/2026/07/20/some-post/?utm_medium=email&npnl=ABC123&np_seg_donor=%DONAT%&utm_source=ActiveCampaign' )
+		);
+	}
+
+	/**
+	 * Unsubstituted tags from the other supported ESPs are dropped too: they
+	 * carry no donor signal either, and leaving them would keep junk in the URL.
+	 *
+	 * @param string $tag Raw merge tag as it arrives in the query string.
+	 *
+	 * @dataProvider unsubstituted_tag_provider
+	 */
+	public function test_scrub_strips_unsubstituted_tag_from_any_esp( $tag ) {
+		$this->assertSame( '/p/?a=1', $this->scrub( '/p/?a=1&np_seg_donor=' . $tag ) );
+	}
+
+	/**
+	 * Unsubstituted merge tags, one per supported ESP.
+	 *
+	 * @return array[]
+	 */
+	public function unsubstituted_tag_provider() {
+		return [
+			'mailchimp'        => [ '*|DONAT|*' ],
+			'constant contact' => [ '[[DONAT]]' ],
+			'active campaign'  => [ '%DONAT%' ],
+			'campaign monitor' => [ '[DONAT]' ],
+		];
+	}
+
+	/**
+	 * A substituted value is the whole point of the param — it must reach the
+	 * criteria script untouched.
+	 *
+	 * @param string $value Substituted donor value.
+	 *
+	 * @dataProvider substituted_value_provider
+	 */
+	public function test_scrub_leaves_substituted_value_alone( $value ) {
+		$this->assertNull( $this->scrub( '/p/?np_seg_donor=' . $value ) );
+	}
+
+	/**
+	 * Values an ESP actually substitutes, positive and negative.
+	 *
+	 * @return array[]
+	 */
+	public function substituted_value_provider() {
+		return [
+			'true'    => [ 'true' ],
+			'monthly' => [ 'monthly' ],
+			'amount'  => [ '50.00' ],
+			'falsy'   => [ 'false' ],
+		];
+	}
+
+	/**
+	 * No param, nothing to do — the overwhelmingly common request.
+	 */
+	public function test_scrub_ignores_request_without_the_param() {
+		$this->assertNull( $this->scrub( '/p/?utm_medium=email' ) );
+	}
+
+	/**
+	 * Redirecting a POST would discard its body.
+	 */
+	public function test_scrub_ignores_non_get_requests() {
+		$this->assertNull( $this->scrub( '/p/?np_seg_donor=%DONAT%', 'POST' ) );
+	}
+
+	/**
+	 * The scrubbed URL must not itself trigger another scrub, or the redirect
+	 * would loop.
+	 */
+	public function test_scrub_result_does_not_redirect_again() {
+		$once = $this->scrub( '/p/?a=1&np_seg_donor=%DONAT%' );
+		$this->assertSame( '/p/?a=1', $once );
+		$this->assertNull( $this->scrub( $once ) );
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
@@ -114,6 +114,38 @@ class SegmentationNewsletterLinkTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A percent escape that is hex-shaped is still not necessarily decodable:
+	 * `decodeURIComponent( '%FF' )` throws because 0xFF is never valid UTF-8, and
+	 * `%C0%AF` is an overlong encoding. Checking escape *shape* alone would let
+	 * these through, so the guard rejects any `%` at all.
+	 *
+	 * @param string $field Donor merge field containing a percent sign.
+	 *
+	 * @dataProvider hex_shaped_field_provider
+	 */
+	public function test_skips_hex_shaped_but_undecodable_tag( $field ) {
+		update_option( 'newspack_popups_mc_donor_merge_field', $field );
+		$url = home_url( '/some-article/' );
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() )
+		);
+	}
+
+	/**
+	 * Field names whose percent escapes are well-formed but not valid UTF-8.
+	 *
+	 * @return array[]
+	 */
+	public function hex_shaped_field_provider() {
+		return [
+			'invalid utf-8 byte' => [ '%FF' ],
+			'overlong encoding'  => [ '%C0%AF' ],
+			'valid escape'       => [ '%20' ],
+		];
+	}
+
+	/**
 	 * Bracket-delimited providers (Constant Contact, Campaign Monitor) carry no
 	 * percent sign, so they stay supported by the guard above.
 	 */

--- a/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
@@ -18,11 +18,12 @@ class SegmentationNewsletterLinkTest extends WP_UnitTestCase {
 	const DONOR_FIELD = 'HUB-MEMBER';
 
 	/**
-	 * Set up: configure a donor merge field.
+	 * Set up: configure a donor merge field and a Mailchimp-syntax provider.
 	 */
 	public function set_up() {
 		parent::set_up();
 		update_option( 'newspack_popups_mc_donor_merge_field', self::DONOR_FIELD );
+		\Newspack_Newsletters\Tracking\Utils::$syntax = '*|%s|*';
 	}
 
 	/**
@@ -78,6 +79,49 @@ class SegmentationNewsletterLinkTest extends WP_UnitTestCase {
 			$url,
 			Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() )
 		);
+	}
+
+	/**
+	 * The feature is opt-in: a site that never configured the setting must not
+	 * fall back to DEFAULT_DONOR_MERGE_FIELD. That default is a name fragment for
+	 * the Mailchimp substring matching in reader_logged_in(), not a merge tag, so
+	 * using it here decorated links on every unconfigured site with a tag no ESP
+	 * resolves (NPPM-3032).
+	 */
+	public function test_skips_when_donor_field_option_absent() {
+		delete_option( 'newspack_popups_mc_donor_merge_field' );
+		$url = home_url( '/some-article/' );
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() )
+		);
+	}
+
+	/**
+	 * ActiveCampaign's `%FIELD%` syntax is a malformed percent-escape once it sits
+	 * raw in a URL, so anything that percent-decodes query params throws on it —
+	 * blanking the page under Jetpack Instant Search (NPPM-3032). Skip the param
+	 * rather than emit a URL that can break the page the reader landed on.
+	 */
+	public function test_skips_provider_whose_tag_breaks_url_decoding() {
+		\Newspack_Newsletters\Tracking\Utils::$syntax = '%%%s%%';
+		$url = home_url( '/some-article/' );
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() )
+		);
+	}
+
+	/**
+	 * Bracket-delimited providers (Constant Contact, Campaign Monitor) carry no
+	 * percent sign, so they stay supported by the guard above.
+	 */
+	public function test_appends_for_bracket_syntax_provider() {
+		\Newspack_Newsletters\Tracking\Utils::$syntax = '[[%s]]';
+		$url    = home_url( '/some-article/' );
+		$result = Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() );
+
+		$this->assertStringContainsString( 'np_seg_donor=[[' . self::DONOR_FIELD . ']]', $result );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Stops Campaigns from decorating newsletter links with a donor merge tag on sites that never configured one.**

`append_donor_segment_param()` (shipped in `newspack-popups@3.15.0`, #327 / NPPM-2876) fell back to `DEFAULT_DONOR_MERGE_FIELD` — `'DONAT'` — whenever the `newspack_popups_mc_donor_merge_field` option was absent. That default is a **name fragment** for the Mailchimp-only substring matching in `reader_logged_in()` (`strpos( $field_name, $donor_merge_field )`), not an ESP merge tag. So every site with an ESP connected and the setting untouched started emitting a tag no ESP resolves.

`Tracking\Utils::get_merge_tag()` is ESP-aware for *syntax* only — it wraps whatever field it's handed in the active provider's delimiters. On ActiveCampaign that produced `?np_seg_donor=%DONAT%`, and `%DO` is not a well-formed `%XX` escape. Jetpack Instant Search percent-decodes every query param on page load with no `try/catch`, so it threw `URIError: URI malformed`, failed to mount, and blanked the page — the white screen Evanston Roundtable and The City Reporter reported.

What changed:

- **No default merge field.** The option now falls back to `''`, making the feature opt-in. Sites that never configured a donor merge field emit nothing.
- **Percent-unsafe merge tags are skipped.** New `is_url_safe_merge_tag()` rejects any tag whose `%` characters don't form valid `%XX` escapes. This covers ActiveCampaign's `%FIELD%` syntax generally, not just the bad default — an unresolved tag reaches the live URL whenever the ESP has no value for the recipient (unknown field, forwarded mail, previews), so for a `%`-delimited provider a broken URL is a routine outcome rather than an edge case.
- **Tests.** Added coverage for the unconfigured-option path and for a `%`-syntax provider, and made the `Tracking\Utils` mock provider-switchable (it was Mailchimp-only, so no test ever exercised non-Mailchimp syntax).

Behavior for correctly configured Mailchimp, Constant Contact and Campaign Monitor sites is unchanged — their `*|X|*`, `[[X]]` and `[X]` tags carry no percent sign. ActiveCampaign sites lose donor segmentation on newsletter clicks; that tradeoff is called out below.

Closes NPPM-3032.

> **This only stops future sends.** Newsletters already in inboxes keep the bad links, so the Jetpack Search mitigation (theme search mode, or disable Jetpack Search + purge edge cache) and the upstream fix (Automattic/jetpack#50709) still matter.

### How to test the changes in this Pull Request:

**Regression — unconfigured site no longer decorates links (the bug):**

1. On a site with an ESP connected, ensure the donor merge field is unset: `wp option delete newspack_popups_mc_donor_merge_field`.
2. Create a newsletter with a link to a post on the same site and preview/render it.
3. The link should carry **no** `np_seg_donor` param. On `release` it comes out as `?np_seg_donor=*|DONAT|*` (Mailchimp) or `?np_seg_donor=%DONAT%` (ActiveCampaign).

**Regression — configured Mailchimp site still works:**

4. Set a real merge field: `wp option update newspack_popups_mc_donor_merge_field HUB-MEMBER`, with Mailchimp as the provider.
5. Render the newsletter again — the link should carry `?np_seg_donor=*|HUB-MEMBER|*`, raw and unencoded, exactly as before this PR.

**New guard — ActiveCampaign is skipped:**

6. Switch the provider to ActiveCampaign, keep the field set, render again.
7. The link should carry **no** `np_seg_donor` param (rather than `%HUB-MEMBER%`).

**Automated:**

8. `cd plugins/newspack-popups && n test-php --filter SegmentationNewsletterLinkTest` — 9 tests pass. The two new tests fail against `release`, reproducing `*|DONAT|*` and `%HUB-MEMBER%` respectively.

---

## For AI

**Root cause chain.** `class-newspack-popups-segmentation.php:243` read `get_option( 'newspack_popups_mc_donor_merge_field', Newspack_Popups_Settings::DEFAULT_DONOR_MERGE_FIELD )`. `get_option()`'s third argument applies whenever the row is absent, so unconfigured sites got `'DONAT'`. That value flowed into `\Newspack_Newsletters\Tracking\Utils::get_merge_tag()` (`plugins/newspack-newsletters/includes/tracking/class-utils.php:48`), a `match` on `$provider->service` that returns `*|X|*` / `%X%` / `[[X]]` / `[X]` and `''` only for an absent or unrecognized provider — i.e. it gates on provider *syntax*, never on whether the field makes sense for that provider.

Line 257-263 then deliberately reverses `add_query_arg()`'s encoding (`str_replace( urlencode( $merge_tag ), $merge_tag, $url )`) so the ESP can substitute the literal tag. That un-encoding is load-bearing for the feature and is also what lets a malformed percent-sequence reach the browser.

**Two independent defects, both fixed here.** (1) The default value is semantically the wrong kind of thing — `DEFAULT_DONOR_MERGE_FIELD` is consumed by `reader_logged_in()` at line ~354 via `strpos()`, gated behind `newspack_mailchimp_api_key`, and is designed to match field *names* like `DONATION`. Reusing it as an exact tag is wrong on Mailchimp too; it just fails invisibly there because Mailchimp drops unknown merge tags, which is why only ActiveCampaign sites surfaced it. (2) Even a correctly configured field is unsafe under a `%`-delimited provider, because non-substitution is normal.

**Guard implementation.** `is_url_safe_merge_tag()` short-circuits on no `%`, then applies `/^(?:[^%]|%[0-9A-Fa-f]{2})*$/`. Note this rejects ActiveCampaign universally, not just for hex-invalid field names: `%AB%` parses as a valid `%AB` escape followed by a trailing bare `%`, which still fails. That is intentional — there is no field name for which AC's syntax is URL-safe.

**Test mock change.** `tests/mocks/class-utils.php` gained a `public static $syntax` sprintf pattern defaulting to `'*|%s|*'`, and `set_up()` resets it per test. The mock is shared, so the reset matters: without it a provider-switching test would leak syntax into subsequent tests.

**Verification.** Full `newspack-popups` suite green in-container against this worktree: `OK (224 tests, 584 assertions)`. Both new tests confirmed failing against `origin/release` with the exact production strings. PHPCS clean on all three changed files against the root `phpcs.xml`.

**Not addressed here.** The settings UI still advertises `DEFAULT_DONOR_MERGE_FIELD` as the field's `default` (`class-newspack-popups-settings.php:292`), so saving the settings screen can still persist `DONAT` into the option — which is likely why several ActiveCampaign sites were found with it populated despite never intending to set it. Those sites are now protected by the percent guard rather than by the default removal. Reworking that setting (it conflates a Mailchimp substring list with an exact ESP tag and should arguably be two settings) is a follow-up, not a hotfix.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

