### PR TITLE
feat(reader-activation): per-direction sync capabilities and toggles

### DIFF
--- a/plugins/newspack-plugin/includes/cli/class-ras-contact-sync.php
+++ b/plugins/newspack-plugin/includes/cli/class-ras-contact-sync.php
@@ -527,6 +527,11 @@ class RAS_Contact_Sync {
 		// than a hard error the operator can resolve by enabling the field.
 		$integrations = Integrations::get_active_configured_integrations();
 		foreach ( $integrations as $integration_id => $integration ) {
+			// The sync run itself skips integrations without an (enabled) push, so
+			// their field selection must not block the backfill of the others.
+			if ( ! $integration->is_push_enabled() ) {
+				continue;
+			}
 			$enabled = $integration->get_enabled_outgoing_fields();
 			$missing = array_values( array_diff( $labels, $enabled ) );
 			if ( ! empty( $missing ) ) {

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/README.md
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/README.md
@@ -119,6 +119,8 @@ class My_Integration extends Integration {
 
 | Method | Purpose |
 | --- | --- |
+| `supports_push()` | Whether the integration can send contact data outbound. Defaults to `true`. Return `false` for an inbound-only integration — see [Direction capabilities and toggles](#direction-capabilities-and-toggles). |
+| `supports_pull()` | Whether the integration can fetch contact data inbound. Defaults to `true`. Return `false` if `pull_contact_data()`/`get_available_incoming_fields()` are not implemented. |
 | `is_set_up()` | Whether the integration is fully configured (external prerequisites **and** the integration's own settings). Defaults to `true`. Used by the Integrations UI to mark cards as ready. |
 | `is_connected()` | Whether the external service prerequisite alone (provider chosen, key entered) is configured at its source. Defaults to `true`. The Integrations UI routes the card's primary action on this: not connected → `get_setup_url()`, connected but not set up → the integration's own settings view ("Finish setup"). |
 | `get_unsupported_reason()` | Non-null string marks the integration as unsupported with the site's current configuration (e.g. the ESP integration while the newsletters provider is "manual"). The Integrations UI shows the string verbatim as the card's error badge and routes the primary action to `get_setup_url()`; the REST layer refuses to enable. Defaults to `null`. |
@@ -196,17 +198,19 @@ $this->update_settings_field_value( 'api_key', $new_value );
 
 ### Built-in metadata fields
 
-Every integration automatically gets three additional fields appended to its settings:
+Each integration automatically gets the fields for the directions it declares (see [Direction capabilities and toggles](#direction-capabilities-and-toggles) — a push-less integration gets none of the outbound rows, a pull-less one none of the inbound rows):
 
-| Field key | Type | Purpose |
-| --- | --- | --- |
-| `metadata_prefix` | `text` | String prepended to every outgoing metadata field name (default `NP_`). Stored at `newspack_integration_metadata_prefix_{id}`. Required so outgoing field names are unique on the external system. |
-| `outgoing_metadata_fields` | `metadata` | Subset of Newspack metadata fields to push. Stored at `newspack_integration_outgoing_fields_{id}`. |
-| `incoming_metadata_fields` | `metadata` | Subset of external fields to pull and store on the Newspack user. Stored at `newspack_integration_incoming_fields_{id}` as a `key => raw_data` map. |
+| Field key | Direction | Type | Purpose |
+| --- | --- | --- | --- |
+| `metadata_prefix` | outbound | `text` | String prepended to every outgoing metadata field name (default `NP_`). Stored at `newspack_integration_metadata_prefix_{id}`. Required so outgoing field names are unique on the external system. |
+| `outgoing_sync_enabled` | outbound | `checkbox` | Whether outbound sync currently runs. Default `true`. Pausing it stops pushes (including account-deletion propagation) while preserving the outgoing field selection. Stored at `newspack_integration_settings_{id}_outgoing_sync_enabled`. |
+| `outgoing_metadata_fields` | outbound | `metadata` | Subset of Newspack metadata fields to push. Stored at `newspack_integration_outgoing_fields_{id}`. |
+| `incoming_sync_enabled` | inbound | `checkbox` | Whether inbound sync currently runs. Default `true`. Pausing it stops pulls while preserving the incoming field selection. Stored at `newspack_integration_settings_{id}_incoming_sync_enabled`. |
+| `incoming_metadata_fields` | inbound | `metadata` | Subset of external fields to pull and store on the Newspack user. Stored at `newspack_integration_incoming_fields_{id}` as a `key => raw_data` map. |
 
 ### Built-in account-deletion fields
 
-In addition to the metadata fields, every integration automatically gets two account-deletion settings:
+Deletion propagates through the push pipeline, so push-capable integrations also get two account-deletion settings (a push-less integration gets neither):
 
 | Field key | Type | Purpose |
 | --- | --- | --- |
@@ -230,6 +234,25 @@ A settings field can declare an optional `condition` so the frontend hides it wh
 ```
 
 The configure-view in `src/wizards/audience/views/integrations/` honors this predicate. Conditions are single-level only (no nesting, no array of conditions).
+
+---
+
+## Direction capabilities and toggles
+
+Each direction is gated twice: by a **capability** the integration declares in code, and by a **toggle** the publisher controls in the wizard.
+
+| Method | Answers |
+| --- | --- |
+| `supports_push()` / `supports_pull()` | *Can* this integration ever sync in that direction? Override to `false` for a direction you don't implement. |
+| `is_push_enabled()` / `is_pull_enabled()` | *Should* it sync right now? `final` — capability AND toggle. Every dispatch site calls these. |
+
+Declaring `supports_push() === false` removes the entire Outbound settings group (metadata prefix, outbound toggle, outgoing fields, both account-deletion fields), keeps the integration out of `Sync::has_one_syncable_integration()`, and skips the push path — so an inbound-only integration renders no dead outbound controls. `supports_pull() === false` does the same for the Inbound group and `Contact_Pull`.
+
+The toggles pause a direction without discarding configuration: the stored field selections survive, so re-enabling restores them. Pausing is not retroactive — changes and deletions that occur while a direction is paused are not replayed on re-enable.
+
+An **undeclared** toggle field reads as enabled. An integration that overrides `get_settings_fields()` without the base metadata group has no toggle to store, so the direction can only ever be paused explicitly — pre-toggle third-party integrations keep syncing. This matches the configure-view, which treats a missing toggle field as enabled.
+
+**Scope caveat.** These toggles govern *this framework's* dispatch only. Newsletter-signup contact upserts reach the ESP through the Newspack Newsletters plugin's own channel and are unaffected by `outgoing_sync_enabled` — pausing outbound sync stops reader-data syncing, not newsletter subscriptions.
 
 ---
 

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-contact-pull.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-contact-pull.php
@@ -128,6 +128,13 @@ class Contact_Pull {
 		$errors = [];
 
 		foreach ( $integrations as $id => $integration ) {
+			// Skip integrations without an (enabled) pull: pausing the inbound
+			// toggle stops pulls while the stored incoming-field selection waits
+			// for re-enable, and pull-less integrations have nothing to pull from.
+			if ( ! $integration->is_pull_enabled() ) {
+				continue;
+			}
+
 			$selected_fields = $integration->get_enabled_incoming_fields();
 			if ( empty( $selected_fields ) ) {
 				continue;
@@ -162,6 +169,9 @@ class Contact_Pull {
 		$errors              = [];
 
 		foreach ( $active_integrations as $integration ) {
+			if ( ! $integration->is_pull_enabled() ) {
+				continue;
+			}
 			$selected_fields = $integration->get_enabled_incoming_fields();
 			if ( empty( $selected_fields ) ) {
 				continue;
@@ -230,6 +240,11 @@ class Contact_Pull {
 		// integration. Skip silently with success — "not set up" is a no-op,
 		// not an error worth surfacing to the loopback caller.
 		if ( ! $integration->is_set_up() ) {
+			wp_send_json_success();
+		}
+
+		// Same defense-in-depth for a paused or pull-less integration.
+		if ( ! $integration->is_pull_enabled() ) {
 			wp_send_json_success();
 		}
 
@@ -428,6 +443,11 @@ class Contact_Pull {
 
 		if ( ! $integration->is_set_up() ) {
 			Logger::log( sprintf( 'Integration "%s" no longer set up on pull retry %d; aborting retry chain.', $integration_id, $retry_count ), self::LOGGER_HEADER );
+			return;
+		}
+
+		if ( ! $integration->is_pull_enabled() ) {
+			Logger::log( sprintf( 'Inbound sync disabled for integration "%s" on pull retry %d; aborting retry chain.', $integration_id, $retry_count ), self::LOGGER_HEADER );
 			return;
 		}
 

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-integration.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-integration.php
@@ -988,7 +988,7 @@ abstract class Integration {
 				'key'         => 'outgoing_sync_enabled',
 				'type'        => 'checkbox',
 				'label'       => __( 'Enable outbound sync', 'newspack-plugin' ),
-				'description' => __( 'Sync reader data to this integration. Disabling pauses outbound sync, including account-deletion sync, and preserves the outgoing field selection.', 'newspack-plugin' ),
+				'description' => __( 'Sync reader data to this integration. Disabling pauses outbound sync, including account-deletion sync, and preserves the outgoing field selection. Changes and deletions that occur while paused are not sent retroactively on re-enable.', 'newspack-plugin' ),
 				'default'     => true,
 			];
 			$fields[] = [

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-integration.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-integration.php
@@ -96,6 +96,21 @@ abstract class Integration {
 	protected $settings_fields = [];
 
 	/**
+	 * Memoized return value of get_settings_fields().
+	 *
+	 * The declarations are stable for the life of the instance — the subclass
+	 * half is already frozen in $settings_fields, and the base-class groups are
+	 * built from per-instance capability flags — but rebuilding them costs a
+	 * __() call per label and description. The direction toggles resolve through
+	 * this array on every is_push_enabled()/is_pull_enabled() call, which run
+	 * once per contact in sync loops, so the array is built once and reused.
+	 * Reset by init(), the only place $settings_fields can change.
+	 *
+	 * @var array|null
+	 */
+	private $settings_fields_cache = null;
+
+	/**
 	 * Constructor.
 	 *
 	 * @param string $id          The unique identifier for this integration.
@@ -295,7 +310,8 @@ abstract class Integration {
 	 * Currently only initializes settings fields, but can be extended by child classes for additional setup.
 	 */
 	public function init() {
-		$this->settings_fields = $this->register_settings_fields();
+		$this->settings_fields       = $this->register_settings_fields();
+		$this->settings_fields_cache = null;
 	}
 
 	/**
@@ -365,6 +381,13 @@ abstract class Integration {
 	 * declared field never resolves to null — get_settings_field_value() falls
 	 * back to the field default.
 	 *
+	 * The stored value is coerced with wp_validate_boolean() rather than a cast
+	 * so this agrees with the wizard's toBool(): both read the strings `'false'`
+	 * and `'0'` as off. The sanctioned write path can't produce `'false'` (the
+	 * checkbox sanitizes to a real bool), but a hand-set option or external
+	 * writer otherwise diverges in the worst direction — UI paused, dispatch
+	 * still pushing.
+	 *
 	 * @return bool True if pushes should run.
 	 */
 	final public function is_push_enabled(): bool {
@@ -372,7 +395,7 @@ abstract class Integration {
 			return false;
 		}
 		$enabled = $this->get_settings_field_value( 'outgoing_sync_enabled' );
-		return null === $enabled || (bool) $enabled;
+		return null === $enabled || \wp_validate_boolean( $enabled );
 	}
 
 	/**
@@ -384,7 +407,8 @@ abstract class Integration {
 	 *
 	 * As with is_push_enabled(), an undeclared toggle field reads as null and
 	 * counts as enabled — only an explicit stored value can pause the
-	 * direction.
+	 * direction — and the stored value is coerced with wp_validate_boolean() so
+	 * PHP and the wizard agree on the falsy string forms.
 	 *
 	 * @return bool True if pulls should run.
 	 */
@@ -393,7 +417,7 @@ abstract class Integration {
 			return false;
 		}
 		$enabled = $this->get_settings_field_value( 'incoming_sync_enabled' );
-		return null === $enabled || (bool) $enabled;
+		return null === $enabled || \wp_validate_boolean( $enabled );
 	}
 
 	/**
@@ -1104,14 +1128,20 @@ abstract class Integration {
 	 * reads as null/falsy, which the deletion dispatcher treats as disabled).
 	 * The metadata groups are capability-gated in get_metadata_fields().
 	 *
+	 * Memoized per instance — see $settings_fields_cache for why.
+	 *
 	 * @return array Array of settings field declarations.
 	 */
 	public function get_settings_fields() {
+		if ( null !== $this->settings_fields_cache ) {
+			return $this->settings_fields_cache;
+		}
 		$fields = $this->settings_fields;
 		if ( $this->supports_push() ) {
 			$fields = array_merge( $fields, $this->get_account_deletion_fields() );
 		}
-		return array_merge( $fields, $this->get_metadata_fields() );
+		$this->settings_fields_cache = array_merge( $fields, $this->get_metadata_fields() );
+		return $this->settings_fields_cache;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-integration.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-integration.php
@@ -319,6 +319,65 @@ abstract class Integration {
 	abstract public function can_sync( $return_errors = false );
 
 	/**
+	 * Whether this integration can push (outbound) contact data to its external
+	 * destination.
+	 *
+	 * Push-capable integrations get the Outbound settings section, the
+	 * account-deletion sync fields and the metadata field prefix, and count
+	 * toward Sync::has_one_syncable_integration(). Inbound-only integrations
+	 * (those whose push_contact_data() is a deliberate no-op) should override
+	 * this to return false so the settings UI shows no dead outbound controls
+	 * and the sync framework skips the push path entirely.
+	 *
+	 * @return bool True if the integration can push contact data.
+	 */
+	public function supports_push(): bool {
+		return true;
+	}
+
+	/**
+	 * Whether this integration can pull (inbound) contact data from its
+	 * external source.
+	 *
+	 * Pull-capable integrations get the Inbound settings section and are
+	 * included in the Contact_Pull dispatch. Integrations that don't implement
+	 * pull_contact_data()/get_available_incoming_fields() should override this
+	 * to return false.
+	 *
+	 * @return bool True if the integration can pull contact data.
+	 */
+	public function supports_pull(): bool {
+		return true;
+	}
+
+	/**
+	 * Whether outbound (push) sync should currently run for this integration.
+	 *
+	 * Combines the push capability with the `outgoing_sync_enabled` toggle,
+	 * which pauses the direction while preserving the configured outgoing
+	 * field selection. Every push dispatch site must consult this — including
+	 * account-deletion propagation, which travels the push pipeline.
+	 *
+	 * @return bool True if pushes should run.
+	 */
+	final public function is_push_enabled(): bool {
+		return $this->supports_push() && (bool) $this->get_settings_field_value( 'outgoing_sync_enabled' );
+	}
+
+	/**
+	 * Whether inbound (pull) sync should currently run for this integration.
+	 *
+	 * Combines the pull capability with the `incoming_sync_enabled` toggle,
+	 * which pauses the direction while preserving the configured incoming
+	 * field selection. Every pull dispatch site must consult this.
+	 *
+	 * @return bool True if pulls should run.
+	 */
+	final public function is_pull_enabled(): bool {
+		return $this->supports_pull() && (bool) $this->get_settings_field_value( 'incoming_sync_enabled' );
+	}
+
+	/**
 	 * Push contact data to the integration destination.
 	 *
 	 * This method should be implemented by child classes to send
@@ -830,9 +889,11 @@ abstract class Integration {
 	/**
 	 * Get the account-deletion fields declared by this integration.
 	 *
-	 * Auto-appended to every integration's settings. The first field is a top-level
-	 * toggle; the second field is gated by the first via the `condition` predicate
-	 * honored by the frontend renderer.
+	 * Auto-appended to push-capable integrations' settings (see
+	 * get_settings_fields()): deletion propagates through the push pipeline, so
+	 * for a push-less integration these would be dead controls. The first field
+	 * is a top-level toggle; the second field is gated by the first via the
+	 * `condition` predicate honored by the frontend renderer.
 	 *
 	 * @return array Array of settings field declarations.
 	 */
@@ -885,30 +946,55 @@ abstract class Integration {
 	/**
 	 * Get the metadata fields declared by this integration.
 	 *
+	 * Capability-aware: the outbound group (metadata prefix, outbound sync
+	 * toggle, outgoing fields) is declared only for push-capable integrations —
+	 * the prefix is only ever read on push paths (prepare_contact()) — and the
+	 * inbound group (inbound sync toggle, incoming fields) only for
+	 * pull-capable ones, so an integration lacking a direction gets no dead
+	 * controls for it.
+	 *
 	 * @return array Array of settings field declarations.
 	 */
 	public function get_metadata_fields() {
-		return [
-			[
+		$fields = [];
+		if ( $this->supports_push() ) {
+			$fields[] = [
 				'key'         => 'metadata_prefix',
 				'type'        => 'text',
 				'label'       => __( 'Metadata field prefix', 'newspack-plugin' ),
 				'description' => __( 'A string to prefix metadata fields synced to the integration. Required to ensure that metadata field names are unique. Default: NP_', 'newspack-plugin' ),
 				'default'     => 'NP_',
-			],
-			[
+			];
+			$fields[] = [
+				'key'         => 'outgoing_sync_enabled',
+				'type'        => 'checkbox',
+				'label'       => __( 'Enable outbound sync', 'newspack-plugin' ),
+				'description' => __( 'Sync reader data to this integration. Disabling pauses outbound sync, including account-deletion sync, and preserves the outgoing field selection.', 'newspack-plugin' ),
+				'default'     => true,
+			];
+			$fields[] = [
 				'key'     => 'outgoing_metadata_fields',
 				'type'    => 'metadata',
 				'label'   => __( 'Outgoing metadata fields', 'newspack-plugin' ),
 				'default' => [],
-			],
-			[
+			];
+		}
+		if ( $this->supports_pull() ) {
+			$fields[] = [
+				'key'         => 'incoming_sync_enabled',
+				'type'        => 'checkbox',
+				'label'       => __( 'Enable inbound sync', 'newspack-plugin' ),
+				'description' => __( 'Pull contact data from this integration. Disabling pauses inbound sync and preserves the incoming field selection.', 'newspack-plugin' ),
+				'default'     => true,
+			];
+			$fields[] = [
 				'key'     => 'incoming_metadata_fields',
 				'type'    => 'metadata',
 				'label'   => __( 'Incoming metadata fields', 'newspack-plugin' ),
 				'default' => [],
-			],
-		];
+			];
+		}
+		return $fields;
 	}
 
 	/**
@@ -993,14 +1079,20 @@ abstract class Integration {
 	/**
 	 * Get the settings fields declared by this integration.
 	 *
+	 * The account-deletion group follows the push capability: deletion sync
+	 * routes through push_contact_data()/delete_contact(), so a push-less
+	 * integration gets neither field (and its `sync_account_deletion` value
+	 * reads as null/falsy, which the deletion dispatcher treats as disabled).
+	 * The metadata groups are capability-gated in get_metadata_fields().
+	 *
 	 * @return array Array of settings field declarations.
 	 */
 	public function get_settings_fields() {
-		return array_merge(
-			$this->settings_fields,
-			$this->get_account_deletion_fields(),
-			$this->get_metadata_fields()
-		);
+		$fields = $this->settings_fields;
+		if ( $this->supports_push() ) {
+			$fields = array_merge( $fields, $this->get_account_deletion_fields() );
+		}
+		return array_merge( $fields, $this->get_metadata_fields() );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-integration.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-integration.php
@@ -358,10 +358,21 @@ abstract class Integration {
 	 * field selection. Every push dispatch site must consult this — including
 	 * account-deletion propagation, which travels the push pipeline.
 	 *
+	 * An undeclared toggle field (e.g. a subclass overriding
+	 * get_settings_fields() without the base metadata group) reads as null and
+	 * counts as enabled: the toggle can only ever pause sync explicitly,
+	 * mirroring the frontend's missing-toggle-means-enabled rendering. A
+	 * declared field never resolves to null — get_settings_field_value() falls
+	 * back to the field default.
+	 *
 	 * @return bool True if pushes should run.
 	 */
 	final public function is_push_enabled(): bool {
-		return $this->supports_push() && (bool) $this->get_settings_field_value( 'outgoing_sync_enabled' );
+		if ( ! $this->supports_push() ) {
+			return false;
+		}
+		$enabled = $this->get_settings_field_value( 'outgoing_sync_enabled' );
+		return null === $enabled || (bool) $enabled;
 	}
 
 	/**
@@ -371,10 +382,18 @@ abstract class Integration {
 	 * which pauses the direction while preserving the configured incoming
 	 * field selection. Every pull dispatch site must consult this.
 	 *
+	 * As with is_push_enabled(), an undeclared toggle field reads as null and
+	 * counts as enabled — only an explicit stored value can pause the
+	 * direction.
+	 *
 	 * @return bool True if pulls should run.
 	 */
 	final public function is_pull_enabled(): bool {
-		return $this->supports_pull() && (bool) $this->get_settings_field_value( 'incoming_sync_enabled' );
+		if ( ! $this->supports_pull() ) {
+			return false;
+		}
+		$enabled = $this->get_settings_field_value( 'incoming_sync_enabled' );
+		return null === $enabled || (bool) $enabled;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
@@ -1178,6 +1178,20 @@ class Contact_Sync extends Sync {
 		$contact    = \apply_filters( 'newspack_esp_sync_contact', $contact, $context );
 		$skip_lists = ! empty( $options['skip_lists'] );
 		foreach ( Integrations::get_active_configured_integrations() as $integration_id => $integration ) {
+			// The real push path skips integrations without an (enabled) push, so
+			// report the skip rather than a payload the run would never send —
+			// a preview that disagrees with the run defeats the point of --dry-run.
+			if ( ! $integration->is_push_enabled() ) {
+				static::log(
+					sprintf(
+						'[dry-run] SKIPPED integration "%s": %s.',
+						$integration_id,
+						$integration->supports_push() ? 'outbound sync is paused' : 'integration does not support outbound sync'
+					)
+				);
+				continue;
+			}
+
 			$prepared = self::prepare_contact_for_integration( $integration, $contact, $options );
 			$metadata = $prepared['metadata'] ?? [];
 			static::log(

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
@@ -285,6 +285,13 @@ class Contact_Sync extends Sync {
 		}
 
 		foreach ( $integrations as $integration_id => $integration ) {
+			// Skip integrations without an (enabled) push: pausing the outbound
+			// toggle stops pushes while the stored outgoing-field selection waits
+			// for re-enable, and push-less integrations have nothing to push to.
+			if ( ! $integration->is_push_enabled() ) {
+				continue;
+			}
+
 			$integration_contact = self::prepare_contact_for_integration( $integration, $contact, $options );
 
 			// Added logging here to more easily monitor integration sync data. Can be removed once integrations are released.
@@ -424,6 +431,12 @@ class Contact_Sync extends Sync {
 		$flag_contact = \apply_filters( 'newspack_esp_sync_contact', $flag_contact, $context );
 
 		foreach ( $integrations as $integration_id => $integration ) {
+			// Deletion propagates through the push pipeline (delete_contact() /
+			// flag-mode push_contact_data()), so it follows the push capability
+			// and the outbound toggle like any other outbound sync.
+			if ( ! $integration->is_push_enabled() ) {
+				continue;
+			}
 			if ( ! $integration->get_settings_field_value( 'sync_account_deletion' ) ) {
 				continue;
 			}
@@ -685,6 +698,11 @@ class Contact_Sync extends Sync {
 			return;
 		}
 
+		if ( ! $integration->is_push_enabled() ) {
+			static::log( sprintf( 'Outbound sync disabled for integration "%s" on retry %d; aborting retry chain.', $integration_id, $retry_count ) );
+			return;
+		}
+
 		static::log( sprintf( 'Executing retry %d/%d for integration "%s" sync of user %d (%s).', $retry_count, self::MAX_RETRIES, $integration_id, $user_id, $contact['email'] ?? 'unknown' ) );
 
 		/** This filter is documented in includes/reader-activation/sync/class-contact-sync.php */
@@ -893,6 +911,11 @@ class Contact_Sync extends Sync {
 
 		if ( ! $integration->is_set_up() ) {
 			static::log( sprintf( 'Integration "%s" no longer set up on deletion retry %d; aborting retry chain.', $integration_id, $retry_count ) );
+			return;
+		}
+
+		if ( ! $integration->is_push_enabled() ) {
+			static::log( sprintf( 'Outbound sync disabled for integration "%s" on deletion retry %d; aborting retry chain.', $integration_id, $retry_count ) );
 			return;
 		}
 

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-sync.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-sync.php
@@ -171,29 +171,53 @@ class Sync {
 			// push never satisfy it, even when their can_sync() reports no errors
 			// (an inbound-only integration has nothing to gate there).
 			if ( ! $integration->is_push_enabled() ) {
-				if ( $integration->supports_push() ) {
-					$result->add(
-						'integration_push_disabled',
-						sprintf(
-							/* translators: %s: integration name. */
-							__( 'Outbound sync is disabled for the %s integration.', 'newspack-plugin' ),
-							$integration->get_name()
-						)
-					);
-				} else {
-					$result->add(
-						'integration_push_not_supported',
-						sprintf(
-							/* translators: %s: integration name. */
-							__( 'The %s integration does not support outbound sync.', 'newspack-plugin' ),
-							$integration->get_name()
-						)
-					);
+				// Only collect a reason when one will be read: the boolean return
+				// paths discard $result, and this is a gating predicate on hot paths,
+				// so building translated messages there is pure waste.
+				if ( $return_errors ) {
+					if ( $integration->supports_push() ) {
+						$result->add(
+							'integration_push_disabled',
+							sprintf(
+								/* translators: %s: integration name. */
+								__( 'Outbound sync is disabled for the %s integration.', 'newspack-plugin' ),
+								$integration->get_name()
+							)
+						);
+					} else {
+						$result->add(
+							'integration_push_not_supported',
+							sprintf(
+								/* translators: %s: integration name. */
+								__( 'The %s integration does not support outbound sync.', 'newspack-plugin' ),
+								$integration->get_name()
+							)
+						);
+					}
 				}
 				continue;
 			}
 
 			$can_sync_integration = $integration->can_sync( true );
+
+			// can_sync() is declared `bool|\WP_Error`, so a subclass may honor that
+			// signature and ignore $return_errors — normalize a bare bool rather than
+			// fatal on has_errors() below. All known subclasses return the WP_Error,
+			// but the contract invites third-party integrations not to.
+			if ( ! is_wp_error( $can_sync_integration ) ) {
+				$normalized = new \WP_Error();
+				if ( ! $can_sync_integration ) {
+					$normalized->add(
+						'integration_cannot_sync',
+						sprintf(
+							/* translators: %s: integration name. */
+							__( 'The %s integration is not ready to sync.', 'newspack-plugin' ),
+							$integration->get_name()
+						)
+					);
+				}
+				$can_sync_integration = $normalized;
+			}
 
 			// If any integration can sync, report success. In errors mode that must
 			// be a fresh WP_Error: $result may already hold reasons collected from

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-sync.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-sync.php
@@ -166,6 +166,33 @@ class Sync {
 		$result = new \WP_Error();
 
 		foreach ( $integrations as $integration ) {
+			// This predicate answers "can at least one integration receive contact
+			// data" — a push-path question, so integrations without an (enabled)
+			// push never satisfy it, even when their can_sync() reports no errors
+			// (an inbound-only integration has nothing to gate there).
+			if ( ! $integration->is_push_enabled() ) {
+				if ( $integration->supports_push() ) {
+					$result->add(
+						'integration_push_disabled',
+						sprintf(
+							/* translators: %s: integration name. */
+							__( 'Outbound sync is disabled for the %s integration.', 'newspack-plugin' ),
+							$integration->get_name()
+						)
+					);
+				} else {
+					$result->add(
+						'integration_push_not_supported',
+						sprintf(
+							/* translators: %s: integration name. */
+							__( 'The %s integration does not support outbound sync.', 'newspack-plugin' ),
+							$integration->get_name()
+						)
+					);
+				}
+				continue;
+			}
+
 			$can_sync_integration = $integration->can_sync( true );
 
 			// If any integration can sync, return true.

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-sync.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-sync.php
@@ -195,10 +195,13 @@ class Sync {
 
 			$can_sync_integration = $integration->can_sync( true );
 
-			// If any integration can sync, return true.
+			// If any integration can sync, report success. In errors mode that must
+			// be a fresh WP_Error: $result may already hold reasons collected from
+			// integrations skipped or failed above, and every $return_errors caller
+			// reads has_errors() as "cannot sync".
 			if ( ! $can_sync_integration->has_errors() ) {
 				if ( $return_errors ) {
-					return $result;
+					return new \WP_Error();
 				} else {
 					return true;
 				}

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -133,6 +133,11 @@ export const reconcileOperators = ( currentMap, options ) => {
 // in JS, so the falsy string forms are matched explicitly.
 const toBool = value => ( typeof value === 'string' ? ! [ '', '0', 'false' ].includes( value.toLowerCase() ) : Boolean( value ) );
 
+// Account-deletion sync travels the push pipeline (see get_account_deletion_fields()
+// in class-integration.php), so these Settings-group controls follow the outbound
+// pause: the dispatcher skips a paused integration before reading them.
+const ACCOUNT_DELETION_KEYS = [ 'sync_account_deletion', 'account_deletion_handling' ];
+
 // True for a plain `{ key => value }` map (the shape `incoming_metadata_fields`
 // uses), excluding arrays and null so those keep their own comparison branches.
 const isMap = value => null !== value && 'object' === typeof value && ! Array.isArray( value );
@@ -228,6 +233,18 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 			} else {
 				groups.settingsFields.push( field );
 			}
+		}
+		// A toggle renders only inside its direction section; without the paired
+		// metadata field there is no section, so fall the toggle through to the
+		// generic Settings group instead of shipping a field the view can neither
+		// display nor edit.
+		if ( groups.inboundToggleField && ! groups.inboundField ) {
+			groups.settingsFields.push( groups.inboundToggleField );
+			groups.inboundToggleField = null;
+		}
+		if ( groups.outboundToggleField && ! groups.outboundField ) {
+			groups.settingsFields.push( groups.outboundToggleField );
+			groups.outboundToggleField = null;
 		}
 		return groups;
 	}, [ integration?.settings ] );
@@ -390,6 +407,13 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 	const inboundEnabled = ! inboundToggleField || toBool( getFieldValue( inboundToggleField ) );
 	const outboundEnabled = ! outboundToggleField || toBool( getFieldValue( outboundToggleField ) );
 
+	// While outbound sync is paused, hide the account-deletion controls along
+	// with the outgoing picker: the dispatcher skips them, and leaving them
+	// active would present deletion sync as live. Stored values are preserved.
+	const visibleSettingsFields = settingsFields.filter(
+		field => fieldIsVisible( field ) && ( outboundEnabled || ! ACCOUNT_DELETION_KEYS.includes( field.key ) )
+	);
+
 	const renderSectionToggle = toggleSetting =>
 		toggleSetting && (
 			<ToggleControl
@@ -406,11 +430,11 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 			{ navBlockDialog }
 			<div className="newspack-configure-view">
 				{ /* Section 1: Settings */ }
-				{ settingsFields.length > 0 && (
+				{ visibleSettingsFields.length > 0 && (
 					<Grid columns={ 2 } gutter={ 32 }>
 						<SectionHeader heading={ 2 } title={ __( 'Settings', 'newspack-plugin' ) } />
 						<Grid columns={ 1 } gutter={ 24 }>
-							{ settingsFields.filter( fieldIsVisible ).map( field => (
+							{ visibleSettingsFields.map( field => (
 								<SettingsField
 									key={ field.key }
 									field={ field }

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -424,15 +424,20 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 
 	const visibleSettingsFields = settingsFields.filter( fieldIsVisible );
 
-	const renderSectionToggle = toggleSetting =>
+	// The divider only renders while the direction is enabled: it separates the
+	// toggle from the section content below it, and a paused section has none.
+	const renderSectionToggle = ( toggleSetting, showDivider ) =>
 		toggleSetting && (
-			<ToggleControl
-				label={ toggleSetting.label }
-				help={ toggleSetting.description }
-				checked={ toBool( getFieldValue( toggleSetting ) ) }
-				onChange={ checked => handleFieldChange( toggleSetting.key, checked ) }
-				__nextHasNoMarginBottom
-			/>
+			<>
+				<ToggleControl
+					label={ toggleSetting.label }
+					help={ toggleSetting.description }
+					checked={ toBool( getFieldValue( toggleSetting ) ) }
+					onChange={ checked => handleFieldChange( toggleSetting.key, checked ) }
+					__nextHasNoMarginBottom
+				/>
+				{ showDivider && <Divider variant="tertiary" marginTop={ 0 } marginBottom={ 0 } /> }
+			</>
 		);
 
 	return (
@@ -463,7 +468,7 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 						<Grid columns={ 2 } gutter={ 32 } noMargin>
 							<SectionHeader heading={ 2 } title={ __( 'Inbound', 'newspack-plugin' ) } noMargin />
 							<Grid columns={ 1 } rowGap={ 8 } noMargin>
-								{ renderSectionToggle( inboundToggleField ) }
+								{ renderSectionToggle( inboundToggleField, inboundEnabled ) }
 								{ inboundEnabled &&
 									( inboundField.options || [] ).map( option => {
 										// Options are always { value, label, matching_function, has_options } objects
@@ -521,7 +526,7 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 						<Grid columns={ 2 } gutter={ 32 } noMargin>
 							<SectionHeader heading={ 2 } title={ __( 'Outbound', 'newspack-plugin' ) } noMargin />
 							<Grid columns={ 1 } rowGap={ 16 } noMargin>
-								{ renderSectionToggle( outboundToggleField ) }
+								{ renderSectionToggle( outboundToggleField, outboundEnabled ) }
 								{ outboundEnabled &&
 									outboundSettingsFields
 										.filter( fieldIsVisible )

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -426,10 +426,10 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 
 	// The divider separates the toggle from the section content below it, so it
 	// only renders when there is content to divide: the caller passes false for a
-	// paused direction or an empty section. `dividerMargin` (applied above and
-	// below) compensates for the sections' different grid rowGaps — Inbound's 8
-	// vs Outbound's 16 — so both sections net the same 16px around the rule.
-	const renderSectionToggle = ( toggleSetting, showDivider, dividerMargin = 0 ) =>
+	// paused direction or an empty section. Its spacing comes entirely from the
+	// section grid's rowGap — `.newspack-grid > *` zeroes child margins with
+	// !important, so margins set on the divider itself can never take effect.
+	const renderSectionToggle = ( toggleSetting, showDivider ) =>
 		toggleSetting && (
 			<>
 				<ToggleControl
@@ -439,7 +439,7 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 					onChange={ checked => handleFieldChange( toggleSetting.key, checked ) }
 					__nextHasNoMarginBottom
 				/>
-				{ showDivider && <Divider variant="tertiary" marginTop={ dividerMargin } marginBottom={ dividerMargin } /> }
+				{ showDivider && <Divider variant="tertiary" marginTop={ 0 } marginBottom={ 0 } /> }
 			</>
 		);
 
@@ -470,53 +470,56 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 						<Divider alignment="full-width" variant="tertiary" marginTop={ 64 } marginBottom={ 64 } />
 						<Grid columns={ 2 } gutter={ 32 } noMargin>
 							<SectionHeader heading={ 2 } title={ __( 'Inbound', 'newspack-plugin' ) } noMargin />
-							<Grid columns={ 1 } rowGap={ 8 } noMargin>
-								{ renderSectionToggle( inboundToggleField, inboundEnabled && ( inboundField.options || [] ).length > 0, 8 ) }
-								{ inboundEnabled &&
-									( inboundField.options || [] ).map( option => {
-										// Options are always { value, label, matching_function, has_options } objects
-										// for this field (see class-integration.php:get_settings_config()).
-										const optionValue = option.value;
-										const optionLabel = option.label || option.value;
-										// The stored value for this field is a { key => operator } map, not an array:
-										// a key present means enabled, and its value is the chosen matching operator.
-										const currentMap = getFieldValue( inboundField ) || {};
-										const checked = Object.prototype.hasOwnProperty.call( currentMap, optionValue );
-										const operatorOptions = operatorOptionsForField( option );
-										// If the stored operator isn't among the options offered for this field's
-										// current value_type (e.g. a field enabled before it declared a type), fall
-										// back to the first option so the control never shows a value with no option.
-										const selectedOperator = operatorOptions.some( o => o.value === currentMap[ optionValue ] )
-											? currentMap[ optionValue ]
-											: operatorOptions[ 0 ]?.value;
-										return (
-											<div className="newspack-configure-view__inbound-field" key={ optionValue }>
-												<CheckboxControl
-													className="newspack-checkbox-control"
-													label={ optionLabel }
-													checked={ checked }
-													onChange={ isChecked =>
-														handleFieldChange( inboundField.key, toggleField( currentMap, option, isChecked ) )
-													}
-												/>
-												{ checked && (
-													<SelectControl
-														className="newspack-configure-view__inbound-operator"
-														label={ __( 'Segment as', 'newspack-plugin' ) }
-														hideLabelFromVision
-														value={ selectedOperator }
-														options={ operatorOptions }
-														onChange={ operator =>
-															handleFieldChange( inboundField.key, {
-																...currentMap,
-																[ optionValue ]: operator,
-															} )
+							<Grid columns={ 1 } rowGap={ 16 } noMargin>
+								{ renderSectionToggle( inboundToggleField, inboundEnabled && ( inboundField.options || [] ).length > 0 ) }
+								{ inboundEnabled && (
+									<Grid columns={ 1 } rowGap={ 8 } noMargin>
+										{ ( inboundField.options || [] ).map( option => {
+											// Options are always { value, label, matching_function, has_options } objects
+											// for this field (see class-integration.php:get_settings_config()).
+											const optionValue = option.value;
+											const optionLabel = option.label || option.value;
+											// The stored value for this field is a { key => operator } map, not an array:
+											// a key present means enabled, and its value is the chosen matching operator.
+											const currentMap = getFieldValue( inboundField ) || {};
+											const checked = Object.prototype.hasOwnProperty.call( currentMap, optionValue );
+											const operatorOptions = operatorOptionsForField( option );
+											// If the stored operator isn't among the options offered for this field's
+											// current value_type (e.g. a field enabled before it declared a type), fall
+											// back to the first option so the control never shows a value with no option.
+											const selectedOperator = operatorOptions.some( o => o.value === currentMap[ optionValue ] )
+												? currentMap[ optionValue ]
+												: operatorOptions[ 0 ]?.value;
+											return (
+												<div className="newspack-configure-view__inbound-field" key={ optionValue }>
+													<CheckboxControl
+														className="newspack-checkbox-control"
+														label={ optionLabel }
+														checked={ checked }
+														onChange={ isChecked =>
+															handleFieldChange( inboundField.key, toggleField( currentMap, option, isChecked ) )
 														}
 													/>
-												) }
-											</div>
-										);
-									} ) }
+													{ checked && (
+														<SelectControl
+															className="newspack-configure-view__inbound-operator"
+															label={ __( 'Segment as', 'newspack-plugin' ) }
+															hideLabelFromVision
+															value={ selectedOperator }
+															options={ operatorOptions }
+															onChange={ operator =>
+																handleFieldChange( inboundField.key, {
+																	...currentMap,
+																	[ optionValue ]: operator,
+																} )
+															}
+														/>
+													) }
+												</div>
+											);
+										} ) }
+									</Grid>
+								) }
 							</Grid>
 						</Grid>
 					</>

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -423,6 +423,7 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 	const outboundEnabled = ! outboundToggleField || toBool( getFieldValue( outboundToggleField ) );
 
 	const visibleSettingsFields = settingsFields.filter( fieldIsVisible );
+	const visibleOutboundSettingsFields = outboundSettingsFields.filter( fieldIsVisible );
 
 	// The divider separates the toggle from the section content below it, so it
 	// only renders when there is content to divide: the caller passes false for a
@@ -532,18 +533,19 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 						<Grid columns={ 2 } gutter={ 32 } noMargin>
 							<SectionHeader heading={ 2 } title={ __( 'Outbound', 'newspack-plugin' ) } noMargin />
 							<Grid columns={ 1 } rowGap={ 16 } noMargin>
-								{ renderSectionToggle( outboundToggleField, outboundEnabled ) }
+								{ renderSectionToggle(
+									outboundToggleField,
+									outboundEnabled && ( visibleOutboundSettingsFields.length > 0 || !! outboundField )
+								) }
 								{ outboundEnabled &&
-									outboundSettingsFields
-										.filter( fieldIsVisible )
-										.map( field => (
-											<SettingsField
-												key={ field.key }
-												field={ field }
-												value={ getFieldValue( field ) }
-												onChange={ val => handleFieldChange( field.key, val ) }
-											/>
-										) ) }
+									visibleOutboundSettingsFields.map( field => (
+										<SettingsField
+											key={ field.key }
+											field={ field }
+											value={ getFieldValue( field ) }
+											onChange={ val => handleFieldChange( field.key, val ) }
+										/>
+									) ) }
 								{ outboundEnabled && outboundField && (
 									<Accordion hideSingleTitle>
 										{ ( outboundField.grouped_options || [] ).map( ( group, index ) => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -2,7 +2,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl, SelectControl } from '@wordpress/components';
+import { CheckboxControl, SelectControl, ToggleControl } from '@wordpress/components';
 import { useDispatch } from '@wordpress/data';
 import { useEffect, useMemo, useRef, useState } from '@wordpress/element';
 
@@ -208,24 +208,28 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 		setDraft( prev => ( { ...prev, [ fieldKey ]: value } ) );
 	};
 
-	// Split settings into groups.
-	const { settingsFields, inboundField, outboundField } = useMemo( () => {
+	// Split settings into groups. The per-direction enable toggles are pulled
+	// out of the generic Settings group so they render inside their section.
+	const { settingsFields, inboundField, outboundField, inboundToggleField, outboundToggleField } = useMemo( () => {
+		const empty = { settingsFields: [], inboundField: null, outboundField: null, inboundToggleField: null, outboundToggleField: null };
 		if ( ! integration?.settings ) {
-			return { settingsFields: [], inboundField: null, outboundField: null };
+			return empty;
 		}
-		const settings = [];
-		let inbound = null;
-		let outbound = null;
+		const groups = { ...empty, settingsFields: [] };
 		for ( const field of integration.settings ) {
 			if ( field.key === 'incoming_metadata_fields' ) {
-				inbound = field;
+				groups.inboundField = field;
 			} else if ( field.key === 'outgoing_metadata_fields' ) {
-				outbound = field;
+				groups.outboundField = field;
+			} else if ( field.key === 'incoming_sync_enabled' ) {
+				groups.inboundToggleField = field;
+			} else if ( field.key === 'outgoing_sync_enabled' ) {
+				groups.outboundToggleField = field;
 			} else {
-				settings.push( field );
+				groups.settingsFields.push( field );
 			}
 		}
-		return { settingsFields: settings, inboundField: inbound, outboundField: outbound };
+		return groups;
 	}, [ integration?.settings ] );
 
 	// Save submits the draft plus, when it needs repair, a reconciled inbound
@@ -379,6 +383,24 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 		return refValue === field.condition.equals;
 	};
 
+	// A direction is considered enabled when its toggle field is absent (an
+	// integration payload predating the toggles) or its live value is truthy.
+	// Disabling hides the field pickers but leaves the stored selections
+	// untouched, so re-enabling restores them.
+	const inboundEnabled = ! inboundToggleField || toBool( getFieldValue( inboundToggleField ) );
+	const outboundEnabled = ! outboundToggleField || toBool( getFieldValue( outboundToggleField ) );
+
+	const renderSectionToggle = toggleSetting =>
+		toggleSetting && (
+			<ToggleControl
+				label={ toggleSetting.label }
+				help={ toggleSetting.description }
+				checked={ toBool( getFieldValue( toggleSetting ) ) }
+				onChange={ checked => handleFieldChange( toggleSetting.key, checked ) }
+				__nextHasNoMarginBottom
+			/>
+		);
+
 	return (
 		<>
 			{ navBlockDialog }
@@ -407,50 +429,52 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 						<Grid columns={ 2 } gutter={ 32 } noMargin>
 							<SectionHeader heading={ 2 } title={ __( 'Inbound', 'newspack-plugin' ) } noMargin />
 							<Grid columns={ 1 } rowGap={ 8 } noMargin>
-								{ ( inboundField.options || [] ).map( option => {
-									// Options are always { value, label, matching_function, has_options } objects
-									// for this field (see class-integration.php:get_settings_config()).
-									const optionValue = option.value;
-									const optionLabel = option.label || option.value;
-									// The stored value for this field is a { key => operator } map, not an array:
-									// a key present means enabled, and its value is the chosen matching operator.
-									const currentMap = getFieldValue( inboundField ) || {};
-									const checked = Object.prototype.hasOwnProperty.call( currentMap, optionValue );
-									const operatorOptions = operatorOptionsForField( option );
-									// If the stored operator isn't among the options offered for this field's
-									// current value_type (e.g. a field enabled before it declared a type), fall
-									// back to the first option so the control never shows a value with no option.
-									const selectedOperator = operatorOptions.some( o => o.value === currentMap[ optionValue ] )
-										? currentMap[ optionValue ]
-										: operatorOptions[ 0 ]?.value;
-									return (
-										<div className="newspack-configure-view__inbound-field" key={ optionValue }>
-											<CheckboxControl
-												className="newspack-checkbox-control"
-												label={ optionLabel }
-												checked={ checked }
-												onChange={ isChecked =>
-													handleFieldChange( inboundField.key, toggleField( currentMap, option, isChecked ) )
-												}
-											/>
-											{ checked && (
-												<SelectControl
-													className="newspack-configure-view__inbound-operator"
-													label={ __( 'Segment as', 'newspack-plugin' ) }
-													hideLabelFromVision
-													value={ selectedOperator }
-													options={ operatorOptions }
-													onChange={ operator =>
-														handleFieldChange( inboundField.key, {
-															...currentMap,
-															[ optionValue ]: operator,
-														} )
+								{ renderSectionToggle( inboundToggleField ) }
+								{ inboundEnabled &&
+									( inboundField.options || [] ).map( option => {
+										// Options are always { value, label, matching_function, has_options } objects
+										// for this field (see class-integration.php:get_settings_config()).
+										const optionValue = option.value;
+										const optionLabel = option.label || option.value;
+										// The stored value for this field is a { key => operator } map, not an array:
+										// a key present means enabled, and its value is the chosen matching operator.
+										const currentMap = getFieldValue( inboundField ) || {};
+										const checked = Object.prototype.hasOwnProperty.call( currentMap, optionValue );
+										const operatorOptions = operatorOptionsForField( option );
+										// If the stored operator isn't among the options offered for this field's
+										// current value_type (e.g. a field enabled before it declared a type), fall
+										// back to the first option so the control never shows a value with no option.
+										const selectedOperator = operatorOptions.some( o => o.value === currentMap[ optionValue ] )
+											? currentMap[ optionValue ]
+											: operatorOptions[ 0 ]?.value;
+										return (
+											<div className="newspack-configure-view__inbound-field" key={ optionValue }>
+												<CheckboxControl
+													className="newspack-checkbox-control"
+													label={ optionLabel }
+													checked={ checked }
+													onChange={ isChecked =>
+														handleFieldChange( inboundField.key, toggleField( currentMap, option, isChecked ) )
 													}
 												/>
-											) }
-										</div>
-									);
-								} ) }
+												{ checked && (
+													<SelectControl
+														className="newspack-configure-view__inbound-operator"
+														label={ __( 'Segment as', 'newspack-plugin' ) }
+														hideLabelFromVision
+														value={ selectedOperator }
+														options={ operatorOptions }
+														onChange={ operator =>
+															handleFieldChange( inboundField.key, {
+																...currentMap,
+																[ optionValue ]: operator,
+															} )
+														}
+													/>
+												) }
+											</div>
+										);
+									} ) }
 							</Grid>
 						</Grid>
 					</>
@@ -462,29 +486,38 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 						<Divider alignment="full-width" variant="tertiary" marginTop={ 64 } marginBottom={ 64 } />
 						<Grid columns={ 2 } gutter={ 32 } noMargin>
 							<SectionHeader heading={ 2 } title={ __( 'Outbound', 'newspack-plugin' ) } noMargin />
-							<Accordion hideSingleTitle>
-								{ ( outboundField.grouped_options || [] ).map( ( group, index ) => {
-									const currentValue = getFieldValue( outboundField );
-									const selected = Array.isArray( currentValue ) ? currentValue : [];
-									return (
-										<AccordionPanel key={ `${ index }-${ group.section }` } title={ group.section } defaultOpen={ index === 0 }>
-											<Grid columns={ 1 } rowGap={ 8 } noMargin>
-												{ group.fields.map( fieldName => (
-													<CheckboxControl
-														className="newspack-checkbox-control"
-														key={ fieldName }
-														label={ fieldName }
-														checked={ selected.includes( fieldName ) }
-														onChange={ checked =>
-															handleCheckboxListChange( outboundField.key, currentValue, fieldName, checked )
-														}
-													/>
-												) ) }
-											</Grid>
-										</AccordionPanel>
-									);
-								} ) }
-							</Accordion>
+							<Grid columns={ 1 } rowGap={ 16 } noMargin>
+								{ renderSectionToggle( outboundToggleField ) }
+								{ outboundEnabled && (
+									<Accordion hideSingleTitle>
+										{ ( outboundField.grouped_options || [] ).map( ( group, index ) => {
+											const currentValue = getFieldValue( outboundField );
+											const selected = Array.isArray( currentValue ) ? currentValue : [];
+											return (
+												<AccordionPanel
+													key={ `${ index }-${ group.section }` }
+													title={ group.section }
+													defaultOpen={ index === 0 }
+												>
+													<Grid columns={ 1 } rowGap={ 8 } noMargin>
+														{ group.fields.map( fieldName => (
+															<CheckboxControl
+																className="newspack-checkbox-control"
+																key={ fieldName }
+																label={ fieldName }
+																checked={ selected.includes( fieldName ) }
+																onChange={ checked =>
+																	handleCheckboxListChange( outboundField.key, currentValue, fieldName, checked )
+																}
+															/>
+														) ) }
+													</Grid>
+												</AccordionPanel>
+											);
+										} ) }
+									</Accordion>
+								) }
+							</Grid>
 						</Grid>
 					</>
 				) }

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -133,10 +133,12 @@ export const reconcileOperators = ( currentMap, options ) => {
 // in JS, so the falsy string forms are matched explicitly.
 const toBool = value => ( typeof value === 'string' ? ! [ '', '0', 'false' ].includes( value.toLowerCase() ) : Boolean( value ) );
 
-// Account-deletion sync travels the push pipeline (see get_account_deletion_fields()
-// in class-integration.php), so these Settings-group controls follow the outbound
-// pause: the dispatcher skips a paused integration before reading them.
-const ACCOUNT_DELETION_KEYS = [ 'sync_account_deletion', 'account_deletion_handling' ];
+// Push-pipeline settings that render inside the Outbound section: the metadata
+// prefix is only read on push paths (prepare_contact()) and account-deletion
+// sync travels the push pipeline (see get_account_deletion_fields() /
+// get_metadata_fields() in class-integration.php), so they belong with — and
+// pause with — outbound sync.
+const OUTBOUND_SETTINGS_KEYS = [ 'metadata_prefix', 'sync_account_deletion', 'account_deletion_handling' ];
 
 // True for a plain `{ key => value }` map (the shape `incoming_metadata_fields`
 // uses), excluding arrays and null so those keep their own comparison branches.
@@ -214,13 +216,22 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 	};
 
 	// Split settings into groups. The per-direction enable toggles are pulled
-	// out of the generic Settings group so they render inside their section.
-	const { settingsFields, inboundField, outboundField, inboundToggleField, outboundToggleField } = useMemo( () => {
-		const empty = { settingsFields: [], inboundField: null, outboundField: null, inboundToggleField: null, outboundToggleField: null };
+	// out of the generic Settings group so they render inside their section, and
+	// the push-pipeline settings (metadata prefix, account-deletion sync) render
+	// inside the Outbound section they act on.
+	const { settingsFields, outboundSettingsFields, inboundField, outboundField, inboundToggleField, outboundToggleField } = useMemo( () => {
+		const empty = {
+			settingsFields: [],
+			outboundSettingsFields: [],
+			inboundField: null,
+			outboundField: null,
+			inboundToggleField: null,
+			outboundToggleField: null,
+		};
 		if ( ! integration?.settings ) {
 			return empty;
 		}
-		const groups = { ...empty, settingsFields: [] };
+		const groups = { ...empty, settingsFields: [], outboundSettingsFields: [] };
 		for ( const field of integration.settings ) {
 			if ( field.key === 'incoming_metadata_fields' ) {
 				groups.inboundField = field;
@@ -230,19 +241,21 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 				groups.inboundToggleField = field;
 			} else if ( field.key === 'outgoing_sync_enabled' ) {
 				groups.outboundToggleField = field;
+			} else if ( OUTBOUND_SETTINGS_KEYS.includes( field.key ) ) {
+				groups.outboundSettingsFields.push( field );
 			} else {
 				groups.settingsFields.push( field );
 			}
 		}
-		// A toggle renders only inside its direction section; without the paired
-		// metadata field there is no section, so fall the toggle through to the
-		// generic Settings group instead of shipping a field the view can neither
-		// display nor edit.
+		// A toggle renders only inside its direction section; when the section
+		// has no other content there is no section at all, so fall the toggle
+		// through to the generic Settings group instead of shipping a field the
+		// view can neither display nor edit.
 		if ( groups.inboundToggleField && ! groups.inboundField ) {
 			groups.settingsFields.push( groups.inboundToggleField );
 			groups.inboundToggleField = null;
 		}
-		if ( groups.outboundToggleField && ! groups.outboundField ) {
+		if ( groups.outboundToggleField && ! groups.outboundField && ! groups.outboundSettingsFields.length ) {
 			groups.settingsFields.push( groups.outboundToggleField );
 			groups.outboundToggleField = null;
 		}
@@ -386,7 +399,9 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 		if ( ! field.condition || typeof field.condition !== 'object' ) {
 			return true;
 		}
-		const ref = settingsFields.find( f => f.key === field.condition.field );
+		// Condition refs may point at a field in any group (e.g. the deletion
+		// handling's ref lives in the Outbound group), so search the full payload.
+		const ref = ( integration?.settings || [] ).find( f => f.key === field.condition.field );
 		if ( ! ref ) {
 			return true;
 		}
@@ -407,12 +422,7 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 	const inboundEnabled = ! inboundToggleField || toBool( getFieldValue( inboundToggleField ) );
 	const outboundEnabled = ! outboundToggleField || toBool( getFieldValue( outboundToggleField ) );
 
-	// While outbound sync is paused, hide the account-deletion controls along
-	// with the outgoing picker: the dispatcher skips them, and leaving them
-	// active would present deletion sync as live. Stored values are preserved.
-	const visibleSettingsFields = settingsFields.filter(
-		field => fieldIsVisible( field ) && ( outboundEnabled || ! ACCOUNT_DELETION_KEYS.includes( field.key ) )
-	);
+	const visibleSettingsFields = settingsFields.filter( fieldIsVisible );
 
 	const renderSectionToggle = toggleSetting =>
 		toggleSetting && (
@@ -505,14 +515,25 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 				) }
 
 				{ /* Section 3: Outbound */ }
-				{ outboundField && (
+				{ ( outboundField || outboundSettingsFields.length > 0 ) && (
 					<>
 						<Divider alignment="full-width" variant="tertiary" marginTop={ 64 } marginBottom={ 64 } />
 						<Grid columns={ 2 } gutter={ 32 } noMargin>
 							<SectionHeader heading={ 2 } title={ __( 'Outbound', 'newspack-plugin' ) } noMargin />
 							<Grid columns={ 1 } rowGap={ 16 } noMargin>
 								{ renderSectionToggle( outboundToggleField ) }
-								{ outboundEnabled && (
+								{ outboundEnabled &&
+									outboundSettingsFields
+										.filter( fieldIsVisible )
+										.map( field => (
+											<SettingsField
+												key={ field.key }
+												field={ field }
+												value={ getFieldValue( field ) }
+												onChange={ val => handleFieldChange( field.key, val ) }
+											/>
+										) ) }
+								{ outboundEnabled && outboundField && (
 									<Accordion hideSingleTitle>
 										{ ( outboundField.grouped_options || [] ).map( ( group, index ) => {
 											const currentValue = getFieldValue( outboundField );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -426,9 +426,10 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 
 	// The divider separates the toggle from the section content below it, so it
 	// only renders when there is content to divide: the caller passes false for a
-	// paused direction or an empty section. `dividerMarginBottom` compensates for
-	// the sections' different grid rowGaps so both net the same visual spacing.
-	const renderSectionToggle = ( toggleSetting, showDivider, dividerMarginBottom = 0 ) =>
+	// paused direction or an empty section. `dividerMargin` (applied above and
+	// below) compensates for the sections' different grid rowGaps — Inbound's 8
+	// vs Outbound's 16 — so both sections net the same 16px around the rule.
+	const renderSectionToggle = ( toggleSetting, showDivider, dividerMargin = 0 ) =>
 		toggleSetting && (
 			<>
 				<ToggleControl
@@ -438,7 +439,7 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 					onChange={ checked => handleFieldChange( toggleSetting.key, checked ) }
 					__nextHasNoMarginBottom
 				/>
-				{ showDivider && <Divider variant="tertiary" marginTop={ 0 } marginBottom={ dividerMarginBottom } /> }
+				{ showDivider && <Divider variant="tertiary" marginTop={ dividerMargin } marginBottom={ dividerMargin } /> }
 			</>
 		);
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.js
@@ -424,9 +424,11 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 
 	const visibleSettingsFields = settingsFields.filter( fieldIsVisible );
 
-	// The divider only renders while the direction is enabled: it separates the
-	// toggle from the section content below it, and a paused section has none.
-	const renderSectionToggle = ( toggleSetting, showDivider ) =>
+	// The divider separates the toggle from the section content below it, so it
+	// only renders when there is content to divide: the caller passes false for a
+	// paused direction or an empty section. `dividerMarginBottom` compensates for
+	// the sections' different grid rowGaps so both net the same visual spacing.
+	const renderSectionToggle = ( toggleSetting, showDivider, dividerMarginBottom = 0 ) =>
 		toggleSetting && (
 			<>
 				<ToggleControl
@@ -436,7 +438,7 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 					onChange={ checked => handleFieldChange( toggleSetting.key, checked ) }
 					__nextHasNoMarginBottom
 				/>
-				{ showDivider && <Divider variant="tertiary" marginTop={ 0 } marginBottom={ 0 } /> }
+				{ showDivider && <Divider variant="tertiary" marginTop={ 0 } marginBottom={ dividerMarginBottom } /> }
 			</>
 		);
 
@@ -468,7 +470,7 @@ const ConfigureViewInner = ( { integrations, loading, inFlightChanges, saving, o
 						<Grid columns={ 2 } gutter={ 32 } noMargin>
 							<SectionHeader heading={ 2 } title={ __( 'Inbound', 'newspack-plugin' ) } noMargin />
 							<Grid columns={ 1 } rowGap={ 8 } noMargin>
-								{ renderSectionToggle( inboundToggleField, inboundEnabled ) }
+								{ renderSectionToggle( inboundToggleField, inboundEnabled && ( inboundField.options || [] ).length > 0, 8 ) }
 								{ inboundEnabled &&
 									( inboundField.options || [] ).map( option => {
 										// Options are always { value, label, matching_function, has_options } objects

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -597,4 +597,58 @@ describe( 'ConfigureView per-direction sections', () => {
 		expect( screen.getByLabelText( 'Full Name' ) ).toBeInTheDocument();
 		expect( screen.getByLabelText( 'VIP' ) ).toBeInTheDocument();
 	} );
+
+	// Deletion sync travels the push pipeline, so its Settings-group controls
+	// follow the outbound pause the same way the outgoing picker does.
+	it( 'hides the account-deletion controls while outbound sync is paused', () => {
+		const integrations = bidirectionalIntegration();
+		integrations.esp.settings = [
+			{ key: 'sync_account_deletion', type: 'checkbox', label: 'Sync account deletion', value: true },
+			{
+				key: 'account_deletion_handling',
+				type: 'select',
+				label: 'Deletion handling',
+				value: 'flag',
+				options: [
+					{ value: 'flag', label: 'Flag' },
+					{ value: 'delete', label: 'Delete' },
+				],
+				condition: { field: 'sync_account_deletion', equals: true },
+			},
+			...integrations.esp.settings,
+		];
+		renderConfigureView( { integrations } );
+		expect( screen.getByLabelText( 'Sync account deletion' ).checked ).toBe( true );
+		expect( screen.getByLabelText( 'Deletion handling' ) ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByLabelText( 'Enable outbound sync' ) );
+		expect( screen.queryByLabelText( 'Sync account deletion' ) ).toBeNull();
+		expect( screen.queryByLabelText( 'Deletion handling' ) ).toBeNull();
+		// The integration's own settings stay put.
+		expect( screen.getByLabelText( 'Audience ID' ) ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByLabelText( 'Enable outbound sync' ) );
+		expect( screen.getByLabelText( 'Sync account deletion' ).checked ).toBe( true );
+	} );
+
+	// A toggle whose paired metadata field is missing (a third-party
+	// get_settings_fields() override) must stay visible and editable rather
+	// than shipping a field the view can neither display nor save.
+	it( 'falls an orphaned direction toggle through to the generic Settings group', async () => {
+		const onSave = jest.fn( () => Promise.resolve() );
+		const integrations = bidirectionalIntegration();
+		integrations.esp.settings = integrations.esp.settings.filter( f => f.key !== 'outgoing_metadata_fields' );
+		renderConfigureView( { integrations, onSave } );
+
+		// No Outbound section without the picker field, but the toggle survives.
+		expect( screen.queryByLabelText( 'Full Name' ) ).toBeNull();
+		const toggle = screen.getByLabelText( 'Enable outbound sync' );
+		expect( toggle.checked ).toBe( true );
+
+		fireEvent.click( toggle );
+		await act( async () => {
+			getLatestSaveAction()();
+		} );
+		expect( onSave ).toHaveBeenCalledWith( 'esp', { outgoing_sync_enabled: false } );
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -49,7 +49,10 @@ jest.mock( '../../../../../packages/components/src', () => ( {
 	Accordion: ( { children } ) => children,
 	AccordionPanel: ( { children } ) => children,
 	Button: ( { children } ) => children,
-	Divider: () => null,
+	// Section dividers pass alignment="full-width"; the divider under a section
+	// toggle does not, so the stub tags them apart for the tests that assert on
+	// whether a toggle divider has anything to divide.
+	Divider: ( { alignment } ) => <hr data-testid={ 'full-width' === alignment ? 'section-divider' : 'toggle-divider' } />,
 	Grid: ( { children } ) => children,
 	SectionHeader: () => null,
 	SelectControl: ( { label, value, onChange } ) => (
@@ -676,5 +679,43 @@ describe( 'ConfigureView per-direction sections', () => {
 			getLatestSaveAction()();
 		} );
 		expect( onSave ).toHaveBeenCalledWith( 'esp', { outgoing_sync_enabled: false } );
+	} );
+
+	// The divider under a section toggle only separates it from the content
+	// below, so a direction with nothing to show must not render one.
+	it( 'renders a toggle divider per enabled section, and none once both are paused', () => {
+		renderConfigureView( { integrations: bidirectionalIntegration() } );
+		expect( screen.queryAllByTestId( 'toggle-divider' ) ).toHaveLength( 2 );
+
+		fireEvent.click( screen.getByLabelText( 'Enable outbound sync' ) );
+		fireEvent.click( screen.getByLabelText( 'Enable inbound sync' ) );
+		expect( screen.queryAllByTestId( 'toggle-divider' ) ).toHaveLength( 0 );
+	} );
+
+	// An enabled Outbound section that declares a settings field but has no
+	// picker, and hides that field behind an unsatisfied condition, still
+	// renders the section — with nothing under the toggle to divide.
+	it( 'renders no outbound toggle divider when every outbound settings field is hidden', () => {
+		renderConfigureView( {
+			integrations: {
+				esp: {
+					...INTEGRATION,
+					settings: [
+						{ key: 'mailchimp_audience_id', type: 'text', label: 'Audience ID', value: '' },
+						{ key: 'outgoing_sync_enabled', type: 'checkbox', label: 'Enable outbound sync', value: true },
+						{
+							key: 'account_deletion_handling',
+							type: 'text',
+							label: 'How to sync deletion',
+							value: 'flag',
+							condition: { field: 'mailchimp_audience_id', equals: 'never-matches' },
+						},
+					],
+				},
+			},
+		} );
+		expect( screen.getByLabelText( 'Enable outbound sync' ).checked ).toBe( true );
+		expect( screen.queryByLabelText( 'How to sync deletion' ) ).toBeNull();
+		expect( screen.queryAllByTestId( 'toggle-divider' ) ).toHaveLength( 0 );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -17,7 +17,24 @@ jest.mock( '@wordpress/data', () => ( {
 // Stub the components barrel: with @wordpress/data mocked, the real barrel eagerly loads @wordpress/rich-text, whose module-load combineReducers() call throws.
 // Cover everything SettingsField imports so a future select/oauth/textarea fixture renders a stub, not `undefined`.
 jest.mock( '@wordpress/components', () => ( {
-	CheckboxControl: () => null,
+	// Real inputs (not null stubs) so the per-direction section tests can assert
+	// on picker visibility and drive the enable toggles.
+	CheckboxControl: ( { label, checked, onChange } ) => (
+		<input
+			type="checkbox"
+			aria-label={ typeof label === 'string' ? label : undefined }
+			checked={ !! checked }
+			onChange={ e => onChange( e.target.checked ) }
+		/>
+	),
+	ToggleControl: ( { label, checked, onChange } ) => (
+		<input
+			type="checkbox"
+			aria-label={ typeof label === 'string' ? label : undefined }
+			checked={ !! checked }
+			onChange={ e => onChange( e.target.checked ) }
+		/>
+	),
 	ExternalLink: ( { children } ) => children,
 	TextareaControl: ( { label, value, onChange } ) => (
 		<textarea aria-label={ label } value={ value || '' } onChange={ e => onChange( e.target.value ) } />
@@ -482,5 +499,102 @@ describe( 'incoming-field operator reconciliation on save', () => {
 			getLatestSaveAction()();
 		} );
 		expect( onSave ).toHaveBeenCalledWith( 'esp', { mailchimp_audience_id: 'abc123' } );
+	} );
+} );
+
+describe( 'ConfigureView per-direction sections', () => {
+	beforeEach( () => {
+		mockSetHeaderData.mockClear();
+		useUnsavedChangesDialog.mockClear();
+		useUnsavedChangesDialog.mockReturnValue( { confirmDialog: null, requestConfirm: jest.fn() } );
+	} );
+
+	// A bidirectional integration as the capability-aware backend declares it:
+	// each direction carries its enable toggle alongside its metadata field.
+	const bidirectionalIntegration = () => ( {
+		esp: {
+			...INTEGRATION,
+			settings: [
+				{ key: 'mailchimp_audience_id', type: 'text', label: 'Audience ID', value: '' },
+				{ key: 'outgoing_sync_enabled', type: 'checkbox', label: 'Enable outbound sync', value: true },
+				{
+					key: 'outgoing_metadata_fields',
+					type: 'metadata',
+					label: 'Outgoing metadata fields',
+					value: [ 'Full Name' ],
+					grouped_options: [ { section: 'Basic', fields: [ 'Full Name', 'Signup Date' ] } ],
+				},
+				{ key: 'incoming_sync_enabled', type: 'checkbox', label: 'Enable inbound sync', value: true },
+				{
+					key: 'incoming_metadata_fields',
+					type: 'metadata',
+					label: 'Incoming metadata fields',
+					value: { vip: 'default' },
+					options: [ { value: 'vip', label: 'VIP', matching_function: 'default', has_options: false } ],
+				},
+			],
+		},
+	} );
+
+	// The backend omits a direction's fields when the integration lacks the
+	// capability, so the view must simply not render that section.
+	it( 'renders no direction sections for an integration that declares neither', () => {
+		renderConfigureView();
+		expect( screen.queryByLabelText( 'Enable outbound sync' ) ).toBeNull();
+		expect( screen.queryByLabelText( 'Enable inbound sync' ) ).toBeNull();
+		expect( screen.queryByLabelText( 'Full Name' ) ).toBeNull();
+		expect( screen.queryByLabelText( 'VIP' ) ).toBeNull();
+	} );
+
+	it( 'renders both sections with their toggles and pickers when enabled', () => {
+		renderConfigureView( { integrations: bidirectionalIntegration() } );
+		expect( screen.getByLabelText( 'Enable outbound sync' ).checked ).toBe( true );
+		expect( screen.getByLabelText( 'Enable inbound sync' ).checked ).toBe( true );
+		expect( screen.getByLabelText( 'Full Name' ).checked ).toBe( true );
+		expect( screen.getByLabelText( 'Signup Date' ).checked ).toBe( false );
+		expect( screen.getByLabelText( 'VIP' ).checked ).toBe( true );
+	} );
+
+	it( 'hides only the outbound picker when outbound sync is toggled off and submits just the toggle', async () => {
+		const onSave = jest.fn( () => Promise.resolve() );
+		renderConfigureView( { integrations: bidirectionalIntegration(), onSave } );
+
+		fireEvent.click( screen.getByLabelText( 'Enable outbound sync' ) );
+		expect( screen.queryByLabelText( 'Full Name' ) ).toBeNull();
+		expect( screen.getByLabelText( 'VIP' ) ).toBeInTheDocument();
+
+		await act( async () => {
+			getLatestSaveAction()();
+		} );
+		// The field selection is not part of the payload: pausing must not
+		// rewrite (or clear) the stored outgoing_metadata_fields option.
+		expect( onSave ).toHaveBeenCalledWith( 'esp', { outgoing_sync_enabled: false } );
+	} );
+
+	it( 'restores the inbound selection after toggling the direction off and back on', () => {
+		renderConfigureView( { integrations: bidirectionalIntegration() } );
+
+		const toggle = () => screen.getByLabelText( 'Enable inbound sync' );
+		fireEvent.click( toggle() );
+		expect( screen.queryByLabelText( 'VIP' ) ).toBeNull();
+		expect( screen.getByLabelText( 'Full Name' ) ).toBeInTheDocument();
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: true } );
+
+		fireEvent.click( toggle() );
+		expect( screen.getByLabelText( 'VIP' ).checked ).toBe( true );
+		// A net-zero toggle leaves nothing pending.
+		expect( useUnsavedChangesDialog ).toHaveBeenLastCalledWith( { when: false } );
+	} );
+
+	// Payloads predating the toggles (or an integration that opted out of them)
+	// must keep rendering the pickers unconditionally.
+	it( 'renders pickers without toggles for a payload lacking the toggle fields', () => {
+		const integrations = bidirectionalIntegration();
+		integrations.esp.settings = integrations.esp.settings.filter( f => ! f.key.endsWith( '_sync_enabled' ) );
+		renderConfigureView( { integrations } );
+		expect( screen.queryByLabelText( 'Enable outbound sync' ) ).toBeNull();
+		expect( screen.queryByLabelText( 'Enable inbound sync' ) ).toBeNull();
+		expect( screen.getByLabelText( 'Full Name' ) ).toBeInTheDocument();
+		expect( screen.getByLabelText( 'VIP' ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/integrations/configure-view.test.js
@@ -598,9 +598,10 @@ describe( 'ConfigureView per-direction sections', () => {
 		expect( screen.getByLabelText( 'VIP' ) ).toBeInTheDocument();
 	} );
 
-	// Deletion sync travels the push pipeline, so its Settings-group controls
-	// follow the outbound pause the same way the outgoing picker does.
-	it( 'hides the account-deletion controls while outbound sync is paused', () => {
+	// The push-pipeline settings (metadata prefix, account-deletion sync) render
+	// inside the Outbound section and follow the outbound pause the same way the
+	// outgoing picker does.
+	it( 'renders push settings in the Outbound section and hides them while paused', () => {
 		const integrations = bidirectionalIntegration();
 		integrations.esp.settings = [
 			{ key: 'sync_account_deletion', type: 'checkbox', label: 'Sync account deletion', value: true },
@@ -615,20 +616,45 @@ describe( 'ConfigureView per-direction sections', () => {
 				],
 				condition: { field: 'sync_account_deletion', equals: true },
 			},
+			{ key: 'metadata_prefix', type: 'text', label: 'Metadata field prefix', value: 'NP_' },
 			...integrations.esp.settings,
 		];
 		renderConfigureView( { integrations } );
 		expect( screen.getByLabelText( 'Sync account deletion' ).checked ).toBe( true );
 		expect( screen.getByLabelText( 'Deletion handling' ) ).toBeInTheDocument();
 
+		// Document order pins the placement: own settings first, then the Inbound
+		// picker, then the push settings inside the Outbound section.
+		const order = screen
+			.getAllByLabelText( /^(Audience ID|VIP|Sync account deletion|Metadata field prefix)$/ )
+			.map( el => el.getAttribute( 'aria-label' ) );
+		expect( order ).toEqual( [ 'Audience ID', 'VIP', 'Sync account deletion', 'Metadata field prefix' ] );
+
 		fireEvent.click( screen.getByLabelText( 'Enable outbound sync' ) );
 		expect( screen.queryByLabelText( 'Sync account deletion' ) ).toBeNull();
 		expect( screen.queryByLabelText( 'Deletion handling' ) ).toBeNull();
+		expect( screen.queryByLabelText( 'Metadata field prefix' ) ).toBeNull();
 		// The integration's own settings stay put.
 		expect( screen.getByLabelText( 'Audience ID' ) ).toBeInTheDocument();
 
 		fireEvent.click( screen.getByLabelText( 'Enable outbound sync' ) );
 		expect( screen.getByLabelText( 'Sync account deletion' ).checked ).toBe( true );
+		expect( screen.getByLabelText( 'Metadata field prefix' ).value ).toBe( 'NP_' );
+	} );
+
+	// With push-group settings but no picker (a partial third-party override),
+	// the Outbound section still renders its toggle and settings.
+	it( 'renders the Outbound section for push settings without a picker', () => {
+		const integrations = bidirectionalIntegration();
+		integrations.esp.settings = [
+			{ key: 'metadata_prefix', type: 'text', label: 'Metadata field prefix', value: 'NP_' },
+			...integrations.esp.settings.filter( f => f.key !== 'outgoing_metadata_fields' ),
+		];
+		renderConfigureView( { integrations } );
+		expect( screen.getByLabelText( 'Metadata field prefix' ) ).toBeInTheDocument();
+
+		fireEvent.click( screen.getByLabelText( 'Enable outbound sync' ) );
+		expect( screen.queryByLabelText( 'Metadata field prefix' ) ).toBeNull();
 	} );
 
 	// A toggle whose paired metadata field is missing (a third-party

--- a/plugins/newspack-plugin/tests/unit-tests/cli/class-test-ras-contact-sync-options.php
+++ b/plugins/newspack-plugin/tests/unit-tests/cli/class-test-ras-contact-sync-options.php
@@ -127,4 +127,54 @@ class Test_RAS_Contact_Sync_Options extends WP_UnitTestCase {
 		$this->assertInstanceOf( \WP_Error::class, $result );
 		$this->assertSame( 'newspack_esp_sync_fields_not_enabled', $result->get_error_code() );
 	}
+
+	/**
+	 * The same missing-field setup must NOT fail the pre-flight when the
+	 * integration's outbound sync is paused: the run skips push-disabled
+	 * integrations entirely, so their field selection can't be a reason to block
+	 * a backfill of the others.
+	 */
+	public function test_field_not_enabled_on_push_disabled_integration_is_ignored() {
+		Failing_Sample_Integration::reset();
+		$integration = new Failing_Sample_Integration( 'preflight_paused', 'Preflight Paused' );
+		Integrations::register( $integration );
+		Integrations::enable( 'preflight_paused' );
+		$integration->update_enabled_outgoing_fields( [ 'Account' ] );
+		$integration->update_settings_field_value( 'outgoing_sync_enabled', false );
+
+		$options = $this->parse( [ 'fields' => 'Content Access' ] );
+
+		Integrations::disable( 'preflight_paused' );
+
+		$this->assertIsArray( $options, 'A paused integration must not block the pre-flight.' );
+		$this->assertSame( [ 'Content Access' ], $options['fields'] );
+	}
+
+	/**
+	 * Same for an integration that declares no push capability at all — it never
+	 * receives contact data, so it has no say in the backfill's field pre-flight.
+	 */
+	public function test_field_not_enabled_on_push_incapable_integration_is_ignored() {
+		Failing_Sample_Integration::reset();
+		$integration = new class( 'preflight_incapable', 'Preflight Incapable' ) extends Failing_Sample_Integration {
+			/**
+			 * Declare no push capability.
+			 *
+			 * @return bool
+			 */
+			public function supports_push(): bool {
+				return false;
+			}
+		};
+		Integrations::register( $integration );
+		Integrations::enable( 'preflight_incapable' );
+		$integration->update_enabled_outgoing_fields( [ 'Account' ] );
+
+		$options = $this->parse( [ 'fields' => 'Content Access' ] );
+
+		Integrations::disable( 'preflight_incapable' );
+
+		$this->assertIsArray( $options, 'A push-incapable integration must not block the pre-flight.' );
+		$this->assertSame( [ 'Content Access' ], $options['fields'] );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-sync-capabilities.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-sync-capabilities.php
@@ -8,6 +8,7 @@
 namespace Newspack\Tests\Unit\Integrations;
 
 use Newspack\Reader_Activation\Contact_Sync;
+use Newspack\Reader_Activation\Integration;
 use Newspack\Reader_Activation\Integrations;
 use Newspack\Reader_Activation\Integrations\Contact_Pull;
 use Newspack\Reader_Activation\Sync;
@@ -78,6 +79,19 @@ class Test_Sync_Capabilities extends \WP_UnitTestCase {
 		$property   = $reflection->getProperty( 'integrations' );
 		$property->setAccessible( true );
 		$property->setValue( null, [] );
+	}
+
+	/**
+	 * Build the wp_options name backing an integration settings field from the
+	 * real prefix and joining scheme, so forced option rows stay coupled to the
+	 * actual storage path.
+	 *
+	 * @param string $integration_id Integration ID.
+	 * @param string $key            Settings field key.
+	 * @return string Option name.
+	 */
+	private function settings_option_name( $integration_id, $key ) {
+		return Integration::SETTINGS_OPTION_PREFIX . $integration_id . '_' . $key;
 	}
 
 	/**
@@ -240,7 +254,7 @@ class Test_Sync_Capabilities extends \WP_UnitTestCase {
 
 		// Even a directly-forced option row must not re-enable a direction the
 		// integration does not support.
-		update_option( 'newspack_integration_settings_cap-forced_outgoing_sync_enabled', true );
+		update_option( $this->settings_option_name( 'cap-forced', 'outgoing_sync_enabled' ), true );
 		$this->assertFalse( $integration->is_push_enabled() );
 	}
 
@@ -307,6 +321,28 @@ class Test_Sync_Capabilities extends \WP_UnitTestCase {
 		$errors = Sync::has_one_syncable_integration( true );
 		$this->assertWPError( $errors );
 		$this->assertContains( 'integration_push_not_supported', $errors->get_error_codes() );
+	}
+
+	/**
+	 * Non-syncable integrations ordered before a healthy one must not poison the
+	 * success return: in errors mode the accumulated reasons are only surfaced
+	 * when nothing syncable exists, so has_errors() stays false on success.
+	 */
+	public function test_has_one_syncable_integration_ignores_earlier_non_syncable() {
+		$pull_only = $this->create_pull_only_integration( 'cap-mixed-inbound', 'Cap Mixed Inbound' );
+		$paused    = new \Sample_Integration( 'cap-mixed-paused', 'Cap Mixed Paused' );
+		$healthy   = new \Sample_Integration( 'cap-mixed-esp', 'Cap Mixed ESP' );
+		Integrations::register( $pull_only );
+		Integrations::register( $paused );
+		Integrations::register( $healthy );
+		update_option( Integrations::OPTION_NAME, [ 'cap-mixed-inbound', 'cap-mixed-paused', 'cap-mixed-esp' ] );
+		$paused->update_settings_field_value( 'outgoing_sync_enabled', false );
+
+		$this->assertTrue( Sync::has_one_syncable_integration(), 'A later healthy integration keeps the predicate true.' );
+
+		$result = Sync::has_one_syncable_integration( true );
+		$this->assertWPError( $result );
+		$this->assertFalse( $result->has_errors(), 'Success must not carry reasons collected from skipped integrations.' );
 	}
 
 	/**
@@ -387,8 +423,8 @@ class Test_Sync_Capabilities extends \WP_UnitTestCase {
 		Integrations::register( $spy );
 		update_option( Integrations::OPTION_NAME, [ 'cap-del-incapable' ] );
 		// Force option rows that would enable deletion sync if the fields were declared.
-		update_option( 'newspack_integration_settings_cap-del-incapable_sync_account_deletion', true );
-		update_option( 'newspack_integration_settings_cap-del-incapable_account_deletion_handling', 'delete' );
+		update_option( $this->settings_option_name( 'cap-del-incapable', 'sync_account_deletion' ), true );
+		update_option( $this->settings_option_name( 'cap-del-incapable', 'account_deletion_handling' ), 'delete' );
 
 		Contact_Sync::handle_account_deletion(
 			'reader@example.com',
@@ -401,6 +437,55 @@ class Test_Sync_Capabilities extends \WP_UnitTestCase {
 
 		$this->assertCount( 0, $spy->delete_calls );
 		$this->assertCount( 0, $spy->push_calls );
+	}
+
+	/**
+	 * The sync retry chain aborts while outbound sync is paused and resumes
+	 * pushing once the toggle is re-enabled.
+	 */
+	public function test_sync_retry_aborts_when_push_disabled() {
+		$spy = new \Deletion_Spy_Integration( 'cap-retry-spy', 'Cap Retry Spy' );
+		Integrations::register( $spy );
+		update_option( Integrations::OPTION_NAME, [ 'cap-retry-spy' ] );
+		$user_id    = $this->factory()->user->create();
+		$retry_data = [
+			'integration_id' => 'cap-retry-spy',
+			'user_id'        => $user_id,
+			'context'        => 'TestContext',
+			'retry_count'    => 1,
+		];
+
+		$spy->update_settings_field_value( 'outgoing_sync_enabled', false );
+		Contact_Sync::execute_integration_retry( $retry_data );
+		$this->assertCount( 0, $spy->push_calls, 'Paused outbound sync must abort the retry chain.' );
+
+		$spy->update_settings_field_value( 'outgoing_sync_enabled', true );
+		Contact_Sync::execute_integration_retry( $retry_data );
+		$this->assertCount( 1, $spy->push_calls, 'Re-enabled outbound sync retries the push.' );
+	}
+
+	/**
+	 * The deletion retry chain aborts while outbound sync is paused and resumes
+	 * once the toggle is re-enabled.
+	 */
+	public function test_deletion_retry_aborts_when_push_disabled() {
+		$spy = new \Deletion_Spy_Integration( 'cap-delretry-spy', 'Cap Del Retry Spy' );
+		Integrations::register( $spy );
+		update_option( Integrations::OPTION_NAME, [ 'cap-delretry-spy' ] );
+		$retry_data = [
+			'integration_id' => 'cap-delretry-spy',
+			'email'          => 'reader@example.com',
+			'mode'           => 'delete',
+			'retry_count'    => 1,
+		];
+
+		$spy->update_settings_field_value( 'outgoing_sync_enabled', false );
+		Contact_Sync::execute_deletion_retry( $retry_data );
+		$this->assertCount( 0, $spy->delete_calls, 'Paused outbound sync must abort the deletion retry chain.' );
+
+		$spy->update_settings_field_value( 'outgoing_sync_enabled', true );
+		Contact_Sync::execute_deletion_retry( $retry_data );
+		$this->assertCount( 1, $spy->delete_calls, 'Re-enabled outbound sync retries the deletion.' );
 	}
 
 	/**
@@ -440,5 +525,88 @@ class Test_Sync_Capabilities extends \WP_UnitTestCase {
 		$integration->update_settings_field_value( 'incoming_sync_enabled', true );
 		Contact_Pull::pull_all( $user_id );
 		$this->assertCount( 1, $integration->pull_calls, 'Re-enabled inbound sync pulls again.' );
+	}
+
+	/**
+	 * The pull retry chain aborts while inbound sync is paused and resumes
+	 * pulling once the toggle is re-enabled.
+	 */
+	public function test_pull_retry_aborts_when_pull_disabled() {
+		$integration = new class( 'cap-pullretry-spy', 'Cap Pull Retry Spy' ) extends \Sample_Integration {
+			/**
+			 * Captured pull_contact_data() calls.
+			 *
+			 * @var array
+			 */
+			public $pull_calls = [];
+
+			/**
+			 * Pull contact data (records the call).
+			 *
+			 * @param int $user_id WordPress user ID.
+			 * @return array
+			 */
+			public function pull_contact_data( $user_id ) {
+				$this->pull_calls[] = $user_id;
+				return [ 'vip_level' => 'gold' ];
+			}
+		};
+		Integrations::register( $integration );
+		update_option( Integrations::OPTION_NAME, [ 'cap-pullretry-spy' ] );
+		$integration->update_enabled_incoming_fields( [ 'vip_level' ] );
+		$user_id    = $this->factory()->user->create();
+		$retry_data = [
+			'integration_id' => 'cap-pullretry-spy',
+			'user_id'        => $user_id,
+			'retry_count'    => 1,
+		];
+
+		$integration->update_settings_field_value( 'incoming_sync_enabled', false );
+		Contact_Pull::execute_integration_retry( $retry_data );
+		$this->assertCount( 0, $integration->pull_calls, 'Paused inbound sync must abort the pull retry chain.' );
+
+		$integration->update_settings_field_value( 'incoming_sync_enabled', true );
+		Contact_Pull::execute_integration_retry( $retry_data );
+		$this->assertCount( 1, $integration->pull_calls, 'Re-enabled inbound sync retries the pull.' );
+	}
+
+	/**
+	 * The synchronous (loopback) pull skips integrations whose inbound sync is
+	 * paused: no loopback request is fired for them.
+	 */
+	public function test_pull_sync_skips_pull_disabled_integration() {
+		$integration = new \Sample_Integration( 'cap-loopback', 'Cap Loopback' );
+		Integrations::register( $integration );
+		update_option( Integrations::OPTION_NAME, [ 'cap-loopback' ] );
+		$integration->update_enabled_incoming_fields( [ 'vip_level' ] );
+
+		$requests  = 0;
+		$intercept = function ( $preempt ) use ( &$requests ) {
+			if ( false !== $preempt ) {
+				return $preempt;
+			}
+			$requests++;
+			return [
+				'headers'  => [],
+				'body'     => '',
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+		add_filter( 'pre_http_request', $intercept );
+
+		$integration->update_settings_field_value( 'incoming_sync_enabled', false );
+		Contact_Pull::pull_sync();
+		$this->assertSame( 0, $requests, 'Paused inbound sync must not fire a loopback pull.' );
+
+		$integration->update_settings_field_value( 'incoming_sync_enabled', true );
+		Contact_Pull::pull_sync();
+		$this->assertSame( 1, $requests, 'Re-enabled inbound sync fires the loopback pull.' );
+
+		remove_filter( 'pre_http_request', $intercept );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-sync-capabilities.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-sync-capabilities.php
@@ -259,6 +259,23 @@ class Test_Sync_Capabilities extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * A stored `'false'` string pauses the direction. The checkbox sanitizer
+	 * can't produce that value, but a hand-set option or an external writer can,
+	 * and it diverges in the worst direction: the wizard's toBool() reads
+	 * `'false'` as off, so a truthy cast here would render the direction paused
+	 * while dispatch kept pushing.
+	 */
+	public function test_falsy_string_toggle_values_pause_directions() {
+		$integration = new \Sample_Integration( 'cap-string-false', 'Cap String False' );
+
+		update_option( $this->settings_option_name( 'cap-string-false', 'outgoing_sync_enabled' ), 'false' );
+		update_option( $this->settings_option_name( 'cap-string-false', 'incoming_sync_enabled' ), 'false' );
+
+		$this->assertFalse( $integration->is_push_enabled(), "Stored 'false' must pause outbound sync." );
+		$this->assertFalse( $integration->is_pull_enabled(), "Stored 'false' must pause inbound sync." );
+	}
+
+	/**
 	 * Pausing a direction preserves the stored field selections, so re-enabling
 	 * does not lose the publisher's configuration.
 	 */
@@ -343,6 +360,71 @@ class Test_Sync_Capabilities extends \WP_UnitTestCase {
 		$result = Sync::has_one_syncable_integration( true );
 		$this->assertWPError( $result );
 		$this->assertFalse( $result->has_errors(), 'Success must not carry reasons collected from skipped integrations.' );
+	}
+
+	/**
+	 * Build an integration whose can_sync() ignores $return_errors and returns a
+	 * bare bool — the documented `bool|\WP_Error` signature invites it, so the
+	 * availability check must survive a third-party integration that does.
+	 *
+	 * @param string $id    Integration ID.
+	 * @param string $name  Integration name.
+	 * @param bool   $value Bool can_sync() should return.
+	 * @return \Sample_Integration
+	 */
+	private function create_bool_can_sync_integration( $id, $name, $value ) {
+		$integration = new class( $id, $name ) extends \Sample_Integration {
+			/**
+			 * Bare bool returned by can_sync() regardless of $return_errors.
+			 *
+			 * @var bool
+			 */
+			public $bool_can_sync = true;
+
+			/**
+			 * Ignore $return_errors and return a bare bool.
+			 *
+			 * @param bool $return_errors Whether to return a WP_Error object.
+			 * @return bool
+			 */
+			public function can_sync( $return_errors = false ) {
+				return $this->bool_can_sync;
+			}
+		};
+		$integration->bool_can_sync = $value;
+		return $integration;
+	}
+
+	/**
+	 * A bool-returning can_sync() must not fatal the availability check on
+	 * WP_Error::has_errors(); a `true` normalizes to "can sync".
+	 */
+	public function test_has_one_syncable_integration_tolerates_true_bool_can_sync() {
+		$integration = $this->create_bool_can_sync_integration( 'cap-bool-true', 'Cap Bool True', true );
+		Integrations::register( $integration );
+		update_option( Integrations::OPTION_NAME, [ 'cap-bool-true' ] );
+
+		$this->assertTrue( Sync::has_one_syncable_integration(), 'A bool-returning can_sync() must not fatal.' );
+
+		$result = Sync::has_one_syncable_integration( true );
+		$this->assertWPError( $result );
+		$this->assertFalse( $result->has_errors(), 'A bool true normalizes to a no-error verdict.' );
+	}
+
+	/**
+	 * A bool `false` from a contract-violating can_sync() normalizes to a
+	 * reason rather than a silent success.
+	 */
+	public function test_has_one_syncable_integration_tolerates_false_bool_can_sync() {
+		$integration = $this->create_bool_can_sync_integration( 'cap-bool-false', 'Cap Bool False', false );
+		Integrations::register( $integration );
+		update_option( Integrations::OPTION_NAME, [ 'cap-bool-false' ] );
+
+		$this->assertFalse( Sync::has_one_syncable_integration() );
+
+		$result = Sync::has_one_syncable_integration( true );
+		$this->assertWPError( $result );
+		$this->assertContains( 'integration_cannot_sync', $result->get_error_codes() );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-sync-capabilities.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-sync-capabilities.php
@@ -1,0 +1,417 @@
+<?php
+/**
+ * Tests for per-direction sync capabilities and toggles in the Integration framework.
+ *
+ * @package Newspack\Tests\Unit\Integrations
+ */
+
+namespace Newspack\Tests\Unit\Integrations;
+
+use Newspack\Reader_Activation\Contact_Sync;
+use Newspack\Reader_Activation\Integrations;
+use Newspack\Reader_Activation\Integrations\Contact_Pull;
+use Newspack\Reader_Activation\Sync;
+
+/**
+ * Sync capabilities test case.
+ *
+ * Covers the push/pull capability declarations (supports_push/supports_pull),
+ * the per-direction enable toggles (outgoing_sync_enabled/incoming_sync_enabled),
+ * and the dispatch sites that honor them.
+ *
+ * @group sync-capabilities
+ */
+class Test_Sync_Capabilities extends \WP_UnitTestCase {
+
+	/**
+	 * Push-group settings keys that must follow the push capability.
+	 *
+	 * @var string[]
+	 */
+	const PUSH_KEYS = [
+		'sync_account_deletion',
+		'account_deletion_handling',
+		'metadata_prefix',
+		'outgoing_sync_enabled',
+		'outgoing_metadata_fields',
+	];
+
+	/**
+	 * Pull-group settings keys that must follow the pull capability.
+	 *
+	 * @var string[]
+	 */
+	const PULL_KEYS = [
+		'incoming_sync_enabled',
+		'incoming_metadata_fields',
+	];
+
+	/**
+	 * Set up the test environment before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		// Allow sync on the test (non-production) site so Sync::can_sync() does
+		// not bail out inside the dispatcher tests below. Scoped via filter and
+		// removed in tear_down.
+		add_filter( 'newspack_reader_activation_is_syncing_allowed', '__return_true' );
+		$this->reset_integrations();
+	}
+
+	/**
+	 * Tear down the test environment after each test.
+	 */
+	public function tear_down() {
+		remove_filter( 'newspack_reader_activation_is_syncing_allowed', '__return_true' );
+		delete_option( Integrations::OPTION_NAME );
+		\Sample_Integration::$declared_settings_fields = [];
+		$this->reset_integrations();
+		Integrations::register_integrations();
+		parent::tear_down();
+	}
+
+	/**
+	 * Reset the static integrations registry so each test starts clean.
+	 */
+	private function reset_integrations() {
+		$reflection = new \ReflectionClass( Integrations::class );
+		$property   = $reflection->getProperty( 'integrations' );
+		$property->setAccessible( true );
+		$property->setValue( null, [] );
+	}
+
+	/**
+	 * Build a pull-only integration (no push capability).
+	 *
+	 * @param string $id   Integration ID.
+	 * @param string $name Integration name.
+	 * @return \Sample_Integration
+	 */
+	private function create_pull_only_integration( $id, $name ) {
+		return new class( $id, $name ) extends \Sample_Integration {
+			/**
+			 * Declare no push capability.
+			 *
+			 * @return bool
+			 */
+			public function supports_push(): bool {
+				return false;
+			}
+		};
+	}
+
+	/**
+	 * Build a push-only integration (no pull capability).
+	 *
+	 * @param string $id   Integration ID.
+	 * @param string $name Integration name.
+	 * @return \Sample_Integration
+	 */
+	private function create_push_only_integration( $id, $name ) {
+		return new class( $id, $name ) extends \Sample_Integration {
+			/**
+			 * Declare no pull capability.
+			 *
+			 * @return bool
+			 */
+			public function supports_pull(): bool {
+				return false;
+			}
+		};
+	}
+
+	/**
+	 * A default integration declares both directions: the push group
+	 * (account deletion, prefix, outbound toggle, outgoing fields) and the
+	 * pull group (inbound toggle, incoming fields).
+	 */
+	public function test_default_integration_declares_both_direction_groups() {
+		$integration = new \Sample_Integration( 'cap-default', 'Cap Default' );
+		$keys        = array_column( $integration->get_settings_fields(), 'key' );
+
+		foreach ( array_merge( self::PUSH_KEYS, self::PULL_KEYS ) as $key ) {
+			$this->assertContains( $key, $keys, "Default integration should declare '$key'." );
+		}
+	}
+
+	/**
+	 * A pull-only integration declares none of the push-group fields — no dead
+	 * deletion-sync controls, no metadata prefix, no outbound section — while
+	 * its own settings and the pull group remain.
+	 */
+	public function test_pull_only_integration_declares_no_push_group_fields() {
+		\Sample_Integration::$declared_settings_fields = [
+			[
+				'key'     => 'own_api_key',
+				'type'    => 'text',
+				'default' => '',
+			],
+		];
+		$integration = $this->create_pull_only_integration( 'cap-pull-only', 'Cap Pull Only' );
+		$keys = array_column( $integration->get_settings_fields(), 'key' );
+
+		foreach ( self::PUSH_KEYS as $key ) {
+			$this->assertNotContains( $key, $keys, "Pull-only integration should not declare '$key'." );
+		}
+		foreach ( self::PULL_KEYS as $key ) {
+			$this->assertContains( $key, $keys, "Pull-only integration should declare '$key'." );
+		}
+		$this->assertContains( 'own_api_key', $keys, 'Own settings fields remain editable.' );
+	}
+
+	/**
+	 * A push-only integration declares no pull-group fields.
+	 */
+	public function test_push_only_integration_declares_no_pull_group_fields() {
+		$integration = $this->create_push_only_integration( 'cap-push-only', 'Cap Push Only' );
+		$keys        = array_column( $integration->get_settings_fields(), 'key' );
+
+		foreach ( self::PULL_KEYS as $key ) {
+			$this->assertNotContains( $key, $keys, "Push-only integration should not declare '$key'." );
+		}
+		foreach ( self::PUSH_KEYS as $key ) {
+			$this->assertContains( $key, $keys, "Push-only integration should declare '$key'." );
+		}
+	}
+
+	/**
+	 * Both directions default to enabled, each toggle pauses only its own
+	 * direction, and re-enabling restores it — including the checkbox-false
+	 * persistence path (unchecking a default-true checkbox on a fresh site).
+	 */
+	public function test_direction_toggles_default_enabled_and_pause_independently() {
+		$integration = new \Sample_Integration( 'cap-toggles', 'Cap Toggles' );
+
+		$this->assertTrue( $integration->is_push_enabled(), 'Push defaults to enabled.' );
+		$this->assertTrue( $integration->is_pull_enabled(), 'Pull defaults to enabled.' );
+
+		$integration->update_settings_field_value( 'outgoing_sync_enabled', false );
+		$this->assertFalse( $integration->is_push_enabled(), 'Outbound toggle off pauses push.' );
+		$this->assertTrue( $integration->is_pull_enabled(), 'Outbound toggle does not affect pull.' );
+
+		$integration->update_settings_field_value( 'incoming_sync_enabled', false );
+		$this->assertFalse( $integration->is_pull_enabled(), 'Inbound toggle off pauses pull.' );
+
+		$integration->update_settings_field_value( 'outgoing_sync_enabled', true );
+		$integration->update_settings_field_value( 'incoming_sync_enabled', true );
+		$this->assertTrue( $integration->is_push_enabled(), 'Push re-enabled.' );
+		$this->assertTrue( $integration->is_pull_enabled(), 'Pull re-enabled.' );
+	}
+
+	/**
+	 * A missing capability wins over any stored toggle value: the toggle field
+	 * isn't declared, its value can't be written through the settings API, and
+	 * is_push_enabled() stays false even with a forced option row.
+	 */
+	public function test_capability_overrides_stored_toggle() {
+		$integration = $this->create_pull_only_integration( 'cap-forced', 'Cap Forced' );
+
+		$this->assertFalse(
+			$integration->update_settings_field_value( 'outgoing_sync_enabled', true ),
+			'Undeclared toggle field is not writable through the settings API.'
+		);
+
+		// Even a directly-forced option row must not re-enable a direction the
+		// integration does not support.
+		update_option( 'newspack_integration_settings_cap-forced_outgoing_sync_enabled', true );
+		$this->assertFalse( $integration->is_push_enabled() );
+	}
+
+	/**
+	 * Pausing a direction preserves the stored field selections, so re-enabling
+	 * does not lose the publisher's configuration.
+	 */
+	public function test_toggling_direction_off_preserves_field_selections() {
+		$integration = new \Sample_Integration( 'cap-preserve', 'Cap Preserve' );
+
+		$defaults  = \Newspack\Reader_Activation\Sync\Metadata::get_default_fields();
+		$selection = array_values( array_slice( $defaults, 0, 2 ) );
+		$this->assertNotEmpty( $selection, 'Precondition: there are default outgoing fields to select.' );
+		$integration->update_enabled_outgoing_fields( $selection );
+		$integration->update_enabled_incoming_fields( [ 'vip_level' ] );
+
+		$integration->update_settings_field_value( 'outgoing_sync_enabled', false );
+		$integration->update_settings_field_value( 'incoming_sync_enabled', false );
+
+		$this->assertSame( $selection, $integration->get_enabled_outgoing_fields(), 'Outgoing selection survives the pause.' );
+		$incoming_keys = array_map(
+			function ( $field ) {
+				return $field->get_key();
+			},
+			$integration->get_enabled_incoming_fields()
+		);
+		$this->assertSame( [ 'vip_level' ], $incoming_keys, 'Incoming selection survives the pause.' );
+	}
+
+	/**
+	 * Sync::has_one_syncable_integration() is a push-path predicate: an active
+	 * integration whose outbound sync is paused does not satisfy it, and
+	 * re-enabling the toggle restores it.
+	 */
+	public function test_has_one_syncable_integration_requires_enabled_push() {
+		$integration = new \Sample_Integration( 'cap-syncable', 'Cap Syncable' );
+		Integrations::register( $integration );
+		update_option( Integrations::OPTION_NAME, [ 'cap-syncable' ] );
+
+		$this->assertTrue( Sync::has_one_syncable_integration(), 'Precondition: enabled push-capable integration is syncable.' );
+
+		$integration->update_settings_field_value( 'outgoing_sync_enabled', false );
+		$this->assertFalse( Sync::has_one_syncable_integration(), 'Paused outbound sync must not count as syncable.' );
+
+		$errors = Sync::has_one_syncable_integration( true );
+		$this->assertWPError( $errors );
+		$this->assertContains( 'integration_push_disabled', $errors->get_error_codes() );
+
+		$integration->update_settings_field_value( 'outgoing_sync_enabled', true );
+		$this->assertTrue( Sync::has_one_syncable_integration(), 'Re-enabling the toggle restores syncability.' );
+	}
+
+	/**
+	 * Sync::has_one_syncable_integration() returns false when the only active
+	 * integration has no push capability at all.
+	 */
+	public function test_has_one_syncable_integration_false_for_pull_only() {
+		$integration = $this->create_pull_only_integration( 'cap-inbound', 'Cap Inbound' );
+		Integrations::register( $integration );
+		update_option( Integrations::OPTION_NAME, [ 'cap-inbound' ] );
+
+		$this->assertFalse( Sync::has_one_syncable_integration() );
+
+		$errors = Sync::has_one_syncable_integration( true );
+		$this->assertWPError( $errors );
+		$this->assertContains( 'integration_push_not_supported', $errors->get_error_codes() );
+	}
+
+	/**
+	 * The push dispatcher skips integrations whose outbound sync is paused and
+	 * resumes pushing once the toggle is re-enabled.
+	 */
+	public function test_contact_sync_skips_push_disabled_integration() {
+		$spy = new \Deletion_Spy_Integration( 'cap-push-spy', 'Cap Push Spy' );
+		Integrations::register( $spy );
+		update_option( Integrations::OPTION_NAME, [ 'cap-push-spy' ] );
+
+		$contact = [
+			'email'    => 'reader@example.com',
+			'metadata' => [],
+		];
+
+		$spy->update_settings_field_value( 'outgoing_sync_enabled', false );
+		Contact_Sync::sync( $contact, 'TestContext' );
+		$this->assertCount( 0, $spy->push_calls, 'Paused outbound sync must not push.' );
+
+		$spy->update_settings_field_value( 'outgoing_sync_enabled', true );
+		Contact_Sync::sync( $contact, 'TestContext' );
+		$this->assertCount( 1, $spy->push_calls, 'Re-enabled outbound sync pushes again.' );
+	}
+
+	/**
+	 * Account-deletion propagation follows the outbound toggle: a paused
+	 * integration receives neither hard deletes nor flag-mode pushes, even with
+	 * deletion sync itself turned on.
+	 */
+	public function test_account_deletion_skips_push_disabled_integration() {
+		$spy = new \Deletion_Spy_Integration( 'cap-del-spy', 'Cap Del Spy' );
+		Integrations::register( $spy );
+		update_option( Integrations::OPTION_NAME, [ 'cap-del-spy' ] );
+		$spy->update_settings_field_value( 'sync_account_deletion', true );
+		$spy->update_settings_field_value( 'account_deletion_handling', 'delete' );
+		$spy->update_settings_field_value( 'outgoing_sync_enabled', false );
+
+		Contact_Sync::handle_account_deletion(
+			'reader@example.com',
+			[
+				'email'    => 'reader@example.com',
+				'metadata' => [],
+			],
+			'TestContext'
+		);
+
+		$this->assertCount( 0, $spy->delete_calls, 'Paused outbound sync must not hard-delete.' );
+		$this->assertCount( 0, $spy->push_calls, 'Paused outbound sync must not flag-push.' );
+
+		$spy->update_settings_field_value( 'outgoing_sync_enabled', true );
+		Contact_Sync::handle_account_deletion(
+			'reader@example.com',
+			[
+				'email'    => 'reader@example.com',
+				'metadata' => [],
+			],
+			'TestContext'
+		);
+		$this->assertCount( 1, $spy->delete_calls, 'Re-enabled outbound sync propagates the deletion.' );
+	}
+
+	/**
+	 * Account-deletion propagation never runs for an integration without push
+	 * capability, regardless of forced deletion-setting option rows.
+	 */
+	public function test_account_deletion_skips_push_incapable_integration() {
+		$spy = new class( 'cap-del-incapable', 'Cap Del Incapable' ) extends \Deletion_Spy_Integration {
+			/**
+			 * Declare no push capability.
+			 *
+			 * @return bool
+			 */
+			public function supports_push(): bool {
+				return false;
+			}
+		};
+		Integrations::register( $spy );
+		update_option( Integrations::OPTION_NAME, [ 'cap-del-incapable' ] );
+		// Force option rows that would enable deletion sync if the fields were declared.
+		update_option( 'newspack_integration_settings_cap-del-incapable_sync_account_deletion', true );
+		update_option( 'newspack_integration_settings_cap-del-incapable_account_deletion_handling', 'delete' );
+
+		Contact_Sync::handle_account_deletion(
+			'reader@example.com',
+			[
+				'email'    => 'reader@example.com',
+				'metadata' => [],
+			],
+			'TestContext'
+		);
+
+		$this->assertCount( 0, $spy->delete_calls );
+		$this->assertCount( 0, $spy->push_calls );
+	}
+
+	/**
+	 * The pull dispatcher skips integrations whose inbound sync is paused and
+	 * resumes pulling once the toggle is re-enabled.
+	 */
+	public function test_contact_pull_skips_pull_disabled_integration() {
+		$integration = new class( 'cap-pull-spy', 'Cap Pull Spy' ) extends \Sample_Integration {
+			/**
+			 * Captured pull_contact_data() calls.
+			 *
+			 * @var array
+			 */
+			public $pull_calls = [];
+
+			/**
+			 * Pull contact data (records the call).
+			 *
+			 * @param int $user_id WordPress user ID.
+			 * @return array
+			 */
+			public function pull_contact_data( $user_id ) {
+				$this->pull_calls[] = $user_id;
+				return [ 'vip_level' => 'gold' ];
+			}
+		};
+		Integrations::register( $integration );
+		update_option( Integrations::OPTION_NAME, [ 'cap-pull-spy' ] );
+		$integration->update_enabled_incoming_fields( [ 'vip_level' ] );
+
+		$user_id = $this->factory()->user->create();
+
+		$integration->update_settings_field_value( 'incoming_sync_enabled', false );
+		Contact_Pull::pull_all( $user_id );
+		$this->assertCount( 0, $integration->pull_calls, 'Paused inbound sync must not pull.' );
+
+		$integration->update_settings_field_value( 'incoming_sync_enabled', true );
+		Contact_Pull::pull_all( $user_id );
+		$this->assertCount( 1, $integration->pull_calls, 'Re-enabled inbound sync pulls again.' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-sync-capabilities.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-test-sync-capabilities.php
@@ -199,6 +199,33 @@ class Test_Sync_Capabilities extends \WP_UnitTestCase {
 	}
 
 	/**
+	 * An integration that does not declare the toggle fields at all (e.g. a
+	 * subclass overriding get_settings_fields() without the base metadata
+	 * group) stays enabled in both directions: the toggles can only pause
+	 * sync explicitly, so pre-toggle third-party integrations keep syncing.
+	 */
+	public function test_undeclared_toggle_fields_leave_directions_enabled() {
+		$integration = new class( 'cap-no-toggles', 'Cap No Toggles' ) extends \Sample_Integration {
+			/**
+			 * Declare only the integration's own fields, omitting the base
+			 * account-deletion and metadata groups (and their toggles).
+			 *
+			 * @return array
+			 */
+			public function get_settings_fields() {
+				return $this->settings_fields;
+			}
+		};
+
+		$this->assertNull(
+			$integration->get_settings_field_value( 'outgoing_sync_enabled' ),
+			'Precondition: the toggle field is not declared.'
+		);
+		$this->assertTrue( $integration->is_push_enabled(), 'Undeclared outbound toggle must not pause push.' );
+		$this->assertTrue( $integration->is_pull_enabled(), 'Undeclared inbound toggle must not pause pull.' );
+	}
+
+	/**
 	 * A missing capability wins over any stored toggle value: the toggle field
 	 * isn't declared, its value can't be written through the settings API, and
 	 * is_push_enabled() stays false even with a forced option row.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The (flag-gated) Audience → Integrations settings framework assumes every integration is a bidirectional sync destination: inbound-only integrations (Form Capture — #684, Fundraise Up) show a dead Outbound section, deletion-sync toggles, and a metadata-prefix field that store options that do nothing, and they count as "syncable" in `Sync::has_one_syncable_integration()`, activating the sync connector for no-op pushes. This is the generalized follow-up PR #684 deferred.

This PR makes the framework capability-aware and gives each direction a pause toggle:

- **Capability declaration** — integrations declare push/pull ability via `supports_push()` / `supports_pull()` on `Integration`. Both default `true`, so existing connectors (ESP) keep today's behavior with no changes. Inbound-only integrations will override `supports_push()` to return `false` (follow-ups: #684 for Form Capture; newspack-manager for Fundraise Up).
- **Capability-aware settings** — the account-deletion fields, the metadata prefix, and the Outbound section follow push ability; the Inbound section follows pull ability. Sections an integration lacks simply aren't declared, so no dead controls render. The deletion-sync fields and metadata prefix render inside the Outbound section itself, alongside the field picker they govern, and pause with it.
- **Per-direction toggles** — each rendered section gets an enable toggle (`outgoing_sync_enabled` / `incoming_sync_enabled`, default on) shown in the section header area. Toggling one off pauses that direction's sync while preserving the configured metadata-field selections, so re-enabling restores them.
- **Framework honors both** — contact pushes, account-deletion propagation, sync/deletion retries, and contact pulls all skip integrations without an (enabled) direction, and `Sync::has_one_syncable_integration()` returns false when no active integration has an enabled push — with distinct `integration_push_disabled` / `integration_push_not_supported` error codes so the Audience wizard can explain why sync is unavailable.

Closes NPPD-2100.

### How to test the changes in this Pull Request:

1. Enable the screen: `wp config set NEWSPACK_INTEGRATIONS_SETTINGS_ENABLED true --raw --type=constant`, with Audience Management enabled and an ESP (e.g. Mailchimp) connected so the ESP integration is configurable.
2. In Audience → Integrations, configure the ESP integration: the Inbound and Outbound sections each show an enable toggle (both on by default) above their field pickers, and the Outbound section also contains the metadata prefix and account-deletion fields (the Settings group keeps only the integration's own fields).
3. Select some outgoing and incoming metadata fields and save. Toggle "Enable outbound sync" off: the outbound picker, metadata prefix, and account-deletion fields hide while the inbound section is unaffected; save, re-enable, and save again — the previous outgoing selection is intact. Repeat for the inbound toggle.
4. With outbound sync disabled on the only active integration, verify sync is reported unavailable: `wp eval 'var_dump( \Newspack\Reader_Activation\Sync::has_one_syncable_integration( true ) );'` returns a WP_Error including `integration_push_disabled`, and reader activity (registration, login) dispatches no ESP pushes. Re-enable and verify pushes resume.
5. With outbound sync disabled, delete a reader account: no deletion propagates to the ESP (no hard delete, no flag-mode push), even with "Sync user account deletion" checked. Re-enable and confirm deletion propagation works again.
6. With inbound sync disabled, browse the site as a logged-in reader: no contact pulls run (no `NEWSPACK-CONTACT-PULL` log entries or Reader Data updates). Re-enable and confirm pulls resume.
7. Simulate an inbound-only integration (or apply #684 on top) by registering an integration that overrides `supports_push(): false`: its configure view shows no Outbound section, deletion-sync fields, or metadata-prefix field; its own settings remain editable; and `has_one_syncable_integration( true )` reports `integration_push_not_supported` when it is the only active integration.
8. Run `n test-php --group sync-capabilities` (12 tests) and the full `n test-php` + `npm test` suites in `plugins/newspack-plugin`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

