### PR TITLE
test(audience): stabilize timing-fragile RTL suites under CPU load

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/save-panel/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/edit/save-panel/index.test.js
@@ -1,12 +1,21 @@
 /**
  * External dependencies.
  */
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, act } from '@testing-library/react';
 
 /**
  * Internal dependencies.
  */
 import SavePanel from './index';
+
+// SavePanel only reads Divider from the components barrel, but the
+// barrel's index evaluates all ~50 components — seconds of module
+// execution per suite that made these tests fragile under CPU load.
+// Re-export just the real Divider; everything else the panel renders
+// (@wordpress/components Modal & controls) stays fully real.
+jest.mock( '../../../../../../../packages/components/src', () => ( {
+	Divider: jest.requireActual( '../../../../../../../packages/components/src/divider' ).default,
+} ) );
 
 const baseProps = {
 	initialStatus: 'draft',
@@ -75,9 +84,22 @@ describe( 'Content Gate SavePanel', () => {
 		} );
 	} );
 
-	it( 'calls onCancel from the Cancel button after the slide-out', async () => {
-		render( <SavePanel { ...baseProps } /> );
-		fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
-		await waitFor( () => expect( baseProps.onCancel ).toHaveBeenCalled() );
+	it( 'calls onCancel from the Cancel button after the slide-out', () => {
+		// The Cancel handler waits out the 200ms slide-out (SLIDE_OUT_MS in
+		// index.tsx) on a real setTimeout before invoking onCancel. Drive the
+		// timer with fake timers instead of polling waitFor against the wall
+		// clock, so the test stays deterministic when CPU load delays timers.
+		jest.useFakeTimers();
+		try {
+			render( <SavePanel { ...baseProps } /> );
+			fireEvent.click( screen.getByRole( 'button', { name: 'Cancel' } ) );
+			expect( baseProps.onCancel ).not.toHaveBeenCalled();
+			act( () => {
+				jest.advanceTimersByTime( 200 );
+			} );
+			expect( baseProps.onCancel ).toHaveBeenCalled();
+		} finally {
+			jest.useRealTimers();
+		}
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/enable-modal.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/enable-modal.test.js
@@ -8,6 +8,23 @@ import { fireEvent, render, screen, waitFor } from '@testing-library/react';
  */
 import { EnableModal, getMissingRequiredFields } from './enable-modal';
 
+// EnableModal + SettingsField read six components from the components
+// barrel, but the barrel's index evaluates all ~50 components (Wizard,
+// PluginInstaller, integration icons, …) — seconds of module execution
+// per suite that made these tests fragile under CPU load. Re-export just
+// the submodules this render tree uses, as their REAL implementations,
+// so modal semantics, label association and disabled state stay fully
+// exercised. If the components under test start using another barrel
+// export, add it here (the failure is a loud "X is not a component").
+jest.mock( '../../../../../packages/components/src', () => ( {
+	Button: jest.requireActual( '../../../../../packages/components/src/button' ).default,
+	Modal: jest.requireActual( '../../../../../packages/components/src/modal' ).default,
+	Notice: jest.requireActual( '../../../../../packages/components/src/notice' ).default,
+	Grid: jest.requireActual( '../../../../../packages/components/src/grid' ).default,
+	SelectControl: jest.requireActual( '../../../../../packages/components/src/select-control' ).default,
+	TextControl: jest.requireActual( '../../../../../packages/components/src/text-control' ).default,
+} ) );
+
 const audienceField = {
 	key: 'mailchimp_audience_id',
 	type: 'select',

--- a/plugins/newspack-plugin/src/wizards/audience/views/setup/emails/emails.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/setup/emails/emails.test.js
@@ -5,6 +5,17 @@
  */
 import { render, screen, waitFor, fireEvent, act } from '@testing-library/react';
 
+/**
+ * Internal dependencies
+ */
+// Import the component (and the mocked barrel's utils) at module scope, not
+// via require() inside tests: module evaluation then happens during suite
+// setup, which jest does not time, instead of inside the first test's 5s
+// timeout. The jest.mock calls below are hoisted above these imports, so the
+// component still resolves every mocked dependency.
+import Emails from './emails';
+import { utils } from '../../../../../../packages/components/src';
+
 jest.mock( './emails.scss', () => ( {} ) );
 
 // Use mock-prefixed names so Jest's hoisted jest.mock can close over them.
@@ -12,18 +23,42 @@ const mockWizardApiFetch = jest.fn();
 const mockResetError = jest.fn();
 let mockErrorMessage = null;
 
+// The hook returns one stable object so every render sees the same function
+// identities. A fresh object per call is the classic effect-churn landmine:
+// emails.tsx only consumes these from a mount-only effect today, but if a
+// future effect lists `wizardApiFetch` in its deps, per-render identities
+// would re-run it on every render. `errorMessage` is a getter so per-test
+// mutations of mockErrorMessage stay visible through the stable object.
+const mockUseWizardApiFetchReturn = {
+	wizardApiFetch: ( ...args ) => mockWizardApiFetch( ...args ),
+	isFetching: false,
+	get errorMessage() {
+		return mockErrorMessage;
+	},
+	resetError: ( ...args ) => mockResetError( ...args ),
+};
+
 jest.mock( '../../../../hooks/use-wizard-api-fetch', () => ( {
-	useWizardApiFetch: () => ( {
-		wizardApiFetch: ( ...args ) => mockWizardApiFetch( ...args ),
-		isFetching: false,
-		errorMessage: mockErrorMessage,
-		resetError: ( ...args ) => mockResetError( ...args ),
-	} ),
+	useWizardApiFetch: () => mockUseWizardApiFetchReturn,
 } ) );
 
 jest.mock( '@wordpress/icons', () => ( {
 	Icon: ( { icon } ) => <span data-testid="icon">{ icon }</span>,
 	envelope: 'envelope',
+} ) );
+
+// Stub @wordpress/components — emails.tsx imports only Button and the
+// experimental HStack from it. Evaluating the real package costs seconds of
+// module execution per suite; because this suite used to require() the
+// component inside each test, that cost landed inside the first test's 5s
+// jest timeout and failed nondeterministically under CPU load. Both call
+// sites pass explicit aria-*/role props, so faithful DOM passthroughs keep
+// every assertion meaningful (same approach as settings-modal.test.js).
+jest.mock( '@wordpress/components', () => ( {
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	Button: ( { children, variant, size, isPressed, isBusy, ...rest } ) => <button { ...rest }>{ children }</button>,
+	// eslint-disable-next-line @typescript-eslint/no-unused-vars
+	__experimentalHStack: ( { children, spacing, justify, alignment, ...rest } ) => <div { ...rest }>{ children }</div>,
 } ) );
 
 jest.mock( '@wordpress/dataviews', () => ( {
@@ -247,7 +282,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'renders reader-revenue emails by default', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		// Default chip is reader-revenue — these rows are visible.
@@ -265,7 +299,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'renders Recipient column with Reader/Admin labels', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -278,7 +311,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'renders status as Enabled / Disabled', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -290,7 +322,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'deactivate action calls wizardApiFetch with draft status', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -298,7 +329,10 @@ describe( 'Emails', () => {
 		} );
 
 		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
-		deactivate.callback( [ mockEmails[ 0 ] ] );
+		// act() because the callback optimistically sets state before fetching.
+		act( () => {
+			deactivate.callback( [ mockEmails[ 0 ] ] );
+		} );
 
 		// updateStatus applies the new status optimistically in local
 		// state before the fetch fires, then passes `onError` only —
@@ -322,7 +356,6 @@ describe( 'Emails', () => {
 	it( 'displays error notice when hook reports an error', async () => {
 		mockErrorMessage = 'Something went wrong';
 
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -332,7 +365,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'activate action calls wizardApiFetch with publish status', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -344,7 +376,10 @@ describe( 'Emails', () => {
 		// actually eligible for activate (category !== 'reader-activation').
 		// Verifies the callback wiring on an item that would pass `isEligible`.
 		expect( activate.isEligible( mockEmails[ 4 ] ) ).toBe( true );
-		activate.callback( [ mockEmails[ 4 ] ] );
+		// act() because the callback optimistically sets state before fetching.
+		act( () => {
+			activate.callback( [ mockEmails[ 4 ] ] );
+		} );
 
 		// updateStatus applies the new status optimistically — onError
 		// is the only callback (rollback on failure). See the matching
@@ -364,7 +399,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'deactivate/activate are not eligible for reader-activation emails', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -383,8 +417,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'reset action calls wizardApiFetch with DELETE after confirmation', async () => {
-		const { utils } = require( '../../../../../../packages/components/src' );
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -392,7 +424,10 @@ describe( 'Emails', () => {
 		} );
 
 		const reset = mockCapturedActions.find( a => a.id === 'reset' );
-		reset.callback( [ mockEmails[ 0 ] ] );
+		// act() because the DELETE's onSuccess refetch resolves into state.
+		act( () => {
+			reset.callback( [ mockEmails[ 0 ] ] );
+		} );
 
 		expect( utils.confirmAction ).toHaveBeenCalled();
 
@@ -408,7 +443,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'reset is eligible for newspack-source rows', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -429,7 +463,6 @@ describe( 'Emails', () => {
 	// Slice 2a — WC surfacing tests below.
 
 	it( 'reset is NOT eligible for a woocommerce-source row', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -444,7 +477,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'deactivate routes string post_id to toggleWcEmail', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -454,7 +486,10 @@ describe( 'Emails', () => {
 		const deactivate = mockCapturedActions.find( a => a.id === 'deactivate' );
 		// WC row is publish + category !== reader-activation → eligible.
 		expect( deactivate.isEligible( mockEmails[ 5 ] ) ).toBe( true );
-		deactivate.callback( [ mockEmails[ 5 ] ] );
+		// act() because the callback optimistically sets state before fetching.
+		act( () => {
+			deactivate.callback( [ mockEmails[ 5 ] ] );
+		} );
 
 		// Type-based routing: string post_id 'wc:new_order' goes to the
 		// toggle endpoint, not to wp/v2 post status update.
@@ -478,7 +513,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'activate routes string post_id to toggleWcEmail', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -488,7 +522,10 @@ describe( 'Emails', () => {
 		const activate = mockCapturedActions.find( a => a.id === 'activate' );
 		// WC draft row → eligible for activate.
 		expect( activate.isEligible( mockEmails[ 6 ] ) ).toBe( true );
-		activate.callback( [ mockEmails[ 6 ] ] );
+		// act() because the callback optimistically sets state before fetching.
+		act( () => {
+			activate.callback( [ mockEmails[ 6 ] ] );
+		} );
 
 		expect( mockWizardApiFetch ).toHaveBeenCalledWith(
 			expect.objectContaining( {
@@ -503,7 +540,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'toggleWcEmail onSuccess replaces local state with the authoritative server response', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -537,7 +573,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'toggleWcEmail onError rolls back the optimistic status change', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -571,7 +606,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'chip filter shows only rows matching activeChip', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		// Default chip = reader-revenue. Auth-account rows are filtered out.
@@ -598,7 +632,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'chip switch resets search and page', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -629,7 +662,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'search bypasses chip filter — operates across all chips', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -659,7 +691,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'chip bar shows both chips unpressed during active search', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -692,7 +723,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'clearing search restores active chip pressed state', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -732,7 +762,6 @@ describe( 'Emails', () => {
 	// `wc:{id}` string for classic-template emails.
 
 	it( 'preview field renders an anchor with aria-label for each row', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -749,7 +778,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'preview field passes the right id to EmailPreview for each render path', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -778,7 +806,6 @@ describe( 'Emails', () => {
 	} );
 
 	it( 'renders the Emails heading as visually hidden (screen-reader only)', async () => {
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {
@@ -798,7 +825,6 @@ describe( 'Emails', () => {
 		// than showing a lone, always-pressed (non-functional) chip. Settings
 		// stays available; the list renders unfiltered.
 		window.newspackAudience.emails.isNewspackPlatform = false;
-		const Emails = require( './emails' ).default;
 		render( <Emails /> );
 
 		await waitFor( () => {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Three audience-wizard RTL suites failed nondeterministically with `Exceeded timeout of 5000 ms` when the machine was under CPU load (e.g. Docker envs running), with the failures wandering between suites across runs. The shared root cause is per-suite evaluation of the `@wordpress/components` module graph and/or the `packages/components/src` barrel (~50 components), which costs seconds per fresh jest worker — and worker assignment decides which suite pays it cold.

Per-suite fixes (test files only, no production code, assertions unchanged):

- **`emails.test.js`** — the suite `require()`d the component inside each test, so the first test executed the entire `@wordpress/components` graph inside its own 5s timeout budget (measured 2.5s on an idle machine, 2.9s under load). The component is now imported at module scope (suite setup is untimed), `@wordpress/components` is stubbed with DOM passthroughs (only `Button`/`HStack` are used, both call sites pass explicit `aria-*` props — same approach as the sibling `settings-modal.test.js`), the `useWizardApiFetch` mock now returns a single stable object instead of a fresh one per render, and bare action-callback invocations are wrapped in `act()` (also removes this suite's React act warnings).
- **`enable-modal.test.js`** — the barrel is narrowed to `jest.requireActual` re-exports of only the six submodules the render tree uses. The components under test stay fully real (label association, modal semantics, disabled state), while the ~44 unrelated barrel modules stop executing.
- **`content-gates/edit/save-panel/index.test.js`** — same barrel narrowing (real `Divider` only), and the slide-out test drives the 200ms animation timer with fake timers (`jest.advanceTimersByTime`) instead of polling a real `setTimeout` against the wall clock; it now also asserts `onCancel` is not called before the animation completes.

Impact: worst per-test time in these suites under heavy artificial contention dropped from 2859ms to ≤169ms (≥30x headroom against jest's 5s timeout), and the full quiet `npm test` run dropped from ~25–32s to ~10–17s. CI runners (2 cores, always cold workers) benefit the most.

### How to test the changes in this Pull Request:

1. `cd plugins/newspack-plugin && npm test` — the full suite passes (45 suites / 417 tests).
2. Re-run `npm test` several times while the machine is busy (e.g. Docker envs running, or a few `node -e 'for(;;);'` busy loops): previously `emails.test.js` ("renders reader-revenue emails by default"), `enable-modal.test.js`, and `save-panel/index.test.js` would intermittently exceed the 5s per-test timeout; they now pass consistently with large margins.
3. Confirm the Emails suite no longer emits `Warning: An update to Emails inside a test was not wrapped in act(...)` in the jest output (it did before).
4. Review that assertions are unchanged: enable-modal/save-panel still render the real Newspack/Gutenberg components (`getByLabelText`, modal title, disabled states), and the emails suite still covers chip filtering, action routing, and preview-id fallbacks.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
