### PR TITLE
fix(content-distribution): don't mark failed dispatch as distributed

### DIFF
--- a/plugins/newspack-network/includes/content-distribution/class-api.php
+++ b/plugins/newspack-network/includes/content-distribution/class-api.php
@@ -178,8 +178,14 @@ class API {
 			return new WP_Error( 'newspack_network_content_distribution_error', $distribution->get_error_message(), [ 'status' => 400 ] );
 		}
 
-		$payload = $outgoing_post->get_payload( $status_on_publish );
-		Data_Events::dispatch( 'network_post_updated', $payload );
+		$payload    = $outgoing_post->get_payload( $status_on_publish );
+		$dispatched = Data_Events::dispatch( 'network_post_updated', $payload );
+
+		// Bail before storing the payload hash if the dispatch failed, so the next
+		// post update retries the distribution instead of being suppressed by the hash.
+		if ( is_wp_error( $dispatched ) ) {
+			return new WP_Error( 'newspack_network_content_distribution_error', $dispatched->get_error_message(), [ 'status' => 500 ] );
+		}
 
 		// Store payload hash to prevent unnecessary updates.
 		update_post_meta( $post_id, Content_Distribution_Class::PAYLOAD_HASH_META, $outgoing_post->get_payload_hash( $payload ) );

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/mock-data-events.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/mock-data-events.php
@@ -1,0 +1,54 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Controllable mock of the Newspack Data Events class.
+ *
+ * The real class lives in newspack-plugin, which is not loaded in this test
+ * suite. Defined here so tests can exercise code paths guarded by
+ * class_exists( 'Newspack\Data_Events' ) and control the dispatch() return value.
+ *
+ * Guarded so it does not collide with the ad-hoc mock evaluated at runtime in
+ * sibling tests; those only rely on dispatch() returning a truthy value, which
+ * the default preserves.
+ *
+ * @package Newspack_Network
+ */
+
+namespace Newspack;
+
+if ( ! class_exists( 'Newspack\Data_Events' ) ) {
+	/**
+	 * Mock Data Events class.
+	 */
+	class Data_Events {
+		/**
+		 * Value returned by dispatch(). Set to a WP_Error to simulate a failed dispatch.
+		 *
+		 * @var mixed
+		 */
+		public static $mock_dispatch_return = true;
+
+		/**
+		 * Mock dispatch.
+		 *
+		 * @param string $action_name   Action name.
+		 * @param array  $data          Data.
+		 * @param bool   $use_client_id Whether to use the client ID.
+		 *
+		 * @return mixed
+		 */
+		public static function dispatch( $action_name, $data = [], $use_client_id = true ) {
+			return self::$mock_dispatch_return;
+		}
+
+		/**
+		 * Mock is_action_registered.
+		 *
+		 * @param string $action_name Action name.
+		 *
+		 * @return bool
+		 */
+		public static function is_action_registered( $action_name ) {
+			return true;
+		}
+	}
+}

