### PR TITLE
fix(group-subscriptions): count group capacity in seats, not members

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -194,9 +194,10 @@ class Group_Subscription_Settings {
 			return $column_content;
 		}
 		$settings = self::get_subscription_settings( $subscription );
-		// The owner counts as a member, so pair the owner-inclusive count with the
+		// The owner occupies a seat, so pair the owner-inclusive count with the
 		// owner-inclusive capacity (the limit) so this matches the member-facing card
-		// and Members tab.
+		// and Members tab. "Seats" rather than "members" because the owner fills one of
+		// them without being a member.
 		$member_count = Group_Subscription::get_member_count( $subscription );
 		$capacity     = Group_Subscription::get_member_capacity( $subscription );
 		$limit        = null !== $capacity
@@ -209,8 +210,8 @@ class Group_Subscription_Settings {
 			\esc_html( $settings['name'] ),
 			\esc_html(
 				sprintf(
-					/* translators: 1: member count, 2: member capacity or "unlimited" */
-					__( '%1$s of %2$s members', 'newspack-plugin' ),
+					/* translators: 1: number of seats taken, 2: total seats or "unlimited" */
+					__( '%1$s of %2$s seats', 'newspack-plugin' ),
 					$member_count,
 					$limit
 				)

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group-picker.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/templates/v1/group-picker.php
@@ -44,20 +44,22 @@ usort(
 		<?php foreach ( $managed as $subscription ) : ?>
 			<?php
 			$settings = Group_Subscription_Settings::get_subscription_settings( $subscription );
-			// The owner counts as a member, so pair the owner-inclusive count with the
+			// The owner occupies a seat, so pair the owner-inclusive count with the
 			// owner-inclusive capacity (the limit) so the card matches the group's Members tab.
+			// "Seats" rather than "members" because the owner fills one of them without
+			// being a member.
 			$member_count        = Group_Subscription::get_member_count( $subscription );
 			$capacity            = Group_Subscription::get_member_capacity( $subscription );
 			$count_label         = $capacity
 				? sprintf(
-					/* translators: 1: member count, 2: member capacity */
-					_x( '%1$d of %2$d members', 'group member count', 'newspack-plugin' ),
+					/* translators: 1: number of seats taken, 2: total seats */
+					_x( '%1$d of %2$d seats', 'group seat count', 'newspack-plugin' ),
 					$member_count,
 					$capacity
 				)
 				: sprintf(
-					/* translators: %d: member count */
-					_n( '%d member', '%d members', $member_count, 'newspack-plugin' ),
+					/* translators: %d: number of seats taken */
+					_n( '%d seat used', '%d seats used', $member_count, 'newspack-plugin' ),
 					$member_count
 				);
 			$subscription_status = $subscription->get_status();

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -512,6 +512,9 @@ class WC_Subscription {
 	public function get_date_created() {
 		return new WC_DateTime( $this->data['date_created'] ?? 'now' );
 	}
+	public function get_edit_order_url() {
+		return admin_url( 'post.php?post=' . $this->get_id() . '&action=edit' );
+	}
 	public function get_date_paid() {
 		return new WC_DateTime( $this->data['date_paid'] );
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription.php
@@ -203,6 +203,38 @@ class Test_Group_Subscription extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The subscriptions list table counts seats, not members: the owner alone fills
+	 * one of the group's seats without being a member, so a limit-of-4 group with no
+	 * other people reads "1 of 4 seats".
+	 */
+	public function test_admin_column_label_counts_seats_not_members() {
+		$owner_id = $this->create_reader_user();
+		$sub      = $this->create_group_subscription( $owner_id, 4 );
+
+		$this->assertStringContainsString(
+			'1 of 4 seats',
+			Group_Subscription_Settings::filter_subscription_column_content( '', $sub, 'order_title' ),
+			'An owner-only group with a limit of 4 should read "1 of 4 seats".'
+		);
+	}
+
+	/**
+	 * An unlimited group has no seat total to count against, so the capacity reads
+	 * "unlimited" in the same seat phrasing.
+	 */
+	public function test_admin_column_label_reads_unlimited_seats_without_a_limit() {
+		$owner_id = $this->create_reader_user();
+		$sub      = $this->create_group_subscription( $owner_id, 0 );
+		$this->add_member( $this->create_reader_user(), $sub );
+
+		$this->assertStringContainsString(
+			'2 of unlimited seats',
+			Group_Subscription_Settings::filter_subscription_column_content( '', $sub, 'order_title' ),
+			'An unlimited group holding the owner and one member should read "2 of unlimited seats".'
+		);
+	}
+
+	/**
 	 * Capacity is the limit whether or not the group has an owner: the owner is one
 	 * of the limited seats, not an extra one, so an ownerless group reads "0 of limit"
 	 * exactly as an owned one would.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The group capacity label pairs an owner-inclusive count (`get_member_count()`) with an owner-inclusive limit (`get_member_capacity()`), so an owner-only group with a limit of 4 read `1 of 4 members`. That `1` is the owner, who occupies a seat without being a member — so the noun was wrong. Both surfaces now count seats:

| Surface | Before | After |
| --- | --- | --- |
| Admin subscriptions list column | `1 of 4 members` | `1 of 4 seats` |
| My Account group picker card | `1 of 4 members` | `1 of 4 seats` |
| …same card, unlimited group | `1 member` | `1 seat used` |

The arithmetic is untouched — this is a labelling change only. The Members tab and its count badge are unaffected: they list people, not seats.

### How to test the changes in this Pull Request:

1. On a site with WooCommerce Subscriptions and a group-enabled subscription product, set the group member limit to 4 and create a subscription for it with no members besides the owner.
2. Go to **WooCommerce > Subscriptions**: the Subscription column reads `<group name> (1 of 4 seats)`.
3. As a reader managing two or more groups, visit the My Account group endpoint without a subscription ID: each card reads `N of M seats`, or `N seats used` for an unlimited group.
4. Run `n test-php --group WooCommerce_Subscriptions_Integration` in `plugins/newspack-plugin`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally? — `OK (148 tests, 347 assertions)`, PHPCS clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BtHxX3oQAxcMR4ZbmPNCEp