### PR TITLE
ci(release): stop committing concretized workspace pins for packages

### DIFF
--- a/.github/scripts/finalize-package-versions.cjs
+++ b/.github/scripts/finalize-package-versions.cjs
@@ -25,9 +25,12 @@
  * Run from the repo root after multi-semantic-release, before pushing. Commits
  * the changed manifests with [skip ci]; the caller pushes.
  *
- * packages/* are intentionally not handled here — they have no internal
- * workspace deps, so their own release configs still commit package.json
- * directly (no lockfile hazard).
+ * packages/* are handled here too. They were originally excluded because they
+ * had no internal workspace deps, but that stopped being true once
+ * packages/components took a dep on newspack-icons and packages/{icons,colors}
+ * on newspack-scripts. Their release config (config/release-package.js) no
+ * longer commits package.json itself, so — exactly like plugins/themes — their
+ * version bump is committed here with internal deps reverted to workspace:*.
  */
 
 const fs = require( 'fs' );
@@ -64,7 +67,7 @@ if ( workspaceNames.size === 0 ) {
 }
 
 const changedPaths = [];
-for ( const group of [ 'plugins', 'themes' ] ) {
+for ( const group of [ 'plugins', 'themes', 'packages' ] ) {
 	if ( ! fs.existsSync( group ) ) {
 		continue;
 	}
@@ -97,8 +100,8 @@ for ( const group of [ 'plugins', 'themes' ] ) {
 	}
 }
 
-// Stage every plugin/theme manifest; git only records the ones that actually
-// differ from HEAD (msr-bumped version and/or the reverted deps).
+// Stage every plugin/theme/package manifest; git only records the ones that
+// actually differ from HEAD (msr-bumped version and/or the reverted deps).
 for ( const rel of changedPaths ) {
 	execFileSync( 'git', [ 'add', '--', rel ] );
 }

--- a/.npmrc
+++ b/.npmrc
@@ -44,3 +44,12 @@ legacy-peer-deps=true
 auto-install-peers=true
 strict-peer-dependencies=false
 dedupe-peer-dependents=true
+
+# Always satisfy an internal dep from packages/ rather than the npm registry.
+# pnpm 10 defaults this to false, so a manifest carrying a concrete version
+# (e.g. "newspack-scripts": "5.10.0-alpha.1") resolves from the registry instead
+# of linking the workspace copy. The registry tarballs ship raw JSX in src/,
+# which sits outside every plugin's babel-loader scope and fails the build with
+# "Unexpected token <SVG". The release tooling no longer writes such pins, but
+# this keeps a stray one from silently switching consumers to a registry copy.
+link-workspace-packages=true

--- a/config/release-package.js
+++ b/config/release-package.js
@@ -14,6 +14,8 @@
  * tagFormat here. These libraries are all unscoped, so the patch is a no-op for
  * them.
  */
+const { gitCommitStep } = require( './release-helpers' );
+
 module.exports = {
 	branches: [
 		'release',
@@ -30,11 +32,20 @@ module.exports = {
 	prepare: [
 		'@semantic-release/changelog',
 		'@semantic-release/npm',
-		{
-			path: '@semantic-release/git',
-			assets: [ 'package.json', 'CHANGELOG.md' ],
-			message:
-				'chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}',
-		},
+		// CHANGELOG.md only, and only on `release` — same contract as the plugins
+		// in config/release.js. package.json is deliberately NOT committed here:
+		// @semantic-release/npm concretizes internal `workspace:*` deps in the
+		// working tree before publishing, so committing the manifest would put
+		// those concrete pins on the branch. That breaks the next
+		// `pnpm install --frozen-lockfile` (the root lockfile is keyed to
+		// workspace:*) and, once installed, makes pnpm resolve the shared
+		// packages from the npm registry instead of linking packages/ — the
+		// registry tarballs ship raw JSX in src/, outside every plugin's
+		// babel-loader scope. The published tarballs still get real dep versions,
+		// because the npm publish phase reads the concretized working tree.
+		// The version bump itself is committed by
+		// .github/scripts/finalize-package-versions.cjs, which reverts the deps
+		// back to workspace:* first.
+		...gitCommitStep( [ 'CHANGELOG.md' ] ),
 	],
 };


### PR DESCRIPTION
## Problem

Today's alpha release committed concretized dependency pins onto `alpha`, breaking CI for every PR targeting it:

- `packages/components` → `newspack-icons: 1.1.0-alpha.1`, `newspack-scripts: 5.10.0-alpha.1`
- `packages/icons` → `newspack-scripts: 5.10.0-alpha.1`
- `packages/colors` → `newspack-scripts: 5.10.0-alpha.1`

Two failures follow:

1. **`ERR_PNPM_OUTDATED_LOCKFILE`** — the root `pnpm-lock.yaml` still records `specifier: workspace:*` / `version: link:../scripts`, so `pnpm install --frozen-lockfile` rejects the merge ref of any PR based on `alpha`.
2. **`Unexpected token <SVG`** — with a bare version pin and no `link-workspace-packages=true`, pnpm 10 (which defaults it to `false`) resolves these from the npm registry instead of linking `packages/`. `newspack-icons` publishes `src/` (raw JSX), which sits outside every plugin's babel-loader scope, so JS and Build ZIP jobs fail.

The release commits carry `[skip ci]`, so `alpha`'s own CI never ran and nothing caught it.

## Root cause

`config/release-helpers.js` exposes `gitCommitStep()`, which returns the `@semantic-release/git` step **only on the `release` branch** — that is what keeps prerelease version/changelog stamps off `alpha`. `config/release.js` (plugins) uses it. `config/release-package.js` (the four published libraries) never adopted it and instead hardcoded an unconditional git step with `assets: [ 'package.json', 'CHANGELOG.md' ]`.

Because `@semantic-release/npm` concretizes internal `workspace:*` deps in the working tree before publishing, that unconditional step commits the version bump **and** the concrete pins, on every channel.

This was latent, not a single bad PR:

| When | Change | Effect |
| --- | --- | --- |
| 2026-05-25 `ee2ae1d49` | `release-package.js` commits `package.json` | Correct at the time — a library's version lives only there |
| 2026-06-01 `011d467ba` | `gitCommitStep()` added, applied to plugins only | Divergence introduced; `packages/*` had no internal deps, so harmless |
| 2026-07-16 #472 | `packages/components` takes a dep on `newspack-icons` | Premise silently invalidated |
| 2026-07-21 #526 | `packages/{icons,colors}` take deps on `newspack-scripts` | Widened |
| 2026-07-23 #711 | npm auth fixed, release finally publishes | Latent bug fires |

`finalize-package-versions.cjs` already contained the revert-to-`workspace:*` machinery, but excluded `packages/*` on the then-accurate comment "they have no internal workspace deps".

## Fix

1. **`config/release-package.js`** — use `gitCommitStep( [ 'CHANGELOG.md' ] )`. `package.json` is no longer committed by the release step, so concretized pins can never reach a branch. Published tarballs still get real dep versions: the npm publish phase reads the concretized working tree, which is untouched.
2. **`finalize-package-versions.cjs`** — include `packages` alongside `plugins`/`themes`, so the version bump is still committed on `release` with internal deps reverted to `workspace:*`. This preserves the anti-drift motivation of `ee2ae1d49` (newspack-scripts once sat at 5.8.0 in-repo while publishing 5.9.x). The stale comment is corrected.

3. **`.npmrc`** — set `link-workspace-packages=true`. pnpm 10 defaults it to `false`, which is what turned a stray concrete pin into a *registry* install rather than a workspace link. Defense-in-depth: even if a pin ever leaks onto a branch again, consumers still link `packages/` and the raw-JSX build failure cannot occur.

Net effect — `packages/*` now behave exactly like `plugins/*`: prerelease channels compute and publish their version but commit nothing; `release` commits the version bump with `workspace:*` intact.

## Testing

- `node --check` clean on both files.
- `gitCommitStep` gating verified directly: `GITHUB_REF_NAME=alpha` → `[]`; `=release` → git step with `assets: ["CHANGELOG.md"]`.
- Reproduced the exact breakage in a scratch git repo — baseline manifests on `workspace:*`, then a simulated post-msr working tree with today's real bumps and pins — and ran the patched script. Result: version bumps preserved (`4.6.0-alpha.1`, `1.1.0-alpha.1`, `1.1.1-alpha.1`, `5.10.0-alpha.1`), all internal deps reverted to `workspace:*`, no concretized pin remaining, working tree clean.

## Scope / coordination

This is the **durable** fix — it stops recurrence on the next release, and carries the `.npmrc` hardening so it is not stranded behind a larger PR.

It does **not** repair the already-broken `alpha` branch: the concrete pins were written onto `alpha` by the release run and `main` never had them, so the manifest reverts are a no-op here and must land on `alpha` directly. That piece is currently inside #686 (`33148cb03`), alongside unrelated changes still in QA. If that is slow to merge, the four manifest entries can be reverted on `alpha` in a standalone PR — note it needs no lockfile regeneration, since the lockfile is already keyed to `workspace:*` and its importer entries record `link:` targets rather than semver.

Also spotted while investigating, and **not** addressed here: `newspack-colors` was bumped `2.0.0` → `1.1.1-alpha.1`, a version regression — semantic-release computed from the last tag while the in-repo manifest had drifted ahead. Reason: 2.0.0 was a manual manifest bump in ab9a7b047 (#287, 2026-06-16), a genuine breaking change (feat(colors)!: redefining neutral 700/800 + overlay tokens, touching colors.module.scss and rippling into blocks/theme SCSS). It was written into package.json by hand, not generated with a `BREAKING CHANGE:` footer as required by semver. The `1.1.1-alpha.1` version string is the proper next semver based on the lack of a prior `BREAKING CHANGE:` commit. If we want to bump the major version for `newspack-colors`, that should happen in a separate PR documenting the breaking changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
