### PR TITLE
fix(blocks): APCA contrast picker and derived accent-contrast color

### DIFF
--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -1387,44 +1387,80 @@ class Newspack_Blocks {
 	}
 
 	/**
-	 * Pick either white or black, whatever has sufficient contrast with the color being passed to it.
-	 * From Newspack Theme functions.
+	 * Pick either black or white text, whichever reads better on the given background.
 	 *
-	 * @param  string $hex Hexidecimal value of the color to adjust.
-	 * @return string Either black or white hexidecimal values.
+	 * Scores pure black and pure white as text against the background and returns
+	 * whichever produces the greater APCA lightness contrast (Lc); ties fall to
+	 * black. The constants are the SA98G set from apca-w3 0.1.9.
 	 *
-	 * @ref https://stackoverflow.com/questions/1331591/given-a-background-color-black-or-white-text
+	 * Keep in sync with getColorForContrast() in src/blocks/donate/utils.ts.
+	 *
+	 * @param string $hex Hexadecimal background color (#RGB or #RRGGBB, with or without #).
+	 * @return string Either 'black' or 'white' (literal CSS color keywords).
 	 */
 	public static function get_color_for_contrast( $hex ) {
-		// Hex RGB.
-		$r1 = hexdec( substr( $hex, 1, 2 ) );
-		$g1 = hexdec( substr( $hex, 3, 2 ) );
-		$b1 = hexdec( substr( $hex, 5, 2 ) );
-		// Black RGB.
-		$black_color    = '#000';
-		$r2_black_color = hexdec( substr( $black_color, 1, 2 ) );
-		$g2_black_color = hexdec( substr( $black_color, 3, 2 ) );
-		$b2_black_color = hexdec( substr( $black_color, 5, 2 ) );
-		// Calc contrast ratio.
-		$l1             = 0.2126 * pow( $r1 / 255, 2.2 ) +
-		0.7152 * pow( $g1 / 255, 2.2 ) +
-		0.0722 * pow( $b1 / 255, 2.2 );
-		$l2             = 0.2126 * pow( $r2_black_color / 255, 2.2 ) +
-		0.7152 * pow( $g2_black_color / 255, 2.2 ) +
-		0.0722 * pow( $b2_black_color / 255, 2.2 );
-		$contrast_ratio = 0;
-		if ( $l1 > $l2 ) {
-			$contrast_ratio = (int) ( ( $l1 + 0.05 ) / ( $l2 + 0.05 ) );
-		} else {
-			$contrast_ratio = (int) ( ( $l2 + 0.05 ) / ( $l1 + 0.05 ) );
+		$background_y = self::get_apca_luminance( $hex );
+		$black_lc     = self::get_apca_contrast( $background_y, self::get_apca_luminance( '#000000' ) );
+		$white_lc     = self::get_apca_contrast( $background_y, self::get_apca_luminance( '#ffffff' ) );
+
+		return abs( $white_lc ) > abs( $black_lc ) ? 'white' : 'black';
+	}
+
+	/**
+	 * Compute the soft-clamped APCA screen luminance (Y) of a hex color.
+	 *
+	 * Accepts #RGB and #RRGGBB, with or without the leading #. Unparseable input
+	 * is treated as white (luminance 1.0) so callers fall back to black text.
+	 *
+	 * @param string $hex Hexadecimal color.
+	 * @return float Soft-clamped luminance in the 0..1 range.
+	 */
+	private static function get_apca_luminance( $hex ) {
+		$hex = ltrim( (string) $hex, '#' );
+		if ( 3 === strlen( $hex ) ) {
+			$hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
 		}
-		if ( $contrast_ratio > 5 ) {
-			// If contrast is more than 5, return black color.
-			return 'black';
-		} else {
-			// if not, return white color.
-			return 'white';
+		if ( 6 !== strlen( $hex ) || ! ctype_xdigit( $hex ) ) {
+			return 1.0;
 		}
+
+		$r = hexdec( substr( $hex, 0, 2 ) ) / 255;
+		$g = hexdec( substr( $hex, 2, 2 ) ) / 255;
+		$b = hexdec( substr( $hex, 4, 2 ) ) / 255;
+
+		$y = 0.2126729 * pow( $r, 2.4 ) + 0.7151522 * pow( $g, 2.4 ) + 0.0721750 * pow( $b, 2.4 );
+
+		// APCA soft-clamp of near-black luminance.
+		if ( $y <= 0.022 ) {
+			$y += pow( 0.022 - $y, 1.414 );
+		}
+
+		return $y;
+	}
+
+	/**
+	 * Compute the APCA lightness contrast (Lc) of text on a background.
+	 *
+	 * Positive values are dark text on a lighter background; negative values are
+	 * light text on a darker background. Both luminances must already be
+	 * soft-clamped.
+	 *
+	 * @param float $background_y Soft-clamped background luminance.
+	 * @param float $text_y       Soft-clamped text luminance.
+	 * @return float The Lc value.
+	 */
+	private static function get_apca_contrast( $background_y, $text_y ) {
+		if ( abs( $background_y - $text_y ) < 0.0005 ) {
+			return 0.0;
+		}
+
+		if ( $background_y > $text_y ) {
+			$sapc = ( pow( $background_y, 0.56 ) - pow( $text_y, 0.57 ) ) * 1.14;
+			return $sapc < 0.1 ? 0.0 : ( $sapc - 0.027 ) * 100;
+		}
+
+		$sapc = ( pow( $background_y, 0.65 ) - pow( $text_y, 0.62 ) ) * 1.14;
+		return $sapc > -0.1 ? 0.0 : ( $sapc + 0.027 ) * 100;
 	}
 
 	/**

--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -1417,7 +1417,7 @@ class Newspack_Blocks {
 	 * @return float Soft-clamped luminance in the 0..1 range.
 	 */
 	private static function get_apca_luminance( $hex ) {
-		$hex = ltrim( (string) $hex, '#' );
+		$hex = ltrim( trim( (string) $hex ), '#' );
 		if ( 3 === strlen( $hex ) ) {
 			$hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
 		} elseif ( 8 === strlen( $hex ) ) {

--- a/plugins/newspack-blocks/includes/class-newspack-blocks.php
+++ b/plugins/newspack-blocks/includes/class-newspack-blocks.php
@@ -1395,7 +1395,7 @@ class Newspack_Blocks {
 	 *
 	 * Keep in sync with getColorForContrast() in src/blocks/donate/utils.ts.
 	 *
-	 * @param string $hex Hexadecimal background color (#RGB or #RRGGBB, with or without #).
+	 * @param string $hex Hexadecimal background color (#RGB, #RRGGBB or #RRGGBBAA, with or without #).
 	 * @return string Either 'black' or 'white' (literal CSS color keywords).
 	 */
 	public static function get_color_for_contrast( $hex ) {
@@ -1409,8 +1409,9 @@ class Newspack_Blocks {
 	/**
 	 * Compute the soft-clamped APCA screen luminance (Y) of a hex color.
 	 *
-	 * Accepts #RGB and #RRGGBB, with or without the leading #. Unparseable input
-	 * is treated as white (luminance 1.0) so callers fall back to black text.
+	 * Accepts #RGB, #RRGGBB and #RRGGBBAA (the alpha pair is stripped), with or
+	 * without the leading #, case-insensitively. Unparseable input is treated as
+	 * white (luminance 1.0) so callers fall back to black text.
 	 *
 	 * @param string $hex Hexadecimal color.
 	 * @return float Soft-clamped luminance in the 0..1 range.
@@ -1419,6 +1420,9 @@ class Newspack_Blocks {
 		$hex = ltrim( (string) $hex, '#' );
 		if ( 3 === strlen( $hex ) ) {
 			$hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+		} elseif ( 8 === strlen( $hex ) ) {
+			// Drop the alpha pair from #RRGGBBAA.
+			$hex = substr( $hex, 0, 6 );
 		}
 		if ( 6 !== strlen( $hex ) || ! ctype_xdigit( $hex ) ) {
 			return 1.0;

--- a/plugins/newspack-blocks/src/blocks/donate/utils.test.js
+++ b/plugins/newspack-blocks/src/blocks/donate/utils.test.js
@@ -21,6 +21,7 @@ describe( 'getColorForContrast', () => {
 		[ '', '#000000' ],
 		[ '#33333380', '#ffffff' ],
 		[ '#FFCC00', '#000000' ],
+		[ ' #178f15 ', '#ffffff' ],
 	] )( 'picks readable text for %s', ( background, expected ) => {
 		expect( getColorForContrast( background ) ).toBe( expected );
 	} );

--- a/plugins/newspack-blocks/src/blocks/donate/utils.test.js
+++ b/plugins/newspack-blocks/src/blocks/donate/utils.test.js
@@ -15,6 +15,12 @@ describe( 'getColorForContrast', () => {
 		[ '#fff', '#000000' ],
 		[ '#36c', '#ffffff' ],
 		[ 'not-a-color', '#000000' ],
+		// Parity cases shared with the PHP fixture table.
+		[ '3366cc', '#ffffff' ],
+		[ '178f15', '#ffffff' ],
+		[ '', '#000000' ],
+		[ '#33333380', '#ffffff' ],
+		[ '#FFCC00', '#000000' ],
 	] )( 'picks readable text for %s', ( background, expected ) => {
 		expect( getColorForContrast( background ) ).toBe( expected );
 	} );

--- a/plugins/newspack-blocks/src/blocks/donate/utils.test.js
+++ b/plugins/newspack-blocks/src/blocks/donate/utils.test.js
@@ -1,0 +1,30 @@
+import { getColorForContrast } from './utils';
+
+describe( 'getColorForContrast', () => {
+	// Must stay in parity with Newspack_Blocks::get_color_for_contrast(), which
+	// runs the same APCA math (see tests/test-color-contrast.php).
+	it.each( [
+		[ '#000000', '#ffffff' ],
+		[ '#ffffff', '#000000' ],
+		[ '#f0f0f0', '#000000' ],
+		[ '#ffcc00', '#000000' ],
+		// APCA flip zone: WCAG2 said black, APCA says white decisively.
+		[ '#178f15', '#ffffff' ],
+		[ '#3366cc', '#ffffff' ],
+		[ '#dd3333', '#ffffff' ],
+		[ '#fff', '#000000' ],
+		[ '#36c', '#ffffff' ],
+		[ 'not-a-color', '#000000' ],
+	] )( 'picks readable text for %s', ( background, expected ) => {
+		expect( getColorForContrast( background ) ).toBe( expected );
+	} );
+
+	it( 'falls back to black when no color is provided', () => {
+		expect( getColorForContrast( undefined ) ).toBe( '#000000' );
+	} );
+
+	it( 'expands 3-digit hex the same as 6-digit hex', () => {
+		expect( getColorForContrast( '#36c' ) ).toBe( getColorForContrast( '#3366cc' ) );
+		expect( getColorForContrast( '#fff' ) ).toBe( getColorForContrast( '#ffffff' ) );
+	} );
+} );

--- a/plugins/newspack-blocks/src/blocks/donate/utils.ts
+++ b/plugins/newspack-blocks/src/blocks/donate/utils.ts
@@ -12,6 +12,49 @@ const hexToRGB = ( hex: string ): number[] => {
 	return parts.map( x => parseInt( x, 16 ) );
 };
 
+// APCA soft-clamps near-black luminance and treats unparseable input as white
+// (luminance 1) so callers fall back to black text.
+const apcaLuminance = ( color: string ): number => {
+	const [ r, g, b ] = hexToRGB( color );
+	if ( Number.isNaN( r ) || Number.isNaN( g ) || Number.isNaN( b ) ) {
+		return 1;
+	}
+
+	let y = 0.2126729 * Math.pow( r / 255, 2.4 ) + 0.7151522 * Math.pow( g / 255, 2.4 ) + 0.072175 * Math.pow( b / 255, 2.4 );
+
+	if ( y <= 0.022 ) {
+		y += Math.pow( 0.022 - y, 1.414 );
+	}
+
+	return y;
+};
+
+// APCA lightness contrast (Lc): positive is dark text on a lighter background,
+// negative is light text on a darker background. Both luminances are clamped.
+const apcaContrast = ( backgroundY: number, textY: number ): number => {
+	if ( Math.abs( backgroundY - textY ) < 0.0005 ) {
+		return 0;
+	}
+
+	if ( backgroundY > textY ) {
+		const sapc = ( Math.pow( backgroundY, 0.56 ) - Math.pow( textY, 0.57 ) ) * 1.14;
+		return sapc < 0.1 ? 0 : ( sapc - 0.027 ) * 100;
+	}
+
+	const sapc = ( Math.pow( backgroundY, 0.65 ) - Math.pow( textY, 0.62 ) ) * 1.14;
+	return sapc > -0.1 ? 0 : ( sapc + 0.027 ) * 100;
+};
+
+/**
+ * Pick either black or white text, whichever reads better on the given background.
+ *
+ * Scores pure black and pure white as text against the background and returns
+ * whichever produces the greater APCA lightness contrast (Lc); ties fall to
+ * black. The constants are the SA98G set from apca-w3 0.1.9.
+ *
+ * Keep in sync with Newspack_Blocks::get_color_for_contrast() in
+ * includes/class-newspack-blocks.php.
+ */
 export const getColorForContrast = ( color?: string ): string => {
 	const blackColor = '#000000';
 	const whiteColor = '#ffffff';
@@ -19,19 +62,11 @@ export const getColorForContrast = ( color?: string ): string => {
 		return blackColor;
 	}
 
-	const backgroundColorRGB = hexToRGB( color );
-	const blackRGB = hexToRGB( blackColor );
+	const backgroundY = apcaLuminance( color );
+	const blackLc = apcaContrast( backgroundY, apcaLuminance( blackColor ) );
+	const whiteLc = apcaContrast( backgroundY, apcaLuminance( whiteColor ) );
 
-	const l1 =
-		0.2126 * Math.pow( backgroundColorRGB[ 0 ] / 255, 2.2 ) +
-		0.7152 * Math.pow( backgroundColorRGB[ 1 ] / 255, 2.2 ) +
-		0.0722 * Math.pow( backgroundColorRGB[ 2 ] / 255, 2.2 );
-	const l2 =
-		0.2126 * Math.pow( blackRGB[ 0 ] / 255, 2.2 ) + 0.7152 * Math.pow( blackRGB[ 1 ] / 255, 2.2 ) + 0.0722 * Math.pow( blackRGB[ 2 ] / 255, 2.2 );
-
-	const contrastRatio = l1 > l2 ? ( l1 + 0.05 ) / ( l2 + 0.05 ) : ( l2 + 0.05 ) / ( l1 + 0.05 );
-
-	return contrastRatio > 5 ? blackColor : whiteColor;
+	return Math.abs( whiteLc ) > Math.abs( blackLc ) ? whiteColor : blackColor;
 };
 
 export const getMigratedAmount = (

--- a/plugins/newspack-blocks/src/blocks/donate/utils.ts
+++ b/plugins/newspack-blocks/src/blocks/donate/utils.ts
@@ -1,11 +1,23 @@
 import { __, _x, sprintf } from '@wordpress/i18n';
 import type { DonationFrequencySlug } from './types';
 
+// Normalize a hex color to exactly six lowercase hex digits (no leading #).
+// Accepts #RGB, #RRGGBB and #RRGGBBAA (the alpha pair is stripped), with or
+// without the leading #, case-insensitively; returns null when unparseable.
+// Keep in sync with Newspack_Blocks::get_apca_luminance() in
+// includes/class-newspack-blocks.php.
+const normalizeHex = ( color: string ): string | null => {
+	let hex = color.trim().replace( /^#/, '' ).toLowerCase();
+	if ( hex.length === 3 ) {
+		hex = hex[ 0 ] + hex[ 0 ] + hex[ 1 ] + hex[ 1 ] + hex[ 2 ] + hex[ 2 ];
+	} else if ( hex.length === 8 ) {
+		hex = hex.substring( 0, 6 );
+	}
+	return /^[a-f\d]{6}$/.test( hex ) ? hex : null;
+};
+
 const hexToRGB = ( hex: string ): number[] => {
-	const parts = hex
-		.replace( /^#?([a-f\d])([a-f\d])([a-f\d])$/i, ( m, r, g, b ) => '#' + r + r + g + g + b + b )
-		.substring( 1 )
-		.match( /.{2}/g );
+	const parts = hex.match( /.{2}/g );
 	if ( parts === null ) {
 		return [ 0, 0, 0 ];
 	}
@@ -15,10 +27,12 @@ const hexToRGB = ( hex: string ): number[] => {
 // APCA soft-clamps near-black luminance and treats unparseable input as white
 // (luminance 1) so callers fall back to black text.
 const apcaLuminance = ( color: string ): number => {
-	const [ r, g, b ] = hexToRGB( color );
-	if ( Number.isNaN( r ) || Number.isNaN( g ) || Number.isNaN( b ) ) {
+	const hex = normalizeHex( color );
+	if ( hex === null ) {
 		return 1;
 	}
+
+	const [ r, g, b ] = hexToRGB( hex );
 
 	let y = 0.2126729 * Math.pow( r / 255, 2.4 ) + 0.7151522 * Math.pow( g / 255, 2.4 ) + 0.072175 * Math.pow( b / 255, 2.4 );
 

--- a/plugins/newspack-blocks/tests/test-color-contrast.php
+++ b/plugins/newspack-blocks/tests/test-color-contrast.php
@@ -31,6 +31,12 @@ class ColorContrastTest extends WP_UnitTestCase {
 			'shorthand white'          => [ '#fff', 'black' ],
 			'shorthand blue'           => [ '#36c', 'white' ],
 			'unparseable input'        => [ 'not-a-color', 'black' ],
+			// Parity cases shared with the jest fixture table.
+			'unprefixed blue'          => [ '3366cc', 'white' ],
+			'unprefixed green'         => [ '178f15', 'white' ],
+			'empty string'             => [ '', 'black' ],
+			'dark 8-digit hex'         => [ '#33333380', 'white' ],
+			'uppercase amber'          => [ '#FFCC00', 'black' ],
 		];
 	}
 

--- a/plugins/newspack-blocks/tests/test-color-contrast.php
+++ b/plugins/newspack-blocks/tests/test-color-contrast.php
@@ -37,6 +37,7 @@ class ColorContrastTest extends WP_UnitTestCase {
 			'empty string'             => [ '', 'black' ],
 			'dark 8-digit hex'         => [ '#33333380', 'white' ],
 			'uppercase amber'          => [ '#FFCC00', 'black' ],
+			'padded green'             => [ ' #178f15 ', 'white' ],
 		];
 	}
 

--- a/plugins/newspack-blocks/tests/test-color-contrast.php
+++ b/plugins/newspack-blocks/tests/test-color-contrast.php
@@ -1,0 +1,48 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class ColorContrastTest
+ *
+ * @package Newspack_Blocks
+ */
+
+/**
+ * Tests for Newspack_Blocks::get_color_for_contrast().
+ *
+ * The expectations must stay in parity with getColorForContrast() in
+ * src/blocks/donate/utils.ts, which runs the same APCA math.
+ */
+class ColorContrastTest extends WP_UnitTestCase {
+	/**
+	 * Background color to expected text color ('black' or 'white').
+	 *
+	 * @return array[]
+	 */
+	public function contrast_provider() {
+		return [
+			'pure black background'    => [ '#000000', 'white' ],
+			'pure white background'    => [ '#ffffff', 'black' ],
+			'near-white background'    => [ '#f0f0f0', 'black' ],
+			'amber background'         => [ '#ffcc00', 'black' ],
+			// APCA flip zone: the old WCAG2 heuristic picked black here, but APCA
+			// scores white decisively higher, so white must win.
+			'mid-tone green flip zone' => [ '#178f15', 'white' ],
+			'blue background'          => [ '#3366cc', 'white' ],
+			'red background'           => [ '#dd3333', 'white' ],
+			'shorthand white'          => [ '#fff', 'black' ],
+			'shorthand blue'           => [ '#36c', 'white' ],
+			'unparseable input'        => [ 'not-a-color', 'black' ],
+		];
+	}
+
+	/**
+	 * The picker returns the readable text color for a background.
+	 *
+	 * @dataProvider contrast_provider
+	 *
+	 * @param string $background Background color to test.
+	 * @param string $expected   Expected text color ('black' or 'white').
+	 */
+	public function test_get_color_for_contrast( $background, $expected ) {
+		$this->assertSame( $expected, Newspack_Blocks::get_color_for_contrast( $background ) );
+	}
+}

--- a/themes/newspack-block-theme/functions.php
+++ b/themes/newspack-block-theme/functions.php
@@ -21,6 +21,7 @@ if ( ! defined( 'NEWSPACK_BLOCK_THEME_FILE' ) ) {
 
 // Include theme resources.
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-core.php';
+require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-contrast.php';
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/blocks/index.php';
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-patterns.php';
 require_once NEWSPACK_BLOCK_THEME_FILE_PATH . '/includes/class-jetpack.php';

--- a/themes/newspack-block-theme/includes/class-contrast.php
+++ b/themes/newspack-block-theme/includes/class-contrast.php
@@ -36,6 +36,13 @@ final class Contrast {
 			return;
 		}
 
+		$contrast = self::get_color_for_contrast( $accent );
+		if ( null === $contrast ) {
+			// The accent is not a parseable hex, so leave the property unset and
+			// let the theme.json base fallback apply.
+			return;
+		}
+
 		$handle = 'newspack-block-theme-accent-contrast';
 		\wp_register_style( $handle, false, [], \wp_get_theme()->get( 'Version' ) );
 		\wp_enqueue_style( $handle );
@@ -43,7 +50,7 @@ final class Contrast {
 			$handle,
 			sprintf(
 				':root, .editor-styles-wrapper { --wp--preset--color--accent-contrast: %s; }',
-				self::get_color_for_contrast( $accent )
+				$contrast
 			)
 		);
 	}
@@ -83,13 +90,16 @@ final class Contrast {
 	 *
 	 * Keep in sync with Newspack_Blocks::get_color_for_contrast().
 	 *
-	 * @param string $hex Hexadecimal background color (#RGB or #RRGGBB, with or without #).
-	 * @return string Either '#000000' or '#ffffff'.
+	 * @param string $hex Hexadecimal background color (#RGB, #RRGGBB or #RRGGBBAA, with or without #).
+	 * @return string|null '#000000' or '#ffffff', or null when the input is not parseable as hex.
 	 */
 	private static function get_color_for_contrast( $hex ) {
 		$background_y = self::get_apca_luminance( $hex );
-		$black_lc     = self::get_apca_contrast( $background_y, self::get_apca_luminance( '#000000' ) );
-		$white_lc     = self::get_apca_contrast( $background_y, self::get_apca_luminance( '#ffffff' ) );
+		if ( null === $background_y ) {
+			return null;
+		}
+		$black_lc = self::get_apca_contrast( $background_y, self::get_apca_luminance( '#000000' ) );
+		$white_lc = self::get_apca_contrast( $background_y, self::get_apca_luminance( '#ffffff' ) );
 
 		return abs( $white_lc ) > abs( $black_lc ) ? '#ffffff' : '#000000';
 	}
@@ -97,19 +107,23 @@ final class Contrast {
 	/**
 	 * Compute the soft-clamped APCA screen luminance (Y) of a hex color.
 	 *
-	 * Accepts #RGB and #RRGGBB, with or without the leading #. Unparseable input
-	 * is treated as white (luminance 1.0) so callers fall back to black text.
+	 * Accepts #RGB, #RRGGBB and #RRGGBBAA (the alpha pair is stripped), with or
+	 * without the leading #, case-insensitively. Unparseable input returns null so
+	 * callers can leave the contrast property unset and fall back to theme.json.
 	 *
 	 * @param string $hex Hexadecimal color.
-	 * @return float Soft-clamped luminance in the 0..1 range.
+	 * @return float|null Soft-clamped luminance in the 0..1 range, or null when unparseable.
 	 */
 	private static function get_apca_luminance( $hex ) {
 		$hex = ltrim( (string) $hex, '#' );
 		if ( 3 === strlen( $hex ) ) {
 			$hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+		} elseif ( 8 === strlen( $hex ) ) {
+			// Drop the alpha pair from #RRGGBBAA.
+			$hex = substr( $hex, 0, 6 );
 		}
 		if ( 6 !== strlen( $hex ) || ! ctype_xdigit( $hex ) ) {
-			return 1.0;
+			return null;
 		}
 
 		$r = hexdec( substr( $hex, 0, 2 ) ) / 255;

--- a/themes/newspack-block-theme/includes/class-contrast.php
+++ b/themes/newspack-block-theme/includes/class-contrast.php
@@ -125,23 +125,28 @@ final class Contrast {
 	}
 
 	/**
-	 * Whether a value is a color-mix expression over the accent preset var.
+	 * Whether a value is the theme's exact default accent hover mix.
 	 *
-	 * Matches loosely: a color-mix that references the accent preset (in either the
-	 * var:preset|color|accent internal form or the var( --wp--preset--color--accent )
-	 * CSS form). It does not attempt to parse the color-mix, and the accent slug is
-	 * matched exactly so accent-contrast and other accent-prefixed slugs do not
-	 * falsely match.
+	 * Matches only the theme default: color-mix( in srgb, <accent> 80%, black ),
+	 * where <accent> is the accent preset in either the var:preset|color|accent
+	 * internal form or the var( --wp--preset--color--accent ) CSS form. The match is
+	 * whitespace-flexible and case-insensitive, but every component is anchored: any
+	 * other mix ratio, color space, mixed-in color, or accent-prefixed slug (such as
+	 * accent-2 or accent-contrast) falls through to false, so the caller emits no
+	 * hover property rather than scoring the wrong background.
 	 *
 	 * @param string $value The resolved background value.
-	 * @return bool True when the value is a color-mix over the accent var.
+	 * @return bool True only when the value is the theme's exact default accent mix.
 	 */
 	private static function is_accent_color_mix( $value ) {
 		if ( ! is_string( $value ) || false === stripos( $value, 'color-mix' ) ) {
 			return false;
 		}
 
-		return (bool) preg_match( '/(?:var:preset\|color\|accent|--wp--preset--color--accent)(?![\w-])/', $value );
+		return (bool) preg_match(
+			'/color-mix\(\s*in\s+srgb\s*,\s*(?:var\(\s*--wp--preset--color--accent(?![\w-])\s*\)|var:preset\|color\|accent(?![\w-]))\s+80%\s*,\s*black\s*\)/i',
+			$value
+		);
 	}
 
 	/**
@@ -268,7 +273,7 @@ final class Contrast {
 	 * @return int[]|null [ $r, $g, $b ] as 0..255 integers, or null when unparseable.
 	 */
 	private static function parse_hex_channels( $hex ) {
-		$hex = ltrim( (string) $hex, '#' );
+		$hex = ltrim( trim( (string) $hex ), '#' );
 		if ( 3 === strlen( $hex ) ) {
 			$hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
 		} elseif ( 8 === strlen( $hex ) ) {

--- a/themes/newspack-block-theme/includes/class-contrast.php
+++ b/themes/newspack-block-theme/includes/class-contrast.php
@@ -144,8 +144,8 @@ final class Contrast {
 		}
 
 		return (bool) preg_match(
-			'/color-mix\(\s*in\s+srgb\s*,\s*(?:var\(\s*--wp--preset--color--accent(?![\w-])\s*\)|var:preset\|color\|accent(?![\w-]))\s+80%\s*,\s*black\s*\)/i',
-			$value
+			'/^color-mix\(\s*in\s+srgb\s*,\s*(?:var\(\s*--wp--preset--color--accent(?![\w-])\s*\)|var:preset\|color\|accent(?![\w-]))\s+80%\s*,\s*black\s*\)$/i',
+			trim( $value )
 		);
 	}
 

--- a/themes/newspack-block-theme/includes/class-contrast.php
+++ b/themes/newspack-block-theme/includes/class-contrast.php
@@ -22,11 +22,16 @@ final class Contrast {
 	}
 
 	/**
-	 * Emit --wp--preset--color--accent-contrast on the front end and the editor canvas.
+	 * Emit the derived accent-contrast custom properties on the front end and the
+	 * editor canvas.
 	 *
-	 * The value is derived, not pickable, so it is intentionally not registered
-	 * as a palette preset and never appears in color pickers. enqueue_block_assets
-	 * runs in both the front end and the iframed editor canvas.
+	 * Two properties are derived and each is emitted only when it resolves:
+	 * --wp--preset--color--accent-contrast for the button rest state (scored
+	 * against the accent) and --wp--preset--color--accent-contrast-hover for the
+	 * button hover state (scored against the resolved hover background). The values
+	 * are derived, not pickable, so they are intentionally not registered as palette
+	 * presets and never appear in color pickers. enqueue_block_assets runs in both
+	 * the front end and the iframed editor canvas.
 	 *
 	 * @return void
 	 */
@@ -36,10 +41,21 @@ final class Contrast {
 			return;
 		}
 
+		$declarations = [];
+
 		$contrast = self::get_color_for_contrast( $accent );
-		if ( null === $contrast ) {
-			// The accent is not a parseable hex, so leave the property unset and
-			// let the theme.json base fallback apply.
+		if ( null !== $contrast ) {
+			$declarations[] = sprintf( '--wp--preset--color--accent-contrast: %s;', $contrast );
+		}
+
+		$contrast_hover = self::get_accent_contrast_hover( $accent );
+		if ( null !== $contrast_hover ) {
+			$declarations[] = sprintf( '--wp--preset--color--accent-contrast-hover: %s;', $contrast_hover );
+		}
+
+		if ( empty( $declarations ) ) {
+			// Nothing derivable, so leave the properties unset and let the
+			// theme.json fallbacks apply.
 			return;
 		}
 
@@ -49,21 +65,159 @@ final class Contrast {
 		\wp_add_inline_style(
 			$handle,
 			sprintf(
-				':root, .editor-styles-wrapper { --wp--preset--color--accent-contrast: %s; }',
-				$contrast
+				':root, .editor-styles-wrapper { %s }',
+				implode( ' ', $declarations )
 			)
+		);
+	}
+
+	/**
+	 * Derive the contrast text color for the button hover state.
+	 *
+	 * Reads the resolved hover background of the button element and picks readable
+	 * text against it. The resolved value is interpreted as follows:
+	 *
+	 * - Absent, or a color-mix over the accent var (the theme default darkens the
+	 *   accent by 20% in srgb): score against the accent darkened per channel by
+	 *   0.8, which is exactly what that color-mix produces.
+	 * - A palette reference (var:preset|color|<slug> or var( --wp--preset--color--<slug> )):
+	 *   score against the palette color the slug resolves to.
+	 * - A plain parseable hex: score it directly.
+	 * - Anything else (arbitrary color-mix, rgb()/hsl(), gradients): not derivable.
+	 *
+	 * @param string $accent The resolved accent palette color.
+	 * @return string|null '#000000' or '#ffffff', or null when not derivable.
+	 */
+	private static function get_accent_contrast_hover( $accent ) {
+		$background = self::get_button_hover_background();
+
+		if ( null === $background || self::is_accent_color_mix( $background ) ) {
+			$darkened = self::darken_hex( $accent, 0.8 );
+			return null === $darkened ? null : self::get_color_for_contrast( $darkened );
+		}
+
+		$hex = self::resolve_color_reference( $background );
+		if ( null !== $hex ) {
+			return self::get_color_for_contrast( $hex );
+		}
+
+		return null;
+	}
+
+	/**
+	 * Read the resolved button hover background from global styles.
+	 *
+	 * The ':hover' pseudo key is a first-class key under the button element node,
+	 * so it is addressable directly in the path. A non-string result (an absent
+	 * leaf makes _wp_array_get fall back to the whole styles array) is treated as
+	 * absent.
+	 *
+	 * @return string|null The resolved background value, or null when absent.
+	 */
+	private static function get_button_hover_background() {
+		$value = \wp_get_global_styles( [ 'elements', 'button', ':hover', 'color', 'background' ] );
+
+		if ( ! is_string( $value ) || '' === $value ) {
+			return null;
+		}
+
+		return $value;
+	}
+
+	/**
+	 * Whether a value is a color-mix expression over the accent preset var.
+	 *
+	 * Matches loosely: a color-mix that references the accent preset (in either the
+	 * var:preset|color|accent internal form or the var( --wp--preset--color--accent )
+	 * CSS form). It does not attempt to parse the color-mix, and the accent slug is
+	 * matched exactly so accent-contrast and other accent-prefixed slugs do not
+	 * falsely match.
+	 *
+	 * @param string $value The resolved background value.
+	 * @return bool True when the value is a color-mix over the accent var.
+	 */
+	private static function is_accent_color_mix( $value ) {
+		if ( ! is_string( $value ) || false === stripos( $value, 'color-mix' ) ) {
+			return false;
+		}
+
+		return (bool) preg_match( '/(?:var:preset\|color\|accent|--wp--preset--color--accent)(?![\w-])/', $value );
+	}
+
+	/**
+	 * Resolve a CSS color reference to a hex string.
+	 *
+	 * Accepts a palette reference in either the var:preset|color|<slug> internal
+	 * form or the var( --wp--preset--color--<slug> ) CSS form, resolving the slug
+	 * against the palette, or a plain parseable hex passed through unchanged.
+	 *
+	 * @param string $value The resolved background value.
+	 * @return string|null The hex color, or null when not a resolvable reference.
+	 */
+	private static function resolve_color_reference( $value ) {
+		if ( ! is_string( $value ) || '' === $value ) {
+			return null;
+		}
+		$value = trim( $value );
+
+		if (
+			preg_match( '/^var:preset\|color\|([\w-]+)$/', $value, $matches )
+			|| preg_match( '/^var\(\s*--wp--preset--color--([\w-]+)\s*\)$/', $value, $matches )
+		) {
+			$color = self::resolve_palette_color( $matches[1] );
+			return '' === $color ? null : $color;
+		}
+
+		if ( null !== self::parse_hex_channels( $value ) ) {
+			return $value;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Darken a hex color by multiplying each RGB channel by a factor.
+	 *
+	 * Operates in gamma-encoded srgb, so a 0.8 factor reproduces exactly what
+	 * color-mix( in srgb, <color> 80%, black ) produces.
+	 *
+	 * @param string $hex    Hexadecimal color.
+	 * @param float  $factor Multiplier applied to each channel.
+	 * @return string|null The darkened '#RRGGBB' color, or null when unparseable.
+	 */
+	private static function darken_hex( $hex, $factor ) {
+		$channels = self::parse_hex_channels( $hex );
+		if ( null === $channels ) {
+			return null;
+		}
+
+		return sprintf(
+			'#%02x%02x%02x',
+			(int) round( $channels[0] * $factor ),
+			(int) round( $channels[1] * $factor ),
+			(int) round( $channels[2] * $factor )
 		);
 	}
 
 	/**
 	 * Resolve the effective accent palette color.
 	 *
-	 * Scans the 'custom' (user override) origin before the 'theme' origin so a
-	 * user-selected accent wins.
-	 *
 	 * @return string The accent color, or an empty string if none resolves.
 	 */
 	private static function get_accent_color() {
+		return self::resolve_palette_color( 'accent' );
+	}
+
+	/**
+	 * Resolve a palette color by slug.
+	 *
+	 * Scans the 'custom' (user override) origin before the 'theme' origin so a
+	 * user-selected color wins.
+	 *
+	 * @param string $slug The palette color slug.
+	 * @return string The color, or an empty string if none resolves.
+	 */
+	private static function resolve_palette_color( $slug ) {
 		$palette = \wp_get_global_settings( [ 'color', 'palette' ] );
 
 		foreach ( [ 'custom', 'theme' ] as $origin ) {
@@ -71,7 +225,7 @@ final class Contrast {
 				continue;
 			}
 			foreach ( $palette[ $origin ] as $entry ) {
-				if ( isset( $entry['slug'], $entry['color'] ) && 'accent' === $entry['slug'] ) {
+				if ( isset( $entry['slug'], $entry['color'] ) && $slug === $entry['slug'] ) {
 					return $entry['color'];
 				}
 			}
@@ -105,16 +259,15 @@ final class Contrast {
 	}
 
 	/**
-	 * Compute the soft-clamped APCA screen luminance (Y) of a hex color.
+	 * Parse a hex color into its 0..255 RGB channels.
 	 *
 	 * Accepts #RGB, #RRGGBB and #RRGGBBAA (the alpha pair is stripped), with or
-	 * without the leading #, case-insensitively. Unparseable input returns null so
-	 * callers can leave the contrast property unset and fall back to theme.json.
+	 * without the leading #, case-insensitively. Unparseable input returns null.
 	 *
 	 * @param string $hex Hexadecimal color.
-	 * @return float|null Soft-clamped luminance in the 0..1 range, or null when unparseable.
+	 * @return int[]|null [ $r, $g, $b ] as 0..255 integers, or null when unparseable.
 	 */
-	private static function get_apca_luminance( $hex ) {
+	private static function parse_hex_channels( $hex ) {
 		$hex = ltrim( (string) $hex, '#' );
 		if ( 3 === strlen( $hex ) ) {
 			$hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
@@ -126,9 +279,32 @@ final class Contrast {
 			return null;
 		}
 
-		$r = hexdec( substr( $hex, 0, 2 ) ) / 255;
-		$g = hexdec( substr( $hex, 2, 2 ) ) / 255;
-		$b = hexdec( substr( $hex, 4, 2 ) ) / 255;
+		return [
+			hexdec( substr( $hex, 0, 2 ) ),
+			hexdec( substr( $hex, 2, 2 ) ),
+			hexdec( substr( $hex, 4, 2 ) ),
+		];
+	}
+
+	/**
+	 * Compute the soft-clamped APCA screen luminance (Y) of a hex color.
+	 *
+	 * Accepts #RGB, #RRGGBB and #RRGGBBAA (the alpha pair is stripped), with or
+	 * without the leading #, case-insensitively. Unparseable input returns null so
+	 * callers can leave the contrast property unset and fall back to theme.json.
+	 *
+	 * @param string $hex Hexadecimal color.
+	 * @return float|null Soft-clamped luminance in the 0..1 range, or null when unparseable.
+	 */
+	private static function get_apca_luminance( $hex ) {
+		$channels = self::parse_hex_channels( $hex );
+		if ( null === $channels ) {
+			return null;
+		}
+
+		$r = $channels[0] / 255;
+		$g = $channels[1] / 255;
+		$b = $channels[2] / 255;
 
 		$y = 0.2126729 * pow( $r, 2.4 ) + 0.7151522 * pow( $g, 2.4 ) + 0.0721750 * pow( $b, 2.4 );
 

--- a/themes/newspack-block-theme/includes/class-contrast.php
+++ b/themes/newspack-block-theme/includes/class-contrast.php
@@ -1,0 +1,155 @@
+<?php
+/**
+ * Newspack Block Theme accent-contrast color.
+ *
+ * @package Newspack_Block_Theme
+ */
+
+namespace Newspack_Block_Theme;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Derives a readable text color for the accent color and exposes it as a CSS
+ * custom property, so button text no longer assumes accent/base always reads.
+ */
+final class Contrast {
+	/**
+	 * Initializer.
+	 */
+	public static function init() {
+		\add_action( 'enqueue_block_assets', [ __CLASS__, 'enqueue_block_assets' ] );
+	}
+
+	/**
+	 * Emit --wp--preset--color--accent-contrast on the front end and the editor canvas.
+	 *
+	 * The value is derived, not pickable, so it is intentionally not registered
+	 * as a palette preset and never appears in color pickers. enqueue_block_assets
+	 * runs in both the front end and the iframed editor canvas.
+	 *
+	 * @return void
+	 */
+	public static function enqueue_block_assets() {
+		$accent = self::get_accent_color();
+		if ( empty( $accent ) ) {
+			return;
+		}
+
+		$handle = 'newspack-block-theme-accent-contrast';
+		\wp_register_style( $handle, false, [], \wp_get_theme()->get( 'Version' ) );
+		\wp_enqueue_style( $handle );
+		\wp_add_inline_style(
+			$handle,
+			sprintf(
+				':root, .editor-styles-wrapper { --wp--preset--color--accent-contrast: %s; }',
+				self::get_color_for_contrast( $accent )
+			)
+		);
+	}
+
+	/**
+	 * Resolve the effective accent palette color.
+	 *
+	 * Scans the 'custom' (user override) origin before the 'theme' origin so a
+	 * user-selected accent wins.
+	 *
+	 * @return string The accent color, or an empty string if none resolves.
+	 */
+	private static function get_accent_color() {
+		$palette = \wp_get_global_settings( [ 'color', 'palette' ] );
+
+		foreach ( [ 'custom', 'theme' ] as $origin ) {
+			if ( empty( $palette[ $origin ] ) || ! is_array( $palette[ $origin ] ) ) {
+				continue;
+			}
+			foreach ( $palette[ $origin ] as $entry ) {
+				if ( isset( $entry['slug'], $entry['color'] ) && 'accent' === $entry['slug'] ) {
+					return $entry['color'];
+				}
+			}
+		}
+
+		return '';
+	}
+
+	/**
+	 * Pick either black or white text, whichever reads better on the given background.
+	 *
+	 * Scores pure black and pure white as text against the background and returns
+	 * whichever produces the greater APCA lightness contrast (Lc); ties fall to
+	 * black. The constants are the SA98G set from apca-w3 0.1.9. Self-contained so
+	 * the theme stays standalone.
+	 *
+	 * Keep in sync with Newspack_Blocks::get_color_for_contrast().
+	 *
+	 * @param string $hex Hexadecimal background color (#RGB or #RRGGBB, with or without #).
+	 * @return string Either '#000000' or '#ffffff'.
+	 */
+	private static function get_color_for_contrast( $hex ) {
+		$background_y = self::get_apca_luminance( $hex );
+		$black_lc     = self::get_apca_contrast( $background_y, self::get_apca_luminance( '#000000' ) );
+		$white_lc     = self::get_apca_contrast( $background_y, self::get_apca_luminance( '#ffffff' ) );
+
+		return abs( $white_lc ) > abs( $black_lc ) ? '#ffffff' : '#000000';
+	}
+
+	/**
+	 * Compute the soft-clamped APCA screen luminance (Y) of a hex color.
+	 *
+	 * Accepts #RGB and #RRGGBB, with or without the leading #. Unparseable input
+	 * is treated as white (luminance 1.0) so callers fall back to black text.
+	 *
+	 * @param string $hex Hexadecimal color.
+	 * @return float Soft-clamped luminance in the 0..1 range.
+	 */
+	private static function get_apca_luminance( $hex ) {
+		$hex = ltrim( (string) $hex, '#' );
+		if ( 3 === strlen( $hex ) ) {
+			$hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+		}
+		if ( 6 !== strlen( $hex ) || ! ctype_xdigit( $hex ) ) {
+			return 1.0;
+		}
+
+		$r = hexdec( substr( $hex, 0, 2 ) ) / 255;
+		$g = hexdec( substr( $hex, 2, 2 ) ) / 255;
+		$b = hexdec( substr( $hex, 4, 2 ) ) / 255;
+
+		$y = 0.2126729 * pow( $r, 2.4 ) + 0.7151522 * pow( $g, 2.4 ) + 0.0721750 * pow( $b, 2.4 );
+
+		// APCA soft-clamp of near-black luminance.
+		if ( $y <= 0.022 ) {
+			$y += pow( 0.022 - $y, 1.414 );
+		}
+
+		return $y;
+	}
+
+	/**
+	 * Compute the APCA lightness contrast (Lc) of text on a background.
+	 *
+	 * Positive values are dark text on a lighter background; negative values are
+	 * light text on a darker background. Both luminances must already be
+	 * soft-clamped.
+	 *
+	 * @param float $background_y Soft-clamped background luminance.
+	 * @param float $text_y       Soft-clamped text luminance.
+	 * @return float The Lc value.
+	 */
+	private static function get_apca_contrast( $background_y, $text_y ) {
+		if ( abs( $background_y - $text_y ) < 0.0005 ) {
+			return 0.0;
+		}
+
+		if ( $background_y > $text_y ) {
+			$sapc = ( pow( $background_y, 0.56 ) - pow( $text_y, 0.57 ) ) * 1.14;
+			return $sapc < 0.1 ? 0.0 : ( $sapc - 0.027 ) * 100;
+		}
+
+		$sapc = ( pow( $background_y, 0.65 ) - pow( $text_y, 0.62 ) ) * 1.14;
+		return $sapc > -0.1 ? 0.0 : ( $sapc + 0.027 ) * 100;
+	}
+}
+
+Contrast::init();

--- a/themes/newspack-block-theme/theme.json
+++ b/themes/newspack-block-theme/theme.json
@@ -1036,13 +1036,13 @@
 				":focus": {
 					"color": {
 						"background": "var( --wp--preset--color--accent )",
-						"text": "var( --wp--preset--color--base )"
+						"text": "var( --wp--preset--color--accent-contrast, var( --wp--preset--color--base ) )"
 					}
 				},
 				":hover": {
 					"color": {
 						"background": "color-mix( in srgb, var( --wp--preset--color--accent ) 80%, black )",
-						"text": "var( --wp--preset--color--base )"
+						"text": "var( --wp--preset--color--accent-contrast, var( --wp--preset--color--base ) )"
 					}
 				},
 				"border": {
@@ -1050,7 +1050,7 @@
 				},
 				"color": {
 					"background": "var( --wp--preset--color--accent )",
-					"text": "var( --wp--preset--color--base )"
+					"text": "var( --wp--preset--color--accent-contrast, var( --wp--preset--color--base ) )"
 				},
 				"spacing": {
 					"padding": {

--- a/themes/newspack-block-theme/theme.json
+++ b/themes/newspack-block-theme/theme.json
@@ -1042,7 +1042,7 @@
 				":hover": {
 					"color": {
 						"background": "color-mix( in srgb, var( --wp--preset--color--accent ) 80%, black )",
-						"text": "var( --wp--preset--color--accent-contrast, var( --wp--preset--color--base ) )"
+						"text": "var( --wp--preset--color--accent-contrast-hover, var( --wp--preset--color--accent-contrast, var( --wp--preset--color--base ) ) )"
 					}
 				},
 				"border": {


### PR DESCRIPTION
Two related color-contrast improvements: the donate CTA's black/white text picker, and how the block theme pairs text with accent-backed surfaces.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**newspack-blocks: APCA text-color picker for the donate CTA.** The donate block picks black or white button text by computing contrast against the background. Two problems with the current heuristic: the PHP truncates the ratio to an integer while the editor JS does not, so any background whose ratio-vs-black lands between 5.0 and 6.0 renders black text in the editor and white on the front end (reproduced with accent `#178f15`); and the WCAG2-style threshold picks AA-failing colors in the mid-tone flip zone (white on `#178f15` is 4.17:1). Both `Newspack_Blocks::get_color_for_contrast()` and `getColorForContrast()` in the donate utils now score black and white with APCA lightness contrast (Lc, SA98G constants from apca-w3 0.1.9) and pick the higher absolute value — identical math in both languages, so editor and front end can never disagree. APCA models these mid-tones perceptually: for `#178f15` it picks white decisively (|Lc| 74 vs 36). Signatures and return formats are unchanged, and 3-digit hex is now handled in PHP too. Parity is locked by the same 10-case fixture table in PHPUnit and jest.

**newspack-block-theme: derived `accent-contrast` color.** theme.json pairs `background: accent` with `text: base` on buttons, assuming that pair always reads — nothing checks it, and a mid-tone accent silently fails. The theme now derives the readable-on-accent color server-side (same APCA picker, resolved from the palette with user overrides winning) and emits it as `--wp--preset--color--accent-contrast` on the front end and in the editor canvas. Buttons reference it with a `base` fallback (`var( --wp--preset--color--accent-contrast, var( --wp--preset--color--base ) )`), so behavior is unchanged wherever the property is not emitted. It is deliberately not a palette preset: derived, not pickable.

### How to test the changes in this Pull Request:

1. Run `n test-php` in `plugins/newspack-blocks` (new `ColorContrastTest`, 10 fixtures) and `pnpm --filter newspack-blocks test` (same table in jest).
2. On a block-theme site, set the accent/primary color to `#178f15` in Styles. Insert a donate block: the button text is white in the editor AND on the front end (previously black vs white).
3. Try a light accent (e.g. `#ffcc00`): text is black in both contexts.
4. Inspect any page: `:root` carries `--wp--preset--color--accent-contrast` matching the accent (white for `#178f15`, black for `#ffcc00`), and core buttons use it.
5. Change the accent in Styles and save: the property follows on reload, front end and editor canvas alike.
6. Deactivate the theme's derived property (e.g. classic theme or filter removed): buttons fall back to `base` exactly as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
