### PR TITLE
fix(republication-tracker-tool): load block from shipped paths

### DIFF
--- a/plugins/republication-tracker-tool/includes/class-republish-button-block.php
+++ b/plugins/republication-tracker-tool/includes/class-republish-button-block.php
@@ -59,7 +59,10 @@ final class Republication_Tracker_Tool_Republish_Button_Block {
 			return;
 		}
 
-		$block_dir = REPUBLICATION_TRACKER_TOOL_PATH . 'src/blocks/republish-button';
+		// block.json is copied into the build directory by the build step; src/
+		// is stripped from the distributed plugin, so registration must read the
+		// shipped copy under dist/.
+		$block_dir = REPUBLICATION_TRACKER_TOOL_PATH . 'dist/blocks/republish-button';
 		$args      = [
 			'render_callback' => [ __CLASS__, 'render_block' ],
 		];

--- a/plugins/republication-tracker-tool/republication-tracker-tool.php
+++ b/plugins/republication-tracker-tool/republication-tracker-tool.php
@@ -32,7 +32,7 @@ require plugin_dir_path( __FILE__ ) . 'includes/class-article-settings.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-widget.php';
 require plugin_dir_path( __FILE__ ) . 'includes/compatibility-co-authors-plus.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-republication-rewrite.php';
-require plugin_dir_path( __FILE__ ) . 'src/blocks/republish-button/class-republish-button-block.php';
+require plugin_dir_path( __FILE__ ) . 'includes/class-republish-button-block.php';
 require plugin_dir_path( __FILE__ ) . 'includes/class-republish-pattern.php';
 
 /**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the WordPress coding standards and VIP Go coding standards?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Fixes a fatal error that took down any site running the latest alpha of the Republication Tracker Tool.**

The republish button block (added in #320) placed its PHP class inside `src/`, and registered the block by reading `block.json` from `src/` as well. But `.distignore` strips the entire `src/` directory from the distributed plugin — `src/` is webpack *input*, not shipped runtime code. So on the released build:

- `require .../src/blocks/republish-button/class-republish-button-block.php` fataled with `Failed opening required` — a white screen on every request.
- Even with that fixed, `register_block_type_from_metadata()` would fail because it read `block.json` from the stripped `src/` path.

It worked locally only because `src/` exists in a dev checkout.

What changed:

- **Moved the block PHP class** from `src/blocks/republish-button/` to `includes/` — the conventional, shipped location that every other `require` in the plugin already uses.
- **Register the block from `dist/`** — `block.json` is copied into `dist/blocks/republish-button/` by the build step and ships in the release. The compiled JS/CSS bundles it references (`file:../../../dist/...`) resolve identically from `dist/blocks/republish-button/` as they did from `src/blocks/republish-button/` (both three levels deep), so editor and frontend assets enqueue correctly.

No behavior change on a dev checkout; the fix is what makes the block load at all in a distributed build.

### How to test the changes in this Pull Request:

1. `n build republication-tracker-tool` — webpack should report `blocks/republish-button/block.json [copied]` into `dist/`.
2. **Simulate the distribution** (this is what broke): from the plugin dir, `rsync -r . /tmp/rtt-dist/republication-tracker-tool --exclude-from=.distignore` and confirm `/tmp/rtt-dist/republication-tracker-tool/src` does **not** exist while `includes/class-republish-button-block.php` and `dist/blocks/republish-button/block.json` **do**.
3. Load a site with the plugin active and open any front-end page — no `Failed opening required` fatal (before this fix, the alpha build white-screens here).
4. In the block editor, add the **Republish Button** block on a block theme — it inserts, the license badge preview renders, and editor styles apply.
5. On a classic theme, confirm the block is still registered (existing content isn't "unknown block") but hidden from the inserter.
6. On the front end of a single post, the button renders with theme button styles and the modal opens.
7. `n test-php --filter RepublishButtonBlock` — passes (11 tests, 19 assertions).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (existing block tests cover the class; the bug was a packaging/path issue not reachable from unit tests without simulating the stripped distribution)
* [x] Have you successfully run tests with your changes locally?

---

## For AI

Root cause: `.distignore` lists `src` (last line), and `release:archive` packages via `rsync --exclude-from=.distignore` after `npm run build`. `dist/` is only gitignored, not distignored, so it ships. PR #320 introduced two runtime reads into `src/`:

- `republication-tracker-tool.php:35` — `require` of `src/blocks/republish-button/class-republish-button-block.php` (PHP is never a webpack asset, so it was never compiled into `dist/`; stripped → fatal).
- `class-republish-button-block.php` `register_block()` — `$block_dir = REPUBLICATION_TRACKER_TOOL_PATH . 'src/blocks/republish-button'`, feeding `register_block_type_from_metadata()` and the classic-theme `wp_json_file_decode( $block_dir . '/block.json' )` supports-merge.

Fix: `git mv` the class to `includes/` and repoint `$block_dir` to `dist/blocks/republish-button`. The build (`newspack-scripts wp-scripts build`) copies `block.json` there verbatim, so its relative `file:../../../dist/*.js|css` asset references resolve to `<plugin>/dist/*` from the same three-level depth. All other asset reads in the class already targeted `dist/` and `assets/`. The PHPUnit `set_up()` still registers from `src/` (always present in a repo checkout, so tests are unaffected).
