### PR TITLE
fix(wizards): let tabs own their sub-view routes

### DIFF
--- a/packages/components/src/tabbed-navigation/index.test.js
+++ b/packages/components/src/tabbed-navigation/index.test.js
@@ -1,6 +1,7 @@
 /**
  * External dependencies.
  */
+import { useEffect } from 'react';
 import { act, fireEvent, render, screen } from '@testing-library/react';
 import { MemoryRouter, Redirect, useHistory } from 'react-router-dom';
 
@@ -207,6 +208,60 @@ describe( 'TabbedNavigation with routed items', () => {
 		act( () => history.push( '/budgets' ) );
 		expect( getTab( 'Budgets' ) ).toHaveAttribute( 'aria-selected', 'true' );
 		expect( screen.getByText( 'Routed content' ).closest( '[role="tabpanel"]' ).id ).toBe( getTab( 'Budgets' ).getAttribute( 'aria-controls' ) );
+	} );
+
+	it( 'remounts the content when a route stops being owned by a tab', () => {
+		// Leaving a tab's ownership moves the content out of its panel, so React
+		// remounts the subtree — losing its state and re-firing its effects. That
+		// cost is why a tab whose sub-views have their own paths should claim them
+		// via `activeTabPaths` rather than lean on the unowned-content fallback.
+		const historyRef = { current: null };
+		const mounts = { current: 0 };
+		const Content = () => {
+			useEffect( () => {
+				mounts.current++;
+			}, [] );
+			return <div>Routed content</div>;
+		};
+		render(
+			<MemoryRouter initialEntries={ [ '/stories' ] }>
+				<HistoryGrabber historyRef={ historyRef } />
+				<TabbedNavigation items={ [ { label: 'Stories', path: '/stories', exact: true } ] } content={ <Content /> } />
+			</MemoryRouter>
+		);
+		expect( screen.getByText( 'Routed content' ).closest( '[role="tabpanel"]' ) ).not.toBeNull();
+		expect( mounts.current ).toBe( 1 );
+
+		act( () => historyRef.current.push( '/stories/42' ) );
+		expect( screen.getByText( 'Routed content' ).closest( '[role="tabpanel"]' ) ).toBeNull();
+		expect( mounts.current ).toBe( 2 );
+	} );
+
+	it( 'keeps the content in the tab panel across subpaths it claims', () => {
+		// The complement of the test above, and the shape the wizard tabs in this
+		// change adopt: with the subpath claimed the content never leaves the panel,
+		// so no remount happens.
+		const historyRef = { current: null };
+		const mounts = { current: 0 };
+		const Content = () => {
+			useEffect( () => {
+				mounts.current++;
+			}, [] );
+			return <div>Routed content</div>;
+		};
+		render(
+			<MemoryRouter initialEntries={ [ '/stories' ] }>
+				<HistoryGrabber historyRef={ historyRef } />
+				<TabbedNavigation
+					items={ [ { label: 'Stories', path: '/stories', exact: true, activeTabPaths: [ '/stories/*' ] } ] }
+					content={ <Content /> }
+				/>
+			</MemoryRouter>
+		);
+		act( () => historyRef.current.push( '/stories/42' ) );
+		expect( getTab( 'Stories' ) ).toHaveAttribute( 'aria-selected', 'true' );
+		expect( screen.getByText( 'Routed content' ).closest( '[role="tabpanel"]' ) ).not.toBeNull();
+		expect( mounts.current ).toBe( 1 );
 	} );
 } );
 

