### PR TITLE
chore(packages): restore workspace:* deps after the alpha release

### DIFF
--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -32,7 +32,7 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"newspack-scripts": "5.10.0-alpha.1"
+		"newspack-scripts": "workspace:*"
 	},
 	"scripts": {
 		"typescript:check": "newspack-scripts typescript-check"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",
 		"moment-range": "^3.1.1",
-		"newspack-icons": "1.1.0-alpha.1",
+		"newspack-icons": "workspace:*",
 		"qs": "^6.15.2",
 		"react-router-dom": "^5.3.4",
 		"@babel/runtime": "^7.29.7",
@@ -58,7 +58,7 @@
 		"@babel/preset-env": "^7.29.7",
 		"@babel/preset-react": "^7.29.7",
 		"@babel/preset-typescript": "^7.29.7",
-		"newspack-scripts": "5.10.0-alpha.1",
+		"newspack-scripts": "workspace:*",
 		"recursive-copy": "^2.0.0"
 	},
 	"babel": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -34,7 +34,7 @@
 	},
 	"devDependencies": {
 		"@types/react": "^18.0.0",
-		"newspack-scripts": "5.10.0-alpha.1"
+		"newspack-scripts": "workspace:*"
 	},
 	"scripts": {
 		"build-types": "node build-types.js",


### PR DESCRIPTION
## What

Reverts the four internal dependency specifiers on `alpha` from concrete versions back to `workspace:*`. Four lines, nothing else.

| File | Dependency | Was | Now |
| --- | --- | --- | --- |
| `packages/components` | newspack-icons | `1.1.0-alpha.1` | `workspace:*` |
| `packages/components` | newspack-scripts | `5.10.0-alpha.1` | `workspace:*` |
| `packages/icons` | newspack-scripts | `5.10.0-alpha.1` | `workspace:*` |
| `packages/colors` | newspack-scripts | `5.10.0-alpha.1` | `workspace:*` |

## Why

Today's alpha release wrote those pins onto `alpha` (`f7380de0c`, `98a701a84`, `f58a1a09a`), which breaks CI for **every** PR targeting `alpha`:

1. **`ERR_PNPM_OUTDATED_LOCKFILE`** — the root `pnpm-lock.yaml` still records `specifier: workspace:*`, so `pnpm install --frozen-lockfile` rejects the merge ref.
2. **`Unexpected token <SVG`** — a bare pin plus pnpm 10's `link-workspace-packages=false` default makes pnpm resolve these from the npm registry instead of linking `packages/`. `newspack-icons` publishes `src/` (raw JSX), which sits outside every plugin's babel-loader scope.

The release commits carry `[skip ci]`, so `alpha`'s own CI never ran and nothing caught it.

The package `version` fields are deliberately left at their released values — they don't affect resolution or lockfile validity, and they correctly record what was published.

## No lockfile regeneration needed

Reverting the manifests restores consistency on its own. The lockfile is already keyed to `workspace:*`, and its importer entries record `link:` targets rather than semver, so the packages' own version bumps don't invalidate it. Verified by comparing every `newspack-*` importer entry against the reverted manifests:

```
MATCH  packages/components newspack-icons:   lock="workspace:*" manifest="workspace:*"
MATCH  packages/components newspack-scripts: lock="workspace:*" manifest="workspace:*"
MATCH  packages/icons      newspack-scripts: lock="workspace:*" manifest="workspace:*"
MATCH  packages/colors     newspack-scripts: lock="workspace:*" manifest="workspace:*"
```

## Relationship to other PRs

- **#686** contains this same revert (`33148cb03`) bundled with unrelated changes still in QA. This PR is deliberately standalone so `alpha` can go green without waiting. Once this merges, #686 can drop its manifest/lockfile hunks and keep its feature work.
- **#712** is the durable fix on `main` — it stops the release tooling from writing these pins again, and adds `link-workspace-packages=true`. This PR only repairs the existing damage on `alpha`; it does not prevent recurrence on its own.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
