### PR TITLE
ci: never treat promotion PRs as stack parents when retargeting

### DIFF
--- a/.github/workflows/retarget-stacked-prs.yml
+++ b/.github/workflows/retarget-stacked-prs.yml
@@ -24,6 +24,12 @@ name: Retarget stacked PRs
 # the squash-merge strategy keeps the merge commit out of main's history
 # anyway. The merge is best-effort – on conflict the child keeps its retarget
 # and gets a comment asking for a manual merge.
+#
+# Promotion PRs between the long-lived branches (main/alpha/release) are
+# excluded: their head branch is permanent, never pruned, and the PRs that
+# target it are not stacked on it. Without the guard, merging a main → alpha
+# promotion makes every open main-based PR look like a stacked child of main
+# and retargets it to alpha (#709 did exactly that to 30 PRs).
 
 on:
   pull_request:
@@ -41,7 +47,10 @@ concurrency:
 jobs:
   retarget:
     name: Retarget PRs stacked on the merged branch
-    if: github.event.pull_request.merged == true && github.event.pull_request.head.repo.full_name == github.repository
+    if: >-
+      github.event.pull_request.merged == true &&
+      github.event.pull_request.head.repo.full_name == github.repository &&
+      !contains(fromJSON('["main", "alpha", "release"]'), github.event.pull_request.head.ref)
     runs-on: ubuntu-latest
     env:
       GH_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The `retarget-stacked-prs` workflow (#659) treats the head branch of any merged PR as a stack parent. A promotion PR between the long-lived branches breaks that assumption: when the `main` → `alpha` promotion #709 merged, the workflow read `main` as a "merged parent branch", decided every open `main`-based PR was stacked on it, retargeted all 30 of them to `alpha`, and merged `alpha` into each branch. (All 30 have since been restored: base back to `main`, bot merge commits force-pushed away.)

This adds a guard to the job condition: when the merged PR's head ref is one of the long-lived branches (`main`, `alpha`, `release`), the workflow does not run. Those branches are permanent and never pruned, so PRs targeting them are not stacked children and must keep their base. The header comment documents the exclusion.

### How to test the changes in this Pull Request:

1. Expression check: the guard is `!contains(fromJSON('["main", "alpha", "release"]'), github.event.pull_request.head.ref)` on the job `if` — evaluate it against #709's event (`head.ref == "main"`): the job must be skipped.
2. Regression check for the intended behavior: for an ordinary stacked-PR merge (head ref is a feature branch, e.g. #608), the added clause evaluates to `true`, so the job still runs exactly as before.
3. After merge, the next branch promotion (`main` → `alpha` or `alpha` → `release`) should produce a skipped `Retarget stacked PRs` run and leave all open PR bases untouched.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?