--- a/packages/components/src/tabbed-navigation/index.test.js
+++ b/packages/components/src/tabbed-navigation/index.test.js
@@ -34,6 +34,31 @@ const renderTabs = ( { initialEntries = [ '/stories' ], ...props } = {} ) => {
 
 const getTab = name => screen.getByRole( 'tab', { name } );
 
+/**
+ * Render a single-tab nav whose content counts its own mounts, so a test can
+ * tell a re-render (the content keeps its state) from a remount (it loses it).
+ *
+ * @param {Object} item The sole tab item, starting on its own path `/stories`.
+ * @return {{history: Object, mounts: {current: number}}} Router history and the mount counter.
+ */
+const renderMountCountingTabs = item => {
+	const historyRef = { current: null };
+	const mounts = { current: 0 };
+	const Content = () => {
+		useEffect( () => {
+			mounts.current++;
+		}, [] );
+		return <div>Routed content</div>;
+	};
+	render(
+		<MemoryRouter initialEntries={ [ '/stories' ] }>
+			<HistoryGrabber historyRef={ historyRef } />
+			<TabbedNavigation items={ [ item ] } content={ <Content /> } />
+		</MemoryRouter>
+	);
+	return { history: historyRef.current, mounts };
+};
+
 describe( 'isItemActive', () => {
 	it( 'treats an explicitly selected item as active regardless of pathname', () => {
 		expect( isItemActive( { selected: true, path: '/other' }, '/current' ) ).toBe( true );
@@ -215,24 +240,11 @@ describe( 'TabbedNavigation with routed items', () => {
 		// remounts the subtree — losing its state and re-firing its effects. That
 		// cost is why a tab whose sub-views have their own paths should claim them
 		// via `activeTabPaths` rather than lean on the unowned-content fallback.
-		const historyRef = { current: null };
-		const mounts = { current: 0 };
-		const Content = () => {
-			useEffect( () => {
-				mounts.current++;
-			}, [] );
-			return <div>Routed content</div>;
-		};
-		render(
-			<MemoryRouter initialEntries={ [ '/stories' ] }>
-				<HistoryGrabber historyRef={ historyRef } />
-				<TabbedNavigation items={ [ { label: 'Stories', path: '/stories', exact: true } ] } content={ <Content /> } />
-			</MemoryRouter>
-		);
+		const { history, mounts } = renderMountCountingTabs( { label: 'Stories', path: '/stories', exact: true } );
 		expect( screen.getByText( 'Routed content' ).closest( '[role="tabpanel"]' ) ).not.toBeNull();
 		expect( mounts.current ).toBe( 1 );
 
-		act( () => historyRef.current.push( '/stories/42' ) );
+		act( () => history.push( '/stories/42' ) );
 		expect( screen.getByText( 'Routed content' ).closest( '[role="tabpanel"]' ) ).toBeNull();
 		expect( mounts.current ).toBe( 2 );
 	} );
@@ -241,26 +253,15 @@ describe( 'TabbedNavigation with routed items', () => {
 		// The complement of the test above, and the shape the wizard tabs in this
 		// change adopt: with the subpath claimed the content never leaves the panel,
 		// so no remount happens.
-		const historyRef = { current: null };
-		const mounts = { current: 0 };
-		const Content = () => {
-			useEffect( () => {
-				mounts.current++;
-			}, [] );
-			return <div>Routed content</div>;
-		};
-		render(
-			<MemoryRouter initialEntries={ [ '/stories' ] }>
-				<HistoryGrabber historyRef={ historyRef } />
-				<TabbedNavigation
-					items={ [ { label: 'Stories', path: '/stories', exact: true, activeTabPaths: [ '/stories/*' ] } ] }
-					content={ <Content /> }
-				/>
-			</MemoryRouter>
-		);
-		act( () => historyRef.current.push( '/stories/42' ) );
+		const { history, mounts } = renderMountCountingTabs( { label: 'Stories', path: '/stories', exact: true, activeTabPaths: [ '/stories/*' ] } );
+		expect( screen.getByText( 'Routed content' ).closest( '[role="tabpanel"]' ) ).not.toBeNull();
+		expect( mounts.current ).toBe( 1 );
+
+		act( () => history.push( '/stories/42' ) );
 		expect( getTab( 'Stories' ) ).toHaveAttribute( 'aria-selected', 'true' );
 		expect( screen.getByText( 'Routed content' ).closest( '[role="tabpanel"]' ) ).not.toBeNull();
+		// Unchanged from before the push: the content stayed put rather than
+		// unmounting and remounting into the same place.
 		expect( mounts.current ).toBe( 1 );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/advertising/index.js
+++ b/plugins/newspack-plugin/src/wizards/advertising/index.js
@@ -150,6 +150,10 @@ class AdvertisingWizard extends Component {
 				label: __( 'Providers', 'newspack-plugin' ),
 				path: '/',
 				exact: true,
+				// The Google Ad Manager screens live under this tab but route to
+				// their own paths. A `/` path always matches exactly, so they
+				// have to be claimed explicitly.
+				activeTabPaths: [ '/google_ad_manager/*' ],
 				breadcrumbs: [ ...ROOT, { label: __( 'Providers', 'newspack-plugin' ) } ],
 			},
 			{

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/index.js
@@ -37,7 +37,9 @@ const tabbedNavigation = [
 	{
 		label: __( 'Campaigns', 'newspack-plugin' ),
 		path: '/campaigns',
-		exact: true,
+		// Selecting a campaign routes to /campaigns/:id, so this tab matches by
+		// prefix rather than exactly — same as the Segments tab below.
+		exact: false,
 		breadcrumbs: [ ...ROOT, { label: __( 'Campaigns', 'newspack-plugin' ) } ],
 	},
 	{

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscription-products/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscription-products/index.tsx
@@ -45,7 +45,11 @@ const AudienceSubscriptionProducts = ( props: object, ref: React.Ref< HTMLDivEle
 					// from every scope tab, so editing a donation or a bundle
 					// highlights this one too — consistent with their shared
 					// `backNav: '#/'`. These entries also win the first-match
-					// lookup in `activeBreadcrumbs`, shadowing the hidden sections.
+					// lookup in `activeBreadcrumbs`, shadowing the hidden
+					// sections — dormant while no section here declares
+					// `breadcrumbs` (every trail falls back to `headerText`),
+					// but the add/edit screens would inherit this tab's trail
+					// the moment one does.
 					activeTabPaths: [ '/new', '/edit/*' ],
 					fullWidth: true,
 				},

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscription-products/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscription-products/index.tsx
@@ -40,6 +40,13 @@ const AudienceSubscriptionProducts = ( props: object, ref: React.Ref< HTMLDivEle
 					render: SubscriptionProductsList,
 					props: { scope: 'subscriptions' },
 					exact: true,
+					// The hidden add/edit screens route to their own paths, which
+					// the exact match above would not claim. They are reachable
+					// from every scope tab, so editing a donation or a bundle
+					// highlights this one too — consistent with their shared
+					// `backNav: '#/'`. These entries also win the first-match
+					// lookup in `activeBreadcrumbs`, shadowing the hidden sections.
+					activeTabPaths: [ '/new', '/edit/*' ],
 					fullWidth: true,
 				},
 				{

--- a/plugins/newspack-plugin/src/wizards/audience/views/subscription-products/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/subscription-products/index.tsx
@@ -40,17 +40,6 @@ const AudienceSubscriptionProducts = ( props: object, ref: React.Ref< HTMLDivEle
 					render: SubscriptionProductsList,
 					props: { scope: 'subscriptions' },
 					exact: true,
-					// The hidden add/edit screens route to their own paths, which
-					// the exact match above would not claim. They are reachable
-					// from every scope tab, so editing a donation or a bundle
-					// highlights this one too — consistent with their shared
-					// `backNav: '#/'`. These entries also win the first-match
-					// lookup in `activeBreadcrumbs`, shadowing the hidden
-					// sections — dormant while no section here declares
-					// `breadcrumbs` (every trail falls back to `headerText`),
-					// but the add/edit screens would inherit this tab's trail
-					// the moment one does.
-					activeTabPaths: [ '/new', '/edit/*' ],
 					fullWidth: true,
 				},
 				{


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Follow-up to #672, which made `TabbedNavigation` render routed content as a sibling of the panels when no visible tab owns the route. That stopped wizard screens going blank, and its docblock names the intended next step:

> for a route that is conceptually a sub-view of a tab, give that tab an `activeTabPaths` entry … so it stays selected and its panel keeps owning the content.

No wizard had been updated to do that yet, so three screens still land on the fallback: the content renders, but with **no tab highlighted**, and because the content changes DOM parent when the route crosses the owned/unowned boundary, React **remounts the whole page subtree** — losing component state and re-firing effects and data fetches on every navigation.

This declares those routes:

| Wizard | Route | Fix |
| --- | --- | --- |
| Audience → Campaigns | `/campaigns/:id` (selecting or creating a campaign) | `exact: false` on the Campaigns tab, matching its sibling Segments tab |
| Advertising → Display Ads | `/google_ad_manager`, `/google_ad_manager/create`, `/google_ad_manager/:id` | `activeTabPaths: [ '/google_ad_manager/*' ]` on Providers |
| Audience → Plans | `/new`, `/edit/:id` | `activeTabPaths: [ '/new', '/edit/*' ]` on Subscriptions |

Campaigns uses `exact: false` rather than a wildcard because its route is already registered non-exactly (`<Route path="/campaigns/:id?">`), so prefix matching states the intent directly. The other two tabs sit at `path: '/'`, which `matchesRoute` always treats as exact, so a wildcard is the only mechanism available there.

Two tests are added for the behaviour that motivates all of this — that crossing the ownership boundary remounts the content, and that a claimed subpath keeps it in the panel with no remount. #672 already covers the fallback itself.

### How to test the changes in this Pull Request:

1. Go to **Audience → Campaigns**, click **Add Campaign** and add one.
2. The URL becomes `#/campaigns/<id>`. Confirm the **Campaigns** tab stays highlighted and the prompt list renders. On `main` the tab goes unhighlighted.
3. Go to **Advertising → Display Ads → Google Ad Manager**. Confirm the **Providers** tab stays highlighted, including on an individual ad unit.
4. Go to **Audience → Plans**, click **Add plan** (and edit an existing one). Confirm the **Subscriptions** tab stays highlighted.
5. `pnpm --filter newspack-components test` and `pnpm --filter newspack test`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

**Verification** — all three wizards browser-tested in an isolated env (`tabnav.test`), measuring `aria-selected` on each tab and whether the page content sits inside a `[role="tabpanel"]`, with only the consumer config differing between runs:

| Wizard / route | `main` today | With this PR |
| --- | --- | --- |
| Campaigns `#/campaigns/:id` | all tabs `false`, content **outside** panel | Campaigns `true`, content **in** panel |
| Advertising `#/google_ad_manager` | all tabs `false`, content **outside** panel | Providers `true`, content **in** panel |
| Advertising `#/google_ad_manager/create` | all tabs `false` | Providers `true` |
| Plans `#/new` | all tabs `false`, **`panelCount: 0`** | Subscriptions `true`, form **in** panel |

No regressions on the routes that already worked: Advertising `#/`, `#/placements`, `#/settings` and Plans `#/`, `#/donations`, `#/bundles` each keep exactly their own tab selected and their content in-panel.

Tests: `newspack-components` 97/97, `newspack-plugin` 429/429, prettier clean.

**Left alone deliberately:** the Campaigns wizard's Settings tab is `exact: true` against a non-exact `<Route path="/settings">`; no `/settings/*` route exists today, so it is unreachable. The Setup wizard's `/campaign` and `/complete` routes are owned by no tab and appear unlinked.


