### PR TITLE
test(e2e): scope snackbar text assertions to the snackbar container

### DIFF
--- a/e2e/tests/reader-registration.spec.ts
+++ b/e2e/tests/reader-registration.spec.ts
@@ -7,6 +7,7 @@ import {
   randomEmailAddress,
   clickMyAccountMenuItem,
   goToMyAccount,
+  getSnackbar,
 } from "./utils";
 
 const emailAddress = randomEmailAddress();
@@ -71,7 +72,7 @@ test("Register on the site", {
   await page.getByPlaceholder("Your Last Name").click();
   await page.getByPlaceholder("Your Last Name").fill("Doe");
   await page.getByRole("button", { name: "Update profile" }).click();
-  await expect(page.getByText("Account details changed successfully.")).toBeVisible();
+  await expect(getSnackbar(page, "Account details changed successfully.")).toBeVisible();
   await expect(page.getByPlaceholder("Your First Name")).toHaveValue("John");
   await expect(page.getByPlaceholder("Your Last Name")).toHaveValue("Doe");
 
@@ -82,7 +83,8 @@ test("Register on the site", {
     .getByRole("link", { name: "Create a password" })
     .click();
   await expect(
-    page.getByText(
+    getSnackbar(
+      page,
       "Please check your email inbox for instructions on how to set a new password."
     )
   ).toBeVisible();
@@ -126,11 +128,11 @@ test("Register on the site", {
   await page.locator("#newspack_account_email").fill(newEmailAddress);
   await page.getByRole("button", { name: "Update profile" }).click();
   const expectedNotification = `A verification email has been sent to ${newEmailAddress}. Please verify to complete the change.`;
-  await expect(page.getByText(expectedNotification)).toBeVisible();
+  await expect(getSnackbar(page, expectedNotification)).toBeVisible();
   await openEmail(page, "Confirm email change", newEmailAddress);
   await clickLinkURL(page, "Confirm email change");
   await expect(
-    page.getByText("Your email address has been successfully updated.")
+    getSnackbar(page, "Your email address has been successfully updated.")
   ).toBeVisible();
   await expect(page.locator("#newspack_account_email")).toHaveValue(
     newEmailAddress

--- a/e2e/tests/utils.ts
+++ b/e2e/tests/utils.ts
@@ -81,3 +81,11 @@ export const clickMyAccountMenuItem = async (page, label) => {
   }
   await link.click();
 };
+
+// Locate a snackbar notice by its message text. Snackbar messages are mirrored
+// into a visually-hidden ARIA live region (#newspack-ui__sr-live-polite / -assertive)
+// for screen readers, so a bare page.getByText() resolves to two elements and
+// trips Playwright's strict mode; scoping to the snackbar container keeps the
+// locator unique.
+export const getSnackbar = (page, text) =>
+  page.locator(".newspack-ui__snackbar").getByText(text);


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The nightly e2e suite has failed since 2026-07-22 on `reader-registration.spec.ts` ("Register on the site", With Woo in Desktop Chrome) with a Playwright strict-mode violation:

```
strict mode violation: getByText('Account details changed successfully.') resolved to 2 elements:
  1) <div class="newspack-ui__snackbar__content">…
  2) <div> inside #newspack-ui__sr-live-polite
```

newspack-plugin 6.46.0 (cut to the release channel on 2026-07-20, now on the staging site) ships the accessible-notices work from #445: snackbar messages are now mirrored into a visually-hidden ARIA live region so screen readers announce them. The message therefore exists twice in the DOM for ~1 second, and the spec's bare `page.getByText(...)` assertions on snackbar messages resolve to both copies. Which assertion trips is a race against the live region's 1s self-cleanup — CI's `slowMo: 1000` hits it every night.

This adds a `getSnackbar( page, text )` helper that scopes the lookup to the `.newspack-ui__snackbar` container (the live region is a sibling, so it can never match) and uses it for all four snackbar-message assertions in the spec. Not a product regression — the notice UI works as intended; only the locator was ambiguous.

### How to test the changes in this Pull Request:

1. Point the suite at an env running the `release` branch (e.g. the `e2e-release` isolated env) and provision it (`USE_SETUP=true`).
2. On `main`, run `npx playwright test --project="With Woo in Desktop Chrome" reader-registration` — it fails with the strict-mode violation above.
3. On this branch, the same run passes (verified locally: 4/4 green, including `--repeat-each=3`).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01UvmyHFekdAAJbE4cexCpkE