### PR TITLE
fix(newsletters): guard fix_public_status exit for non-page requests

### DIFF
--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
@@ -1595,6 +1595,14 @@ final class Newspack_Newsletters {
 		}
 		$is_public = (bool) get_post_meta( $post->ID, 'is_public', true );
 		if ( 'publish' === $post->post_status && ! $is_public ) {
+			// Correcting to `private` does NOT trigger an ESP send. A
+			// publish -> private transition stays within the controlled
+			// statuses (`['publish', 'private']`), so neither `pre_post_update()`
+			// (which sends when a newsletter moves out of / into that set) nor
+			// `transition_post_status()` (which sends only when `$old_status` is
+			// `'future'`) fires. This matters because, with the `exit` below now
+			// scoped to page views, a single request can correct many rows
+			// instead of stopping at the first — many corrections, still no sends.
 			wp_update_post(
 				[
 					'ID'          => $post->ID,
@@ -1646,7 +1654,19 @@ final class Newspack_Newsletters {
 		}
 		// A feed is a front-end request but not a page view; an `exit` here
 		// would truncate the feed's XML mid-document. Newsletters can appear in
-		// feeds via `display_newsletters_in_archives()`.
+		// feeds via `display_newsletters_in_archives()`. Behaviour change worth
+		// naming: a feed containing a just-corrected newsletter now serves that
+		// item once in the current response (a reader hitting the feed at that
+		// moment sees it) rather than emitting invalid XML, and it drops out of
+		// subsequent requests once healed — one slightly-stale item beats broken
+		// XML.
+		//
+		// This check MUST stay after the REST/AJAX/cron/CLI/XML-RPC returns
+		// above — the ordering is load-bearing, not stylistic. `is_feed()` is a
+		// main-query conditional; called with `$wp_query` unset (e.g. mid-REST)
+		// it triggers `_doing_it_wrong()` and returns false, which would let the
+		// `exit` through in exactly the contexts this guard protects. Do not
+		// reorder these into alphabetical / "cheapest check first" order.
 		if ( is_feed() ) {
 			return false;
 		}

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
@@ -1616,11 +1616,12 @@ final class Newspack_Newsletters {
 
 	/**
 	 * Whether the current request is a genuine front-end page view, as opposed
-	 * to an admin screen, REST or AJAX request, cron run, or WP-CLI invocation.
+	 * to an admin screen, REST/AJAX/XML-RPC request, cron run, WP-CLI
+	 * invocation, or feed render.
 	 *
 	 * Used to decide whether it is safe to `exit` the request: on a page view a
-	 * redirect is the intended behavior, but on any programmatic request an
-	 * `exit` would truncate the response mid-flight.
+	 * redirect is the intended behavior, but on any programmatic request or
+	 * streamed response an `exit` would truncate the output mid-flight.
 	 *
 	 * @return bool True on a front-end page request, false otherwise.
 	 */
@@ -1638,6 +1639,15 @@ final class Newspack_Newsletters {
 			return false;
 		}
 		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return false;
+		}
+		if ( defined( 'XMLRPC_REQUEST' ) && XMLRPC_REQUEST ) {
+			return false;
+		}
+		// A feed is a front-end request but not a page view; an `exit` here
+		// would truncate the feed's XML mid-document. Newsletters can appear in
+		// feeds via `display_newsletters_in_archives()`.
+		if ( is_feed() ) {
 			return false;
 		}
 		return true;

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
@@ -1603,12 +1603,44 @@ final class Newspack_Newsletters {
 				false,
 				false
 			);
-			// Force a page refresh on the front-end.
-			if ( ! is_admin() ) {
+			// Force a page refresh, but only on a genuine front-end page view.
+			// During REST, AJAX, cron or WP-CLI the `exit` would truncate the
+			// current request (e.g. a REST collection would return a partial,
+			// short-circuited response), so restrict it to real page loads.
+			if ( self::is_front_end_page_request() ) {
 				header( 'Refresh:0' );
 				exit;
 			}
 		}
+	}
+
+	/**
+	 * Whether the current request is a genuine front-end page view, as opposed
+	 * to an admin screen, REST or AJAX request, cron run, or WP-CLI invocation.
+	 *
+	 * Used to decide whether it is safe to `exit` the request: on a page view a
+	 * redirect is the intended behavior, but on any programmatic request an
+	 * `exit` would truncate the response mid-flight.
+	 *
+	 * @return bool True on a front-end page request, false otherwise.
+	 */
+	private static function is_front_end_page_request() {
+		if ( is_admin() ) {
+			return false;
+		}
+		if ( defined( 'REST_REQUEST' ) && REST_REQUEST ) {
+			return false;
+		}
+		if ( wp_doing_ajax() ) {
+			return false;
+		}
+		if ( wp_doing_cron() ) {
+			return false;
+		}
+		if ( defined( 'WP_CLI' ) && WP_CLI ) {
+			return false;
+		}
+		return true;
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/test-controlled-statuses.php
+++ b/plugins/newspack-newsletters/tests/test-controlled-statuses.php
@@ -72,10 +72,11 @@ class Newsletter_Controlled_Statuses_Test extends WP_UnitTestCase {
 	/**
 	 * The front-end refresh/exit in fix_public_status() must be suppressed on
 	 * programmatic requests (REST, AJAX, cron, WP-CLI, XML-RPC) and feed
-	 * renders, where an exit would truncate the response mid-flight. The
-	 * REST_REQUEST, WP_CLI, and XMLRPC_REQUEST branches hinge on `define()`
-	 * constants that cannot be toggled per-test, so they are covered by the
-	 * filter-toggleable AJAX/cron/feed branches that share the same guard.
+	 * renders, where an exit would truncate the response mid-flight. The REST
+	 * branch — the actual regression this fixes — is pinned separately in
+	 * test_public_status_refresh_suppressed_during_rest(); the WP_CLI and
+	 * XMLRPC_REQUEST branches hinge on `define()` constants and share this same
+	 * guard, so the filter-toggleable AJAX/cron/feed branches cover them here.
 	 */
 	public function test_public_status_refresh_suppressed_off_page() {
 		$is_front_end = new ReflectionMethod( 'Newspack_Newsletters', 'is_front_end_page_request' );
@@ -99,6 +100,21 @@ class Newsletter_Controlled_Statuses_Test extends WP_UnitTestCase {
 		$wp_query->is_feed = true;
 		$this->assertFalse( $is_front_end->invoke( null ), 'Refresh must be suppressed during a feed render.' );
 		$wp_query->is_feed = false;
+	}
+
+	/**
+	 * Pins the REST branch — the exact regression this fix addresses — in CI.
+	 * `REST_REQUEST` is a `define()` constant, so this runs in a separate
+	 * process to set it without leaking the constant into other tests.
+	 *
+	 * @runInSeparateProcess
+	 * @preserveGlobalState disabled
+	 */
+	public function test_public_status_refresh_suppressed_during_rest() {
+		define( 'REST_REQUEST', true );
+		$is_front_end = new ReflectionMethod( 'Newspack_Newsletters', 'is_front_end_page_request' );
+		$is_front_end->setAccessible( true );
+		$this->assertFalse( $is_front_end->invoke( null ), 'Refresh must be suppressed during a REST request.' );
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/test-controlled-statuses.php
+++ b/plugins/newspack-newsletters/tests/test-controlled-statuses.php
@@ -70,6 +70,58 @@ class Newsletter_Controlled_Statuses_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The front-end refresh/exit in fix_public_status() must be suppressed on
+	 * programmatic requests (REST, AJAX, cron, WP-CLI), where an exit would
+	 * truncate the response.
+	 */
+	public function test_public_status_refresh_suppressed_off_page() {
+		$is_front_end = new ReflectionMethod( 'Newspack_Newsletters', 'is_front_end_page_request' );
+		$is_front_end->setAccessible( true );
+
+		// A plain (non-admin) context reads as a front-end page request.
+		$this->assertTrue( $is_front_end->invoke( null ), 'A plain request should be treated as a page view.' );
+
+		// AJAX must suppress the refresh.
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		$this->assertFalse( $is_front_end->invoke( null ), 'Refresh must be suppressed during AJAX.' );
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+
+		// Cron must suppress the refresh.
+		add_filter( 'wp_doing_cron', '__return_true' );
+		$this->assertFalse( $is_front_end->invoke( null ), 'Refresh must be suppressed during cron.' );
+		remove_filter( 'wp_doing_cron', '__return_true' );
+	}
+
+	/**
+	 * Corrects an invalid publish + non-public newsletter to private on a
+	 * programmatic request (via fix_public_status()), without exiting.
+	 */
+	public function test_fix_public_status_corrects_without_exit_off_page() {
+		$post_id = self::factory()->post->create(
+			[
+				'post_type'   => \Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status' => 'draft',
+			]
+		);
+		\Newspack_Newsletters::set_newsletter_sent( $post_id );
+
+		// Force the invalid publish + non-public state directly, bypassing the
+		// publish-time guard, so fix_public_status() has something to correct.
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching -- Test setup forces an invalid state that the publish-time guard would otherwise correct.
+		$wpdb->update( $wpdb->posts, [ 'post_status' => 'publish' ], [ 'ID' => $post_id ] );
+		clean_post_cache( $post_id );
+
+		// Simulate a cron request so the redirect/exit path is not taken; before
+		// the guard fix this call would `exit` and abort the test run.
+		add_filter( 'wp_doing_cron', '__return_true' );
+		\Newspack_Newsletters::fix_public_status( get_post( $post_id ) );
+		remove_filter( 'wp_doing_cron', '__return_true' );
+
+		$this->assertEquals( 'private', get_post( $post_id )->post_status, 'A non-public newsletter should be corrected to private.' );
+	}
+
+	/**
 	 * Test that is_newsletter_sent handles valid and invalid publish dates correctly.
 	 */
 	public function test_is_newsletter_sent_with_invalid_date() {

--- a/plugins/newspack-newsletters/tests/test-controlled-statuses.php
+++ b/plugins/newspack-newsletters/tests/test-controlled-statuses.php
@@ -71,8 +71,11 @@ class Newsletter_Controlled_Statuses_Test extends WP_UnitTestCase {
 
 	/**
 	 * The front-end refresh/exit in fix_public_status() must be suppressed on
-	 * programmatic requests (REST, AJAX, cron, WP-CLI), where an exit would
-	 * truncate the response.
+	 * programmatic requests (REST, AJAX, cron, WP-CLI, XML-RPC) and feed
+	 * renders, where an exit would truncate the response mid-flight. The
+	 * REST_REQUEST, WP_CLI, and XMLRPC_REQUEST branches hinge on `define()`
+	 * constants that cannot be toggled per-test, so they are covered by the
+	 * filter-toggleable AJAX/cron/feed branches that share the same guard.
 	 */
 	public function test_public_status_refresh_suppressed_off_page() {
 		$is_front_end = new ReflectionMethod( 'Newspack_Newsletters', 'is_front_end_page_request' );
@@ -90,6 +93,12 @@ class Newsletter_Controlled_Statuses_Test extends WP_UnitTestCase {
 		add_filter( 'wp_doing_cron', '__return_true' );
 		$this->assertFalse( $is_front_end->invoke( null ), 'Refresh must be suppressed during cron.' );
 		remove_filter( 'wp_doing_cron', '__return_true' );
+
+		// A feed render must suppress the refresh (an exit would truncate the XML).
+		global $wp_query;
+		$wp_query->is_feed = true;
+		$this->assertFalse( $is_front_end->invoke( null ), 'Refresh must be suppressed during a feed render.' );
+		$wp_query->is_feed = false;
 	}
 
 	/**


### PR DESCRIPTION
### Changes proposed in this Pull Request

`Newspack_Newsletters::fix_public_status()` is hooked on `the_post` and, for a `publish` newsletter whose `is_public` meta is falsey, flips it to `private` and then issues `header( 'Refresh:0' ); exit;` to reload the front-end page. That `exit` was guarded only by `! is_admin()`.

During a **REST** request (and cron / WP-CLI / XML-RPC / a feed render), `is_admin()` is `false`, so the guard passed and the request `exit`ed mid-flight the first time such a newsletter appeared in the loop — truncating the response. This surfaced while QA-testing the new newsletters admin list ([#677](https://github.com/Automattic/newspack-workspace/pull/677)): the batched "All" fetch (`per_page=100`, pages 2+) returned a partial page and the UI showed "Only some items could be loaded." The list code there is correct; this hook was the root cause, and it is pre-existing (independent of #677).

This restricts the redirect/`exit` to a genuine front-end page view:

- Extracts the decision into a small `is_front_end_page_request()` helper.
- Returns `false` (so no `exit`) for `is_admin()`, `REST_REQUEST`, `wp_doing_ajax()`, `wp_doing_cron()`, `WP_CLI`, `XMLRPC_REQUEST`, and `is_feed()`.

Feeds and XML-RPC are streamed/programmatic responses rather than page views — and newsletters can appear in feeds via `display_newsletters_in_archives()` — so an `exit` there would truncate the output (e.g. a feed's XML) mid-document just as it did for REST.

The status correction itself (publish → private for non-public newsletters) is unchanged and still runs in every context; only the page-refresh `exit` is now scoped to real page loads.

### How to test the changes in this Pull Request

1. `cd plugins/newspack-newsletters && n test-php --filter Newsletter_Controlled_Statuses_Test` — the group passes, including the new tests:
   - `test_public_status_refresh_suppressed_off_page` — the guard returns `false` under AJAX / cron / feed (the constant-gated REST, WP-CLI and XML-RPC branches share the same helper and are covered end-to-end by the env run below).
   - `test_fix_public_status_corrects_without_exit_off_page` — an invalid publish + non-public newsletter is still corrected to `private` without exiting (pre-fix, this call would `exit` and abort the run).
2. On a site with many `publish`-but-non-public newsletters, request the newsletters REST collection at `per_page=100` across multiple pages and confirm each page returns in full rather than truncating. (Verified in an isolated env: 250 seeded newsletters, 240 forced into the invalid state → pages returned 100 / 100 / 50, `X-WP-Total: 250`, no truncation, rows self-healed to `private`, debug log clean.)

### Other information

- Root-caused during the manual QA of #677 (DSGNEWS-200); split out as its own fix since it is pre-existing and independent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
