### PR TITLE
ci(release): pass NODE_AUTH_TOKEN to the release dry-run gate

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,6 +104,11 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+          # The dry-run runs semantic-release's verifyConditions, which calls
+          # npm whoami. setup-node's registry-url wrote an .npmrc keyed on
+          # ${NODE_AUTH_TOKEN}; without it npm auth 401s and the gate fails even
+          # though the token is valid. Mirror the Release step below.
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
           NODE_OPTIONS: --max-old-space-size=12288
       - name: Build shared packages
         if: steps.plan.outputs.release_needed == 'true'


### PR DESCRIPTION
## Problem

The release job fails at the **Plan release (does any package need a release?)** dry-run gate with:

```
npm error 401 Unauthorized - GET https://registry.npmjs.org/-/whoami
EINVALIDNPMTOKEN  Invalid npm token.
```

Rotating `NPM_TOKEN` does not help — a locally-verified valid token is still rejected in this step. This blocked the current alpha release (#709) and would block **every** release until fixed.

## Root cause

`actions/setup-node` runs with `registry-url: 'https://registry.npmjs.org'`, which writes an `.npmrc` keyed on `${NODE_AUTH_TOKEN}`. semantic-release's `verifyConditions` calls `npm whoami`, which reads that token.

The **Release** step sets both `NPM_TOKEN` and `NODE_AUTH_TOKEN` (with a comment explaining exactly this). The **Plan release** dry-run gate — added in #124 — sets only `NPM_TOKEN`, so `${NODE_AUTH_TOKEN}` expands to empty, the `.npmrc` token is blank, and `whoami` 401s regardless of how valid the real token is.

This is a fresh regression this cycle: #124 merged to `main` on 2026-07-20 and reached `alpha` for the first time via #709 — so this gate's first-ever real execution self-blocked the release carrying it. Verified that the last successful alpha release commit (`3c949d6c`, 07-22) had no Plan release step.

## Fix

Add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to the Plan release step's `env`, mirroring the Release step. One-line change (plus an explanatory comment); no token rotation required — the existing secret is valid.

## Rollout

This PR targets `main`, where the regression was introduced (#124), so the fix lands at the source rather than only on a release branch.

To unblock the **currently blocked alpha release**, cherry-pick this commit onto `alpha` once merged. That push to `alpha` triggers a fresh Release run using the corrected workflow, which will publish the pending packages. (Re-running the previously-failed run does **not** help — it is pinned to the buggy `#709` merge commit.)

`release` carries the same gate and will need the fix before the next stable, via the normal promotion flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
