### PR TITLE
fix(content-gate): surface the Institutions entry point when institutions exist (NPPD-1492)

### DIFF
--- a/packages/components/src/section-header/index.js
+++ b/packages/components/src/section-header/index.js
@@ -102,6 +102,14 @@ const SectionHeader = ( {
 						? badges.map( ( badge, i ) => <Badge key={ i } text={ badge.label } level={ badge.level || 'default' } /> )
 						: null }
 				</HeadingTag>
+				{ /* Secondary action before the overflow menu, so a promoted link reads as an action rather than sitting to the right of the kebab. */ }
+				{ secondaryAction && (
+					<div className="newspack-section-header__secondary-action">
+						<Button variant="link" href={ secondaryAction.href } onClick={ secondaryAction.action }>
+							{ secondaryAction.label }
+						</Button>
+					</div>
+				) }
 				{ menu?.length > 0 && (
 					<DropdownMenu className="newspack-section-header__menu" icon={ moreVertical } label={ __( 'More options', 'newspack-plugin' ) }>
 						{ () =>
@@ -119,13 +127,6 @@ const SectionHeader = ( {
 							) )
 						}
 					</DropdownMenu>
-				) }
-				{ secondaryAction && (
-					<div className="newspack-section-header__secondary-action">
-						<Button variant="link" href={ secondaryAction.href } onClick={ secondaryAction.action }>
-							{ secondaryAction.label }
-						</Button>
-					</div>
 				) }
 			</div>
 		);

--- a/plugins/newspack-plugin/includes/content-gate/class-institution.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-institution.php
@@ -165,6 +165,20 @@ class Institution {
 	}
 
 	/**
+	 * Whether any institution is configured.
+	 *
+	 * Callers that only need existence should use this rather than counting
+	 * get_cached_institutions(): the cache is returned verbatim from a
+	 * transient, whose value passes through the pre_transient/transient filters
+	 * and so is not guaranteed to be an array a caller can count().
+	 *
+	 * @return bool
+	 */
+	public static function has_institutions() {
+		return ! empty( self::get_cached_institutions() );
+	}
+
+	/**
 	 * Rebuild the institutions transient cache.
 	 *
 	 * @return array The rebuilt cache.

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
@@ -402,7 +402,7 @@ class Audience_Content_Gates extends Wizard {
 				'content_gifting'   => Content_Gifting::get_settings(),
 				'advanced_settings' => $advanced_settings_response,
 				'has_newsletters'   => Reader_Activation::is_esp_configured(),
-				'has_institutions'  => count( Institution::get_cached_institutions() ) > 0,
+				'has_institutions'  => Institution::has_institutions(),
 			],
 		];
 		return rest_ensure_response( $config );

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
@@ -402,6 +402,7 @@ class Audience_Content_Gates extends Wizard {
 				'content_gifting'   => Content_Gifting::get_settings(),
 				'advanced_settings' => $advanced_settings_response,
 				'has_newsletters'   => Reader_Activation::is_esp_configured(),
+				'has_institutions'  => count( Institution::get_cached_institutions() ) > 0,
 			],
 		];
 		return rest_ensure_response( $config );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates.test.js
@@ -10,6 +10,11 @@
  */
 import { render } from '@testing-library/react';
 
+/**
+ * Internal dependencies
+ */
+import ContentGates from './content-gates';
+
 // mock-prefixed so Jest's hoisted jest.mock factories may close over them.
 const mockSetHeaderData = jest.fn();
 let mockWizardData = {};
@@ -34,22 +39,35 @@ jest.mock( '@wordpress/data', () => ( {
 	useSelect: () => ( {} ),
 } ) );
 