--- a/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
+++ b/plugins/newspack-network/tests/unit-tests/content-distribution/test-api.php
@@ -1,0 +1,139 @@
+<?php
+/**
+ * Class TestApi
+ *
+ * @package Newspack_Network
+ */
+
+namespace Test\Content_Distribution;
+
+require_once __DIR__ . '/mock-data-events.php';
+
+use Newspack\Data_Events;
+use Newspack_Network\Content_Distribution as Content_Distribution_Class;
+use Newspack_Network\Content_Distribution\API;
+use Newspack_Network\Content_Distribution\Outgoing_Post;
+use Newspack_Network\Hub\Node as Hub_Node;
+use WP_REST_Request;
+
+/**
+ * Test the content-distribution REST API.
+ *
+ * @group content-distribution-api
+ */
+class TestApi extends \WP_UnitTestCase {
+	/**
+	 * "Mocked" network nodes.
+	 *
+	 * @var array
+	 */
+	protected $network = [
+		[
+			'id'    => 1234,
+			'title' => 'Test Node',
+			'url'   => 'https://node.test',
+		],
+	];
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		update_option( Hub_Node::HUB_NODES_SYNCED_OPTION, $this->network );
+		Data_Events::$mock_dispatch_return = true;
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		Data_Events::$mock_dispatch_return = true;
+		parent::tear_down();
+	}
+
+	/**
+	 * Build a distributable post and a distribute request for it.
+	 *
+	 * @return array The post ID and the WP_REST_Request.
+	 */
+	private function make_distribute_request() {
+		$author  = $this->factory->user->create( [ 'role' => 'editor' ] );
+		$post_id = $this->factory->post->create(
+			[
+				'post_type'   => 'post',
+				'post_status' => 'publish',
+				'post_author' => $author,
+			]
+		);
+
+		$request = new WP_REST_Request( 'POST', '/newspack-network/v1/content-distribution/distribute/' . $post_id );
+		$request->set_param( 'post_id', $post_id );
+		$request->set_param( 'urls', [ $this->network[0]['url'] ] );
+		$request->set_param( 'status_on_publish', 'draft' );
+
+		return [ $post_id, $request ];
+	}
+
+	/**
+	 * A failed dispatch must be surfaced as an error, not a 200 response.
+	 */
+	public function test_distribute_returns_error_when_dispatch_fails() {
+		Data_Events::$mock_dispatch_return = new \WP_Error(
+			'newspack_data_events_action_not_registered',
+			'Action not registered.'
+		);
+
+		list( , $request ) = $this->make_distribute_request();
+		$result            = API::distribute( $request );
+
+		$this->assertWPError(
+			$result,
+			'distribute() must return a WP_Error when Data_Events::dispatch() fails.'
+		);
+		$this->assertSame(
+			500,
+			$result->get_error_data()['status'],
+			'A failed dispatch is a server-side condition and must return HTTP 500.'
+		);
+	}
+
+	/**
+	 * A failed dispatch must not write the payload hash, and must leave the destination
+	 * recorded in distribution meta, so the next post update retries distribution.
+	 */
+	public function test_distribute_does_not_store_payload_hash_when_dispatch_fails() {
+		Data_Events::$mock_dispatch_return = new \WP_Error(
+			'newspack_data_events_action_not_registered',
+			'Action not registered.'
+		);
+
+		list( $post_id, $request ) = $this->make_distribute_request();
+		API::distribute( $request );
+
+		$this->assertEmpty(
+			get_post_meta( $post_id, Content_Distribution_Class::PAYLOAD_HASH_META, true ),
+			'The payload hash must not be stored when dispatch fails.'
+		);
+		$this->assertNotEmpty(
+			get_post_meta( $post_id, Outgoing_Post::DISTRIBUTED_POST_META, true ),
+			'The destination must stay recorded so the next save retries distribution.'
+		);
+	}
+
+	/**
+	 * The happy path is unaffected: a successful dispatch stores the payload hash.
+	 */
+	public function test_distribute_stores_payload_hash_on_success() {
+		Data_Events::$mock_dispatch_return = null; // Real dispatch() returns void on success.
+
+		list( $post_id, $request ) = $this->make_distribute_request();
+		$result                    = API::distribute( $request );
+
+		$this->assertNotWPError( $result, 'distribute() must succeed when dispatch succeeds.' );
+		$this->assertNotEmpty(
+			get_post_meta( $post_id, Content_Distribution_Class::PAYLOAD_HASH_META, true ),
+			'The payload hash must be stored on a successful dispatch.'
+		);
+	}
+}


### PR DESCRIPTION
Fixes NPPM-3036.

### Changes proposed in this Pull Request

The content-distribution REST endpoint `API::distribute()` (`plugins/newspack-network/includes/content-distribution/class-api.php`) discarded the return value of `Data_Events::dispatch( 'network_post_updated', $payload )`.

`Data_Events::dispatch()` returns a `WP_Error` when the action is not registered (and when a `newspack_data_events_dispatch_body` filter cancels the dispatch); it returns void otherwise. Because that value was ignored, when a dispatch failed the endpoint still:

1. wrote the `_newspack_network_payload_hash` post-meta, and
2. returned HTTP 200.

The stored hash then tells the plugin "this version was already sent" and suppresses the self-healing re-sync on the next post update — so the source site believes the post was distributed while the destination never received it, and the hash actively prevents recovery.

This PR captures the dispatch result and, on `is_wp_error()`, returns a `WP_Error` (HTTP 500) **before** writing the payload hash. Skipping the hash on failure is the important part: it leaves the post's payload hash empty so the next save re-attempts distribution. The already-recorded destination in the distribution meta is intentionally left in place so the post self-heals on the next update.

The failure path is hard to reach in a normal install (`network_post_updated` is registered during init), so this is a latent correctness hole rather than something publishers are hitting today.

### How to test the changes in this Pull Request

Covered by new PHPUnit tests in `tests/unit-tests/content-distribution/test-api.php` (with a controllable `Newspack\Data_Events` mock in `mock-data-events.php`):

1. `n test-php --group content-distribution-api` (from `plugins/newspack-network`) — passes.
2. Before the fix, the two failure-path tests fail: the endpoint returned a `WP_REST_Response` (200) instead of a `WP_Error`, and wrote the payload-hash meta despite the failed dispatch.
3. After the fix: a failed dispatch returns a `WP_Error` with `status` 500, does not write the payload hash, and leaves the destination recorded so the next save retries. The happy path still stores the hash and returns a response.
4. Full suite green: `n test-php` in `plugins/newspack-network` (192 tests).

### Follow-up (not in this PR)

The same ignored-`dispatch()`-return pattern exists in the automatic on-save distribution paths — `Content_Distribution::distribute_post()` (`includes/class-content-distribution.php:498-500`) and `distribute_post_partial()` (`:535-537`) — which write the payload hash unconditionally after dispatch. Those are the shutdown-deferred paths that run on every save, so completing the same guard there makes the self-heal robust across repeated failures. Kept out of this hotfix to stay minimal; worth a fast-follow.

### Other information

- [x] Have you added an explanation of what your changes do and why you'd like us to include them?
- [x] Have you written new tests for your changes, as applicable?
- [x] Have you successfully run tests with your changes locally?
