### PR TITLE
docs: note worktree JS build silent-failure mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -154,6 +154,7 @@ n env cleanup                 # Interactive bulk cleanup
 - Worktrees override individual plugins while the rest are shared. Monorepo worktrees live in `worktrees/<branch>/`; standalone `repos/` worktrees in `worktrees-repos/<name>/<branch>/`, mounted over just that path so other envs keep the base checkout. Destroying a monorepo worktree deletes its branch; a `repos/` worktree keeps it.
 - All env containers share the `newspack_envs` bridge network with their domain as a DNS alias, so they can reach each other (hub/node setups).
 - `n env destroy` removes the container, DB, html dir, hosts entry and worktrees.
+- **Building a worktree plugin's JS** (`docker exec newspack_env_<name> bash -c "/var/scripts/build-repos.sh <plugin>"`) can fail with exit 1 and completely empty stdout/stderr, leaving `dist/` deleted (the plugin's `build` script runs `clean` before webpack) but not rebuilt. One observed cause: the worktree carries its own `node_modules`, separate from the main checkout's, and it isn't automatically kept in step — a package present in main's install can be missing there, and pnpm/webpack fail silently on the missing module before printing anything. To diagnose, run the same build on the host from the worktree root (`pnpm --filter <pkg> run build`) — it surfaces the real error where the container path doesn't. If it's a missing package, `pnpm install` at the worktree root and rebuild.
 
 With the `newspack` Claude Code plugin installed, `newspack:env-create`, `newspack:env-destroy` and `newspack:worktree` wrap these.
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Adds a short note to `AGENTS.md`, under "Isolated environments", documenting a failure mode of `bin/build-repos.sh`: building a worktree-mounted plugin's JS inside an env container can exit non-zero with completely empty stdout/stderr, while also having already deleted `dist/` (the plugin's `build` script runs `clean` first). One observed cause was the worktree's own `node_modules` being out of step with the main checkout's install — the note gives the diagnosis (rerun the build on the host from the worktree root, which surfaces the real error) and recovery (`pnpm install` at the worktree root, then rebuild) steps.

This was observed once, not established as routine, so the note is scoped as a failure mode and its recovery rather than a required setup step.

Whether the underlying tooling behavior (deleting `dist/` before the build succeeds, and the container swallowing webpack's output on failure) is worth changing is tracked separately in [NPPM-3044](https://linear.app/a8c/issue/NPPM-3044) rather than attempted here, since neither the failure's routineness nor the exact cause of the silent output is established yet.

### How to test the changes in this Pull Request:

1. Read the added bullet under "Isolated environments" in `AGENTS.md` and confirm it accurately describes the diagnosis/recovery steps (docs-only change, no functional testing applies).

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?