+// Passthrough only the components the view actually uses. The real
+// @wordpress/components cannot be loaded in this jsdom env (its data-store
+// side effects throw at import), so instead of a plain object — where a newly
+// imported component reads back as undefined and fails deep in React with an
+// opaque "Element type is invalid" — wrap the mock in a Proxy that throws for
+// any export the test has not provided, naming the missing one.
+const failLoudlyMock = ( moduleName, exports ) =>
+	new Proxy( exports, {
+		get( target, prop ) {
+			if ( prop in target || typeof prop === 'symbol' || prop === '__esModule' ) {
+				return target[ prop ];
+			}
+			throw new Error(
+				`content-gates.test mock of '${ moduleName }' has no '${ String( prop ) }'. ` + 'Add it to the mock in content-gates.test.js.'
+			);
+		},
+	} );
+
 jest.mock( '@wordpress/components', () => {
 	const React = require( 'react' );
 	// forwardRef because the component attaches a ref to VStack.
 	const Passthrough = React.forwardRef( ( { children }, ref ) => React.createElement( 'div', { ref }, children ) );
-	return {
-		__experimentalVStack: Passthrough,
-	};
+	return failLoudlyMock( '@wordpress/components', { __experimentalVStack: Passthrough } );
 } );
 
 jest.mock( '../../../../../packages/components/src', () => {
 	const React = require( 'react' );
 	const Passthrough = ( { children } ) => React.createElement( 'div', null, children );
-	return {
-		Divider: Passthrough,
-		Grid: Passthrough,
-	};
+	return failLoudlyMock( 'packages/components/src', { Divider: Passthrough, Grid: Passthrough } );
 } );
 
 jest.mock( '../../../../../packages/components/src/wizard/store/utils', () => ( {
@@ -67,32 +85,79 @@ jest.mock( './content-gate-settings', () => () => null );
 jest.mock( './advanced-settings', () => () => null );
 jest.mock( './settings-card', () => () => null );
 
-const ContentGates = require( './content-gates' ).default;
+const gatesOfLength = length =>
+	Array.from( { length }, ( _unused, index ) => ( {
+		id: index + 1,
+		title: `Gate ${ index + 1 }`,
+		status: 'publish',
+		priority: index,
+	} ) );
 
-const singleGate = [ { id: 1, title: 'Gate A', status: 'publish', priority: 0 } ];
+const lastHeaderData = () => {
+	const { calls } = mockSetHeaderData.mock;
+	if ( calls.length === 0 ) {
+		throw new Error( 'setHeaderData was never called; the header effect did not run.' );
+	}
+	return calls[ calls.length - 1 ][ 0 ];
+};
 
-const lastHeaderData = () => mockSetHeaderData.mock.calls[ mockSetHeaderData.mock.calls.length - 1 ][ 0 ];
+const menuLabels = headerData => headerData.sectionMenu.map( item => item.label );
 
 describe( 'Content Gates header — Institutions entry point (NPPD-1492)', () => {
 	beforeEach( () => {
 		mockSetHeaderData.mockReset();
 	} );
 
-	it( 'keeps Institutions in the kebab menu when the site has no institutions', () => {
-		mockWizardData = { gates: singleGate, config: { has_institutions: false } };
+	// The full gate-count × institutions matrix: Gate Priority appears only
+	// with more than one gate, and Institutions moves between the kebab menu
+	// and the promoted secondary action depending on whether any exist.
+	it.each( [
+		{
+			name: 'one gate, no institutions',
+			gateCount: 1,
+			hasInstitutions: false,
+			expectedMenu: [ 'Institutions', 'Advanced Settings' ],
+			expectSecondary: false,
+		},
+		{
+			name: 'two gates, no institutions',
+			gateCount: 2,
+			hasInstitutions: false,
+			expectedMenu: [ 'Gate Priority', 'Institutions', 'Advanced Settings' ],
+			expectSecondary: false,
+		},
+		{
+			name: 'one gate, institutions present',
+			gateCount: 1,
+			hasInstitutions: true,
+			expectedMenu: [ 'Advanced Settings' ],
+			expectSecondary: true,
+		},
+		{
+			name: 'two gates, institutions present',
+			gateCount: 2,
+			hasInstitutions: true,
+			expectedMenu: [ 'Gate Priority', 'Advanced Settings' ],
+			expectSecondary: true,
+		},
+	] )( 'builds the header menu for $name', ( { gateCount, hasInstitutions, expectedMenu, expectSecondary } ) => {
+		mockWizardData = { gates: gatesOfLength( gateCount ), config: { has_institutions: hasInstitutions } };
 		render( <ContentGates updateGatesData={ () => {} } /> );
 
 		const headerData = lastHeaderData();
-		expect( headerData.sectionMenu.map( item => item.label ) ).toContain( 'Institutions' );
-		expect( headerData.sectionSecondaryAction ).toBeUndefined();
-	} );
+		// Assert the whole ordered menu, so the chained conditional order is pinned.
+		expect( menuLabels( headerData ) ).toEqual( expectedMenu );
 
-	it( 'promotes Institutions to a visible header action when the site has institutions', () => {
-		mockWizardData = { gates: singleGate, config: { has_institutions: true } };
-		render( <ContentGates updateGatesData={ () => {} } /> );
-
-		const headerData = lastHeaderData();
-		expect( headerData.sectionSecondaryAction ).toEqual( expect.objectContaining( { label: 'Institutions', href: '#/institutions' } ) );
-		expect( headerData.sectionMenu.map( item => item.label ) ).not.toContain( 'Institutions' );
+		if ( expectSecondary ) {
+			// Pin the href, not just the label: the promotion changed this
+			// entry from an action callback to an href, and a label-only
+			// assertion would still pass on a dead link.
+			expect( headerData.sectionSecondaryAction ).toEqual( expect.objectContaining( { label: 'Institutions', href: '#/institutions' } ) );
+		} else {
+			expect( headerData.sectionSecondaryAction ).toBeUndefined();
+			// The kebab entry must also still navigate, not just carry a label.
+			const institutionsItem = headerData.sectionMenu.find( item => item.label === 'Institutions' );
+			expect( institutionsItem ).toEqual( expect.objectContaining( { href: '#/institutions' } ) );
+		}
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates.test.js
@@ -1,0 +1,98 @@
+/**
+ * NPPD-1492 — the "Institutions" entry point on the Access Control screen must
+ * be plainly visible (header secondary action) when the site has at least one
+ * institution, and may stay tucked in the kebab menu only while the publisher
+ * is not using institutions.
+ */
+
+/**
+ * External dependencies
+ */
+import { render } from '@testing-library/react';
+
+// mock-prefixed so Jest's hoisted jest.mock factories may close over them.
+const mockSetHeaderData = jest.fn();
+let mockWizardData = {};
+
+jest.mock( '../../../hooks/use-wizard-api-fetch', () => ( {
+	useWizardApiFetch: () => ( {
+		wizardApiFetch: jest.fn(),
+		isFetching: false,
+		errorMessage: null,
+		resetError: jest.fn(),
+	} ),
+} ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		addNotice: jest.fn(),
+		resetNotices: jest.fn(),
+		resetHeaderData: jest.fn(),
+		setHeaderData: ( ...args ) => mockSetHeaderData( ...args ),
+		updateWizardSettings: jest.fn(),
+	} ),
+	useSelect: () => ( {} ),
+} ) );
+
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+	// forwardRef because the component attaches a ref to VStack.
+	const Passthrough = React.forwardRef( ( { children }, ref ) => React.createElement( 'div', { ref }, children ) );
+	return {
+		__experimentalVStack: Passthrough,
+	};
+} );
+
+jest.mock( '../../../../../packages/components/src', () => {
+	const React = require( 'react' );
+	const Passthrough = ( { children } ) => React.createElement( 'div', null, children );
+	return {
+		Divider: Passthrough,
+		Grid: Passthrough,
+	};
+} );
+
+jest.mock( '../../../../../packages/components/src/wizard/store/utils', () => ( {
+	useWizardData: () => mockWizardData,
+} ) );
+
+jest.mock( '../../../../../packages/components/src/wizard/store', () => ( {
+	WIZARD_STORE_NAMESPACE: 'newspack/wizards',
+} ) );
+
+// Child views are irrelevant to the header contract under test.
+jest.mock( './content-gates-onboarding', () => () => null );
+jest.mock( './content-gates-priority', () => () => null );
+jest.mock( './content-gate-settings', () => () => null );
+jest.mock( './advanced-settings', () => () => null );
+jest.mock( './settings-card', () => () => null );
+
+const ContentGates = require( './content-gates' ).default;
+
+const singleGate = [ { id: 1, title: 'Gate A', status: 'publish', priority: 0 } ];
+
+const lastHeaderData = () => mockSetHeaderData.mock.calls[ mockSetHeaderData.mock.calls.length - 1 ][ 0 ];
+
+describe( 'Content Gates header — Institutions entry point (NPPD-1492)', () => {
+	beforeEach( () => {
+		mockSetHeaderData.mockReset();
+	} );
+
+	it( 'keeps Institutions in the kebab menu when the site has no institutions', () => {
+		mockWizardData = { gates: singleGate, config: { has_institutions: false } };
+		render( <ContentGates updateGatesData={ () => {} } /> );
+
+		const headerData = lastHeaderData();
+		expect( headerData.sectionMenu.map( item => item.label ) ).toContain( 'Institutions' );
+		expect( headerData.sectionSecondaryAction ).toBeUndefined();
+	} );
+
+	it( 'promotes Institutions to a visible header action when the site has institutions', () => {
+		mockWizardData = { gates: singleGate, config: { has_institutions: true } };
+		render( <ContentGates updateGatesData={ () => {} } /> );
+
+		const headerData = lastHeaderData();
+		expect( headerData.sectionSecondaryAction ).toEqual( expect.objectContaining( { label: 'Institutions', href: '#/institutions' } ) );
+		expect( headerData.sectionMenu.map( item => item.label ) ).not.toContain( 'Institutions' );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -45,27 +45,27 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 			resetHeaderData();
 			return;
 		}
-		const institutionsMenuItem: { label: string; action?: () => void; href?: string } = {
+		const institutionsLink: SectionMenuItem = {
 			label: __( 'Institutions', 'newspack-plugin' ),
 			href: '#/institutions',
 		};
-		const sectionMenu: { label: string; action?: () => void; href?: string }[] = [
-			{
-				label: __( 'Advanced Settings', 'newspack-plugin' ),
-				action: () => setShowAdvancedSettings( true ),
-			},
+		const gatePriorityItem: SectionMenuItem = {
+			label: __( 'Gate Priority', 'newspack-plugin' ),
+			action: () => setShowPriorityModal( true ),
+		};
+		const advancedSettingsItem: SectionMenuItem = {
+			label: __( 'Advanced Settings', 'newspack-plugin' ),
+			action: () => setShowAdvancedSettings( true ),
+		};
+		// Built in display order. Gate Priority only appears once there is more
+		// than one gate to order; Institutions is promoted out of the kebab to
+		// a visible entry point beside the title while it is in use, so it stays
+		// in the menu only when it is not.
+		const sectionMenu: SectionMenuItem[] = [
+			...( gates.length > 1 ? [ gatePriorityItem ] : [] ),
+			...( ! hasInstitutions ? [ institutionsLink ] : [] ),
+			advancedSettingsItem,
 		];
-		// Institutions in use get a visible entry point next to the section
-		// title; otherwise the link stays tucked away in the kebab menu.
-		if ( ! hasInstitutions ) {
-			sectionMenu.unshift( institutionsMenuItem );
-		}
-		if ( gates.length > 1 ) {
-			sectionMenu.unshift( {
-				label: __( 'Gate Priority', 'newspack-plugin' ),
-				action: () => setShowPriorityModal( true ),
-			} );
-		}
 		setHeaderData( {
 			actions: [
 				{
@@ -80,7 +80,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 				'newspack-plugin'
 			),
 			sectionMenu,
-			sectionSecondaryAction: hasInstitutions ? institutionsMenuItem : undefined,
+			sectionSecondaryAction: hasInstitutions ? institutionsLink : undefined,
 		} );
 	}, [ isFetching, gates, hasInstitutions ] );
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -13,7 +13,6 @@ import { useEffect, useRef, useState } from '@wordpress/element';
 /**
  * Internal dependencies
  */
-import Router from '../../../../../packages/components/src/proxied-imports/router';
 import { Divider, Grid } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
@@ -26,10 +25,7 @@ import SettingsCard from './settings-card';
 import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from './consts';
 import './style.scss';
 
-const { useHistory } = Router;
-
 const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] ) => void } ) => {
-	const history = useHistory();
 	const wizardData = useWizardData( AUDIENCE_CONTENT_GATES_WIZARD_SLUG ) as WizardData;
 	const { wizardApiFetch, isFetching, errorMessage, resetError } = useWizardApiFetch( AUDIENCE_CONTENT_GATES_WIZARD_SLUG );
 	const { addNotice, resetNotices, resetHeaderData, setHeaderData, updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
@@ -39,6 +35,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 	const gates = ( wizardData?.gates || [] ) as Gate[];
 	const config = ( wizardData?.config || {} ) as GateSettings;
 	const hasMetering = gates.some( gate => gate.registration?.metering?.enabled || gate.custom_access?.metering?.enabled );
+	const hasInstitutions = !! config.has_institutions;
 
 	useEffect( () => {
 		if ( isFetching ) {
@@ -48,16 +45,21 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 			resetHeaderData();
 			return;
 		}
-		const sectionMenu = [
-			{
-				label: __( 'Institutions', 'newspack-plugin' ),
-				action: () => history.push( '/institutions' ),
-			},
+		const institutionsMenuItem: { label: string; action?: () => void; href?: string } = {
+			label: __( 'Institutions', 'newspack-plugin' ),
+			href: '#/institutions',
+		};
+		const sectionMenu: { label: string; action?: () => void; href?: string }[] = [
 			{
 				label: __( 'Advanced Settings', 'newspack-plugin' ),
 				action: () => setShowAdvancedSettings( true ),
 			},
 		];
+		// Institutions in use get a visible entry point next to the section
+		// title; otherwise the link stays tucked away in the kebab menu.
+		if ( ! hasInstitutions ) {
+			sectionMenu.unshift( institutionsMenuItem );
+		}
 		if ( gates.length > 1 ) {
 			sectionMenu.unshift( {
 				label: __( 'Gate Priority', 'newspack-plugin' ),
@@ -78,8 +80,9 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 				'newspack-plugin'
 			),
 			sectionMenu,
+			sectionSecondaryAction: hasInstitutions ? institutionsMenuItem : undefined,
 		} );
-	}, [ isFetching, gates ] );
+	}, [ isFetching, gates, hasInstitutions ] );
 
 	const toggleCountdownBanner = useRef< () => void >();
 	const handleToggleCountdownBanner = () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/index.test.js
@@ -1,0 +1,90 @@
+/**
+ * NPPD-1492 — the institutions list keeps the gates screen header in sync by
+ * writing `config.has_institutions` into the wizard store after each fetch.
+ * This is the half the "no reload" behaviour rests on: the gates config is
+ * resolved once per page load, so without this write a publisher who creates
+ * their first institution and navigates back sees a stale header.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, waitFor } from '@testing-library/react';
+
+/**
+ * Internal dependencies
+ */
+import Institutions from './index';
+
+// mock-prefixed so Jest's hoisted jest.mock factories may close over them.
+const mockUpdateWizardSettings = jest.fn();
+const mockApiFetch = jest.fn();
+
+jest.mock( '@wordpress/api-fetch', () => ( { __esModule: true, default: ( ...args ) => mockApiFetch( ...args ) } ) );
+
+jest.mock( '@wordpress/data', () => ( {
+	useDispatch: () => ( {
+		setHeaderData: jest.fn(),
+		addNotice: jest.fn(),
+		updateWizardSettings: ( ...args ) => mockUpdateWizardSettings( ...args ),
+	} ),
+} ) );
+
+// The real @wordpress/components and @wordpress/dataviews cannot load in this
+// jsdom env (data-store side effects throw at import); the store-sync contract
+// under test does not touch either.
+jest.mock( '@wordpress/components', () => {
+	const React = require( 'react' );
+	const Passthrough = ( { children } ) => React.createElement( 'div', null, children );
+	return { Button: Passthrough, Spinner: Passthrough };
+} );
+
+jest.mock( '@wordpress/dataviews', () => ( {
+	filterSortAndPaginate: data => ( { data, paginationInfo: { totalItems: data.length, totalPages: 1 } } ),
+} ) );
+
+// DataViews and the router are irrelevant to the store-sync contract.
+jest.mock( '../../../../../../packages/components/src', () => {
+	const React = require( 'react' );
+	return {
+		DataViews: () => React.createElement( 'div', null, 'DataViews' ),
+		Router: { useHistory: () => ( { push: jest.fn() } ) },
+	};
+} );
+
+jest.mock( '../../../../../../packages/components/src/wizard/store', () => ( {
+	WIZARD_STORE_NAMESPACE: 'newspack/wizards',
+} ) );
+
+jest.mock( '../consts', () => ( {
+	AUDIENCE_CONTENT_GATES_WIZARD_SLUG: 'newspack-audience-access-control',
+} ) );
+
+jest.mock( './onboarding', () => () => null );
+
+describe( 'Institutions list — gates header sync (NPPD-1492)', () => {
+	beforeEach( () => {
+		mockUpdateWizardSettings.mockReset();
+		mockApiFetch.mockReset();
+	} );
+
+	it.each( [
+		{ name: 'has institutions', institutions: [ { id: 1, title: { raw: 'Uni' }, meta: {} } ], expected: true },
+		{ name: 'has none', institutions: [], expected: false },
+	] )( 'writes has_institutions=$expected when the site $name', async ( { institutions, expected } ) => {
+		mockApiFetch.mockResolvedValue( institutions );
+
+		render( <Institutions /> );
+
+		await waitFor( () => expect( mockUpdateWizardSettings ).toHaveBeenCalled() );
+		expect( mockUpdateWizardSettings ).toHaveBeenCalledWith( {
+			slug: 'newspack-audience-access-control',
+			path: [ 'config', 'has_institutions' ],
+			value: expected,
+		} );
+		// The initial fetch changes the value from unknown to its result, so
+		// exactly one write happens; the per-instance ref guards later fetches
+		// that leave the derived boolean unchanged.
+		expect( mockUpdateWizardSettings ).toHaveBeenCalledTimes( 1 );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/index.tsx
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState, useEffect, useCallback, useMemo } from '@wordpress/element';
+import { useState, useEffect, useCallback, useMemo, useRef } from '@wordpress/element';
 import { useDispatch } from '@wordpress/data';
 import apiFetch from '@wordpress/api-fetch';
 import { filterSortAndPaginate } from '@wordpress/dataviews';
@@ -45,6 +45,9 @@ export default function Institutions() {
 	const [ data, setData ] = useState< Institution[] >( [] );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
+	// The last has_institutions value pushed to the gates screen, so a fetch
+	// that does not change it does not clone the whole wizard payload.
+	const lastHasInstitutions = useRef< boolean | undefined >( undefined );
 
 	useEffect( () => {
 		const actions: HeaderAction[] = [
@@ -74,12 +77,18 @@ export default function Institutions() {
 				setData( institutions );
 				// Keep the gates screen header in sync: it promotes the
 				// Institutions entry point out of the kebab menu when the site
-				// has at least one institution.
-				updateWizardSettings( {
-					slug: AUDIENCE_CONTENT_GATES_WIZARD_SLUG,
-					path: [ 'config', 'has_institutions' ],
-					value: institutions.length > 0,
-				} );
+				// has at least one institution. Only write when the derived
+				// value actually changes, since UPDATE_WIZARD_SETTINGS clones
+				// the whole wizard payload and this runs on every list fetch.
+				const hasInstitutions = institutions.length > 0;
+				if ( hasInstitutions !== lastHasInstitutions.current ) {
+					lastHasInstitutions.current = hasInstitutions;
+					updateWizardSettings( {
+						slug: AUDIENCE_CONTENT_GATES_WIZARD_SLUG,
+						path: [ 'config', 'has_institutions' ],
+						value: hasInstitutions,
+					} );
+				}
 			} )
 			.catch( () => {
 				addNotice( {

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/index.tsx
@@ -18,6 +18,7 @@ import { Button, Spinner } from '@wordpress/components';
  */
 import { DataViews, Router } from '../../../../../../packages/components/src';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../../packages/components/src/wizard/store';
+import { AUDIENCE_CONTENT_GATES_WIZARD_SLUG } from '../consts';
 import InstitutionsOnboarding from './onboarding';
 
 const { useHistory } = Router;
@@ -40,7 +41,7 @@ const DEFAULT_VIEW: View = {
 
 export default function Institutions() {
 	const history = useHistory();
-	const { setHeaderData, addNotice } = useDispatch( WIZARD_STORE_NAMESPACE );
+	const { setHeaderData, addNotice, updateWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ data, setData ] = useState< Institution[] >( [] );
 	const [ isLoading, setIsLoading ] = useState( true );
 	const [ view, setView ] = useState< View >( DEFAULT_VIEW );
@@ -69,7 +70,17 @@ export default function Institutions() {
 	const fetchData = useCallback( () => {
 		setIsLoading( true );
 		apiFetch< Institution[] >( { path: `${ API_PATH }?per_page=100&context=edit&_embed=wp:featuredmedia` } )
-			.then( setData )
+			.then( institutions => {
+				setData( institutions );
+				// Keep the gates screen header in sync: it promotes the
+				// Institutions entry point out of the kebab menu when the site
+				// has at least one institution.
+				updateWizardSettings( {
+					slug: AUDIENCE_CONTENT_GATES_WIZARD_SLUG,
+					path: [ 'config', 'has_institutions' ],
+					value: institutions.length > 0,
+				} );
+			} )
 			.catch( () => {
 				addNotice( {
 					message: __( 'Failed to load institutions. Please refresh the page.', 'newspack-plugin' ),
@@ -78,7 +89,7 @@ export default function Institutions() {
 				} );
 			} )
 			.finally( () => setIsLoading( false ) );
-	}, [ addNotice ] );
+	}, [ addNotice, updateWizardSettings ] );
 
 	useEffect( () => {
 		fetchData();

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -12,6 +12,11 @@ type HeaderAction = {
 	separator?: boolean;
 };
 
+// An entry in a section's kebab menu, or the header's secondary action. A
+// HeaderAction without the store-assigned `type`: either an `action` callback
+// or an `href` carries the behaviour.
+type SectionMenuItem = Omit< HeaderAction, 'type' >;
+
 type GateAccessRuleValue = string | string[] | boolean;
 type AccessRule = {
 	name: string;

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/types/index.d.ts
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/types/index.d.ts
@@ -154,6 +154,7 @@ type GateSettings = {
 	content_gifting?: ContentGiftingConfig;
 	countdown_banner?: MeteringCountdownConfig;
 	advanced_settings?: AdvancedSettingsConfig;
+	has_institutions?: boolean;
 };
 
 type GateConfig = {

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-institution.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-institution.php
@@ -136,6 +136,30 @@ class Newspack_Test_Institution extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The has_institutions() helper reflects existence without depending on the
+	 * cache being a countable array, which count() at the call site would have.
+	 */
+	public function test_has_institutions() {
+		delete_transient( Institution::TRANSIENT_KEY );
+		$this->assertFalse( Institution::has_institutions(), 'No institutions means has_institutions() is false.' );
+
+		$institution_id = Institution::create( 'Existence University' );
+		$this->assertIsInt( $institution_id );
+		$this->post_ids[] = $institution_id;
+
+		$this->assertTrue( Institution::has_institutions(), 'A published institution means has_institutions() is true.' );
+
+		// A filter returning a non-array transient value must not fatal the way
+		// count() at the call site would; existence is all the caller needs.
+		$non_array_transient = function () {
+			return 'not-an-array';
+		};
+		add_filter( 'pre_transient_' . Institution::TRANSIENT_KEY, $non_array_transient );
+		$this->assertTrue( Institution::has_institutions(), 'A scalar cache value is treated as present, not fatal.' );
+		remove_filter( 'pre_transient_' . Institution::TRANSIENT_KEY, $non_array_transient );
+	}
+
+	/**
 	 * Test cache is built and can be invalidated.
 	 */
 	public function test_cache_built_and_invalidated() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

From internal validation (scenario I-01): the Institutions entry point was hidden behind the section kebab menu regardless of use — "Okay to hide when publisher is not using, but when using, should show."

- `get_config()` adds `has_institutions` to the existing wizard config payload (reuses the 300s institutions transient — no extra request; the transient is invalidated on institution save/delete, so the flag is fresh).
- With ≥1 institution, "Institutions" renders as a visible link (`href="#/institutions"`, a true anchor via the `SectionHeader` `secondaryAction` slot) beside the section title, and the kebab keeps only Advanced Settings. With none, the kebab placement is unchanged.
- Creating the first institution promotes the header link without a page reload (the institutions list fetch syncs the wizard store).
- Side effect: the explicit typing needed for the restructure fixes a pre-existing repo TS error (net −1; zero new errors, verified against the baseline type-check).

Closes NPPD-1492.

### How to test the changes in this Pull Request:

1. Audience > Access Control with no institutions: "Institutions" is in the section kebab, as before.
2. Create an institution (kebab → Institutions → Add new): on returning to Access Control, "Institutions" appears as a visible link beside the section title — no reload needed — and the kebab now holds only Advanced Settings.
3. The link navigates to the institutions list; middle-click opens it in a new tab.
4. Delete the institution: the entry returns to the kebab.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? (RTL tests for both header states, red/green)
* [x] Have you successfully run tests with your changes locally? (jest 46 suites / 431 tests; `n test-php --group content-gate` and `--group Access_Rules` green; PHPCS + ESLint clean)

**Known corner (pre-existing, filed as NPPD-2114):** with institutions but zero gates, the wizard shows the onboarding screen and no Institutions entry point exists anywhere — unchanged by this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Myjt7Uvz86A2TvSomqrhE1