### PR TITLE
test(e2e): scope prompt deletion to the test's own card

### DIFF
--- a/e2e/tests/campaigns.spec.ts
+++ b/e2e/tests/campaigns.spec.ts
@@ -85,11 +85,17 @@ test("Create and view a prompt",  {
     .click();
   await expect(page.getByText(campaignBody)).not.toBeVisible();
 
-  // Delete the prompt.
+  // Delete the prompt. A prior run's retry — say a network blip during this
+  // cleanup step — can leave its prompt published, and a bare "More options"
+  // locator then matches one button per leftover card and fails strict mode.
+  // Scope to this test's own card, matching on the title element rather than
+  // the card's whole text: prompts sharing a segment each grow a "Conflict
+  // detected" notice naming the others, so a whole-card match is ambiguous too.
   await goToAdminMenu("Audience", "Campaigns", page);
-  await page.getByLabel("More options").click();
+  const promptCard = page.locator(".newspack-action-card").filter({
+    has: page.locator(".newspack-action-card__title", { hasText: campaignTitle }),
+  });
+  await promptCard.getByLabel("More options").click();
   await page.getByRole("menuitem", { name: "Delete" }).click();
-  await expect(
-    page.getByText("No active prompts in this segment.")
-  ).toBeVisible();
+  await expect(promptCard).not.toBeVisible();
 });


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`campaigns.spec.ts` cleaned up with a page-wide `getByLabel("More options")`, which assumes the Campaigns list holds exactly one prompt. That assumption breaks the moment a previous attempt leaves a prompt behind — and Playwright's own retry is what creates that state.

That is what turned a transient blip into a red nightly on 2026-07-24 ([build 18642791](https://teamcity.a8c.com/buildConfiguration/Newspack_E2eTests/18642791)):

1. Attempt 1 died at `page.goto("/wp-admin")` with `net::ERR_NETWORK_CHANGED` — during this very cleanup step, so its prompt was never deleted.
2. The retry created a second prompt, and `getByLabel("More options")` then matched two buttons:

```
strict mode violation: getByLabel('More options') resolved to 2 elements
```

So the retry could never pass, whatever the site did. The test now scopes the delete to the card it created and asserts that card disappears, instead of asserting the whole segment is empty.

Matching is done on the card's **title element**, not the card's whole text. Prompts sharing a segment each render a "Conflict detected" notice naming the *other* prompts, so a whole-card text match is ambiguous too — my first attempt at this fix failed for exactly that reason, with `.filter({ hasText })` resolving to two cards.

### How to test the changes in this Pull Request:

1. Point `e2e/.env` at a release-channel site (e.g. the `e2e-release` isolated env) and provision it.
2. Seed a leftover prompt: `wp post create --post_type=newspack_popups_cpt --post_title="Leftover" --post_status=publish`.
3. On `main`, run `npx playwright test --project="Vanilla in Desktop Chrome" -g "Create and view a prompt"` → fails with the strict-mode violation above.
4. On this branch, same command → passes, and the leftover prompt is left untouched.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

**Verification** — run against the `e2e-release` isolated env (release-channel build, matching what the nightly drives):

| Case | Result |
| --- | --- |
| Original spec + 1 leftover prompt | **FAIL** — reproduced the nightly's exact `strict mode violation … resolved to 2 elements` at line 90 |
| Fixed spec + 3 leftover prompts | **PASS** — deleted only its own prompt, left all 3 leftovers untouched |
| Fixed spec, consecutive re-run with leftovers still present | **PASS** |
| Fixed spec, clean env (the nightly's normal case) | **PASS** |

Note this only makes the *retry* survivable; it does not address the underlying network flake, which is a CI-agent condition rather than something the suite controls.
