### PR TITLE
fix(theme): keep tag labels clear of cat-links styling (NPPM-3048)

### DIFF
--- a/themes/newspack-theme/newspack-theme/inc/newspack-tag-labels.php
+++ b/themes/newspack-theme/newspack-theme/inc/newspack-tag-labels.php
@@ -54,8 +54,12 @@ if ( ! function_exists( 'newspack_display_tag_labels' ) ) :
 	 * @return null
 	 */
 	function newspack_display_tag_labels( $labels = null, $links = true ) {
-		if ( class_exists( '\Newspack\Tag_Labels' ) && method_exists( '\Newspack\Tag_Labels', 'display' ) ) {
-			\Newspack\Tag_Labels::display( $labels, $links, 'span' );
+		if ( class_exists( '\Newspack\Tag_Labels' ) && method_exists( '\Newspack\Tag_Labels', 'generate_html' ) ) {
+			// Render WITHOUT the `cat-links` wrapper class: per-category `.cat-links a`
+			// styling (a common per-section pattern on publisher sites) must never
+			// restyle tag labels (NPPM-3048). Layout parity lives in
+			// sass/plugins/newspack-tag-labels.scss.
+			echo wp_kses_post( \Newspack\Tag_Labels::generate_html( $labels, $links, array( 'tag-labels' ), array( 'tag-label', 'flag' ), 'span' ) . ' ' );
 		}
 
 		return null;

--- a/themes/newspack-theme/newspack-theme/inc/newspack-tag-labels.php
+++ b/themes/newspack-theme/newspack-theme/inc/newspack-tag-labels.php
@@ -59,7 +59,10 @@ if ( ! function_exists( 'newspack_display_tag_labels' ) ) :
 			// styling (a common per-section pattern on publisher sites) must never
 			// restyle tag labels (NPPM-3048). Layout parity lives in
 			// sass/plugins/newspack-tag-labels.scss.
-			echo wp_kses_post( \Newspack\Tag_Labels::generate_html( $labels, $links, array( 'tag-labels' ), array( 'tag-label', 'flag' ), 'span' ) . ' ' );
+			$labels_html = \Newspack\Tag_Labels::generate_html( $labels, $links, array( 'tag-labels' ), array( 'tag-label', 'flag' ), 'span' );
+			if ( '' !== $labels_html ) {
+				echo wp_kses_post( $labels_html . ' ' );
+			}
 		}
 
 		return null;

--- a/themes/newspack-theme/newspack-theme/inc/typography.php
+++ b/themes/newspack-theme/newspack-theme/inc/typography.php
@@ -48,6 +48,7 @@ function newspack_custom_typography_css() {
 		$css_blocks .= '
 			.tags-links span:first-child,
 			.cat-links,
+			.tag-labels,
 			.page-title,
 			.highlight-menu .menu-label {
 				text-transform: uppercase;

--- a/themes/newspack-theme/newspack-theme/sass/plugins/newspack-tag-labels.scss
+++ b/themes/newspack-theme/newspack-theme/sass/plugins/newspack-tag-labels.scss
@@ -7,6 +7,10 @@
 .tag-labels {
 	align-items: stretch;
 	display: inline-flex;
+	// Parity with the base `.cat-links` rule the wrapper matched before
+	// NPPM-3048 (labels sized and spaced like the adjacent category chips).
+	font-size: var(--newspack-theme-font-size-xs);
+	margin: 0 0 #{0.75 * structure.$size__spacing-unit};
 	position: relative;
 
 	a,
@@ -23,7 +27,7 @@
 	a,
 	.tag-label {
 		display: inline-block;
-		margin: 0 0.25rem 0.25rem 0;
+		margin: 0 #{0.25 * structure.$size__spacing-unit} #{0.25 * structure.$size__spacing-unit} 0;
 	}
 }
 
@@ -32,7 +36,6 @@
 .search .tag-labels a {
 	font-size: 0.65rem;
 	margin-bottom: 0;
-	padding: 0.25em 0.5em;
 }
 
 /* stylelint-disable selector-type-no-unknown  */

--- a/themes/newspack-theme/newspack-theme/sass/plugins/newspack-tag-labels.scss
+++ b/themes/newspack-theme/newspack-theme/sass/plugins/newspack-tag-labels.scss
@@ -17,6 +17,22 @@
 	a:hover {
 		opacity: 0.8;
 	}
+
+	// Layout parity with `.cat-links a` — tag labels no longer carry the
+	// `cat-links` class (NPPM-3048), so the chip layout is declared here.
+	a,
+	.tag-label {
+		display: inline-block;
+		margin: 0 0.25rem 0.25rem 0;
+	}
+}
+
+.archive .tag-labels a,
+.blog .tag-labels a,
+.search .tag-labels a {
+	font-size: 0.65rem;
+	margin-bottom: 0;
+	padding: 0.25em 0.5em;
 }
 
 /* stylelint-disable selector-type-no-unknown  */
@@ -51,7 +67,8 @@ amp-script .tag-labels {
 
 	// Workaround margin/padding override for featured images.
 	.featured-image-behind {
-		.cat-links.tag-labels {
+		// Selector updated with the markup: labels no longer carry `cat-links` (NPPM-3048).
+		.tag-labels {
 			a,
 			a:hover {
 				padding: 0.3em 0.5em;

--- a/themes/newspack-theme/newspack-theme/sass/typography/_headings.scss
+++ b/themes/newspack-theme/newspack-theme/sass/typography/_headings.scss
@@ -9,6 +9,7 @@
 .discussion-meta-info,
 .entry-meta,
 .cat-links,
+.tag-labels,
 .entry-footer,
 .author-bio .author-link,
 .author-meta,
@@ -62,7 +63,8 @@ h6 {
 }
 
 /* stylelint-disable selector-type-no-unknown  */
-amp-script .cat-links {
+amp-script .cat-links,
+amp-script .tag-labels {
 	font-family: var(--newspack-theme-font-heading);
 }
 /* stylelint-enable */

--- a/themes/newspack-theme/newspack-theme/sass/typography/_headings.scss
+++ b/themes/newspack-theme/newspack-theme/sass/typography/_headings.scss
@@ -76,6 +76,7 @@ amp-script .tag-labels {
 .wp-block-query-pagination,
 .comments-title,
 .cat-links,
+.tag-labels,
 .comment-author .fn,
 .no-comments,
 .site-title,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)? *(phpcs, root ruleset, and stylelint are clean)*
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change? *(#736 is the block-side counterpart and should merge after this PR)*

### Changes proposed in this Pull Request:

**Problem.** The Tag Labels customizer color (Appearance → Customize → Tag Labels) applies in some template contexts but not others. On the reporting publisher's staging site, a single page showed labels in three different colors: the chosen customizer color plus two per-section category colors.

**Root cause.** Theme-rendered tag labels shared their wrapper class with category links (`tag-labels cat-links`). Publisher CSS that styles category chips per section — e.g. `.category-communities .entry-header .cat-links a { background: … }` — matches the tag-label anchor at higher specificity than the customizer-emitted rule (`.tag-labels .tag-label.flag`, 0-3-0), so the category color wins wherever such rules exist. Block contexts were unaffected only because `.wpnbha` resets `cat-links` backgrounds.

**Fix.** Scope theme-rendered label markup to `.tag-labels` only:

- The theme shim now renders via `Tag_Labels::generate_html()` without the `cat-links` outer class (with an empty-label guard), instead of `Tag_Labels::display()`.
- The tag-labels stylesheet declares the chip layout the class pairing used to provide: display and margins, `font-size-xs`, wrapper bottom margin, archive sizing.
- `.tag-labels` joins the heading-font and accent-allcaps selector lists for typography parity.
- The one compound selector referencing `.cat-links.tag-labels` is updated.

After this, CSS written against category chips simply doesn't apply to tag labels, so the fix doesn't depend on winning a specificity race.

**Evidence.** I reproduced the bug in an isolated env by injecting a per-section rule mirroring the publisher's CSS: a label on the tag archive computed the category color, the same symptom as staging. With the fix, every label across single, archive, and homepage contexts computes the customizer color, and real category chips keep their publisher styling.

Fixes NPPM-3048.

### How to test the changes in this Pull Request:

1. Set a Tag Labels color in the customizer (Appearance → Customize → Tag Labels) on a site using newspack-theme, with at least one labeled tag assigned to posts.
2. Inject a hostile per-section rule mirroring publisher CSS, e.g. `.category-<slug> .entry-header .cat-links a { background: …; }`.
3. Verify every rendered label computes the customizer color in all three contexts — single, archive, and homepage — while real category chips keep the injected per-section styling. (A scripted browser check covering exactly this passes in all three contexts.)
4. Compare computed layout against the adjacent category chip: font family and size, padding, and margins all match the pre-change values.
5. Confirm phpcs (root ruleset) and stylelint are clean.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? *(no unit tests — verification is the scripted browser check above; the block-side counterpart #736 adds the unit-level contract tests)*
* [x] Have you successfully run tests with your changes locally?

Notes for reviewers:

- **Release-note callout needed:** publisher CSS targeting `.tag-labels.cat-links` (or styling labels via `.cat-links`) silently stops matching; it should re-target `.tag-labels`.
- **Follow-up:** block-rendered labels (`Newspack_Blocks::display_tag_labels()` → `Tag_Labels::display()`) and the block editor preview still emit `cat-links`; the same treatment lands plugin/blocks-side in #736 (NPPM-3049).
- The issue's secondary label-offset complaint is positioning, not color, and is left for a design decision.
- Style variations intentionally stop applying category-chip flourishes (fonts, `::before` markers) to labels; a quick visual pass per variation is suggested.
