### PR TITLE
fix(campaigns): Contextual Prompt panel refinements

### DIFF
--- a/plugins/newspack-popups/src/blocks/contextual-prompt/candidates.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/candidates.js
@@ -32,19 +32,26 @@ export const FRAMING_LABELS = {
 
 /**
  * The framing implied by a block's position among the article's top-level
- * blocks, with a small buffer: a prompt sitting two paragraphs in still reads
- * as a top-of-story ask, and likewise near the end.
+ * blocks, as a coarse ratio-based bucket: top / mid / end.
+ *
+ * Mirrors get_placement() in class-newspack-popups-contextual-prompt-block.php,
+ * which computes the server-side analytics placement. Keep the two in sync: if
+ * they diverge, the generated copy is framed for a different position than the
+ * one analytics reports.
  *
  * @param {number} index Block index.
  * @param {number} total Top-level block count.
  * @return {string} One of 'top' | 'mid' | 'end'.
  */
 export const framingForPosition = ( index, total ) => {
-	const FRAMING_BUFFER = 3;
-	if ( index < FRAMING_BUFFER ) {
+	if ( total <= 1 ) {
 		return 'top';
 	}
-	if ( index >= total - FRAMING_BUFFER ) {
+	const ratio = index / ( total - 1 );
+	if ( ratio <= 1 / 3 ) {
+		return 'top';
+	}
+	if ( ratio >= 2 / 3 ) {
 		return 'end';
 	}
 	return 'mid';

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/candidates.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/candidates.js
@@ -31,6 +31,26 @@ export const FRAMING_LABELS = {
 };
 
 /**
+ * The framing implied by a block's position among the article's top-level
+ * blocks, with a small buffer: a prompt sitting two paragraphs in still reads
+ * as a top-of-story ask, and likewise near the end.
+ *
+ * @param {number} index Block index.
+ * @param {number} total Top-level block count.
+ * @return {string} One of 'top' | 'mid' | 'end'.
+ */
+export const framingForPosition = ( index, total ) => {
+	const FRAMING_BUFFER = 3;
+	if ( index < FRAMING_BUFFER ) {
+		return 'top';
+	}
+	if ( index >= total - FRAMING_BUFFER ) {
+		return 'end';
+	}
+	return 'mid';
+};
+
+/**
  * Request donation prompt candidates for a post.
  *
  * @param {Object} args           Request arguments.

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/candidates.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/candidates.js
@@ -1,0 +1,71 @@
+/**
+ * Shared Contextual Prompt generation UI.
+ *
+ * Single source of truth for everything the block's Copy panel and the
+ * document-settings panel both need: the post-type label, framing labels, the
+ * generation request, and the generate-button / candidate-list presentation.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __, sprintf } from '@wordpress/i18n';
+import apiFetch from '@wordpress/api-fetch';
+import { Button } from '@wordpress/components';
+
+// The block editor and the document-settings panel are separate entries with
+// separate localized objects; either may be the one present.
+export const POST_TYPE_LABEL =
+	window.newspack_popups_blocks_data?.post_type_label || window.newspackPopupsContextualPrompt?.postTypeLabel || __( 'post', 'newspack-popups' );
+
+export const FRAMING_LABELS = {
+	/* translators: %s: the edited content's post type label, e.g. "post", "page". */
+	top: sprintf( __( 'Top of %s', 'newspack-popups' ), POST_TYPE_LABEL ),
+	/* translators: %s: the edited content's post type label, e.g. "post", "page". */
+	mid: sprintf( __( 'Mid-%s', 'newspack-popups' ), POST_TYPE_LABEL ),
+	/* translators: %s: the edited content's post type label, e.g. "post", "page". */
+	end: sprintf( __( 'End of %s', 'newspack-popups' ), POST_TYPE_LABEL ),
+};
+
+/**
+ * Request donation prompt candidates for a post.
+ *
+ * @param {Object} args           Request arguments.
+ * @param {number} args.postId    The post being edited.
+ * @param {string} args.content   The edited post content.
+ * @param {string} [args.framing] Optional framing; when set, candidates are variants of it.
+ * @return {Promise<Array>} The candidate list (possibly empty).
+ */
+export const generateCandidates = async ( { postId, content, framing } ) => {
+	const response = await apiFetch( {
+		path: '/wp/v2/newspack-editorial-assistant/generate/donation',
+		method: 'POST',
+		data: { post_id: postId, content, ...( framing ? { framing } : {} ) },
+	} );
+	const payload = response && response.data ? response.data : response;
+	return payload?.candidates || [];
+};
+
+export const GenerateButton = ( { busy, onClick, children } ) => (
+	<Button
+		variant="secondary"
+		onClick={ onClick }
+		disabled={ busy }
+		isBusy={ busy }
+		__next40pxDefaultSize
+		style={ { width: '100%', justifyContent: 'center' } }
+	>
+		{ busy ? __( 'Generating…', 'newspack-popups' ) : children }
+	</Button>
+);
+
+export const CandidateList = ( { candidates, onApply } ) =>
+	candidates.map( ( candidate, index ) => (
+		<div key={ index } style={ { marginTop: '16px' } }>
+			<strong>{ FRAMING_LABELS[ candidate.framing ] || candidate.framing }</strong>
+			<p style={ { margin: '4px 0 8px' } }>{ candidate.body }</p>
+			<Button variant="primary" size="small" onClick={ () => onApply( candidate ) }>
+				{ __( 'Apply', 'newspack-popups' ) }
+			</Button>
+		</div>
+	) );

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/candidates.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/candidates.js
@@ -18,13 +18,16 @@ import { Button } from '@wordpress/components';
 export const POST_TYPE_LABEL =
 	window.newspack_popups_blocks_data?.post_type_label || window.newspackPopupsContextualPrompt?.postTypeLabel || __( 'post', 'newspack-popups' );
 
+// Title Case variant for the framing headings.
+const POST_TYPE_HEADING = POST_TYPE_LABEL.charAt( 0 ).toUpperCase() + POST_TYPE_LABEL.slice( 1 );
+
 export const FRAMING_LABELS = {
-	/* translators: %s: the edited content's post type label, e.g. "post", "page". */
-	top: sprintf( __( 'Top of %s', 'newspack-popups' ), POST_TYPE_LABEL ),
-	/* translators: %s: the edited content's post type label, e.g. "post", "page". */
-	mid: sprintf( __( 'Mid-%s', 'newspack-popups' ), POST_TYPE_LABEL ),
-	/* translators: %s: the edited content's post type label, e.g. "post", "page". */
-	end: sprintf( __( 'End of %s', 'newspack-popups' ), POST_TYPE_LABEL ),
+	/* translators: %s: the edited content's post type label, e.g. "Post", "Page". */
+	top: sprintf( __( 'Top of %s', 'newspack-popups' ), POST_TYPE_HEADING ),
+	/* translators: %s: the edited content's post type label, e.g. "Post", "Page". */
+	mid: sprintf( __( 'Mid-%s', 'newspack-popups' ), POST_TYPE_HEADING ),
+	/* translators: %s: the edited content's post type label, e.g. "Post", "Page". */
+	end: sprintf( __( 'End of %s', 'newspack-popups' ), POST_TYPE_HEADING ),
 };
 
 /**
@@ -62,6 +65,9 @@ export const GenerateButton = ( { busy, onClick, children } ) => (
 export const CandidateList = ( { candidates, onApply } ) =>
 	candidates.map( ( candidate, index ) => (
 		<div key={ index } style={ { marginTop: '16px' } }>
+			{ index > 0 && (
+				<hr style={ { margin: '0 0 16px', border: 'none', borderTop: '1px solid var(--wpds-color-stroke-surface-neutral-weak, #f0f0f0)' } } />
+			) }
 			<strong>{ FRAMING_LABELS[ candidate.framing ] || candidate.framing }</strong>
 			<p style={ { margin: '4px 0 8px' } }>{ candidate.body }</p>
 			<Button variant="primary" size="small" onClick={ () => onApply( candidate ) }>

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/candidates.test.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/candidates.test.js
@@ -1,0 +1,21 @@
+import { framingForPosition } from './candidates';
+
+describe( 'framingForPosition', () => {
+	// Boundary cases mirroring get_placement() in
+	// class-newspack-popups-contextual-prompt-block.php: the two must agree.
+	it.each( [
+		[ 0, 1, 'top' ],
+		[ 0, 4, 'top' ],
+		[ 1, 4, 'top' ], // ratio exactly 1/3.
+		[ 2, 4, 'end' ], // ratio exactly 2/3.
+		[ 3, 4, 'end' ],
+		[ 2, 6, 'mid' ],
+		[ 0, 10, 'top' ],
+		[ 3, 10, 'top' ], // 3/9 = 1/3.
+		[ 4, 10, 'mid' ],
+		[ 6, 10, 'end' ], // 6/9 = 2/3.
+		[ 9, 10, 'end' ],
+	] )( 'index %i of %i → %s', ( index, total, expected ) => {
+		expect( framingForPosition( index, total ) ).toEqual( expected );
+	} );
+} );

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/edit.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/edit.js
@@ -168,7 +168,7 @@ export const ContextualPromptEditor = ( { clientId } ) => {
 						) }
 					</p>
 					<GenerateButton busy={ generating } onClick={ regenerate }>
-						{ __( 'Regenerate suggestions', 'newspack-popups' ) }
+						{ __( 'Regenerate Suggestions', 'newspack-popups' ) }
 					</GenerateButton>
 					<CandidateList candidates={ candidates } onApply={ apply } />
 				</PanelBody>

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/edit.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/edit.js
@@ -24,7 +24,7 @@ import { PanelBody } from '@wordpress/components';
 /**
  * Internal dependencies.
  */
-import { POST_TYPE_LABEL, FRAMING_LABELS, generateCandidates, GenerateButton, CandidateList } from './candidates';
+import { POST_TYPE_LABEL, FRAMING_LABELS, framingForPosition, generateCandidates, GenerateButton, CandidateList } from './candidates';
 
 // The CTA follows the site's reader-revenue setup: the donate block when
 // Newspack donations are native, a plain button otherwise. The button defaults
@@ -65,23 +65,11 @@ export const ContextualPromptEditor = ( { clientId } ) => {
 			const blockEditor = select( blockEditorStore );
 			const copyId = blockEditor.getClientIdsOfDescendants( clientId ).find( id => 'core/paragraph' === blockEditor.getBlockName( id ) );
 			const content = copyId ? blockEditor.getBlockAttributes( copyId ).content : undefined;
-			// The framing follows the block's actual position in the story, with a
-			// small buffer: a prompt sitting two paragraphs in still reads as a
-			// top-of-story ask, and likewise near the end.
-			const FRAMING_BUFFER = 3;
-			const index = blockEditor.getBlockIndex( clientId );
-			const total = blockEditor.getBlockCount();
-			let position = 'mid';
-			if ( index < FRAMING_BUFFER ) {
-				position = 'top';
-			} else if ( index >= total - FRAMING_BUFFER ) {
-				position = 'end';
-			}
 			return {
 				postId: select( 'core/editor' ).getCurrentPostId(),
 				copyClientId: copyId,
 				copyIsEmpty: ! content || ! content.toString().trim(),
-				framing: position,
+				framing: framingForPosition( blockEditor.getBlockIndex( clientId ), blockEditor.getBlockCount() ),
 			};
 		},
 		[ clientId ]

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/edit.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/edit.js
@@ -15,23 +15,16 @@
  * WordPress dependencies.
  */
 import { __, sprintf } from '@wordpress/i18n';
-import apiFetch from '@wordpress/api-fetch';
 import { useEffect, useRef, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { InspectorControls, useBlockProps, useInnerBlocksProps, store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock, createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
-import { Button, PanelBody } from '@wordpress/components';
+import { PanelBody } from '@wordpress/components';
 
-const POST_TYPE_LABEL = window.newspack_popups_blocks_data?.post_type_label || __( 'post', 'newspack-popups' );
-
-const FRAMING_LABELS = {
-	/* translators: %s: the edited content's post type label, e.g. "post", "page". */
-	top: sprintf( __( 'Top of %s', 'newspack-popups' ), POST_TYPE_LABEL ),
-	/* translators: %s: the edited content's post type label, e.g. "post", "page". */
-	mid: sprintf( __( 'Mid-%s', 'newspack-popups' ), POST_TYPE_LABEL ),
-	/* translators: %s: the edited content's post type label, e.g. "post", "page". */
-	end: sprintf( __( 'End of %s', 'newspack-popups' ), POST_TYPE_LABEL ),
-};
+/**
+ * Internal dependencies.
+ */
+import { POST_TYPE_LABEL, FRAMING_LABELS, generateCandidates, GenerateButton, CandidateList } from './candidates';
 
 // The CTA follows the site's reader-revenue setup: the donate block when
 // Newspack donations are native, a plain button otherwise. The button defaults
@@ -127,13 +120,11 @@ export const ContextualPromptEditor = ( { clientId } ) => {
 	const fetchCandidates = async () => {
 		setGenerating( true );
 		try {
-			const response = await apiFetch( {
-				path: '/wp/v2/newspack-editorial-assistant/generate/donation',
-				method: 'POST',
-				data: { post_id: postId, content: wp.data.select( 'core/editor' ).getEditedPostContent(), framing },
+			return await generateCandidates( {
+				postId,
+				content: wp.data.select( 'core/editor' ).getEditedPostContent(),
+				framing,
 			} );
-			const payload = response && response.data ? response.data : response;
-			return payload?.candidates || [];
 		} finally {
 			setGenerating( false );
 		}
@@ -176,25 +167,10 @@ export const ContextualPromptEditor = ( { clientId } ) => {
 							FRAMING_LABELS[ framing ].toLowerCase()
 						) }
 					</p>
-					<Button
-						variant="secondary"
-						onClick={ regenerate }
-						disabled={ generating }
-						isBusy={ generating }
-						__next40pxDefaultSize
-						style={ { width: '100%', justifyContent: 'center' } }
-					>
-						{ generating ? __( 'Generating…', 'newspack-popups' ) : __( 'Regenerate suggestions', 'newspack-popups' ) }
-					</Button>
-					{ candidates.map( ( candidate, index ) => (
-						<div key={ index } style={ { marginTop: '16px' } }>
-							<strong>{ FRAMING_LABELS[ candidate.framing ] || candidate.framing }</strong>
-							<p style={ { margin: '4px 0 8px' } }>{ candidate.body }</p>
-							<Button variant="primary" size="small" onClick={ () => apply( candidate ) }>
-								{ __( 'Apply', 'newspack-popups' ) }
-							</Button>
-						</div>
-					) ) }
+					<GenerateButton busy={ generating } onClick={ regenerate }>
+						{ __( 'Regenerate suggestions', 'newspack-popups' ) }
+					</GenerateButton>
+					<CandidateList candidates={ candidates } onApply={ apply } />
 				</PanelBody>
 			</InspectorControls>
 			<div { ...innerBlocksProps } />

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/edit.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/edit.js
@@ -105,6 +105,19 @@ export const ContextualPromptEditor = ( { clientId } ) => {
 	const [ candidates, setCandidates ] = useState( [] );
 	const autoRan = useRef( false );
 
+	// The block can be moved after a request is in flight; a request framed for
+	// the old position must not overwrite the current one's candidates.
+	const framingRef = useRef( framing );
+	useEffect( () => {
+		framingRef.current = framing;
+	} );
+
+	// Candidates are framed for a specific position, so a move to a different
+	// bucket invalidates any already listed.
+	useEffect( () => {
+		setCandidates( [] );
+	}, [ framing ] );
+
 	const fetchCandidates = async () => {
 		setGenerating( true );
 		try {
@@ -125,7 +138,17 @@ export const ContextualPromptEditor = ( { clientId } ) => {
 		setCandidates( [] );
 	};
 
-	const regenerate = () => fetchCandidates().then( setCandidates );
+	const regenerate = () => {
+		const requestedFraming = framing;
+		return fetchCandidates().then( list => {
+			// The block moved to a different framing bucket while the request was
+			// in flight — the response is for a stale position, so drop it.
+			if ( ( framingRef.current || undefined ) !== ( requestedFraming || undefined ) ) {
+				return;
+			}
+			setCandidates( list );
+		} );
+	};
 
 	// A fresh prompt generates its own copy — inserting the block should never
 	// leave the editor with an empty placeholder to fill by hand.

--- a/plugins/newspack-popups/src/document-settings/contextual-prompt-panel.js
+++ b/plugins/newspack-popups/src/document-settings/contextual-prompt-panel.js
@@ -24,7 +24,7 @@ import {
  * Internal dependencies
  */
 import { createPromptBlock } from '../blocks/contextual-prompt/edit';
-import { POST_TYPE_LABEL, generateCandidates, GenerateButton, CandidateList } from '../blocks/contextual-prompt/candidates';
+import { POST_TYPE_LABEL, framingForPosition, generateCandidates, GenerateButton, CandidateList } from '../blocks/contextual-prompt/candidates';
 
 const BLOCK_NAME = 'newspack-popups/contextual-prompt';
 
@@ -43,15 +43,19 @@ const findCopyBlock = blocks => {
 };
 
 const ContextualPromptPanel = () => {
-	const { postId, postType, content, blockCount, instance } = useSelect( select => {
+	const { postId, postType, content, blockCount, instance, instanceFraming } = useSelect( select => {
 		const editor = select( 'core/editor' );
 		const blocks = select( 'core/block-editor' ).getBlocks() || [];
+		const instanceIndex = blocks.findIndex( block => BLOCK_NAME === block.name );
 		return {
 			postId: editor.getCurrentPostId(),
 			postType: editor.getCurrentPostType(),
 			content: editor.getEditedPostContent(),
 			blockCount: blocks.length,
-			instance: blocks.find( block => BLOCK_NAME === block.name ) || null,
+			instance: -1 === instanceIndex ? null : blocks[ instanceIndex ],
+			// Once the prompt is placed, its position decides the framing — the
+			// top/mid/end choice is only on offer before the first insert.
+			instanceFraming: -1 === instanceIndex ? null : framingForPosition( instanceIndex, blocks.length ),
 		};
 	}, [] );
 
@@ -73,7 +77,7 @@ const ContextualPromptPanel = () => {
 		setGenerating( true );
 		setError( '' );
 		try {
-			const list = await generateCandidates( { postId, content } );
+			const list = await generateCandidates( { postId, content, framing: instanceFraming || undefined } );
 			setCandidates( list );
 			if ( ! list.length ) {
 				setError( __( 'No suggestions were returned. Try generating again.', 'newspack-popups' ) );

--- a/plugins/newspack-popups/src/document-settings/contextual-prompt-panel.js
+++ b/plugins/newspack-popups/src/document-settings/contextual-prompt-panel.js
@@ -4,7 +4,8 @@
  * The prompt is a block living in the post content, so the canvas is the source
  * of truth: copy is edited inline, position is the block's position, and the
  * design comes from block supports. The panel's only jobs are AI generation and
- * managing that one block.
+ * managing that one block. Generation and candidate presentation are shared
+ * with the block's Copy panel (see the block's candidates module).
  */
 
 /**
@@ -17,16 +18,15 @@ import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import {
 	Button,
 	Notice,
-	Spinner,
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import apiFetch from '@wordpress/api-fetch';
 
 /**
  * Internal dependencies
  */
 import { createPromptBlock } from '../blocks/contextual-prompt/edit';
+import { POST_TYPE_LABEL, generateCandidates, GenerateButton, CandidateList } from '../blocks/contextual-prompt/candidates';
 
 const BLOCK_NAME = 'newspack-popups/contextual-prompt';
 
@@ -42,17 +42,6 @@ const findCopyBlock = blocks => {
 		}
 	}
 	return null;
-};
-
-const POST_TYPE_LABEL = window.newspackPopupsContextualPrompt?.postTypeLabel || __( 'post', 'newspack-popups' );
-
-const FRAMING_LABELS = {
-	/* translators: %s: the edited content's post type label, e.g. "post", "page". */
-	top: sprintf( __( 'Top of %s', 'newspack-popups' ), POST_TYPE_LABEL ),
-	/* translators: %s: the edited content's post type label, e.g. "post", "page". */
-	mid: sprintf( __( 'Mid-%s', 'newspack-popups' ), POST_TYPE_LABEL ),
-	/* translators: %s: the edited content's post type label, e.g. "post", "page". */
-	end: sprintf( __( 'End of %s', 'newspack-popups' ), POST_TYPE_LABEL ),
 };
 
 const ContextualPromptPanel = () => {
@@ -86,13 +75,7 @@ const ContextualPromptPanel = () => {
 		setGenerating( true );
 		setError( '' );
 		try {
-			const response = await apiFetch( {
-				path: '/wp/v2/newspack-editorial-assistant/generate/donation',
-				method: 'POST',
-				data: { post_id: postId, content },
-			} );
-			const payload = response && response.data ? response.data : response;
-			const list = ( payload && payload.candidates ) || [];
+			const list = await generateCandidates( { postId, content } );
 			setCandidates( list );
 			if ( ! list.length ) {
 				setError( __( 'No suggestions were returned. Try generating again.', 'newspack-popups' ) );
@@ -151,10 +134,10 @@ const ContextualPromptPanel = () => {
 							) }
 						</p>
 						<HStack justify="flex-start" spacing={ 2 } wrap>
-							<Button variant="secondary" onClick={ () => selectBlock( instance.clientId ) }>
+							<Button variant="secondary" __next40pxDefaultSize onClick={ () => selectBlock( instance.clientId ) }>
 								{ __( 'Select prompt', 'newspack-popups' ) }
 							</Button>
-							<Button isDestructive variant="tertiary" onClick={ () => removeBlock( instance.clientId ) }>
+							<Button isDestructive variant="tertiary" __next40pxDefaultSize onClick={ () => removeBlock( instance.clientId ) }>
 								{ __( 'Remove', 'newspack-popups' ) }
 							</Button>
 						</HStack>
@@ -169,23 +152,12 @@ const ContextualPromptPanel = () => {
 					</p>
 				) }
 
-				<Button variant="secondary" onClick={ generate } disabled={ generating }>
-					{ generating && <Spinner /> }
-					{ generating ? __( 'Generating…', 'newspack-popups' ) : generateLabel }
-				</Button>
-
-				{ candidates.map( ( candidate, index ) => (
-					<VStack key={ index } spacing={ 2 }>
-						<strong>{ FRAMING_LABELS[ candidate.framing ] || candidate.framing }</strong>
-						<p style={ { margin: 0 } }>{ candidate.body }</p>
-						<div>
-							<Button variant="secondary" onClick={ () => applyCandidate( candidate ) }>
-								{ __( 'Apply', 'newspack-popups' ) }
-							</Button>
-						</div>
-					</VStack>
-				) ) }
+				<GenerateButton busy={ generating } onClick={ generate }>
+					{ generateLabel }
+				</GenerateButton>
 			</VStack>
+
+			<CandidateList candidates={ candidates } onApply={ applyCandidate } />
 		</PluginDocumentSettingPanel>
 	);
 };

--- a/plugins/newspack-popups/src/document-settings/contextual-prompt-panel.js
+++ b/plugins/newspack-popups/src/document-settings/contextual-prompt-panel.js
@@ -12,7 +12,7 @@
  * WordPress dependencies
  */
 import { __, sprintf } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
+import { useEffect, useRef, useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import {
@@ -65,6 +65,20 @@ const ContextualPromptPanel = () => {
 	const [ generating, setGenerating ] = useState( false );
 	const [ error, setError ] = useState( '' );
 
+	// The block can be moved after a request is in flight; a request framed for
+	// the old position must not overwrite the current one's candidates.
+	const framingRef = useRef( instanceFraming );
+	useEffect( () => {
+		framingRef.current = instanceFraming;
+	} );
+
+	// Candidates are framed for a specific position, so a move to a different
+	// bucket invalidates any already listed.
+	useEffect( () => {
+		setCandidates( [] );
+		setError( '' );
+	}, [ instanceFraming ] );
+
 	const optedIn = window.newspackPopupsContextualPrompt?.enabled;
 	const isPrompt = 'newspack_popups_cpt' === postType;
 
@@ -76,8 +90,14 @@ const ContextualPromptPanel = () => {
 	const generate = async () => {
 		setGenerating( true );
 		setError( '' );
+		const requestedFraming = instanceFraming || undefined;
 		try {
-			const list = await generateCandidates( { postId, content, framing: instanceFraming || undefined } );
+			const list = await generateCandidates( { postId, content, framing: requestedFraming } );
+			// The block moved to a different framing bucket while the request was
+			// in flight — the response is for a stale position, so drop it.
+			if ( ( framingRef.current || undefined ) !== requestedFraming ) {
+				return;
+			}
 			setCandidates( list );
 			if ( ! list.length ) {
 				setError( __( 'No suggestions were returned. Try generating again.', 'newspack-popups' ) );

--- a/plugins/newspack-popups/src/document-settings/contextual-prompt-panel.js
+++ b/plugins/newspack-popups/src/document-settings/contextual-prompt-panel.js
@@ -16,9 +16,7 @@ import { useState } from '@wordpress/element';
 import { useSelect, useDispatch } from '@wordpress/data';
 import { PluginDocumentSettingPanel } from '@wordpress/edit-post';
 import {
-	Button,
 	Notice,
-	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 
@@ -57,7 +55,7 @@ const ContextualPromptPanel = () => {
 		};
 	}, [] );
 
-	const { insertBlock, removeBlock, updateBlockAttributes, selectBlock } = useDispatch( 'core/block-editor' );
+	const { insertBlock, updateBlockAttributes, selectBlock } = useDispatch( 'core/block-editor' );
 
 	const [ candidates, setCandidates ] = useState( [] );
 	const [ generating, setGenerating ] = useState( false );
@@ -113,7 +111,7 @@ const ContextualPromptPanel = () => {
 	};
 
 	const generateLabel =
-		candidates.length || instance ? __( 'Regenerate suggestions', 'newspack-popups' ) : __( 'Generate suggestions', 'newspack-popups' );
+		candidates.length || instance ? __( 'Regenerate Suggestions', 'newspack-popups' ) : __( 'Generate Suggestions', 'newspack-popups' );
 
 	return (
 		<PluginDocumentSettingPanel name="newspack-contextual-prompt" title={ __( 'Contextual Prompt', 'newspack-popups' ) }>
@@ -124,33 +122,19 @@ const ContextualPromptPanel = () => {
 					</Notice>
 				) }
 
-				{ instance ? (
-					<>
-						<p style={ { margin: 0 } }>
-							{ sprintf(
+				<p style={ { margin: 0 } }>
+					{ instance
+						? sprintf(
 								/* translators: %1$s: the edited content's post type label, e.g. "post", "page". */
 								__( 'This %1$s has a Contextual Prompt. Edit its copy directly in the %1$s.', 'newspack-popups' ),
 								POST_TYPE_LABEL
-							) }
-						</p>
-						<HStack justify="flex-start" spacing={ 2 } wrap>
-							<Button variant="secondary" __next40pxDefaultSize onClick={ () => selectBlock( instance.clientId ) }>
-								{ __( 'Select prompt', 'newspack-popups' ) }
-							</Button>
-							<Button isDestructive variant="tertiary" __next40pxDefaultSize onClick={ () => removeBlock( instance.clientId ) }>
-								{ __( 'Remove', 'newspack-popups' ) }
-							</Button>
-						</HStack>
-					</>
-				) : (
-					<p style={ { margin: 0 } }>
-						{ sprintf(
-							/* translators: %s: the edited content's post type label, e.g. "post", "page". */
-							__( 'Generate a donation prompt specific to this %s.', 'newspack-popups' ),
-							POST_TYPE_LABEL
-						) }
-					</p>
-				) }
+						  )
+						: sprintf(
+								/* translators: %s: the edited content's post type label, e.g. "post", "page". */
+								__( 'Generate a donation prompt specific to this %s.', 'newspack-popups' ),
+								POST_TYPE_LABEL
+						  ) }
+				</p>
 
 				<GenerateButton busy={ generating } onClick={ generate }>
 					{ generateLabel }


### PR DESCRIPTION
Contextual Prompt panel refinements, stacked on `feat/contextual-prompts` (#686). Follows the post-editor panel review: the panel earns its keep at generation time, and the two prompt surfaces should look and behave like one feature.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

- **Shared generation UI.** New `candidates` module next to the block owns everything the block's Copy panel and the document-settings panel both need: the post-type label (reading whichever localized object the entry ships), the framing labels, the endpoint call, the position-to-framing bucketing, and the generate-button / candidate-list presentation. Both surfaces consume it, so they render identically and cannot drift.
- **Panel polish.** Light separator between suggestions (`var(--wpds-color-stroke-surface-neutral-weak, #f0f0f0)`), Title Case for buttons and framing headings ("Top of Post", "Mid-Post", "End of Post"), and the panel is trimmed to its real job: description, Generate/Regenerate Suggestions, candidates. The Select Prompt / Remove actions are gone; once the prompt is a block in the canvas it is easy enough to select or remove there.
- **Same-framing regeneration.** The top/mid/end choice is only meaningful before the first insert, where it doubles as a position picker. Once the prompt is placed, the panel now derives the framing from the block's actual position and sends it with the request, so regeneration returns variants of that one framing, matching the block's own Copy panel. The manager endpoint's `framing` support ships in Automattic/newspack-manager#667; until that lands the endpoint returns the one-per-framing set, which the panel renders as before.

### How to test the changes in this Pull Request:

1. On an env with Contextual Prompts on (`NEWSPACK_CONTEXTUAL_PROMPTS` + Campaigns opt-in), open a post without a prompt. The Contextual Prompt panel shows the description and a full-width 40px "Generate Suggestions" button, matching the block's Copy panel.
2. Generate: three candidates appear ("Top of Post" / "Mid-Post" / "End of Post"), separated by light rules, each with a primary small Apply, and no separator above the first.
3. Apply one: the block is inserted at the position implied by the framing, and the panel now shows only the description and "Regenerate Suggestions" (no Select Prompt / Remove).
4. Regenerate: all returned candidates carry the placed block's framing (on the env, the local generator stub honors the `framing` param).
5. Select the block: its Copy panel renders the same button and candidate presentation as the panel.
6. Move the block near the top or end of the story and regenerate from either surface: the framing follows the new position.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
