### PR TITLE
feat(performance): defer reader-facing JS assets (NPPM-3037)

### DIFF
--- a/plugins/newspack-ads/includes/blocks/class-tabs-block.php
+++ b/plugins/newspack-ads/includes/blocks/class-tabs-block.php
@@ -77,6 +77,20 @@ final class Tabs_Block {
 			return $block_content;
 		}
 
+		// Enqueue the frontend script whenever a tabs block actually renders —
+		// including inside synced patterns, which content sniffing cannot detect.
+		// The script prints in the footer, so enqueueing at render time is safe.
+		\wp_enqueue_script(
+			'newspack-ads-media-kit-frontend',
+			Core::plugin_url( 'dist/media-kit-frontend.js' ),
+			[],
+			NEWSPACK_ADS_VERSION,
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
+		);
+
 		if ( $block['innerBlocks'] ) {
 
 			// Add tab navigation controls.

--- a/plugins/newspack-ads/includes/blocks/class-tabs-block.php
+++ b/plugins/newspack-ads/includes/blocks/class-tabs-block.php
@@ -77,7 +77,7 @@ final class Tabs_Block {
 			return $block_content;
 		}
 
-		// Enqueue the frontend script whenever a tabs block actually renders —
+		// Enqueue the frontend assets whenever a tabs block actually renders —
 		// including inside synced patterns, which content sniffing cannot detect.
 		// The script prints in the footer, so enqueueing at render time is safe.
 		\wp_enqueue_script(
@@ -90,6 +90,7 @@ final class Tabs_Block {
 				'strategy'  => 'defer',
 			]
 		);
+		Media_Kit::enqueue_frontend_style();
 
 		if ( $block['innerBlocks'] ) {
 

--- a/plugins/newspack-ads/includes/class-bidding.php
+++ b/plugins/newspack-ads/includes/class-bidding.php
@@ -186,6 +186,7 @@ final class Bidding {
 		if ( ! self::is_enabled() ) {
 			return;
 		}
+		// Note: tag output is overridden by the script_loader_tag filter below; a script strategy here would have no effect.
 		wp_enqueue_script(
 			self::PREBID_SCRIPT_HANDLE,
 			plugins_url( '../dist/prebid.js', __FILE__ ),

--- a/plugins/newspack-ads/includes/class-core.php
+++ b/plugins/newspack-ads/includes/class-core.php
@@ -65,7 +65,10 @@ final class Core {
 			plugins_url( '../dist/frontend.js', __FILE__ ),
 			[],
 			$asset_file['version'],
-			true
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
 		);
 
 		\wp_register_style(

--- a/plugins/newspack-ads/includes/media-kit/class-media-kit.php
+++ b/plugins/newspack-ads/includes/media-kit/class-media-kit.php
@@ -195,6 +195,13 @@ final class Media_Kit {
 	 * Equeue frontend scripts.
 	 */
 	public static function enqueue_scripts() {
+		// The media kit page (and any page using its patterns) is always a
+		// singular view, so skip the content sniffing everywhere else. The
+		// frontend JS is enqueued from the tabs block render path instead
+		// (see Tabs_Block::render_tab_navigation()).
+		if ( ! is_singular() ) {
+			return;
+		}
 		// Get current page content and check for the special class used in the patterns, or block usage.
 		$page_content = get_the_content();
 		$has_pattern = false !== strpos( $page_content, 'media-kit-page__wrapper' );
@@ -208,18 +215,6 @@ final class Media_Kit {
 			);
 			\wp_style_add_data( 'newspack-ads-media-kit-frontend', 'rtl', 'replace' );
 			\wp_enqueue_style( 'newspack-ads-media-kit-frontend' );
-		}
-		if ( $has_block ) {
-			\wp_enqueue_script(
-				'newspack-ads-media-kit-frontend',
-				Core::plugin_url( 'dist/media-kit-frontend.js' ),
-				[],
-				NEWSPACK_ADS_VERSION,
-				[
-					'in_footer' => true,
-					'strategy'  => 'defer',
-				]
-			);
 		}
 	}
 

--- a/plugins/newspack-ads/includes/media-kit/class-media-kit.php
+++ b/plugins/newspack-ads/includes/media-kit/class-media-kit.php
@@ -207,15 +207,26 @@ final class Media_Kit {
 		$has_pattern = false !== strpos( $page_content, 'media-kit-page__wrapper' );
 		$has_block = false !== strpos( $page_content, '<!-- wp:newspack/tabs' );
 		if ( $has_pattern || $has_block ) {
-			\wp_register_style(
-				'newspack-ads-media-kit-frontend',
-				Core::plugin_url( 'dist/media-kit-frontend.css' ),
-				null,
-				filemtime( dirname( NEWSPACK_ADS_PLUGIN_FILE ) . '/dist/media-kit-frontend.css' )
-			);
-			\wp_style_add_data( 'newspack-ads-media-kit-frontend', 'rtl', 'replace' );
-			\wp_enqueue_style( 'newspack-ads-media-kit-frontend' );
+			self::enqueue_frontend_style();
 		}
+	}
+
+	/**
+	 * Enqueue the media kit frontend stylesheet.
+	 *
+	 * Called both from the content sniffing above (the page wrapper carries styles of
+	 * its own) and from the tabs block render path, which is the only way to catch a
+	 * block nested in a synced pattern.
+	 */
+	public static function enqueue_frontend_style() {
+		\wp_register_style(
+			'newspack-ads-media-kit-frontend',
+			Core::plugin_url( 'dist/media-kit-frontend.css' ),
+			null,
+			filemtime( dirname( NEWSPACK_ADS_PLUGIN_FILE ) . '/dist/media-kit-frontend.css' )
+		);
+		\wp_style_add_data( 'newspack-ads-media-kit-frontend', 'rtl', 'replace' );
+		\wp_enqueue_style( 'newspack-ads-media-kit-frontend' );
 	}
 
 	/**

--- a/plugins/newspack-ads/includes/media-kit/class-media-kit.php
+++ b/plugins/newspack-ads/includes/media-kit/class-media-kit.php
@@ -197,8 +197,8 @@ final class Media_Kit {
 	public static function enqueue_scripts() {
 		// Get current page content and check for the special class used in the patterns, or block usage.
 		$page_content = get_the_content();
-		$has_pattern = strpos( $page_content, 'media-kit-page__wrapper' ) >= 0;
-		$has_block = strpos( $page_content, '<!-- wp:newspack/tabs' ) >= 0;
+		$has_pattern = false !== strpos( $page_content, 'media-kit-page__wrapper' );
+		$has_block = false !== strpos( $page_content, '<!-- wp:newspack/tabs' );
 		if ( $has_pattern || $has_block ) {
 			\wp_register_style(
 				'newspack-ads-media-kit-frontend',

--- a/plugins/newspack-ads/includes/media-kit/class-media-kit.php
+++ b/plugins/newspack-ads/includes/media-kit/class-media-kit.php
@@ -215,7 +215,10 @@ final class Media_Kit {
 				Core::plugin_url( 'dist/media-kit-frontend.js' ),
 				[],
 				NEWSPACK_ADS_VERSION,
-				true
+				[
+					'in_footer' => true,
+					'strategy'  => 'defer',
+				]
 			);
 		}
 	}

--- a/plugins/newspack-blocks/includes/class-newspack-blocks-caching.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks-caching.php
@@ -253,9 +253,9 @@ class Newspack_Blocks_Caching {
 		}
 
 		if ( 'newspack-blocks/homepage-articles' === $block_data['blockName'] ) {
-			Newspack_Blocks::enqueue_view_assets( 'homepage-articles' );
+			Newspack_Blocks::enqueue_view_assets( 'homepage-articles', 'defer' );
 		} elseif ( 'newspack-blocks/carousel' === $block_data['blockName'] ) {
-			Newspack_Blocks::enqueue_view_assets( 'carousel' );
+			Newspack_Blocks::enqueue_view_assets( 'carousel', 'defer' );
 		}
 
 		return $cached_data['cached_content'];

--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -340,9 +340,11 @@ class Newspack_Blocks {
 	/**
 	 * Enqueue view scripts and styles for a single block.
 	 *
-	 * @param string $type The block's type.
+	 * @param string      $type     The block's type.
+	 * @param string|null $strategy Optional. Script loading strategy to apply to the
+	 *                              view script ('defer' or 'async'). Default null (no strategy).
 	 */
-	public static function enqueue_view_assets( $type ) {
+	public static function enqueue_view_assets( $type, $strategy = null ) {
 		$style_path = apply_filters(
 			'newspack_blocks_enqueue_view_assets',
 			NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view.css',
@@ -362,13 +364,17 @@ class Newspack_Blocks {
 		}
 		$script_data = static::script_enqueue_helper( NEWSPACK_BLOCKS__BLOCKS_DIRECTORY . $type . '/view.js' );
 		if ( $script_data ) {
+			$handle = "newspack-blocks-{$type}";
 			wp_enqueue_script(
-				"newspack-blocks-{$type}",
+				$handle,
 				$script_data['script_path'],
 				$script_data['dependencies'],
 				$script_data['version'],
 				true
 			);
+			if ( $strategy ) {
+				wp_script_add_data( $handle, 'strategy', $strategy );
+			}
 		}
 	}
 

--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -342,7 +342,9 @@ class Newspack_Blocks {
 	 *
 	 * @param string      $type     The block's type.
 	 * @param string|null $strategy Optional. Script loading strategy to apply to the
-	 *                              view script ('defer' or 'async'). Default null (no strategy).
+	 *                              view script ('defer' or 'async'). First write wins:
+	 *                              ignored if a strategy is already set on the handle.
+	 *                              Default null (no strategy).
 	 */
 	public static function enqueue_view_assets( $type, $strategy = null ) {
 		$style_path = apply_filters(
@@ -372,7 +374,7 @@ class Newspack_Blocks {
 				$script_data['version'],
 				true
 			);
-			if ( $strategy ) {
+			if ( $strategy && ! wp_scripts()->get_data( $handle, 'strategy' ) ) {
 				wp_script_add_data( $handle, 'strategy', $strategy );
 			}
 		}

--- a/plugins/newspack-blocks/src/blocks/author-list/view.php
+++ b/plugins/newspack-blocks/src/blocks/author-list/view.php
@@ -78,8 +78,8 @@ function newspack_blocks_render_block_author_list( $attributes ) {
 	}
 
 	// Enqueue required front-end assets.
-	Newspack_Blocks::enqueue_view_assets( 'author-list' );
-	Newspack_Blocks::enqueue_view_assets( 'author-profile' );
+	Newspack_Blocks::enqueue_view_assets( 'author-list', 'defer' );
+	Newspack_Blocks::enqueue_view_assets( 'author-profile', 'defer' );
 
 	// Class names for the list container.
 	$container_classes = [ 'newspack-blocks__author-list-container' ];

--- a/plugins/newspack-blocks/src/blocks/author-profile/view.php
+++ b/plugins/newspack-blocks/src/blocks/author-profile/view.php
@@ -320,7 +320,7 @@ function newspack_blocks_render_block_author_profile( $attributes, $content, $bl
 		return '';
 	}
 
-	Newspack_Blocks::enqueue_view_assets( 'author-profile' );
+	Newspack_Blocks::enqueue_view_assets( 'author-profile', 'defer' );
 
 	// NESTED MODE: Determined by layoutVersion attribute, not theme type.
 	// Once a block is created in nested mode (layoutVersion 2), it stays nested.

--- a/plugins/newspack-blocks/src/blocks/carousel/view.php
+++ b/plugins/newspack-blocks/src/blocks/carousel/view.php
@@ -269,7 +269,7 @@ function newspack_blocks_render_block_carousel( $attributes ) {
 		$data_attributes[] = 'data-autoplay=1';
 		$data_attributes[] = sprintf( 'data-autoplay_delay=%s', esc_attr( $delay ) );
 	}
-	Newspack_Blocks::enqueue_view_assets( 'carousel' );
+	Newspack_Blocks::enqueue_view_assets( 'carousel', 'defer' );
 	if ( 1 === $counter ) {
 		$selector = '';
 	}

--- a/plugins/newspack-blocks/src/blocks/checkout-button/view.php
+++ b/plugins/newspack-blocks/src/blocks/checkout-button/view.php
@@ -49,7 +49,7 @@ function render_callback( $attributes ) {
 		? $attributes['product']
 		: $product_id;
 	\Newspack_Blocks\Modal_Checkout::enqueue_modal( $modal_product_id );
-	\Newspack_Blocks::enqueue_view_assets( 'checkout-button' );
+	\Newspack_Blocks::enqueue_view_assets( 'checkout-button', 'defer' );
 
 	$background_color           = $attributes['backgroundColor'] ?? '';
 	$text_color                 = $attributes['textColor'] ?? '';

--- a/plugins/newspack-blocks/src/blocks/homepage-articles/view.php
+++ b/plugins/newspack-blocks/src/blocks/homepage-articles/view.php
@@ -422,7 +422,7 @@ function newspack_blocks_render_block_homepage_articles( $attributes ) {
 	<?php
 
 	$content = ob_get_clean();
-	Newspack_Blocks::enqueue_view_assets( 'homepage-articles' );
+	Newspack_Blocks::enqueue_view_assets( 'homepage-articles', 'defer' );
 
 	return $content;
 }

--- a/plugins/newspack-blocks/src/blocks/iframe/view.php
+++ b/plugins/newspack-blocks/src/blocks/iframe/view.php
@@ -13,7 +13,7 @@
  * @return string
  */
 function newspack_blocks_render_block_iframe( $attributes ) {
-	Newspack_Blocks::enqueue_view_assets( 'iframe' );
+	Newspack_Blocks::enqueue_view_assets( 'iframe', 'defer' );
 
 	return newspack_blocks_get_iframe( $attributes );
 }

--- a/plugins/newspack-listings/includes/class-blocks.php
+++ b/plugins/newspack-listings/includes/class-blocks.php
@@ -187,7 +187,10 @@ final class Blocks {
 				NEWSPACK_LISTINGS_URL . 'dist/curated-list.js',
 				[ 'mediaelement-core' ],
 				NEWSPACK_LISTINGS_VERSION,
-				true
+				[
+					'in_footer' => true,
+					'strategy'  => 'defer',
+				]
 			);
 		}
 	}

--- a/plugins/newspack-plugin/includes/class-newspack-ui.php
+++ b/plugins/newspack-plugin/includes/class-newspack-ui.php
@@ -60,6 +60,11 @@ class Newspack_UI {
 			true
 		);
 
+		// Defer on the front end only; admin and block editor requests (is_admin()) are left untouched.
+		if ( ! is_admin() ) {
+			wp_script_add_data( 'newspack-ui', 'strategy', 'defer' );
+		}
+
 		$icons = [];
 		foreach ( self::get_type_icons() as $type => $icon_name ) {
 			$icons[ $type ] = wp_kses( Newspack_UI_Icons::get_svg( $icon_name ), Newspack_UI_Icons::sanitize_svgs() );

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -586,6 +586,11 @@ final class Newspack {
 		);
 		wp_enqueue_script( 'newspack_commons' );
 
+		// Defer on the front end only; admin and block editor requests (is_admin()) are left untouched.
+		if ( ! is_admin() ) {
+			wp_script_add_data( 'newspack_commons', 'strategy', 'defer' );
+		}
+
 		wp_register_style(
 			'newspack-commons',
 			self::plugin_url() . '/dist/commons.css',

--- a/plugins/newspack-plugin/includes/class-post-date.php
+++ b/plugins/newspack-plugin/includes/class-post-date.php
@@ -437,7 +437,16 @@ class Post_Date {
 
 		$asset = include NEWSPACK_ABSPATH . 'dist/other-scripts/relative-time.asset.php';
 
-		wp_enqueue_script( $handle, $url, $asset['dependencies'] ?? [], $asset['version'] ?? false, true );
+		wp_enqueue_script(
+			$handle,
+			$url,
+			$asset['dependencies'] ?? [],
+			$asset['version'] ?? false,
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
+		);
 		wp_localize_script(
 			$handle,
 			'newspackRelativeTime',

--- a/plugins/newspack-plugin/includes/collections/class-enqueuer.php
+++ b/plugins/newspack-plugin/includes/collections/class-enqueuer.php
@@ -95,7 +95,14 @@ class Enqueuer {
 		}
 
 		// Enqueue frontend assets.
-		self::enqueue_script( self::SCRIPT_NAME_FRONTEND, [ 'wp-dom-ready' ] );
+		self::enqueue_script(
+			self::SCRIPT_NAME_FRONTEND,
+			[ 'wp-dom-ready' ],
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
+		);
 		self::enqueue_style( self::SCRIPT_NAME_FRONTEND );
 		self::localize_data( self::SCRIPT_NAME_FRONTEND );
 	}
@@ -103,16 +110,17 @@ class Enqueuer {
 	/**
 	 * Enqueue a script.
 	 *
-	 * @param string $handle       Script handle.
-	 * @param array  $dependencies Script dependencies. Default is empty array.
+	 * @param string     $handle       Script handle.
+	 * @param array      $dependencies Script dependencies. Default is empty array.
+	 * @param array|bool $args         Script args (or in_footer bool) passed to wp_enqueue_script(). Default is true.
 	 */
-	private static function enqueue_script( $handle, $dependencies = [] ) {
+	private static function enqueue_script( $handle, $dependencies = [], $args = true ) {
 		wp_enqueue_script(
 			$handle,
 			\Newspack\Newspack::plugin_url() . '/dist/' . $handle . '.js',
 			$dependencies,
 			\Newspack\Newspack::asset_version( $handle ),
-			true
+			$args
 		);
 	}
 

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -449,7 +449,16 @@ class Content_Gate {
 			if ( is_singular() && self::has_gate() && self::is_post_restricted() && Metering::is_frontend_metering() ) {
 				$asset['dependencies'][] = 'newspack-content-gate-metering';
 			}
-			wp_enqueue_script( 'newspack-content-banner', Newspack::plugin_url() . '/dist/content-banner.js', $asset['dependencies'], Newspack::asset_version( 'content-banner' ), true );
+			wp_enqueue_script(
+				'newspack-content-banner',
+				Newspack::plugin_url() . '/dist/content-banner.js',
+				$asset['dependencies'],
+				Newspack::asset_version( 'content-banner' ),
+				[
+					'in_footer' => true,
+					'strategy'  => 'defer',
+				]
+			);
 			wp_enqueue_style( 'newspack-content-banner', Newspack::plugin_url() . '/dist/content-banner.css', [], Newspack::asset_version( 'content-banner' ) );
 		}
 	}

--- a/plugins/newspack-plugin/includes/content-gate/class-metering-countdown.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-metering-countdown.php
@@ -186,7 +186,7 @@ class Metering_Countdown {
 				return;
 			}
 			\Newspack_Blocks\Modal_Checkout::enqueue_modal( $product->get_id() );
-			\Newspack_Blocks::enqueue_view_assets( 'checkout-button' );
+			\Newspack_Blocks::enqueue_view_assets( 'checkout-button', 'defer' );
 			$checkout_data = \Newspack_Blocks\Modal_Checkout\Checkout_Data::get_checkout_data( $product );
 			?>
 			<div class="wp-block-newspack-blocks-checkout-button">

--- a/plugins/newspack-plugin/includes/content-gate/class-metering.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-metering.php
@@ -306,7 +306,10 @@ class Metering {
 			Newspack::plugin_url() . '/dist/content-gate-metering.js',
 			[],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/content-gate-metering.js' ),
-			true
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
 		);
 
 		$settings = self::get_effective_settings( $gate_post_id, false );

--- a/plugins/newspack-plugin/includes/content-gate/content-gifting/class-content-gifting-cta.php
+++ b/plugins/newspack-plugin/includes/content-gate/content-gifting/class-content-gifting-cta.php
@@ -177,7 +177,7 @@ class Content_Gifting_CTA {
 				return;
 			}
 			\Newspack_Blocks\Modal_Checkout::enqueue_modal( $product_id );
-			\Newspack_Blocks::enqueue_view_assets( 'checkout-button' );
+			\Newspack_Blocks::enqueue_view_assets( 'checkout-button', 'defer' );
 			$checkout_data = \Newspack_Blocks\Modal_Checkout\Checkout_Data::get_checkout_data( $product );
 			?>
 			<div class="wp-block-newspack-blocks-checkout-button">

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-cover-fees.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/class-woocommerce-cover-fees.php
@@ -211,7 +211,10 @@ class WooCommerce_Cover_Fees {
 			\Newspack\Newspack::plugin_url() . '/dist/other-scripts/wc-cover-fees.js',
 			[ 'jquery' ],
 			\Newspack\Newspack::asset_version( 'other-scripts/wc-cover-fees' ),
-			[ 'in_footer' => true ]
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
 		);
 	}
 

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-my-account-ui-v1.php
@@ -137,7 +137,10 @@ class My_Account_UI_V1 {
 				\Newspack\Newspack::plugin_url() . '/dist/account-frontend.js',
 				[],
 				\Newspack\Newspack::asset_version( 'account-frontend' ),
-				true
+				[
+					'in_footer' => true,
+					'strategy'  => 'defer',
+				]
 			);
 			\wp_localize_script(
 				'newspack-account-frontend',
@@ -150,7 +153,10 @@ class My_Account_UI_V1 {
 				\Newspack\Newspack::plugin_url() . '/dist/my-account-v1.js',
 				[ 'newspack-ui' ],
 				\Newspack\Newspack::asset_version( 'my-account-v1' ),
-				true
+				[
+					'in_footer' => true,
+					'strategy'  => 'defer',
+				]
 			);
 			\wp_localize_script(
 				'newspack-my-account-v1',

--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -324,7 +324,10 @@ class WooCommerce_My_Account {
 				\Newspack\Newspack::plugin_url() . '/dist/my-account.js',
 				[],
 				\Newspack\Newspack::asset_version( 'my-account' ),
-				true
+				[
+					'in_footer' => true,
+					'strategy'  => 'defer',
+				]
 			);
 			\wp_localize_script(
 				'newspack-my-account',

--- a/plugins/newspack-plugin/includes/polyfills/class-amp-polyfills.php
+++ b/plugins/newspack-plugin/includes/polyfills/class-amp-polyfills.php
@@ -177,7 +177,10 @@ class AMP_Polyfills {
 				\Newspack\Newspack::plugin_url() . '/dist/other-scripts/lightbox.js',
 				[],
 				\Newspack\Newspack::asset_version( 'other-scripts/lightbox' ),
-				true
+				[
+					'in_footer' => true,
+					'strategy'  => 'defer',
+				]
 			);
 			\wp_enqueue_style(
 				'newspack-image-lightbox',

--- a/plugins/newspack-plugin/includes/reader-activation/class-my-account.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-my-account.php
@@ -176,7 +176,6 @@ class My_Account {
 			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
-		\wp_script_add_data( 'newspack-ui', 'strategy', 'defer' );
 		\wp_add_inline_script(
 			'newspack-ui',
 			"( function() {

--- a/plugins/newspack-plugin/includes/reader-activation/class-my-account.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-my-account.php
@@ -176,6 +176,10 @@ class My_Account {
 			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
+		// Defer on the front end only; admin and block editor requests (is_admin()) are left untouched.
+		if ( ! \is_admin() ) {
+			\wp_script_add_data( 'newspack-ui', 'strategy', 'defer' );
+		}
 		\wp_add_inline_script(
 			'newspack-ui',
 			"( function() {

--- a/plugins/newspack-plugin/includes/reader-activation/class-my-account.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-my-account.php
@@ -176,10 +176,7 @@ class My_Account {
 			NEWSPACK_PLUGIN_VERSION,
 			true
 		);
-		// Defer on the front end only; admin and block editor requests (is_admin()) are left untouched.
-		if ( ! \is_admin() ) {
-			\wp_script_add_data( 'newspack-ui', 'strategy', 'defer' );
-		}
+		\wp_script_add_data( 'newspack-ui', 'strategy', 'defer' );
 		\wp_add_inline_script(
 			'newspack-ui',
 			"( function() {
@@ -193,7 +190,8 @@ class My_Account {
 						} );
 					}
 				} );
-			} )();"
+			} )();",
+			'before'
 		);
 	}
 

--- a/plugins/newspack-plugin/src/blocks/content-gate/countdown/class-content-gate-countdown-block.php
+++ b/plugins/newspack-plugin/src/blocks/content-gate/countdown/class-content-gate-countdown-block.php
@@ -35,7 +35,10 @@ class Content_Gate_Countdown_Block {
 			\Newspack\Newspack::plugin_url() . '/dist/content-gate-countdown-block.js',
 			[ 'wp-i18n', 'newspack-content-gate-metering' ],
 			Newspack::asset_version( 'content-gate-countdown-block' ),
-			true
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
 		);
 	}
 

--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -1058,7 +1058,10 @@ final class Newspack_Popups_Inserter {
 					Newspack_Popups_Criteria::SCRIPT_HANDLE,
 				],
 				filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/view.js' ),
-				true
+				[
+					'in_footer' => true,
+					'strategy'  => 'defer',
+				]
 			);
 
 			$script_data = [

--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -1058,10 +1058,7 @@ final class Newspack_Popups_Inserter {
 					Newspack_Popups_Criteria::SCRIPT_HANDLE,
 				],
 				filemtime( dirname( NEWSPACK_POPUPS_PLUGIN_FILE ) . '/dist/view.js' ),
-				[
-					'in_footer' => true,
-					'strategy'  => 'defer',
-				]
+				true
 			);
 
 			$script_data = [

--- a/plugins/republication-tracker-tool/includes/class-republication-rewrite.php
+++ b/plugins/republication-tracker-tool/includes/class-republication-rewrite.php
@@ -167,7 +167,10 @@ class Republication_Tracker_Tool_Rewrite_Endpoint {
 			REPUBLICATION_TRACKER_TOOL_URL . 'assets/clipboard-utils.js',
 			array(),
 			REPUBLICATION_TRACKER_TOOL_VERSION,
-			true
+			array(
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			)
 		);
 
 		// Enqueue the republish page scripts.
@@ -176,7 +179,10 @@ class Republication_Tracker_Tool_Rewrite_Endpoint {
 			REPUBLICATION_TRACKER_TOOL_URL . 'assets/republish-template.js',
 			array( 'republication-tracker-tool-clipboard-utils' ),
 			REPUBLICATION_TRACKER_TOOL_VERSION,
-			true
+			array(
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			)
 		);
 	}
 }

--- a/plugins/republication-tracker-tool/includes/class-republish-button-block.php
+++ b/plugins/republication-tracker-tool/includes/class-republish-button-block.php
@@ -212,7 +212,10 @@ final class Republication_Tracker_Tool_Republish_Button_Block {
 			REPUBLICATION_TRACKER_TOOL_URL . 'assets/clipboard-utils.js',
 			[],
 			REPUBLICATION_TRACKER_TOOL_VERSION,
-			true
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
 		);
 
 		// Block frontend script.
@@ -229,7 +232,10 @@ final class Republication_Tracker_Tool_Republish_Button_Block {
 			REPUBLICATION_TRACKER_TOOL_URL . 'dist/republish-button-view.js',
 			array_merge( $asset['dependencies'], [ 'republication-tracker-tool-clipboard-utils' ] ),
 			$asset['version'],
-			true
+			[
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			]
 		);
 	}
 }

--- a/plugins/republication-tracker-tool/includes/class-widget.php
+++ b/plugins/republication-tracker-tool/includes/class-widget.php
@@ -59,7 +59,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 				'republication-tracker-tool-clipboard-utils',
 				plugins_url( 'assets/clipboard-utils.js', __DIR__ ),
 				array(),
-				filemtime( plugin_dir_path( __FILE__ ) ),
+				REPUBLICATION_TRACKER_TOOL_VERSION,
 				array(
 					'in_footer' => false,
 					'strategy'  => 'defer',
@@ -69,7 +69,7 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 				'republication-tracker-tool-js',
 				plugins_url( 'assets/widget.js', __DIR__ ),
 				array( 'jquery', 'republication-tracker-tool-clipboard-utils' ),
-				filemtime( plugin_dir_path( __FILE__ ) ),
+				REPUBLICATION_TRACKER_TOOL_VERSION,
 				array(
 					'in_footer' => false,
 					'strategy'  => 'defer',

--- a/plugins/republication-tracker-tool/includes/class-widget.php
+++ b/plugins/republication-tracker-tool/includes/class-widget.php
@@ -55,8 +55,26 @@ class Republication_Tracker_Tool_Widget extends WP_Widget {
 		$is_amp = self::is_amp();
 
 		if ( ! $is_amp ) {
-			wp_enqueue_script( 'republication-tracker-tool-clipboard-utils', plugins_url( 'assets/clipboard-utils.js', __DIR__ ), array(), filemtime( plugin_dir_path( __FILE__ ) ), false );
-			wp_enqueue_script( 'republication-tracker-tool-js', plugins_url( 'assets/widget.js', __DIR__ ), array( 'jquery', 'republication-tracker-tool-clipboard-utils' ), filemtime( plugin_dir_path( __FILE__ ) ), false );
+			wp_enqueue_script(
+				'republication-tracker-tool-clipboard-utils',
+				plugins_url( 'assets/clipboard-utils.js', __DIR__ ),
+				array(),
+				filemtime( plugin_dir_path( __FILE__ ) ),
+				array(
+					'in_footer' => false,
+					'strategy'  => 'defer',
+				)
+			);
+			wp_enqueue_script(
+				'republication-tracker-tool-js',
+				plugins_url( 'assets/widget.js', __DIR__ ),
+				array( 'jquery', 'republication-tracker-tool-clipboard-utils' ),
+				filemtime( plugin_dir_path( __FILE__ ) ),
+				array(
+					'in_footer' => false,
+					'strategy'  => 'defer',
+				)
+			);
 		}
 		wp_enqueue_style( 'republication-tracker-tool-css', plugins_url( 'assets/widget.css', __DIR__ ), array(), filemtime( plugin_dir_path( __FILE__ ) ) );
 

--- a/themes/newspack-block-theme/includes/class-core.php
+++ b/themes/newspack-block-theme/includes/class-core.php
@@ -69,7 +69,16 @@ final class Core {
 		);
 
 		// Enqueue front-end JavaScript.
-		wp_enqueue_script( 'newspack-main', get_theme_file_uri( '/dist/main.js' ), array(), wp_get_theme()->get( 'Version' ), true );
+		wp_enqueue_script(
+			'newspack-main',
+			get_theme_file_uri( '/dist/main.js' ),
+			array(),
+			wp_get_theme()->get( 'Version' ),
+			array(
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			)
+		);
 		wp_localize_script( 'newspack-main', 'newspackScreenReaderText', $newspack_l10n );
 	}
 

--- a/themes/newspack-theme/newspack-theme/functions.php
+++ b/themes/newspack-theme/newspack-theme/functions.php
@@ -483,11 +483,29 @@ function newspack_scripts() {
 			wp_enqueue_script( 'comment-reply' );
 		}
 
-		wp_enqueue_script( 'newspack-amp-fallback', get_theme_file_uri( '/js/dist/amp-fallback.js' ), array(), wp_get_theme()->get( 'Version' ), true );
+		wp_enqueue_script(
+			'newspack-amp-fallback',
+			get_theme_file_uri( '/js/dist/amp-fallback.js' ),
+			array(),
+			wp_get_theme()->get( 'Version' ),
+			array(
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			)
+		);
 		wp_localize_script( 'newspack-amp-fallback', 'newspackScreenReaderText', $newspack_l10n );
 	}
 
-	wp_enqueue_script( 'newspack-menu-accessibility', get_theme_file_uri( '/js/dist/menu-accessibility.js' ), array(), wp_get_theme()->get( 'Version' ), true );
+	wp_enqueue_script(
+		'newspack-menu-accessibility',
+		get_theme_file_uri( '/js/dist/menu-accessibility.js' ),
+		array(),
+		wp_get_theme()->get( 'Version' ),
+		array(
+			'in_footer' => true,
+			'strategy'  => 'defer',
+		)
+	);
 	wp_localize_script( 'newspack-menu-accessibility', 'newspackScreenReaderText', $newspack_l10n );
 
 	if ( newspack_is_sticky_animated_header() ) {
@@ -495,7 +513,16 @@ function newspack_scripts() {
 		wp_enqueue_script( 'amp-position-observer', 'https://cdn.ampproject.org/v0/amp-position-observer-0.1.js', array(), '0.1', true );
 	}
 
-	wp_enqueue_script( 'newspack-font-loading', get_theme_file_uri( '/js/dist/font-loading.js' ), array(), wp_get_theme()->get( 'Version' ), true );
+	wp_enqueue_script(
+		'newspack-font-loading',
+		get_theme_file_uri( '/js/dist/font-loading.js' ),
+		array(),
+		wp_get_theme()->get( 'Version' ),
+		array(
+			'in_footer' => true,
+			'strategy'  => 'defer',
+		)
+	);
 	wp_localize_script(
 		'newspack-font-loading',
 		'newspackFontLoading',

--- a/themes/newspack-theme/newspack-theme/inc/newspack-sponsors.php
+++ b/themes/newspack-theme/newspack-theme/inc/newspack-sponsors.php
@@ -29,7 +29,16 @@ function newspack_sponsors_enqueue_scripts() {
 			'close_info' => esc_html__( 'Close', 'newspack-theme' ),
 		);
 
-		wp_enqueue_script( 'newspack-amp-fallback-sponsors', get_theme_file_uri( '/js/dist/amp-fallback-newspack-sponsors.js' ), array(), wp_get_theme()->get( 'Version' ), true );
+		wp_enqueue_script(
+			'newspack-amp-fallback-sponsors',
+			get_theme_file_uri( '/js/dist/amp-fallback-newspack-sponsors.js' ),
+			array(),
+			wp_get_theme()->get( 'Version' ),
+			array(
+				'in_footer' => true,
+				'strategy'  => 'defer',
+			)
+		);
 		wp_localize_script( 'newspack-amp-fallback-sponsors', 'newspackScreenReaderTextSponsors', $newspack_l10n );
 	}
 }


### PR DESCRIPTION
## What

Adds the native WP `strategy: defer` (WP 6.3+; our floor is 6.9) to **31 audited reader-facing first-party JS handles** across 8 monorepo units, reclaiming render-blocking-JS control from Perfmatters. Perf-only: the enqueue layer changes, the JS does not. Closes NPPM-3037.

Per-unit commits for reviewability; intended to **squash-merge** as `feat(performance): defer reader-facing JS assets (NPPM-3037)` (`perf:` doesn't trigger release jobs).

## Why

The Perfmatters performance study showed render-blocking JS is the dominant native performance gap: without Perfmatters, ~1080 KB of JS blocks first paint, and only ~60 KB defers. The single biggest cause: `newspack_commons` had no strategy, so WP silently downgraded the four RAS scripts that already declare `defer` back to blocking (core downgrades a dependent when its dependency lacks a compatible strategy). This PR defers commons (front-end only) and the rest of the audited set.

## Measured impact (isolated env, gzip wire bytes, deterministic server-side harness)

Render-blocking JS, homepage (article & donate pages within ±4 KB). Re-measured after review feedback, so these numbers reflect the branch as it stands:

|  | Perfmatters ON (Newspack defaults) | Perfmatters OFF (native) |
|---|---|---|
| **Before** (main @ 6ebb8c4) | 231.3 KB / 9 scripts | **1079.5 KB / 23 scripts** |
| **After** (this branch) | **231.3 KB / 9** — byte-parity, no regression | **257.2 KB / 14** |

- **Native render-blocking JS: −822.3 KB (−76%)**; 873 KB now defers without Perfmatters (vs 60 KB before).
- Native defer closes **97% of the gap** to Perfmatters' result. The remaining ~26 KB is the WP-core vendor bundle (out of scope) plus the Campaigns view script, which is deliberately left blocking (see below).
- With Perfmatters active, output is byte-identical — its defer and ours are idempotent.

Total render-blocking payload (JS + CSS), homepage: **1470.8 KB → 647.0 KB** without Perfmatters.

Two review-driven changes moved these numbers in opposite directions, and both are wanted:

- The Campaigns view script went back to blocking (+2.4 KB, +1 script) so above-header prompts keep revealing immediately (NPPM-2934).
- Media kit styles and script no longer load on every page, which is where part of the CSS reduction comes from.

## What changed, per unit

| Unit | Handles | Mechanism |
|---|---|---|
| newspack-plugin | 10 + `newspack_commons` & `newspack-ui` | array-args `strategy`; commons/ui deferred via `wp_script_add_data` **gated `! is_admin()`** (both also load in admin/editor, which stays byte-identical) |
| newspack-blocks | 6 view handles | optional `$strategy` param on shared `enqueue_view_assets()` (incl. the caching-class fan-out); donate/modal callers pass nothing |
| newspack-theme | 4 | bool→array 5th-arg conversion |
| newspack-block-theme | 1 (`newspack-main`) | bool→array |
| newspack-popups | none — see review response below | `view.js` defer reverted; `criteria.js` defer predates this branch |
| newspack-ads | 2 (+ comment on `prebid`, whose tag a `script_loader_tag` filter rebuilds — strategy would be dead code) | array-args; media kit assets moved to the tabs block render path |
| newspack-listings | 1 | array-args |
| republication-tracker-tool | 4 (6 call sites) | array-args, `in_footer` values preserved |

**Deliberately untouched:** all already-`async` handles (donate ×3, modal ×2, reCAPTCHA, content-gate frontend, newsletters subscribe — async is already non-render-blocking; flipping to defer changes ordering semantics for zero gain); WP core handles; the AMP CDN scripts; `class-patches.php` (its legacy async/defer data keys are disjoint from the native `strategy` key — verified no handle carries both).

## Verification

- **Per-unit task reviews** (spec + quality) all clean; **final whole-branch review: READY**, 0 critical/important.
- **Browser QA** (isolated env, anonymous, Perfmatters off — the native path this PR owns): homepage (Homepage Posts hydration, menus, font-loading), single article (content gate renders, **RAS sign-in modal opens** — exercising the newly-effective commons → reader-activation → reader-auth → newspack-ui defer chain), donate page (block interactive, frequency switching; donate/modal still async), my-account (all account scripts defer, sign-in UI works). **0 console errors** on every page.
- **Admin/editor unchanged**: verified via strategy-data inspection under `set_current_screen('dashboard')` → no strategy set in admin contexts.
- PHPCS + `php -l` clean on every changed file.

## Review notes (from the final whole-branch review)

Three minor, non-blocking notes logged for triage:
1. `class-my-account.php` — on the *native* (non-WooCommerce) My Account page, `newspack-ui`'s pre-existing `after`-position inline script made WP core keep it blocking. Since fixed on this branch: the inline moved to `before`.
2. `republication-tracker-tool/includes/class-widget.php` — `in_footer => false` faithfully preserves the original positional arg, intentionally diverging from the unit's other call sites.
3. `newspack-blocks` `wp_script_add_data` path bypasses `wp_register_script`'s strategy-value validation; harmless (docblock constrains callers), noted for awareness.

Also: `newspack-block-theme`'s `newspack-main` was verified via strategy-data inspection rather than a rendered FSE page (env runs newspack-theme); worth a one-page spot check in a block-theme env if one is handy.

## Self-review fixes (post-open, `/code-review` pass)

A high-effort multi-angle self-review (8 finder angles + per-candidate verification against WP core source) produced 4 confirmed findings, all fixed on the branch:

1. **`fix(newspack-ads)`** — `class-media-kit.php` used `strpos( ... ) >= 0` for both content gates; `false >= 0` is `true` in PHP, so **media-kit CSS + JS enqueued on every front-end page sitewide** (pre-existing platform bug surfaced by the review; rolled into this PR because removing sitewide asset load directly serves its goal). Now `false !== strpos( ... )` — verified the homepage no longer loads media-kit assets and a real media-kit page still does.
2. **checkout-button defer extended to content-gate CTAs** — the metering-countdown and content-gifting CTAs render their own markup (the block's `view.php` never runs), so they enqueued `newspack-blocks-checkout-button` without the strategy on exactly the paywall pages this PR targets. Both call sites now pass `'defer'`.
3. **My Account `newspack-ui` defer was dead code** — the same method attaches an inline script in WP's default `'after'` position, and core's `filter_eligible_strategies()` force-downgrades such handles to blocking. The inline script (a DOMContentLoaded-listener registration, safe either side) now passes `'before'`, making the defer effective; verified via a live counterfactual (`'after'` → no defer attr, `'before'` → defer survives).
4. **Dead `is_admin()` guard removed** in the same method — it's hooked only on `wp_enqueue_scripts`, which never fires in admin, so the guard (a copy-paste from the two genuinely mixed-context call sites) was an always-true branch with a misleading comment.

One review candidate was closed as no-change: the deprecated video-playlist block turns out to ship **no view.js at all** (its `enqueue_view_assets` call no-ops on `file_exists`), so nothing is over-enqueued and there is nothing to defer.

Re-measured after fixes: render-blocking JS unchanged (media-kit JS was already deferred by this PR); the media-kit fix additionally removes its CSS + ~10 KB of deferred JS from every non-media-kit page. Perfmatters-ON parity still holds.

## Review response (@miguelpeixe)

Six threads, all addressed. Five are resolved; the defer-as-default suggestion stays open for your take.

- **Campaigns view script (blocking):** reverted in 367c5d676. #449 excludes this script from defer only when above-header prompts are published, and the native strategy here applied unconditionally, so it would have overridden that. The same reveal-path context is available to the enqueue if we want a conditional native strategy later.
- **Media kit:** e5248f922 and a403c8441 add the `is_singular()` early return and move both the script and the stylesheet to `Tabs_Block::render_tab_navigation()`. Moving only the script would have left a block nested in a synced pattern unstyled, since the content sniff also backed the CSS. Sniffing still covers `media-kit-page__wrapper`, which styles the page shell rather than the block.
- **`defer` as the default with per-caller opt-out:** left as opt-in. `newspack-blocks-donate` stays `async`, and the generic `manage_view_scripts()` fallback registers a callback for any future block with a `view.js` and no `view.php` — a default would apply a strategy to scripts before anyone has audited them. Worth revisiting once the remaining view scripts are audited.
- **Shared-handle strategy:** 40bc17ee0 makes the guard first-write-wins, which also skips the repeat work when a block renders more than once per page.
- **`newspack-ui` double-set:** removed in f8c4749f4. The inline script position change stays, since an `after`-position inline makes core drop the strategy entirely.
- **Widget cache-buster:** 3621fe21c versions both widget registrations with `REPUBLICATION_TRACKER_TOOL_VERSION`.

## How to test

1. Isolated env with the branch, Perfmatters **deactivated**, anonymous window.
2. View source on the homepage: first-party `newspack-*` scripts (commons, reader-activation, newspack-ui, popups view/criteria, theme scripts, blocks view scripts) carry `defer data-wp-strategy="defer"`; donate/modal scripts still carry `async`.
3. Click **Sign In** → RAS modal opens. Load an article → prompts/gate render. Donate page → frequency/amount switching works. `/my-account/` → sign-in UI renders. Console: no errors.
4. Reactivate Perfmatters → pages render identically (its defer wraps the same handles).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

