### PR TITLE
feat: add a Style section to the Contextual Prompts wizard

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/contextual-prompts-settings.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/contextual-prompts-settings.js
@@ -3,8 +3,8 @@
  *
  * Presentational: the parent tab owns the fetched status/values and the header
  * Save/Disable actions. When the feature is off this renders an empty state with
- * an admin opt-in (AI-use disclosure modal); when on, the publisher-profile and
- * site-wide override fields in the branch's grid/divider layout.
+ * an admin opt-in (AI-use disclosure modal); when on, the publisher-profile,
+ * site-wide override and style sections in the branch's grid/divider layout.
  */
 
 /**
@@ -29,6 +29,7 @@ import { megaphone } from '@wordpress/icons';
  */
 import { Button, Divider, Grid, Modal, SectionHeader } from '../../../../../../packages/components/src';
 import WizardsTab from '../../../../wizards-tab';
+import StyleSection from './style-section';
 
 const DISCLOSURE = __(
 	"Contextual Prompts lets editors draft donation call-to-action copy with AI. The story's content is sent to a third-party AI provider, which retains it for up to 30 days for abuse monitoring and never uses it to train AI models or in other AI products. Every suggestion is a draft an editor reviews and approves; nothing is published automatically.",
@@ -48,7 +49,7 @@ const OVERRIDE_ENABLED_KEY = 'newspack_contextual_prompts_override_enabled';
 const OVERRIDE_CTA_KEY = 'newspack_contextual_prompts_override_cta';
 const OVERRIDE_BUTTON_KEYS = [ 'newspack_contextual_prompts_override_label', 'newspack_contextual_prompts_override_url' ];
 
-const ContextualPromptsSettings = ( { status, values, error, inFlight, onSetValue, onEnable } ) => {
+const ContextualPromptsSettings = ( { status, values, blockStyles, error, inFlight, onSetValue, onChangeStyles, onEnable } ) => {
 	const [ modalOpen, setModalOpen ] = useState( false );
 	const { enabled, can_manage: canManage, fields } = status;
 
@@ -228,6 +229,8 @@ const ContextualPromptsSettings = ( { status, values, error, inFlight, onSetValu
 				/>
 				<VStack spacing={ 6 }>{ renderFields( 'override' ) }</VStack>
 			</Grid>
+			<Divider alignment="full-width" variant="tertiary" />
+			<StyleSection status={ status } styles={ blockStyles } inFlight={ inFlight } onChangeStyles={ onChangeStyles } />
 		</WizardsTab>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/contextual-prompts-settings.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/contextual-prompts-settings.js
@@ -137,6 +137,10 @@ const ContextualPromptsSettings = ( { status, values, blockStyles, error, inFlig
 	const hasCtaToggle = ( fields || [] ).some( field => OVERRIDE_CTA_KEY === field.key );
 	const effectiveCta = hasCtaToggle ? values[ OVERRIDE_CTA_KEY ] || 'form' : 'button';
 	const overrideEnabled = !! values[ OVERRIDE_ENABLED_KEY ];
+	// The Style section needs the style payload newspack-popups only started
+	// sending alongside it. Against an older one its controls would render empty
+	// and every save would be silently dropped, so the section stays out.
+	const hasStylePayload = 'is_block_theme' in status;
 
 	// Fields are grouped by section server-side so the override controls can sit
 	// under their own heading rather than trailing the publisher profile.
@@ -229,8 +233,12 @@ const ContextualPromptsSettings = ( { status, values, blockStyles, error, inFlig
 				/>
 				<VStack spacing={ 6 }>{ renderFields( 'override' ) }</VStack>
 			</Grid>
-			<Divider alignment="full-width" variant="tertiary" />
-			<StyleSection status={ status } styles={ blockStyles } inFlight={ inFlight } onChangeStyles={ onChangeStyles } />
+			{ hasStylePayload && (
+				<>
+					<Divider alignment="full-width" variant="tertiary" />
+					<StyleSection status={ status } styles={ blockStyles } inFlight={ inFlight } onChangeStyles={ onChangeStyles } />
+				</>
+			) }
 		</WizardsTab>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/contextual-prompts-settings.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/contextual-prompts-settings.test.js
@@ -32,6 +32,17 @@ const TOGGLE_FIELD = {
 const LABEL_FIELD = { ...FIELD_DEFAULTS, key: 'newspack_contextual_prompts_override_label', label: 'Override button label', type: 'text' };
 const URL_FIELD = { ...FIELD_DEFAULTS, key: 'newspack_contextual_prompts_override_url', label: 'Override button URL', type: 'text' };
 
+// The style keys the status payload carries; the Style section itself is covered
+// in style-section.test.js, so the block-theme shape (a handoff, no controls) is
+// enough to see the section render at all.
+const STYLE_PAYLOAD = {
+	is_block_theme: true,
+	style_defaults: {},
+	style_palette: [],
+	style_font_sizes: [],
+	site_editor_styles_url: 'https://example.test/wp-admin/site-editor.php?p=%2Fstyles',
+};
+
 const fieldsToValues = fields => ( fields || [] ).reduce( ( acc, field ) => ( { ...acc, [ field.key ]: field.value ?? '' } ), {} );
 
 // Enabled body needs live values so the field-gating interactions can be exercised.
@@ -93,6 +104,25 @@ describe( 'ContextualPromptsSettings enabled body', () => {
 	it( 'renders the two settings sections', () => {
 		render(
 			<ContextualPromptsSettings
+				status={ { enabled: true, can_manage: true, fields: [ ENABLE_FIELD ], ...STYLE_PAYLOAD } }
+				values={ fieldsToValues( [ ENABLE_FIELD ] ) }
+				error={ null }
+				inFlight={ false }
+				onSetValue={ () => {} }
+				onEnable={ () => Promise.resolve() }
+			/>
+		);
+
+		expect( screen.getByRole( 'heading', { name: 'Publisher Profile' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Site-Wide Override' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'heading', { name: 'Style' } ) ).toBeInTheDocument();
+	} );
+
+	// An older newspack-popups answers the status endpoint without the style keys:
+	// the section's controls would render empty and its saves would be dropped.
+	it( 'leaves out the Style section when the payload carries no style keys', () => {
+		render(
+			<ContextualPromptsSettings
 				status={ { enabled: true, can_manage: true, fields: [ ENABLE_FIELD ] } }
 				values={ fieldsToValues( [ ENABLE_FIELD ] ) }
 				error={ null }
@@ -104,6 +134,7 @@ describe( 'ContextualPromptsSettings enabled body', () => {
 
 		expect( screen.getByRole( 'heading', { name: 'Publisher Profile' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'heading', { name: 'Site-Wide Override' } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'heading', { name: 'Style' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'shows only the enable toggle while the override is off', () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
@@ -1,4 +1,9 @@
 /**
+ * External dependencies
+ */
+import isEqual from 'lodash/isEqual';
+
+/**
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
@@ -40,6 +45,7 @@ const ContextualPromptsScreen = withWizardScreen( ( { children } ) => <>{ childr
 const ContextualPrompts = props => {
 	const [ status, setStatus ] = useState( null );
 	const [ values, setValues ] = useState( {} );
+	const [ blockStyles, setBlockStyles ] = useState( {} );
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ error, setError ] = useState( null );
 	const [ loaded, setLoaded ] = useState( false );
@@ -49,6 +55,8 @@ const ContextualPrompts = props => {
 	const [ snackbar, setSnackbar ] = useState( null );
 	// Values as of the last successful status fetch / profile save, to detect dirt.
 	const savedValuesRef = useRef( {} );
+	// Same, for the block style overrides: the save only sends them when they differ.
+	const savedStylesRef = useRef( {} );
 	// Monotonic id so a slow status response can't clobber state written by a
 	// newer request or mutation.
 	const statusRequestRef = useRef( 0 );
@@ -66,6 +74,9 @@ const ContextualPrompts = props => {
 				const nextValues = fieldsToValues( next.fields );
 				setValues( nextValues );
 				savedValuesRef.current = nextValues;
+				const nextStyles = next.styles || {};
+				setBlockStyles( nextStyles );
+				savedStylesRef.current = nextStyles;
 			} )
 			.catch( err => {
 				if ( requestId === statusRequestRef.current ) {
@@ -91,6 +102,9 @@ const ContextualPrompts = props => {
 				const nextValues = fieldsToValues( next.fields );
 				setValues( nextValues );
 				savedValuesRef.current = nextValues;
+				const nextStyles = next.styles || {};
+				setBlockStyles( nextStyles );
+				savedStylesRef.current = nextStyles;
 				return next;
 			} )
 			.catch( err => {
@@ -114,6 +128,9 @@ const ContextualPrompts = props => {
 				const nextValues = fieldsToValues( next.fields );
 				setValues( nextValues );
 				savedValuesRef.current = nextValues;
+				const nextStyles = next.styles || {};
+				setBlockStyles( nextStyles );
+				savedStylesRef.current = nextStyles;
 				return next;
 			} )
 			.catch( err => {
@@ -122,13 +139,21 @@ const ContextualPrompts = props => {
 			} )
 			.finally( () => setInFlight( false ) );
 	};
-	const saveProfile = () =>
-		request( PROFILE_PATH, { fields: values } )
+	// The endpoint replaces the whole styles option when the key is present and
+	// leaves it alone when it is absent, so only an actual edit sends it.
+	const stylesDirty = ! isEqual( blockStyles, savedStylesRef.current );
+	const saveProfile = () => {
+		const data = { fields: values };
+		if ( stylesDirty ) {
+			data.styles = blockStyles;
+		}
+		return request( PROFILE_PATH, data )
 			.then( () => setSnackbar( __( 'Settings saved.', 'newspack-plugin' ) ) )
 			.catch( () => {} );
+	};
 	const setValue = ( key, value ) => setValues( previous => ( { ...previous, [ key ]: value } ) );
 
-	const isDirty = ! valuesEqual( values, savedValuesRef.current );
+	const isDirty = ! valuesEqual( values, savedValuesRef.current ) || stylesDirty;
 	// Guard stays active during an in-flight save: the edits are only safe once
 	// a successful response has refreshed the saved snapshot.
 	const { confirmDialog, requestConfirm } = useUnsavedChangesDialog( { when: isDirty } );
@@ -178,9 +203,11 @@ const ContextualPrompts = props => {
 			<ContextualPromptsSettings
 				status={ status }
 				values={ values }
+				blockStyles={ blockStyles }
 				error={ error }
 				inFlight={ inFlight }
 				onSetValue={ setValue }
+				onChangeStyles={ setBlockStyles }
 				onEnable={ onEnable }
 			/>
 		);

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
@@ -32,6 +32,11 @@ const MIN_TOGGLE_MS = 2000;
 
 const fieldsToValues = fields => ( fields || [] ).reduce( ( acc, field ) => ( { ...acc, [ field.key ]: field.value ?? '' } ), {} );
 
+// No overrides can arrive as an empty JSON array, and the controls only ever
+// produce plain objects: an array snapshot would never compare equal to one, so
+// edits that net back to nothing would stay dirty forever.
+const normalizeStyles = styles => ( styles && ! Array.isArray( styles ) ? styles : {} );
+
 // Values are scalars, so key/value equality is a full compare.
 const valuesEqual = ( a, b ) => {
 	const keys = Object.keys( a );
@@ -74,7 +79,7 @@ const ContextualPrompts = props => {
 				const nextValues = fieldsToValues( next.fields );
 				setValues( nextValues );
 				savedValuesRef.current = nextValues;
-				const nextStyles = next.styles || {};
+				const nextStyles = normalizeStyles( next.styles );
 				setBlockStyles( nextStyles );
 				savedStylesRef.current = nextStyles;
 			} )
@@ -102,7 +107,7 @@ const ContextualPrompts = props => {
 				const nextValues = fieldsToValues( next.fields );
 				setValues( nextValues );
 				savedValuesRef.current = nextValues;
-				const nextStyles = next.styles || {};
+				const nextStyles = normalizeStyles( next.styles );
 				setBlockStyles( nextStyles );
 				savedStylesRef.current = nextStyles;
 				return next;
@@ -128,7 +133,7 @@ const ContextualPrompts = props => {
 				const nextValues = fieldsToValues( next.fields );
 				setValues( nextValues );
 				savedValuesRef.current = nextValues;
-				const nextStyles = next.styles || {};
+				const nextStyles = normalizeStyles( next.styles );
 				setBlockStyles( nextStyles );
 				savedStylesRef.current = nextStyles;
 				return next;

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
@@ -51,6 +51,9 @@ const styledStatus = () => ( {
 	site_editor_styles_url: 'https://example.test/wp-admin/site-editor.php?p=%2Fstyles',
 } );
 
+// With nothing stored, PHP hands back an empty JSON array rather than an object.
+const unstyledStatus = () => ( { ...styledStatus(), styles: [] } );
+
 // Each style group renders its Reset beside its own heading.
 const groupReset = label => screen.getByRole( 'heading', { name: label, level: 3 } ).parentElement.querySelector( 'button' );
 
@@ -142,6 +145,23 @@ describe( 'ContextualPrompts tab', () => {
 		expect( data.fields ).toEqual( { [ PROFILE_FIELD.key ]: 'Newsroom X' } );
 		// Absent means "leave the stored styles alone"; sending them would be a no-op write.
 		expect( data ).not.toHaveProperty( 'styles' );
+	} );
+
+	it( 'goes clean again when a style edit is undone from an empty array payload', async () => {
+		apiFetch.mockResolvedValueOnce( unstyledStatus() );
+		renderTab();
+
+		await waitFor( () => expect( screen.getByRole( 'button', { name: 'Text' } ) ).toBeInTheDocument() );
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Text' } ) );
+		fireEvent.click( screen.getByRole( 'option', { name: 'Accent' } ) );
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
+
+		// Clicking the selected swatch clears it, leaving no overrides at all: the
+		// saved snapshot has to compare equal to that, empty array payload or not.
+		fireEvent.click( screen.getByRole( 'option', { name: 'Accent' } ) );
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
 	} );
 
 	it( 'includes the whole style object in the save payload when a style is edited', async () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
@@ -26,6 +26,34 @@ jest.mock( '../../../../../../packages/components/src/with-wizard-screen', () =>
 // The confirmDialog uses react-router history, so a Router must wrap the tab.
 const renderTab = () => render( <ContextualPrompts />, { wrapper: MemoryRouter } );
 
+const PROFILE_FIELD = {
+	key: 'newspack_contextual_prompts_publisher_name',
+	label: 'Publisher name',
+	type: 'text',
+	section: 'profile',
+	value: '',
+};
+
+// A saved override on two groups: resetting one is a real style edit that leaves
+// the other in place, so the payload assertion also covers "send the full object".
+const SAVED_STYLES = { color: { background: '#123456' }, border: { radius: '4px', width: '1px' } };
+
+// Classic theme, so the Style section renders its controls rather than the handoff.
+const styledStatus = () => ( {
+	enabled: true,
+	can_manage: true,
+	fields: [ PROFILE_FIELD ],
+	is_block_theme: false,
+	styles: SAVED_STYLES,
+	style_defaults: { color: { background: '#f7f7f7' }, border: { radius: '10px' } },
+	style_palette: [ { name: 'Accent', slug: 'accent', color: '#178f15' } ],
+	style_font_sizes: [ { name: 'Small', slug: 'small', size: '14px' } ],
+	site_editor_styles_url: 'https://example.test/wp-admin/site-editor.php?p=%2Fstyles',
+} );
+
+// Each style group renders its Reset beside its own heading.
+const groupReset = label => screen.getByRole( 'heading', { name: label, level: 3 } ).parentElement.querySelector( 'button' );
+
 describe( 'ContextualPrompts tab', () => {
 	beforeEach( () => jest.clearAllMocks() );
 
@@ -89,5 +117,49 @@ describe( 'ContextualPrompts tab', () => {
 		fireEvent.click( screen.getByText( 'Cancel' ) );
 		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
 		expect( screen.getByRole( 'textbox', { name: 'Publisher name' } ) ).toHaveValue( 'Newsroom X' );
+	} );
+
+	it( 'renders the Style section when enabled', async () => {
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		renderTab();
+
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: 'Style', level: 2 } ) ).toBeInTheDocument() );
+		expect( screen.getByText( 'Background' ) ).toBeInTheDocument();
+	} );
+
+	it( 'omits styles from the save payload when they are untouched', async () => {
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		renderTab();
+
+		await waitFor( () => expect( screen.getByRole( 'textbox', { name: 'Publisher name' } ) ).toBeInTheDocument() );
+		fireEvent.change( screen.getByRole( 'textbox', { name: 'Publisher name' } ), { target: { value: 'Newsroom X' } } );
+
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+		const { data } = apiFetch.mock.calls[ 1 ][ 0 ];
+		expect( data.fields ).toEqual( { [ PROFILE_FIELD.key ]: 'Newsroom X' } );
+		// Absent means "leave the stored styles alone"; sending them would be a no-op write.
+		expect( data ).not.toHaveProperty( 'styles' );
+	} );
+
+	it( 'includes the whole style object in the save payload when a style is edited', async () => {
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		renderTab();
+
+		await waitFor( () => expect( screen.getByRole( 'heading', { name: 'Border', level: 3 } ) ).toBeInTheDocument() );
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+
+		fireEvent.click( groupReset( 'Border' ) );
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
+
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+		const { data } = apiFetch.mock.calls[ 1 ][ 0 ];
+		expect( data.styles ).toEqual( { color: { background: '#123456' }, border: { radius: '4px' } } );
+		expect( data.fields ).toEqual( { [ PROFILE_FIELD.key ]: '' } );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
@@ -54,8 +54,11 @@ const styledStatus = () => ( {
 // With nothing stored, PHP hands back an empty JSON array rather than an object.
 const unstyledStatus = () => ( { ...styledStatus(), styles: [] } );
 
-// Each style group renders its Reset beside its own heading.
-const groupReset = label => screen.getByRole( 'heading', { name: label, level: 3 } ).parentElement.querySelector( 'button' );
+// Each style group resets from the options menu in its ToolsPanel header.
+const resetStyleItem = ( panel, item ) => {
+	fireEvent.click( screen.getByRole( 'button', { name: `${ panel } options` } ) );
+	fireEvent.click( screen.getByRole( 'menuitem', { name: `Reset ${ item }` } ) );
+};
 
 describe( 'ContextualPrompts tab', () => {
 	beforeEach( () => jest.clearAllMocks() );
@@ -171,7 +174,7 @@ describe( 'ContextualPrompts tab', () => {
 		await waitFor( () => expect( screen.getByRole( 'heading', { name: 'Border', level: 3 } ) ).toBeInTheDocument() );
 		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
 
-		fireEvent.click( groupReset( 'Border' ) );
+		resetStyleItem( 'Border', 'Border' );
 		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
 
 		apiFetch.mockResolvedValueOnce( styledStatus() );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -6,6 +6,11 @@
  */
 
 /**
+ * External dependencies
+ */
+import classnames from 'classnames';
+
+/**
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
@@ -21,8 +26,9 @@ import {
 	__experimentalBorderBoxControl as BorderBoxControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalBoxControl as BoxControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	__experimentalHeading as Heading, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
@@ -79,20 +85,10 @@ const withoutRadius = border => {
 	return next;
 };
 
-const StyleGroup = ( { label, hasOverride, onReset, disabled, children } ) => (
-	<VStack spacing={ 3 }>
-		<HStack justify="space-between" alignment="center" spacing={ 2 }>
-			<Heading level={ 3 } size={ 13 }>
-				{ label }
-			</Heading>
-			{ hasOverride && (
-				<Button variant="tertiary" isSmall onClick={ onReset } disabled={ disabled }>
-					{ __( 'Reset', 'newspack-plugin' ) }
-				</Button>
-			) }
-		</HStack>
-		{ children }
-	</VStack>
+// Each group is one of the editor's block support panels: the group label and the
+// options menu in the header, which offers a reset per item and a Reset all.
+const StylePanel = ( { className, ...props } ) => (
+	<ToolsPanel headingLevel={ 3 } className={ classnames( 'newspack-prompt-style-panel', className ) } { ...props } />
 );
 
 // The editor's color rows, composed from stable primitives: @wordpress/block-editor
@@ -164,6 +160,9 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 		}
 		onChangeStyles( setPath( styles, [ 'border' ], hasKeys( next ) ? next : undefined ) );
 	};
+	// The radius is its own group, so clearing the border keeps it.
+	const clearBorder = () =>
+		onChangeStyles( setPath( styles, [ 'border' ], undefined !== styles.border?.radius ? { radius: styles.border.radius } : undefined ) );
 
 	const setRadius = value => onChangeStyles( setPath( styles, [ 'border', 'radius' ], value || undefined ) );
 	// The slider only moves the number, so it writes back with the unit already in
@@ -175,14 +174,21 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 	const classicControls = (
 		<Disabled isDisabled={ !! inFlight }>
 			<HStack alignment="top" justify="flex-end">
-				<VStack spacing={ 6 } className="newspack-prompt-style-controls">
-					<StyleGroup
+				<VStack spacing={ 0 } className="newspack-prompt-style-controls">
+					<StylePanel
 						label={ __( 'Color', 'newspack-plugin' ) }
-						hasOverride={ hasKeys( styles.color ) }
-						onReset={ () => onChangeStyles( setPath( styles, [ 'color' ], undefined ) ) }
-						disabled={ inFlight }
+						className="newspack-prompt-style-panel--color"
+						resetAll={ () => onChangeStyles( setPath( styles, [ 'color' ], undefined ) ) }
+						__experimentalFirstVisibleItemClass="newspack-prompt-style-colors--first"
+						__experimentalLastVisibleItemClass="newspack-prompt-style-colors--last"
 					>
-						<VStack spacing={ 0 } className="newspack-prompt-style-colors">
+						<ToolsPanelItem
+							className="newspack-prompt-style-colors"
+							label={ __( 'Text', 'newspack-plugin' ) }
+							hasValue={ () => undefined !== styles.color?.text }
+							onDeselect={ () => setColor( 'text' ) }
+							isShownByDefault
+						>
 							<ColorRow label={ __( 'Text', 'newspack-plugin' ) } colorValue={ text } disabled={ inFlight }>
 								<ColorPalette
 									aria-label={ __( 'Text', 'newspack-plugin' ) }
@@ -191,6 +197,14 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 									onChange={ value => setColor( 'text', value ) }
 								/>
 							</ColorRow>
+						</ToolsPanelItem>
+						<ToolsPanelItem
+							className="newspack-prompt-style-colors"
+							label={ __( 'Background', 'newspack-plugin' ) }
+							hasValue={ () => undefined !== styles.color?.background }
+							onDeselect={ () => setColor( 'background' ) }
+							isShownByDefault
+						>
 							<ColorRow label={ __( 'Background', 'newspack-plugin' ) } colorValue={ background } disabled={ inFlight }>
 								<ColorPalette
 									aria-label={ __( 'Background', 'newspack-plugin' ) }
@@ -199,94 +213,107 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 									onChange={ value => setColor( 'background', value ) }
 								/>
 							</ColorRow>
-						</VStack>
+						</ToolsPanelItem>
 						{ null !== ratio && ratio < MIN_CONTRAST_RATIO && (
-							<Notice status="warning" isDismissible={ false } style={ { margin: 0 } }>
+							<Notice status="warning" isDismissible={ false } className="newspack-prompt-style-notice">
 								{ __( 'This color combination may be hard for people to read.', 'newspack-plugin' ) }
 							</Notice>
 						) }
-					</StyleGroup>
-					<StyleGroup
+					</StylePanel>
+					<StylePanel
 						label={ __( 'Typography', 'newspack-plugin' ) }
-						hasOverride={ hasKeys( styles.typography ) }
-						onReset={ () => onChangeStyles( setPath( styles, [ 'typography' ], undefined ) ) }
-						disabled={ inFlight }
+						resetAll={ () => onChangeStyles( setPath( styles, [ 'typography' ], undefined ) ) }
 					>
-						<FontSizePicker
-							fontSizes={ fontSizes }
-							value={ effective( [ 'typography', 'fontSize' ] ) }
-							onChange={ setFontSize }
-							withReset={ false }
-							__next40pxDefaultSize
-						/>
-					</StyleGroup>
-					<StyleGroup
+						<ToolsPanelItem
+							label={ __( 'Font Size', 'newspack-plugin' ) }
+							hasValue={ () => undefined !== styles.typography?.fontSize }
+							onDeselect={ () => setFontSize() }
+							isShownByDefault
+						>
+							<FontSizePicker
+								fontSizes={ fontSizes }
+								value={ effective( [ 'typography', 'fontSize' ] ) }
+								onChange={ setFontSize }
+								withReset={ false }
+								__next40pxDefaultSize
+							/>
+						</ToolsPanelItem>
+					</StylePanel>
+					<StylePanel
 						label={ __( 'Padding', 'newspack-plugin' ) }
-						hasOverride={ undefined !== styles.spacing?.padding }
-						onReset={ () => onChangeStyles( setPath( styles, [ 'spacing', 'padding' ], undefined ) ) }
-						disabled={ inFlight }
+						resetAll={ () => onChangeStyles( setPath( styles, [ 'spacing', 'padding' ], undefined ) ) }
 					>
-						<BoxControl
+						<ToolsPanelItem
 							label={ __( 'Padding', 'newspack-plugin' ) }
-							values={ effective( [ 'spacing', 'padding' ] ) }
-							onChange={ setPadding }
-							splitOnAxis={ false }
-							allowReset={ false }
-							__next40pxDefaultSize
-						/>
-					</StyleGroup>
-					<StyleGroup
-						label={ __( 'Border', 'newspack-plugin' ) }
-						hasOverride={ hasKeys( borderOverride ) }
-						onReset={ () =>
-							onChangeStyles(
-								setPath( styles, [ 'border' ], undefined !== styles.border?.radius ? { radius: styles.border.radius } : undefined )
-							)
-						}
-						disabled={ inFlight }
-					>
-						<BorderBoxControl
+							hasValue={ () => undefined !== styles.spacing?.padding }
+							onDeselect={ () => setPadding() }
+							isShownByDefault
+						>
+							<BoxControl
+								label={ __( 'Padding', 'newspack-plugin' ) }
+								values={ effective( [ 'spacing', 'padding' ] ) }
+								onChange={ setPadding }
+								splitOnAxis={ false }
+								allowReset={ false }
+								__next40pxDefaultSize
+							/>
+						</ToolsPanelItem>
+					</StylePanel>
+					<StylePanel label={ __( 'Border', 'newspack-plugin' ) } resetAll={ clearBorder }>
+						<ToolsPanelItem
 							label={ __( 'Border', 'newspack-plugin' ) }
-							hideLabelFromVision
-							colors={ paletteColors }
-							value={ hasKeys( borderOverride ) ? borderOverride : withoutRadius( defaults.border ) }
-							onChange={ setBorder }
-							enableStyle
-							__next40pxDefaultSize
-						/>
-					</StyleGroup>
-					<StyleGroup
+							hasValue={ () => hasKeys( borderOverride ) }
+							onDeselect={ clearBorder }
+							isShownByDefault
+						>
+							<BorderBoxControl
+								label={ __( 'Border', 'newspack-plugin' ) }
+								hideLabelFromVision
+								colors={ paletteColors }
+								value={ hasKeys( borderOverride ) ? borderOverride : withoutRadius( defaults.border ) }
+								onChange={ setBorder }
+								enableStyle
+								__next40pxDefaultSize
+							/>
+						</ToolsPanelItem>
+					</StylePanel>
+					<StylePanel
 						label={ __( 'Border Radius', 'newspack-plugin' ) }
-						hasOverride={ undefined !== styles.border?.radius }
-						onReset={ () => onChangeStyles( setPath( styles, [ 'border', 'radius' ], undefined ) ) }
-						disabled={ inFlight }
+						resetAll={ () => onChangeStyles( setPath( styles, [ 'border', 'radius' ], undefined ) ) }
 					>
-						<HStack spacing={ 4 } className="newspack-prompt-style-radius">
-							<UnitControl
-								label={ __( 'Radius', 'newspack-plugin' ) }
-								hideLabelFromVision
-								value={ radiusValue }
-								onChange={ setRadius }
-								min={ 0 }
-								disabled={ inFlight }
-								__next40pxDefaultSize
-							/>
-							<RangeControl
-								label={ __( 'Border radius', 'newspack-plugin' ) }
-								hideLabelFromVision
-								value={ radiusQuantity }
-								onChange={ setRadiusQuantity }
-								min={ 0 }
-								max={ RADIUS_SLIDER_MAX }
-								step={ 'px' === ( radiusUnit || 'px' ) || '%' === radiusUnit ? 1 : 0.1 }
-								initialPosition={ 0 }
-								withInputField={ false }
-								disabled={ inFlight }
-								__nextHasNoMarginBottom
-								__next40pxDefaultSize
-							/>
-						</HStack>
-					</StyleGroup>
+						<ToolsPanelItem
+							label={ __( 'Radius', 'newspack-plugin' ) }
+							hasValue={ () => undefined !== styles.border?.radius }
+							onDeselect={ () => setRadius() }
+							isShownByDefault
+						>
+							<HStack spacing={ 4 } className="newspack-prompt-style-radius">
+								<UnitControl
+									label={ __( 'Radius', 'newspack-plugin' ) }
+									hideLabelFromVision
+									value={ radiusValue }
+									onChange={ setRadius }
+									min={ 0 }
+									disabled={ inFlight }
+									__next40pxDefaultSize
+								/>
+								<RangeControl
+									label={ __( 'Border radius', 'newspack-plugin' ) }
+									hideLabelFromVision
+									value={ radiusQuantity }
+									onChange={ setRadiusQuantity }
+									min={ 0 }
+									max={ RADIUS_SLIDER_MAX }
+									step={ 'px' === ( radiusUnit || 'px' ) || '%' === radiusUnit ? 1 : 0.1 }
+									initialPosition={ 0 }
+									withInputField={ false }
+									disabled={ inFlight }
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+								/>
+							</HStack>
+						</ToolsPanelItem>
+					</StylePanel>
 				</VStack>
 			</HStack>
 		</Disabled>

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -39,7 +39,7 @@ import { Icon, cornerAll } from '@wordpress/icons';
  * Internal dependencies
  */
 import { Button, Grid, Handoff, SectionHeader } from '../../../../../../packages/components/src';
-import { contrastRatio, presetRefForColor, relativeLuminance, resolveColor } from './style-utils';
+import { contrastRatio, perceivedBrightness, presetRefForColor, resolveColor } from './style-utils';
 import './style-section.scss';
 
 const MIN_CONTRAST_RATIO = 4.5;
@@ -77,6 +77,11 @@ const setPath = ( source, path, value ) => {
 	return next;
 };
 
+// A theme can register its font size presets as plain numbers, and FontSizePicker
+// hands back whatever shape it was given. Stored styles are CSS strings, and the
+// REST layer keeps string leaves only, so a bare number would be dropped on save.
+const withPixelUnit = size => ( 'number' === typeof size ? `${ size }px` : size );
+
 // Border radius is its own group, so the border group reads and writes every
 // border key except the radius.
 const withoutRadius = border => {
@@ -91,8 +96,10 @@ const withoutRadius = border => {
 
 // The editor's contrast warning, verbatim: the suggestion pushes the pair the way
 // it already leans, so a dark background asks for a darker background still.
+// Which one leans dark is core's perceived-brightness question, not a WCAG
+// luminance one — the two disagree on saturated hues.
 const contrastMessage = ( background, text ) =>
-	relativeLuminance( background ) < relativeLuminance( text )
+	perceivedBrightness( background ) < perceivedBrightness( text )
 		? __(
 				'This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.',
 				'newspack-plugin'
@@ -141,7 +148,7 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 	// Global settings presets carry extra keys (fluid font sizes, gradients); the
 	// controls only take the shapes they document.
 	const paletteColors = palette.map( ( { name, slug, color } ) => ( { name, slug, color } ) );
-	const fontSizes = ( styleFontSizes || [] ).map( ( { name, slug, size } ) => ( { name, slug, size } ) );
+	const fontSizes = ( styleFontSizes || [] ).map( ( { name, slug, size } ) => ( { name, slug, size: withPixelUnit( size ) } ) );
 	const effective = path => getPath( styles, path ) ?? getPath( defaults, path );
 
 	const radius = effective( [ 'border', 'radius' ] );
@@ -157,7 +164,7 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 
 	const setColor = ( key, value ) => onChangeStyles( setPath( styles, [ 'color', key ], value ? presetRefForColor( value, palette ) : undefined ) );
 
-	const setFontSize = value => onChangeStyles( setPath( styles, [ 'typography', 'fontSize' ], value || undefined ) );
+	const setFontSize = value => onChangeStyles( setPath( styles, [ 'typography', 'fontSize' ], value ? withPixelUnit( value ) : undefined ) );
 
 	const setPadding = value => {
 		const sides = {};

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -187,127 +187,129 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 	// `disabled` prop, so the whole stack goes inert while a save is in flight.
 	const classicControls = (
 		<Disabled isDisabled={ !! inFlight }>
-			<VStack spacing={ 6 }>
-				<StyleGroup
-					label={ __( 'Color', 'newspack-plugin' ) }
-					hasOverride={ hasKeys( styles.color ) }
-					onReset={ () => onChangeStyles( setPath( styles, [ 'color' ], undefined ) ) }
-					disabled={ inFlight }
-				>
-					<VStack spacing={ 0 } className="newspack-prompt-style-colors">
-						<ColorRow label={ __( 'Text', 'newspack-plugin' ) } colorValue={ text } disabled={ inFlight }>
-							<ColorPalette
-								aria-label={ __( 'Text', 'newspack-plugin' ) }
-								colors={ paletteColors }
-								value={ text ?? undefined }
-								onChange={ value => setColor( 'text', value ) }
-							/>
-						</ColorRow>
-						<ColorRow label={ __( 'Background', 'newspack-plugin' ) } colorValue={ background } disabled={ inFlight }>
-							<ColorPalette
-								aria-label={ __( 'Background', 'newspack-plugin' ) }
-								colors={ paletteColors }
-								value={ background ?? undefined }
-								onChange={ value => setColor( 'background', value ) }
-							/>
-						</ColorRow>
-					</VStack>
-					{ null !== ratio && ratio < MIN_CONTRAST_RATIO && (
-						<Notice status="warning" isDismissible={ false } style={ { margin: 0 } }>
-							{ __( 'This color combination may be hard for people to read.', 'newspack-plugin' ) }
-						</Notice>
-					) }
-				</StyleGroup>
-				<StyleGroup
-					label={ __( 'Typography', 'newspack-plugin' ) }
-					hasOverride={ hasKeys( styles.typography ) }
-					onReset={ () => onChangeStyles( setPath( styles, [ 'typography' ], undefined ) ) }
-					disabled={ inFlight }
-				>
-					<FontSizePicker
-						fontSizes={ fontSizes }
-						value={ effective( [ 'typography', 'fontSize' ] ) }
-						onChange={ setFontSize }
-						withReset={ false }
-						__next40pxDefaultSize
-					/>
-				</StyleGroup>
-				<StyleGroup
-					label={ __( 'Padding', 'newspack-plugin' ) }
-					hasOverride={ undefined !== styles.spacing?.padding }
-					onReset={ () => onChangeStyles( setPath( styles, [ 'spacing', 'padding' ], undefined ) ) }
-					disabled={ inFlight }
-				>
-					<BoxControl
-						label={ __( 'Padding', 'newspack-plugin' ) }
-						values={ effective( [ 'spacing', 'padding' ] ) }
-						onChange={ setPadding }
-						splitOnAxis={ false }
-						allowReset={ false }
-						__next40pxDefaultSize
-					/>
-				</StyleGroup>
-				<StyleGroup
-					label={ __( 'Border', 'newspack-plugin' ) }
-					hasOverride={ hasKeys( borderOverride ) }
-					onReset={ () =>
-						onChangeStyles(
-							setPath( styles, [ 'border' ], undefined !== styles.border?.radius ? { radius: styles.border.radius } : undefined )
-						)
-					}
-					disabled={ inFlight }
-				>
-					<BorderBoxControl
-						label={ __( 'Border', 'newspack-plugin' ) }
-						hideLabelFromVision
-						colors={ paletteColors }
-						value={ hasKeys( borderOverride ) ? borderOverride : withoutRadius( defaults.border ) }
-						onChange={ setBorder }
-						enableStyle
-						__next40pxDefaultSize
-					/>
-				</StyleGroup>
-				<StyleGroup
-					label={ __( 'Border Radius', 'newspack-plugin' ) }
-					hasOverride={ undefined !== styles.border?.radius }
-					onReset={ () => onChangeStyles( setPath( styles, [ 'border', 'radius' ], undefined ) ) }
-					disabled={ inFlight }
-				>
-					<HStack alignment="flex-end" justify="space-between" spacing={ 2 }>
-						{ radiusLinked ? (
-							<UnitControl
-								label={ __( 'Radius', 'newspack-plugin' ) }
-								value={ isSplitRadius ? '' : radius }
-								onChange={ setRadius }
-								min={ 0 }
-								disabled={ inFlight }
-								__next40pxDefaultSize
-							/>
-						) : (
-							<Grid columns={ 2 } gutter={ 8 } noMargin>
-								{ RADIUS_CORNERS.map( ( [ corner, cornerLabel ] ) => (
-									<UnitControl
-										key={ corner }
-										label={ cornerLabel }
-										value={ isSplitRadius ? radius[ corner ] : radius }
-										onChange={ value => setRadiusCorner( corner, value ) }
-										min={ 0 }
-										disabled={ inFlight }
-										__next40pxDefaultSize
-									/>
-								) ) }
-							</Grid>
+			<HStack alignment="top" justify="flex-end">
+				<VStack spacing={ 6 } className="newspack-prompt-style-controls">
+					<StyleGroup
+						label={ __( 'Color', 'newspack-plugin' ) }
+						hasOverride={ hasKeys( styles.color ) }
+						onReset={ () => onChangeStyles( setPath( styles, [ 'color' ], undefined ) ) }
+						disabled={ inFlight }
+					>
+						<VStack spacing={ 0 } className="newspack-prompt-style-colors">
+							<ColorRow label={ __( 'Text', 'newspack-plugin' ) } colorValue={ text } disabled={ inFlight }>
+								<ColorPalette
+									aria-label={ __( 'Text', 'newspack-plugin' ) }
+									colors={ paletteColors }
+									value={ text ?? undefined }
+									onChange={ value => setColor( 'text', value ) }
+								/>
+							</ColorRow>
+							<ColorRow label={ __( 'Background', 'newspack-plugin' ) } colorValue={ background } disabled={ inFlight }>
+								<ColorPalette
+									aria-label={ __( 'Background', 'newspack-plugin' ) }
+									colors={ paletteColors }
+									value={ background ?? undefined }
+									onChange={ value => setColor( 'background', value ) }
+								/>
+							</ColorRow>
+						</VStack>
+						{ null !== ratio && ratio < MIN_CONTRAST_RATIO && (
+							<Notice status="warning" isDismissible={ false } style={ { margin: 0 } }>
+								{ __( 'This color combination may be hard for people to read.', 'newspack-plugin' ) }
+							</Notice>
 						) }
-						<Button
-							icon={ radiusLinked ? link : linkOff }
-							label={ radiusLinked ? __( 'Unlink Corners', 'newspack-plugin' ) : __( 'Link Corners', 'newspack-plugin' ) }
-							onClick={ () => setRadiusLinked( ! radiusLinked ) }
-							disabled={ inFlight }
-							isSmall
+					</StyleGroup>
+					<StyleGroup
+						label={ __( 'Typography', 'newspack-plugin' ) }
+						hasOverride={ hasKeys( styles.typography ) }
+						onReset={ () => onChangeStyles( setPath( styles, [ 'typography' ], undefined ) ) }
+						disabled={ inFlight }
+					>
+						<FontSizePicker
+							fontSizes={ fontSizes }
+							value={ effective( [ 'typography', 'fontSize' ] ) }
+							onChange={ setFontSize }
+							withReset={ false }
+							__next40pxDefaultSize
 						/>
-					</HStack>
-				</StyleGroup>
-			</VStack>
+					</StyleGroup>
+					<StyleGroup
+						label={ __( 'Padding', 'newspack-plugin' ) }
+						hasOverride={ undefined !== styles.spacing?.padding }
+						onReset={ () => onChangeStyles( setPath( styles, [ 'spacing', 'padding' ], undefined ) ) }
+						disabled={ inFlight }
+					>
+						<BoxControl
+							label={ __( 'Padding', 'newspack-plugin' ) }
+							values={ effective( [ 'spacing', 'padding' ] ) }
+							onChange={ setPadding }
+							splitOnAxis={ false }
+							allowReset={ false }
+							__next40pxDefaultSize
+						/>
+					</StyleGroup>
+					<StyleGroup
+						label={ __( 'Border', 'newspack-plugin' ) }
+						hasOverride={ hasKeys( borderOverride ) }
+						onReset={ () =>
+							onChangeStyles(
+								setPath( styles, [ 'border' ], undefined !== styles.border?.radius ? { radius: styles.border.radius } : undefined )
+							)
+						}
+						disabled={ inFlight }
+					>
+						<BorderBoxControl
+							label={ __( 'Border', 'newspack-plugin' ) }
+							hideLabelFromVision
+							colors={ paletteColors }
+							value={ hasKeys( borderOverride ) ? borderOverride : withoutRadius( defaults.border ) }
+							onChange={ setBorder }
+							enableStyle
+							__next40pxDefaultSize
+						/>
+					</StyleGroup>
+					<StyleGroup
+						label={ __( 'Border Radius', 'newspack-plugin' ) }
+						hasOverride={ undefined !== styles.border?.radius }
+						onReset={ () => onChangeStyles( setPath( styles, [ 'border', 'radius' ], undefined ) ) }
+						disabled={ inFlight }
+					>
+						<HStack alignment="flex-end" justify="space-between" spacing={ 2 }>
+							{ radiusLinked ? (
+								<UnitControl
+									label={ __( 'Radius', 'newspack-plugin' ) }
+									value={ isSplitRadius ? '' : radius }
+									onChange={ setRadius }
+									min={ 0 }
+									disabled={ inFlight }
+									__next40pxDefaultSize
+								/>
+							) : (
+								<Grid columns={ 2 } gutter={ 8 } noMargin>
+									{ RADIUS_CORNERS.map( ( [ corner, cornerLabel ] ) => (
+										<UnitControl
+											key={ corner }
+											label={ cornerLabel }
+											value={ isSplitRadius ? radius[ corner ] : radius }
+											onChange={ value => setRadiusCorner( corner, value ) }
+											min={ 0 }
+											disabled={ inFlight }
+											__next40pxDefaultSize
+										/>
+									) ) }
+								</Grid>
+							) }
+							<Button
+								icon={ radiusLinked ? link : linkOff }
+								label={ radiusLinked ? __( 'Unlink Corners', 'newspack-plugin' ) : __( 'Link Corners', 'newspack-plugin' ) }
+								onClick={ () => setRadiusLinked( ! radiusLinked ) }
+								disabled={ inFlight }
+								isSmall
+							/>
+						</HStack>
+					</StyleGroup>
+				</VStack>
+			</HStack>
 		</Disabled>
 	);
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -11,9 +11,11 @@
 import { __ } from '@wordpress/i18n';
 import { useState } from '@wordpress/element';
 import {
-	BaseControl,
+	ColorIndicator,
 	ColorPalette,
 	Disabled,
+	Dropdown,
+	FlexItem,
 	FontSizePicker,
 	Notice,
 	__experimentalBorderBoxControl as BorderBoxControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -30,6 +32,7 @@ import { link, linkOff } from '@wordpress/icons';
  */
 import { Button, Grid, Handoff, SectionHeader } from '../../../../../../packages/components/src';
 import { contrastRatio, presetRefForColor, resolveColor } from './style-utils';
+import './style-section.scss';
 
 const MIN_CONTRAST_RATIO = 4.5;
 const PADDING_SIDES = [ 'top', 'right', 'bottom', 'left' ];
@@ -93,6 +96,25 @@ const StyleGroup = ( { label, hasOverride, onReset, disabled, children } ) => (
 		</HStack>
 		{ children }
 	</VStack>
+);
+
+// The editor's color rows, composed from stable primitives: @wordpress/block-editor
+// owns ColorGradientSettingsDropdown and is not loaded on the wizard page.
+const ColorRow = ( { label, colorValue, disabled, children } ) => (
+	<Dropdown
+		className="newspack-prompt-style-colors__row"
+		contentClassName="newspack-prompt-style-colors__popover"
+		popoverProps={ { placement: 'bottom-start', shift: true } }
+		renderToggle={ ( { isOpen, onToggle } ) => (
+			<Button onClick={ onToggle } aria-expanded={ isOpen } disabled={ disabled } __next40pxDefaultSize>
+				<HStack justify="flex-start" spacing={ 3 }>
+					<ColorIndicator colorValue={ colorValue || undefined } />
+					<FlexItem>{ label }</FlexItem>
+				</HStack>
+			</Button>
+		) }
+		renderContent={ () => children }
+	/>
 );
 
 const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
@@ -172,23 +194,23 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 					onReset={ () => onChangeStyles( setPath( styles, [ 'color' ], undefined ) ) }
 					disabled={ inFlight }
 				>
-					<VStack spacing={ 2 }>
-						<BaseControl.VisualLabel>{ __( 'Background', 'newspack-plugin' ) }</BaseControl.VisualLabel>
-						<ColorPalette
-							aria-label={ __( 'Background', 'newspack-plugin' ) }
-							colors={ paletteColors }
-							value={ background ?? undefined }
-							onChange={ value => setColor( 'background', value ) }
-						/>
-					</VStack>
-					<VStack spacing={ 2 }>
-						<BaseControl.VisualLabel>{ __( 'Text', 'newspack-plugin' ) }</BaseControl.VisualLabel>
-						<ColorPalette
-							aria-label={ __( 'Text', 'newspack-plugin' ) }
-							colors={ paletteColors }
-							value={ text ?? undefined }
-							onChange={ value => setColor( 'text', value ) }
-						/>
+					<VStack spacing={ 0 } className="newspack-prompt-style-colors">
+						<ColorRow label={ __( 'Text', 'newspack-plugin' ) } colorValue={ text } disabled={ inFlight }>
+							<ColorPalette
+								aria-label={ __( 'Text', 'newspack-plugin' ) }
+								colors={ paletteColors }
+								value={ text ?? undefined }
+								onChange={ value => setColor( 'text', value ) }
+							/>
+						</ColorRow>
+						<ColorRow label={ __( 'Background', 'newspack-plugin' ) } colorValue={ background } disabled={ inFlight }>
+							<ColorPalette
+								aria-label={ __( 'Background', 'newspack-plugin' ) }
+								colors={ paletteColors }
+								value={ background ?? undefined }
+								onChange={ value => setColor( 'background', value ) }
+							/>
+						</ColorRow>
 					</VStack>
 					{ null !== ratio && ratio < MIN_CONTRAST_RATIO && (
 						<Notice status="warning" isDismissible={ false } style={ { margin: 0 } }>

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -15,6 +15,7 @@ import classnames from 'classnames';
  */
 import { __ } from '@wordpress/i18n';
 import {
+	BaseControl,
 	ColorIndicator,
 	ColorPalette,
 	Disabled,
@@ -32,15 +33,18 @@ import {
 	__experimentalUnitControl as UnitControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
+import { Icon, cornerAll } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { Button, Grid, Handoff, SectionHeader } from '../../../../../../packages/components/src';
-import { contrastRatio, presetRefForColor, resolveColor } from './style-utils';
+import { contrastRatio, presetRefForColor, relativeLuminance, resolveColor } from './style-utils';
 import './style-section.scss';
 
 const MIN_CONTRAST_RATIO = 4.5;
+// The size the editor gives the icon in front of a dimension input.
+const ICON_SIZE = 24;
 const PADDING_SIDES = [ 'top', 'right', 'bottom', 'left' ];
 // The radius slider works in the value's own number space, capped where core's
 // BorderControl caps its width slider.
@@ -84,6 +88,19 @@ const withoutRadius = border => {
 	} );
 	return next;
 };
+
+// The editor's contrast warning, verbatim: the suggestion pushes the pair the way
+// it already leans, so a dark background asks for a darker background still.
+const contrastMessage = ( background, text ) =>
+	relativeLuminance( background ) < relativeLuminance( text )
+		? __(
+				'This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.',
+				'newspack-plugin'
+		  )
+		: __(
+				'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.',
+				'newspack-plugin'
+		  );
 
 // Each group is one of the editor's block support panels: the group label and the
 // options menu in the header, which offers a reset per item and a Reset all.
@@ -216,7 +233,7 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 						</ToolsPanelItem>
 						{ null !== ratio && ratio < MIN_CONTRAST_RATIO && (
 							<Notice status="warning" isDismissible={ false } className="newspack-prompt-style-notice">
-								{ __( 'This color combination may be hard for people to read.', 'newspack-plugin' ) }
+								{ contrastMessage( background, text ) }
 							</Notice>
 						) }
 					</StylePanel>
@@ -259,7 +276,10 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 							/>
 						</ToolsPanelItem>
 					</StylePanel>
-					<StylePanel label={ __( 'Border', 'newspack-plugin' ) } resetAll={ clearBorder }>
+					<StylePanel
+						label={ __( 'Border', 'newspack-plugin' ) }
+						resetAll={ () => onChangeStyles( setPath( styles, [ 'border' ], undefined ) ) }
+					>
 						<ToolsPanelItem
 							label={ __( 'Border', 'newspack-plugin' ) }
 							hasValue={ () => hasKeys( borderOverride ) }
@@ -276,42 +296,41 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 								__next40pxDefaultSize
 							/>
 						</ToolsPanelItem>
-					</StylePanel>
-					<StylePanel
-						label={ __( 'Border Radius', 'newspack-plugin' ) }
-						resetAll={ () => onChangeStyles( setPath( styles, [ 'border', 'radius' ], undefined ) ) }
-					>
 						<ToolsPanelItem
 							label={ __( 'Radius', 'newspack-plugin' ) }
 							hasValue={ () => undefined !== styles.border?.radius }
 							onDeselect={ () => setRadius() }
 							isShownByDefault
 						>
-							<HStack spacing={ 4 } className="newspack-prompt-style-radius">
-								<UnitControl
-									label={ __( 'Radius', 'newspack-plugin' ) }
-									hideLabelFromVision
-									value={ radiusValue }
-									onChange={ setRadius }
-									min={ 0 }
-									disabled={ inFlight }
-									__next40pxDefaultSize
-								/>
-								<RangeControl
-									label={ __( 'Border radius', 'newspack-plugin' ) }
-									hideLabelFromVision
-									value={ radiusQuantity }
-									onChange={ setRadiusQuantity }
-									min={ 0 }
-									max={ RADIUS_SLIDER_MAX }
-									step={ 'px' === ( radiusUnit || 'px' ) || '%' === radiusUnit ? 1 : 0.1 }
-									initialPosition={ 0 }
-									withInputField={ false }
-									disabled={ inFlight }
-									__nextHasNoMarginBottom
-									__next40pxDefaultSize
-								/>
-							</HStack>
+							<VStack spacing={ 2 }>
+								<BaseControl.VisualLabel>{ __( 'Radius', 'newspack-plugin' ) }</BaseControl.VisualLabel>
+								<HStack spacing={ 4 } className="newspack-prompt-style-radius">
+									<Icon className="newspack-prompt-style-radius__icon" icon={ cornerAll } size={ ICON_SIZE } />
+									<UnitControl
+										label={ __( 'Radius', 'newspack-plugin' ) }
+										hideLabelFromVision
+										value={ radiusValue }
+										onChange={ setRadius }
+										min={ 0 }
+										disabled={ inFlight }
+										__next40pxDefaultSize
+									/>
+									<RangeControl
+										label={ __( 'Border radius', 'newspack-plugin' ) }
+										hideLabelFromVision
+										value={ radiusQuantity }
+										onChange={ setRadiusQuantity }
+										min={ 0 }
+										max={ RADIUS_SLIDER_MAX }
+										step={ 'px' === ( radiusUnit || 'px' ) || '%' === radiusUnit ? 1 : 0.1 }
+										initialPosition={ 0 }
+										withInputField={ false }
+										disabled={ inFlight }
+										__nextHasNoMarginBottom
+										__next40pxDefaultSize
+									/>
+								</HStack>
+							</VStack>
 						</ToolsPanelItem>
 					</StylePanel>
 				</VStack>

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -1,0 +1,52 @@
+/**
+ * Contextual Prompts Style section.
+ *
+ * Block themes hand off to the Site Editor's Styles panel; classic themes get
+ * controls that write site-wide defaults for the Contextual Prompt block.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
+import { __experimentalVStack as VStack } from '@wordpress/components';
+
+/**
+ * Internal dependencies
+ */
+import { Grid, Handoff, SectionHeader } from '../../../../../../packages/components/src';
+
+// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -- the classic controls that read these land in the next task.
+const StyleSection = ( { status, styles, inFlight, onChangeStyles } ) => {
+	const { is_block_theme: isBlockTheme, site_editor_styles_url: siteEditorStylesUrl } = status;
+
+	return (
+		<Grid columns={ 2 } gutter={ 32 } noMargin>
+			<SectionHeader
+				heading={ 2 }
+				title={ __( 'Style', 'newspack-plugin' ) }
+				description={
+					isBlockTheme
+						? __( "Contextual Prompt styles are managed in the Site Editor's Styles panel.", 'newspack-plugin' )
+						: __(
+								'Site-wide default styles for the Contextual Prompt block. Styles set on an individual block override these.',
+								'newspack-plugin'
+						  )
+				}
+				noMargin
+			/>
+			{ isBlockTheme ? (
+				<VStack spacing={ 6 } alignment="start">
+					<Handoff url={ siteEditorStylesUrl } __next40pxDefaultSize>
+						{ __( 'Edit Styles', 'newspack-plugin' ) }
+					</Handoff>
+				</VStack>
+			) : (
+				<VStack spacing={ 6 }>{ /* Classic controls land in the next task. */ }</VStack>
+			) }
+		</Grid>
+	);
+};
+
+export default StyleSection;

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -9,17 +9,285 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-// eslint-disable-next-line @wordpress/no-unsafe-wp-apis
-import { __experimentalVStack as VStack } from '@wordpress/components';
+import { useState } from '@wordpress/element';
+import {
+	BaseControl,
+	ColorPalette,
+	Disabled,
+	FontSizePicker,
+	Notice,
+	__experimentalBorderBoxControl as BorderBoxControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalBoxControl as BoxControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalHeading as Heading, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalUnitControl as UnitControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+} from '@wordpress/components';
+import { link, linkOff } from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
-import { Grid, Handoff, SectionHeader } from '../../../../../../packages/components/src';
+import { Button, Grid, Handoff, SectionHeader } from '../../../../../../packages/components/src';
+import { contrastRatio, presetRefForColor, resolveColor } from './style-utils';
 
-// eslint-disable-next-line no-unused-vars, @typescript-eslint/no-unused-vars -- the classic controls that read these land in the next task.
-const StyleSection = ( { status, styles, inFlight, onChangeStyles } ) => {
-	const { is_block_theme: isBlockTheme, site_editor_styles_url: siteEditorStylesUrl } = status;
+const MIN_CONTRAST_RATIO = 4.5;
+const PADDING_SIDES = [ 'top', 'right', 'bottom', 'left' ];
+const RADIUS_CORNERS = [
+	[ 'topLeft', __( 'Top left', 'newspack-plugin' ) ],
+	[ 'topRight', __( 'Top right', 'newspack-plugin' ) ],
+	[ 'bottomLeft', __( 'Bottom left', 'newspack-plugin' ) ],
+	[ 'bottomRight', __( 'Bottom right', 'newspack-plugin' ) ],
+];
+
+const getPath = ( source, path ) => path.reduce( ( node, key ) => node?.[ key ], source );
+
+const hasKeys = value => !! value && 0 < Object.keys( value ).length;
+
+// Immutable deep-set that deletes the key when the value is undefined and prunes
+// nodes left empty: the REST layer replaces the whole object, and an all-empty
+// one clears the stored option, so `{ color: {} }` residue would keep it alive.
+const setPath = ( source, path, value ) => {
+	const [ head, ...rest ] = path;
+	const next = { ...source };
+	if ( 0 === rest.length ) {
+		if ( undefined === value ) {
+			delete next[ head ];
+		} else {
+			next[ head ] = value;
+		}
+	} else {
+		const child = setPath( next[ head ] || {}, rest, value );
+		if ( 0 === Object.keys( child ).length ) {
+			delete next[ head ];
+		} else {
+			next[ head ] = child;
+		}
+	}
+	return next;
+};
+
+// Border radius is its own group, so the border group reads and writes every
+// border key except the radius.
+const withoutRadius = border => {
+	const next = {};
+	Object.entries( border || {} ).forEach( ( [ key, value ] ) => {
+		if ( 'radius' !== key && undefined !== value ) {
+			next[ key ] = value;
+		}
+	} );
+	return next;
+};
+
+const StyleGroup = ( { label, hasOverride, onReset, disabled, children } ) => (
+	<VStack spacing={ 3 }>
+		<HStack justify="space-between" alignment="center" spacing={ 2 }>
+			<Heading level={ 3 } size={ 13 }>
+				{ label }
+			</Heading>
+			{ hasOverride && (
+				<Button variant="tertiary" isSmall onClick={ onReset } disabled={ disabled }>
+					{ __( 'Reset', 'newspack-plugin' ) }
+				</Button>
+			) }
+		</HStack>
+		{ children }
+	</VStack>
+);
+
+const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
+	const {
+		is_block_theme: isBlockTheme,
+		site_editor_styles_url: siteEditorStylesUrl,
+		style_defaults: styleDefaults,
+		style_palette: stylePalette,
+		style_font_sizes: styleFontSizes,
+	} = status;
+
+	const defaults = styleDefaults || {};
+	const palette = stylePalette || [];
+	// Global settings presets carry extra keys (fluid font sizes, gradients); the
+	// controls only take the shapes they document.
+	const paletteColors = palette.map( ( { name, slug, color } ) => ( { name, slug, color } ) );
+	const fontSizes = ( styleFontSizes || [] ).map( ( { name, slug, size } ) => ( { name, slug, size } ) );
+	const effective = path => getPath( styles, path ) ?? getPath( defaults, path );
+
+	const radius = effective( [ 'border', 'radius' ] );
+	const isSplitRadius = !! radius && 'object' === typeof radius;
+	const [ radiusLinked, setRadiusLinked ] = useState( ! isSplitRadius );
+
+	const background = resolveColor( effective( [ 'color', 'background' ] ), palette );
+	const text = resolveColor( effective( [ 'color', 'text' ] ), palette );
+	const ratio = background && text ? contrastRatio( background, text ) : null;
+
+	const setColor = ( key, value ) => onChangeStyles( setPath( styles, [ 'color', key ], value ? presetRefForColor( value, palette ) : undefined ) );
+
+	const setFontSize = value => onChangeStyles( setPath( styles, [ 'typography', 'fontSize' ], value || undefined ) );
+
+	const setPadding = value => {
+		const sides = {};
+		PADDING_SIDES.forEach( side => {
+			if ( undefined !== value?.[ side ] ) {
+				sides[ side ] = value[ side ];
+			}
+		} );
+		onChangeStyles( setPath( styles, [ 'spacing', 'padding' ], hasKeys( sides ) ? sides : undefined ) );
+	};
+
+	const borderOverride = withoutRadius( styles.border );
+	const setBorder = value => {
+		const next = withoutRadius( value );
+		if ( undefined !== styles.border?.radius ) {
+			next.radius = styles.border.radius;
+		}
+		onChangeStyles( setPath( styles, [ 'border' ], hasKeys( next ) ? next : undefined ) );
+	};
+
+	const setRadius = value => onChangeStyles( setPath( styles, [ 'border', 'radius' ], value || undefined ) );
+	// Unlinking an unsplit radius carries its value onto every corner, so the
+	// corners the publisher does not touch keep what they were showing.
+	const setRadiusCorner = ( corner, value ) => {
+		const next = isSplitRadius ? { ...radius } : {};
+		if ( ! isSplitRadius && radius ) {
+			RADIUS_CORNERS.forEach( ( [ key ] ) => {
+				next[ key ] = radius;
+			} );
+		}
+		if ( value ) {
+			next[ corner ] = value;
+		} else {
+			delete next[ corner ];
+		}
+		onChangeStyles( setPath( styles, [ 'border', 'radius' ], hasKeys( next ) ? next : undefined ) );
+	};
+
+	// ColorPalette, FontSizePicker, BoxControl and BorderBoxControl take no
+	// `disabled` prop, so the whole stack goes inert while a save is in flight.
+	const classicControls = (
+		<Disabled isDisabled={ !! inFlight }>
+			<VStack spacing={ 6 }>
+				<StyleGroup
+					label={ __( 'Color', 'newspack-plugin' ) }
+					hasOverride={ hasKeys( styles.color ) }
+					onReset={ () => onChangeStyles( setPath( styles, [ 'color' ], undefined ) ) }
+					disabled={ inFlight }
+				>
+					<VStack spacing={ 2 }>
+						<BaseControl.VisualLabel>{ __( 'Background', 'newspack-plugin' ) }</BaseControl.VisualLabel>
+						<ColorPalette
+							aria-label={ __( 'Background', 'newspack-plugin' ) }
+							colors={ paletteColors }
+							value={ background ?? undefined }
+							onChange={ value => setColor( 'background', value ) }
+						/>
+					</VStack>
+					<VStack spacing={ 2 }>
+						<BaseControl.VisualLabel>{ __( 'Text', 'newspack-plugin' ) }</BaseControl.VisualLabel>
+						<ColorPalette
+							aria-label={ __( 'Text', 'newspack-plugin' ) }
+							colors={ paletteColors }
+							value={ text ?? undefined }
+							onChange={ value => setColor( 'text', value ) }
+						/>
+					</VStack>
+					{ null !== ratio && ratio < MIN_CONTRAST_RATIO && (
+						<Notice status="warning" isDismissible={ false } style={ { margin: 0 } }>
+							{ __( 'This color combination may be hard for people to read.', 'newspack-plugin' ) }
+						</Notice>
+					) }
+				</StyleGroup>
+				<StyleGroup
+					label={ __( 'Typography', 'newspack-plugin' ) }
+					hasOverride={ hasKeys( styles.typography ) }
+					onReset={ () => onChangeStyles( setPath( styles, [ 'typography' ], undefined ) ) }
+					disabled={ inFlight }
+				>
+					<FontSizePicker
+						fontSizes={ fontSizes }
+						value={ effective( [ 'typography', 'fontSize' ] ) }
+						onChange={ setFontSize }
+						withReset={ false }
+						__next40pxDefaultSize
+					/>
+				</StyleGroup>
+				<StyleGroup
+					label={ __( 'Padding', 'newspack-plugin' ) }
+					hasOverride={ undefined !== styles.spacing?.padding }
+					onReset={ () => onChangeStyles( setPath( styles, [ 'spacing', 'padding' ], undefined ) ) }
+					disabled={ inFlight }
+				>
+					<BoxControl
+						label={ __( 'Padding', 'newspack-plugin' ) }
+						values={ effective( [ 'spacing', 'padding' ] ) }
+						onChange={ setPadding }
+						splitOnAxis={ false }
+						allowReset={ false }
+						__next40pxDefaultSize
+					/>
+				</StyleGroup>
+				<StyleGroup
+					label={ __( 'Border', 'newspack-plugin' ) }
+					hasOverride={ hasKeys( borderOverride ) }
+					onReset={ () =>
+						onChangeStyles(
+							setPath( styles, [ 'border' ], undefined !== styles.border?.radius ? { radius: styles.border.radius } : undefined )
+						)
+					}
+					disabled={ inFlight }
+				>
+					<BorderBoxControl
+						label={ __( 'Border', 'newspack-plugin' ) }
+						hideLabelFromVision
+						colors={ paletteColors }
+						value={ hasKeys( borderOverride ) ? borderOverride : withoutRadius( defaults.border ) }
+						onChange={ setBorder }
+						enableStyle
+						__next40pxDefaultSize
+					/>
+				</StyleGroup>
+				<StyleGroup
+					label={ __( 'Border Radius', 'newspack-plugin' ) }
+					hasOverride={ undefined !== styles.border?.radius }
+					onReset={ () => onChangeStyles( setPath( styles, [ 'border', 'radius' ], undefined ) ) }
+					disabled={ inFlight }
+				>
+					<HStack alignment="flex-end" justify="space-between" spacing={ 2 }>
+						{ radiusLinked ? (
+							<UnitControl
+								label={ __( 'Radius', 'newspack-plugin' ) }
+								value={ isSplitRadius ? '' : radius }
+								onChange={ setRadius }
+								min={ 0 }
+								disabled={ inFlight }
+								__next40pxDefaultSize
+							/>
+						) : (
+							<Grid columns={ 2 } gutter={ 8 } noMargin>
+								{ RADIUS_CORNERS.map( ( [ corner, cornerLabel ] ) => (
+									<UnitControl
+										key={ corner }
+										label={ cornerLabel }
+										value={ isSplitRadius ? radius[ corner ] : radius }
+										onChange={ value => setRadiusCorner( corner, value ) }
+										min={ 0 }
+										disabled={ inFlight }
+										__next40pxDefaultSize
+									/>
+								) ) }
+							</Grid>
+						) }
+						<Button
+							icon={ radiusLinked ? link : linkOff }
+							label={ radiusLinked ? __( 'Unlink Corners', 'newspack-plugin' ) : __( 'Link Corners', 'newspack-plugin' ) }
+							onClick={ () => setRadiusLinked( ! radiusLinked ) }
+							disabled={ inFlight }
+							isSmall
+						/>
+					</HStack>
+				</StyleGroup>
+			</VStack>
+		</Disabled>
+	);
 
 	return (
 		<Grid columns={ 2 } gutter={ 32 } noMargin>
@@ -43,7 +311,7 @@ const StyleSection = ( { status, styles, inFlight, onChangeStyles } ) => {
 					</Handoff>
 				</VStack>
 			) : (
-				<VStack spacing={ 6 }>{ /* Classic controls land in the next task. */ }</VStack>
+				classicControls
 			) }
 		</Grid>
 	);

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -9,7 +9,6 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { useState } from '@wordpress/element';
 import {
 	ColorIndicator,
 	ColorPalette,
@@ -18,14 +17,15 @@ import {
 	FlexItem,
 	FontSizePicker,
 	Notice,
+	RangeControl,
 	__experimentalBorderBoxControl as BorderBoxControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalBoxControl as BoxControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHeading as Heading, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { link, linkOff } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -36,12 +36,9 @@ import './style-section.scss';
 
 const MIN_CONTRAST_RATIO = 4.5;
 const PADDING_SIDES = [ 'top', 'right', 'bottom', 'left' ];
-const RADIUS_CORNERS = [
-	[ 'topLeft', __( 'Top left', 'newspack-plugin' ) ],
-	[ 'topRight', __( 'Top right', 'newspack-plugin' ) ],
-	[ 'bottomLeft', __( 'Bottom left', 'newspack-plugin' ) ],
-	[ 'bottomRight', __( 'Bottom right', 'newspack-plugin' ) ],
-];
+// The radius slider works in the value's own number space, capped where core's
+// BorderControl caps its width slider.
+const RADIUS_SLIDER_MAX = 100;
 
 const getPath = ( source, path ) => path.reduce( ( node, key ) => node?.[ key ], source );
 
@@ -135,8 +132,11 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 	const effective = path => getPath( styles, path ) ?? getPath( defaults, path );
 
 	const radius = effective( [ 'border', 'radius' ] );
+	// A stored per-corner object predates this single control: show nothing rather
+	// than a wrong number, and leave it stored until an edit replaces it.
 	const isSplitRadius = !! radius && 'object' === typeof radius;
-	const [ radiusLinked, setRadiusLinked ] = useState( ! isSplitRadius );
+	const radiusValue = isSplitRadius ? '' : radius;
+	const [ radiusQuantity, radiusUnit ] = parseQuantityAndUnitFromRawValue( radiusValue );
 
 	const background = resolveColor( effective( [ 'color', 'background' ] ), palette );
 	const text = resolveColor( effective( [ 'color', 'text' ] ), palette );
@@ -166,22 +166,9 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 	};
 
 	const setRadius = value => onChangeStyles( setPath( styles, [ 'border', 'radius' ], value || undefined ) );
-	// Unlinking an unsplit radius carries its value onto every corner, so the
-	// corners the publisher does not touch keep what they were showing.
-	const setRadiusCorner = ( corner, value ) => {
-		const next = isSplitRadius ? { ...radius } : {};
-		if ( ! isSplitRadius && radius ) {
-			RADIUS_CORNERS.forEach( ( [ key ] ) => {
-				next[ key ] = radius;
-			} );
-		}
-		if ( value ) {
-			next[ corner ] = value;
-		} else {
-			delete next[ corner ];
-		}
-		onChangeStyles( setPath( styles, [ 'border', 'radius' ], hasKeys( next ) ? next : undefined ) );
-	};
+	// The slider only moves the number, so it writes back with the unit already in
+	// play, as core's BorderControl does for the border width.
+	const setRadiusQuantity = value => setRadius( undefined === value ? undefined : `${ value }${ radiusUnit || 'px' }` );
 
 	// ColorPalette, FontSizePicker, BoxControl and BorderBoxControl take no
 	// `disabled` prop, so the whole stack goes inert while a save is in flight.
@@ -274,37 +261,29 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 						onReset={ () => onChangeStyles( setPath( styles, [ 'border', 'radius' ], undefined ) ) }
 						disabled={ inFlight }
 					>
-						<HStack alignment="flex-end" justify="space-between" spacing={ 2 }>
-							{ radiusLinked ? (
-								<UnitControl
-									label={ __( 'Radius', 'newspack-plugin' ) }
-									value={ isSplitRadius ? '' : radius }
-									onChange={ setRadius }
-									min={ 0 }
-									disabled={ inFlight }
-									__next40pxDefaultSize
-								/>
-							) : (
-								<Grid columns={ 2 } gutter={ 8 } noMargin>
-									{ RADIUS_CORNERS.map( ( [ corner, cornerLabel ] ) => (
-										<UnitControl
-											key={ corner }
-											label={ cornerLabel }
-											value={ isSplitRadius ? radius[ corner ] : radius }
-											onChange={ value => setRadiusCorner( corner, value ) }
-											min={ 0 }
-											disabled={ inFlight }
-											__next40pxDefaultSize
-										/>
-									) ) }
-								</Grid>
-							) }
-							<Button
-								icon={ radiusLinked ? link : linkOff }
-								label={ radiusLinked ? __( 'Unlink Corners', 'newspack-plugin' ) : __( 'Link Corners', 'newspack-plugin' ) }
-								onClick={ () => setRadiusLinked( ! radiusLinked ) }
+						<HStack spacing={ 4 } className="newspack-prompt-style-radius">
+							<UnitControl
+								label={ __( 'Radius', 'newspack-plugin' ) }
+								hideLabelFromVision
+								value={ radiusValue }
+								onChange={ setRadius }
+								min={ 0 }
 								disabled={ inFlight }
-								isSmall
+								__next40pxDefaultSize
+							/>
+							<RangeControl
+								label={ __( 'Border radius', 'newspack-plugin' ) }
+								hideLabelFromVision
+								value={ radiusQuantity }
+								onChange={ setRadiusQuantity }
+								min={ 0 }
+								max={ RADIUS_SLIDER_MAX }
+								step={ 'px' === ( radiusUnit || 'px' ) || '%' === radiusUnit ? 1 : 0.1 }
+								initialPosition={ 0 }
+								withInputField={ false }
+								disabled={ inFlight }
+								__nextHasNoMarginBottom
+								__next40pxDefaultSize
 							/>
 						</HStack>
 					</StyleGroup>

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -23,8 +23,9 @@
 		border-top: 1px solid wp-colors.$gray-300;
 	}
 
-	// Direct child only: the palette renders in a popover inside the same
-	// wrapper and its own buttons must keep their sizing.
+	// The row's own toggle fills the row. Direct child only, so the rule stays
+	// tied to that toggle; the palette's buttons are out of reach anyway, since
+	// the popover portals to document.body.
 	&__row > .components-button {
 		border-radius: 0;
 		width: 100%;

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -1,42 +1,35 @@
 /**
  * Contextual Prompts Style section.
  *
- * The style groups are core ToolsPanels, stacked into one list the way the
+ * The style groups are core ToolsPanels, stacked into one ringed list the way the
  * editor's inspector stacks them. Color rows mirror the editor's color panel: a
  * bordered group of flat, full-width toggles, each showing a round indicator and
  * the color's name.
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
-@use "~@wordpress/base-styles/variables" as wp-variables;
+@use "~@wordpress/base-styles/variables" as wp-vars;
 
-// The controls column hugs the end of the section grid, capped at the editor
-// sidebar's content width: the 280px sidebar less its 16px gutters.
+// The controls column hugs the end of the section grid at the editor sidebar's
+// width, so the panels inside give their controls the width they have there. The
+// ring closes the stack off: the panels only carry the separators between them.
 .newspack-prompt-style-controls {
-	max-width: calc(#{wp-variables.$sidebar-width} - #{wp-variables.$grid-unit-20} * 2);
+	border-radius: wp-vars.$radius-small;
+	box-shadow: 0 0 0 wp-vars.$border-width wp-colors.$gray-300;
+	max-width: wp-vars.$sidebar-width;
+	overflow: hidden;
 	width: 100%;
 
-	// The panel's own side padding goes: this column is already the width the
-	// controls should be. The first panel drops its separator, which would read as
-	// a stray rule above the column.
-	.newspack-prompt-style-panel {
-		padding-inline: 0;
-
-		&:first-child {
-			border-top: 0;
-			padding-top: 0;
-		}
-	}
-
 	// The color rows butt up against each other into a single bordered list
-	// instead of sitting apart on the panel's row gap.
+	// instead of sitting apart on the panel's row gap, which the first row then
+	// restores under the header.
 	.newspack-prompt-style-panel--color {
 		row-gap: 0;
 	}
 
 	.newspack-prompt-style-notice {
 		grid-column: 1 / -1;
-		margin: wp-variables.$grid-unit-20 0 0;
+		margin: wp-vars.$grid-unit-20 0 0;
 	}
 
 	.newspack-prompt-style-colors {
@@ -45,13 +38,20 @@
 
 		&--first {
 			border-top: 1px solid wp-colors.$gray-300;
-			border-start-start-radius: 2px;
-			border-start-end-radius: 2px;
+			border-start-start-radius: wp-vars.$radius-small;
+			border-start-end-radius: wp-vars.$radius-small;
+			margin-top: wp-vars.$grid-unit-20;
 		}
 
 		&--last {
-			border-end-start-radius: 2px;
-			border-end-end-radius: 2px;
+			border-end-start-radius: wp-vars.$radius-small;
+			border-end-end-radius: wp-vars.$radius-small;
+		}
+
+		// A Dropdown is inline-block, so the row has to be told to fill its item,
+		// as the editor's color rows are.
+		&__row {
+			display: block;
 		}
 
 		// The row's own toggle fills the row. Direct child only, so the rule stays
@@ -60,6 +60,20 @@
 		&__row > .components-button {
 			border-radius: 0;
 			width: 100%;
+
+			// The editor's states: hovering only takes the accent text color, which
+			// core gives the button itself, while an open or focused row greys. The
+			// focus ring is inset so it follows the row rather than straddling the
+			// group's border.
+			&[aria-expanded="true"],
+			&:focus-visible {
+				background: wp-colors.$gray-100;
+			}
+
+			&:focus-visible {
+				box-shadow: inset 0 0 0 var(--wp-admin-border-width-focus, #{wp-vars.$border-width-focus-fallback}) var(--wp-admin-theme-color);
+				outline: wp-vars.$border-width-focus-fallback solid transparent;
+			}
 		}
 
 		.component-color-indicator {
@@ -67,9 +81,14 @@
 		}
 	}
 
-	// Split the radius row the way core's BorderControl splits its width row:
-	// input on the left, slider taking the rest.
+	// Split the radius row the way core's BorderControl splits its width row: the
+	// corners icon, then the input, then the slider taking the rest.
 	.newspack-prompt-style-radius {
+		&__icon {
+			fill: currentcolor;
+			flex: none;
+		}
+
 		.components-unit-control-wrapper {
 			flex: 1 1 40%;
 		}

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -6,6 +6,14 @@
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
+@use "~@wordpress/base-styles/variables" as wp-variables;
+
+// The controls column hugs the end of the section grid, capped at the editor
+// sidebar's content width: the 280px sidebar less its 16px gutters.
+.newspack-prompt-style-controls {
+	max-width: calc(#{wp-variables.$sidebar-width} - #{wp-variables.$grid-unit-20} * 2);
+	width: 100%;
+}
 
 .newspack-prompt-style-colors {
 	border: 1px solid wp-colors.$gray-300;

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -1,0 +1,35 @@
+/**
+ * Contextual Prompts Style section.
+ *
+ * Color rows mirroring the editor's color panel: a bordered group of flat,
+ * full-width toggles, each showing a round indicator and the color's name.
+ */
+
+@use "~@wordpress/base-styles/colors" as wp-colors;
+
+.newspack-prompt-style-colors {
+	border: 1px solid wp-colors.$gray-300;
+	border-radius: 2px;
+
+	> * + * {
+		border-top: 1px solid wp-colors.$gray-300;
+	}
+
+	// Direct child only: the palette renders in a popover inside the same
+	// wrapper and its own buttons must keep their sizing.
+	&__row > .components-button {
+		border-radius: 0;
+		width: 100%;
+	}
+
+	.component-color-indicator {
+		flex-shrink: 0;
+	}
+}
+
+// Popover content is `width: min-content`, which would collapse the palette to
+// a single column; 260px matches the editor's color panel.
+.newspack-prompt-style-colors__popover.components-dropdown__content .components-popover__content {
+	padding: 16px;
+	width: 260px;
+}

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -36,6 +36,18 @@
 	}
 }
 
+// Split the radius row the way core's BorderControl splits its width row:
+// input on the left, slider taking the rest.
+.newspack-prompt-style-radius {
+	.components-unit-control-wrapper {
+		flex: 1 1 40%;
+	}
+
+	.components-range-control {
+		flex: 1 1 60%;
+	}
+}
+
 // Popover content is `width: min-content`, which would collapse the palette to
 // a single column; 260px matches the editor's color panel.
 .newspack-prompt-style-colors__popover.components-dropdown__content .components-popover__content {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -1,8 +1,10 @@
 /**
  * Contextual Prompts Style section.
  *
- * Color rows mirroring the editor's color panel: a bordered group of flat,
- * full-width toggles, each showing a round indicator and the color's name.
+ * The style groups are core ToolsPanels, stacked into one list the way the
+ * editor's inspector stacks them. Color rows mirror the editor's color panel: a
+ * bordered group of flat, full-width toggles, each showing a round indicator and
+ * the color's name.
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
@@ -13,38 +15,68 @@
 .newspack-prompt-style-controls {
 	max-width: calc(#{wp-variables.$sidebar-width} - #{wp-variables.$grid-unit-20} * 2);
 	width: 100%;
-}
 
-.newspack-prompt-style-colors {
-	border: 1px solid wp-colors.$gray-300;
-	border-radius: 2px;
+	// The panel's own side padding goes: this column is already the width the
+	// controls should be. The first panel drops its separator, which would read as
+	// a stray rule above the column.
+	.newspack-prompt-style-panel {
+		padding-inline: 0;
 
-	> * + * {
-		border-top: 1px solid wp-colors.$gray-300;
+		&:first-child {
+			border-top: 0;
+			padding-top: 0;
+		}
 	}
 
-	// The row's own toggle fills the row. Direct child only, so the rule stays
-	// tied to that toggle; the palette's buttons are out of reach anyway, since
-	// the popover portals to document.body.
-	&__row > .components-button {
-		border-radius: 0;
-		width: 100%;
+	// The color rows butt up against each other into a single bordered list
+	// instead of sitting apart on the panel's row gap.
+	.newspack-prompt-style-panel--color {
+		row-gap: 0;
 	}
 
-	.component-color-indicator {
-		flex-shrink: 0;
-	}
-}
-
-// Split the radius row the way core's BorderControl splits its width row:
-// input on the left, slider taking the rest.
-.newspack-prompt-style-radius {
-	.components-unit-control-wrapper {
-		flex: 1 1 40%;
+	.newspack-prompt-style-notice {
+		grid-column: 1 / -1;
+		margin: wp-variables.$grid-unit-20 0 0;
 	}
 
-	.components-range-control {
-		flex: 1 1 60%;
+	.newspack-prompt-style-colors {
+		border: 1px solid wp-colors.$gray-300;
+		border-top: 0;
+
+		&--first {
+			border-top: 1px solid wp-colors.$gray-300;
+			border-start-start-radius: 2px;
+			border-start-end-radius: 2px;
+		}
+
+		&--last {
+			border-end-start-radius: 2px;
+			border-end-end-radius: 2px;
+		}
+
+		// The row's own toggle fills the row. Direct child only, so the rule stays
+		// tied to that toggle; the palette's buttons are out of reach anyway, since
+		// the popover portals to document.body.
+		&__row > .components-button {
+			border-radius: 0;
+			width: 100%;
+		}
+
+		.component-color-indicator {
+			flex-shrink: 0;
+		}
+	}
+
+	// Split the radius row the way core's BorderControl splits its width row:
+	// input on the left, slider taking the rest.
+	.newspack-prompt-style-radius {
+		.components-unit-control-wrapper {
+			flex: 1 1 40%;
+		}
+
+		.components-range-control {
+			flex: 1 1 60%;
+		}
 	}
 }
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -59,7 +59,12 @@ describe( 'StyleSection on a block theme', () => {
 	} );
 } );
 
-const CONTRAST_WARNING = 'This color combination may be hard for people to read.';
+// The editor's two contrast messages, verbatim: the suggestion follows the way the
+// pair already leans.
+const CONTRAST_WARNING_DARKER_BACKGROUND =
+	'This color combination may be hard for people to read. Try using a darker background color and/or a brighter text color.';
+const CONTRAST_WARNING_BRIGHTER_BACKGROUND =
+	'This color combination may be hard for people to read. Try using a brighter background color and/or a darker text color.';
 // A Notice announces itself into the a11y-speak region, which duplicates its text
 // in the document, so the queries below are scoped to the rendered notice.
 const NOTICE_CONTENT = '.components-notice__content';
@@ -95,10 +100,12 @@ describe( 'StyleSection on a classic theme', () => {
 		expect( screen.getByRole( 'button', { name: 'Text' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Background' } ) ).toBeInTheDocument();
 
-		// Each group offers its resets from an options menu, not a Reset button.
-		[ 'Color', 'Typography', 'Padding', 'Border', 'Border Radius' ].forEach( label =>
+		// Each group offers its resets from an options menu, not a Reset button, and
+		// the radius belongs to the Border group rather than one of its own.
+		[ 'Color', 'Typography', 'Padding', 'Border' ].forEach( label =>
 			expect( screen.getByRole( 'button', { name: `${ label } options` } ) ).toBeInTheDocument()
 		);
+		expect( screen.queryByRole( 'button', { name: 'Border Radius options' } ) ).toBeNull();
 		expect( screen.queryByRole( 'button', { name: 'Reset' } ) ).toBeNull();
 	} );
 
@@ -180,13 +187,29 @@ describe( 'StyleSection on a classic theme', () => {
 			/>
 		);
 
-		// The radius is its own group, so resetting the border leaves it behind.
+		// The radius is its own item, so resetting the border leaves it behind.
 		openPanelMenu( 'Border' );
 		clickMenuItem( 'Reset Border' );
 		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { radius: '4px' } } );
 	} );
 
-	it( 'keeps the border radius when the whole border group is reset', () => {
+	it( 'resets only the radius from the radius item', () => {
+		const onChangeStyles = jest.fn();
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ { border: { radius: '4px', width: '1px' } } }
+				inFlight={ false }
+				onChangeStyles={ onChangeStyles }
+			/>
+		);
+
+		openPanelMenu( 'Border' );
+		clickMenuItem( 'Reset Radius' );
+		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { width: '1px' } } );
+	} );
+
+	it( 'clears the radius too when the whole border group is reset', () => {
 		const onChangeStyles = jest.fn();
 		render(
 			<StyleSection
@@ -199,23 +222,7 @@ describe( 'StyleSection on a classic theme', () => {
 
 		openPanelMenu( 'Border' );
 		clickMenuItem( 'Reset all' );
-		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { radius: '4px' } } );
-	} );
-
-	it( 'resets only the radius from the Border Radius group', () => {
-		const onChangeStyles = jest.fn();
-		render(
-			<StyleSection
-				status={ CLASSIC_STATUS }
-				styles={ { border: { radius: '4px', width: '1px' } } }
-				inFlight={ false }
-				onChangeStyles={ onChangeStyles }
-			/>
-		);
-
-		openPanelMenu( 'Border Radius' );
-		clickMenuItem( 'Reset Radius' );
-		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { width: '1px' } } );
+		expect( onChangeStyles ).toHaveBeenCalledWith( {} );
 	} );
 
 	it( 'disables the controls that take a disabled prop while a save is in flight', () => {
@@ -237,6 +244,9 @@ describe( 'StyleSection on a classic theme', () => {
 		expect( screen.getByLabelText( 'Radius' ) ).toHaveValue( 10 );
 		expect( screen.getByRole( 'slider', { name: 'Border radius' } ) ).toHaveValue( '10' );
 		expect( screen.queryByLabelText( 'Top left' ) ).toBeNull();
+
+		// The Border group's header no longer names the radius, so its row does.
+		expect( screen.getByText( 'Radius', { selector: '.components-base-control__label' } ) ).toBeInTheDocument();
 	} );
 
 	it( 'writes the border radius as a single string', () => {
@@ -274,7 +284,7 @@ describe( 'StyleSection on a classic theme', () => {
 		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { radius: '12px' } } );
 	} );
 
-	it( 'warns on a low-contrast pair', () => {
+	it( 'warns on a low-contrast pair, suggesting a darker background under lighter text', () => {
 		render(
 			<StyleSection
 				status={ CLASSIC_STATUS }
@@ -283,14 +293,16 @@ describe( 'StyleSection on a classic theme', () => {
 				onChangeStyles={ () => {} }
 			/>
 		);
-		expect( screen.getByText( CONTRAST_WARNING, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
+		// The background is the darker of the two, so the fix is to push it darker
+		// still and lift the text.
+		expect( screen.getByText( CONTRAST_WARNING_DARKER_BACKGROUND, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
 	} );
 
 	it( 'warns using the default background when only text is set', () => {
 		render( <StyleSection status={ CLASSIC_STATUS } styles={ { color: { text: '#888888' } } } inFlight={ false } onChangeStyles={ () => {} } /> );
 		// Default background #f7f7f7 vs #888888 is below 4.5 too, so the warning
-		// must consider defaults: expect it present.
-		expect( screen.getByText( CONTRAST_WARNING, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
+		// must consider defaults: expect it present, this time the other way around.
+		expect( screen.getByText( CONTRAST_WARNING_BRIGHTER_BACKGROUND, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
 	} );
 
 	it( 'warns using the inherited text color when only the background is set', () => {
@@ -302,6 +314,6 @@ describe( 'StyleSection on a classic theme', () => {
 			style_defaults: { ...CLASSIC_STATUS.style_defaults, color: { background: '#f7f7f7', text: '#111111' } },
 		};
 		render( <StyleSection status={ status } styles={ { color: { background: '#7a5c3e' } } } inFlight={ false } onChangeStyles={ () => {} } /> );
-		expect( screen.getByText( CONTRAST_WARNING, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
+		expect( screen.getByText( CONTRAST_WARNING_BRIGHTER_BACKGROUND, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -1,0 +1,59 @@
+/**
+ * Contextual Prompts Style section: on a block theme it only offers the handoff
+ * to the Site Editor's Styles panel, with no site-wide style controls.
+ */
+
+/**
+ * External dependencies
+ */
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import '@testing-library/jest-dom';
+
+/**
+ * WordPress dependencies
+ */
+import apiFetch from '@wordpress/api-fetch';
+
+/**
+ * Internal dependencies
+ */
+import StyleSection from './style-section';
+
+jest.mock( '@wordpress/api-fetch', () => jest.fn() );
+
+const HANDOFF_LINK = 'https://example.test/wp-admin/site-editor.php?handoff=1';
+const RETURN_URL = 'https://example.test/wp-admin/admin.php?page=newspack-audience';
+
+const BLOCK_THEME_STATUS = {
+	is_block_theme: true,
+	style_defaults: {},
+	style_palette: [],
+	style_font_sizes: [],
+	site_editor_styles_url: 'https://example.test/wp-admin/site-editor.php?p=%2Fstyles',
+};
+
+describe( 'StyleSection on a block theme', () => {
+	beforeEach( () => {
+		apiFetch.mockReset();
+		apiFetch.mockResolvedValue( { HandoffLink: HANDOFF_LINK } );
+		delete window.location;
+		window.location = { href: RETURN_URL };
+	} );
+
+	it( 'renders the handoff to the Styles panel and no controls', async () => {
+		render( <StyleSection status={ BLOCK_THEME_STATUS } styles={ {} } inFlight={ false } onChangeStyles={ () => {} } /> );
+
+		expect( screen.queryByText( 'Background' ) ).toBeNull();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Edit Styles' } ) );
+
+		await waitFor( () => expect( window.location.href ).toBe( HANDOFF_LINK ) );
+		expect( apiFetch ).toHaveBeenCalledWith(
+			expect.objectContaining( {
+				path: '/newspack/v1/handoff',
+				method: 'POST',
+				data: expect.objectContaining( { destinationUrl: BLOCK_THEME_STATUS.site_editor_styles_url } ),
+			} )
+		);
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -284,6 +284,24 @@ describe( 'StyleSection on a classic theme', () => {
 		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { radius: '12px' } } );
 	} );
 
+	it( 'writes a numeric font size preset as a px string', () => {
+		const onChangeStyles = jest.fn();
+		const status = {
+			...CLASSIC_STATUS,
+			// A theme.json may declare a preset size as a bare number, and the picker
+			// hands back the shape it was given.
+			style_font_sizes: [
+				{ name: 'Small', slug: 'small', size: 16 },
+				{ name: 'Normal', slug: 'normal', size: 20 },
+			],
+		};
+		render( <StyleSection status={ status } styles={ {} } inFlight={ false } onChangeStyles={ onChangeStyles } /> );
+
+		fireEvent.click( screen.getByRole( 'radio', { name: 'Normal' } ) );
+
+		expect( onChangeStyles ).toHaveBeenCalledWith( { typography: { fontSize: '20px' } } );
+	} );
+
 	it( 'warns on a low-contrast pair, suggesting a darker background under lighter text', () => {
 		render(
 			<StyleSection
@@ -303,6 +321,22 @@ describe( 'StyleSection on a classic theme', () => {
 		// Default background #f7f7f7 vs #888888 is below 4.5 too, so the warning
 		// must consider defaults: expect it present, this time the other way around.
 		expect( screen.getByText( CONTRAST_WARNING_BRIGHTER_BACKGROUND, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
+	} );
+
+	it( 'picks the suggestion by perceived brightness, as the editor does', () => {
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ { color: { background: '#00ff00', text: '#cccccc' } } }
+				inFlight={ false }
+				onChangeStyles={ () => {} }
+			/>
+		);
+		// Green reads darker than light gray by core's perceived brightness (149.7 vs
+		// 204) while WCAG relative luminance calls it the lighter of the two (0.715 vs
+		// 0.604), so the two metrics point the suggestion opposite ways here. The
+		// editor's answer is the brightness one.
+		expect( screen.getByText( CONTRAST_WARNING_DARKER_BACKGROUND, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
 	} );
 
 	it( 'warns using the inherited text color when only the background is set', () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -165,7 +165,51 @@ describe( 'StyleSection on a classic theme', () => {
 		expect( groupReset( 'Color' ) ).toBeDisabled();
 		expect( screen.getByRole( 'button', { name: 'Text' } ) ).toBeDisabled();
 		expect( screen.getByLabelText( 'Radius' ) ).toBeDisabled();
-		expect( screen.getByRole( 'button', { name: 'Unlink Corners' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'slider', { name: 'Border radius' } ) ).toBeDisabled();
+	} );
+
+	it( 'offers one border radius input paired with a slider', () => {
+		render( <StyleSection status={ CLASSIC_STATUS } styles={ {} } inFlight={ false } onChangeStyles={ () => {} } /> );
+
+		// The default radius shows in both, and there are no per-corner inputs.
+		expect( screen.getByLabelText( 'Radius' ) ).toHaveValue( 10 );
+		expect( screen.getByRole( 'slider', { name: 'Border radius' } ) ).toHaveValue( '10' );
+		expect( screen.queryByLabelText( 'Top left' ) ).toBeNull();
+	} );
+
+	it( 'writes the border radius as a single string', () => {
+		const onChangeStyles = jest.fn();
+		render( <StyleSection status={ CLASSIC_STATUS } styles={ {} } inFlight={ false } onChangeStyles={ onChangeStyles } /> );
+
+		fireEvent.change( screen.getByLabelText( 'Radius' ), { target: { value: '8' } } );
+
+		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { radius: '8px' } } );
+
+		// The slider moves the number and keeps the unit in play.
+		fireEvent.change( screen.getByRole( 'slider', { name: 'Border radius' } ), { target: { value: '24' } } );
+
+		expect( onChangeStyles ).toHaveBeenLastCalledWith( { border: { radius: '24px' } } );
+	} );
+
+	it( 'replaces a legacy per-corner radius on the first edit, showing nothing until then', () => {
+		const onChangeStyles = jest.fn();
+		const cornerRadius = { topLeft: '4px', topRight: '8px' };
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ { border: { radius: cornerRadius } } }
+				inFlight={ false }
+				onChangeStyles={ onChangeStyles }
+			/>
+		);
+
+		// No single value to show, and nothing written just by rendering.
+		expect( screen.getByLabelText( 'Radius' ) ).toHaveValue( null );
+		expect( onChangeStyles ).not.toHaveBeenCalled();
+
+		fireEvent.change( screen.getByLabelText( 'Radius' ), { target: { value: '12' } } );
+
+		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { radius: '12px' } } );
 	} );
 
 	it( 'warns on a low-contrast pair', () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -180,7 +180,7 @@ describe( 'StyleSection on a classic theme', () => {
 		expect( screen.getByText( CONTRAST_WARNING, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
 	} );
 
-	it( 'does not warn when only one color resolves', () => {
+	it( 'warns using the default background when only text is set', () => {
 		render( <StyleSection status={ CLASSIC_STATUS } styles={ { color: { text: '#888888' } } } inFlight={ false } onChangeStyles={ () => {} } /> );
 		// Default background #f7f7f7 vs #888888 is below 4.5 too, so the warning
 		// must consider defaults: expect it present.

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -230,4 +230,16 @@ describe( 'StyleSection on a classic theme', () => {
 		// must consider defaults: expect it present.
 		expect( screen.getByText( CONTRAST_WARNING, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
 	} );
+
+	it( 'warns using the inherited text color when only the background is set', () => {
+		// The block's default design carries no text color, so the defaults stand in
+		// the one the prompt inherits from the site; without it a background chosen
+		// on its own would never be checked.
+		const status = {
+			...CLASSIC_STATUS,
+			style_defaults: { ...CLASSIC_STATUS.style_defaults, color: { background: '#f7f7f7', text: '#111111' } },
+		};
+		render( <StyleSection status={ status } styles={ { color: { background: '#7a5c3e' } } } inFlight={ false } onChangeStyles={ () => {} } /> );
+		expect( screen.getByText( CONTRAST_WARNING, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
+	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -64,9 +64,10 @@ const CONTRAST_WARNING = 'This color combination may be hard for people to read.
 // in the document, so the queries below are scoped to the rendered notice.
 const NOTICE_CONTENT = '.components-notice__content';
 
-// Every group renders its Reset beside its own heading, so a group can be reset by
-// name while other groups also hold an override.
-const groupReset = label => screen.getByRole( 'heading', { name: label, level: 3 } ).parentElement.querySelector( 'button' );
+// Every group is a ToolsPanel whose header carries an options menu, named after
+// the group: it offers a reset per item holding an override, plus Reset all.
+const openPanelMenu = label => fireEvent.click( screen.getByRole( 'button', { name: `${ label } options` } ) );
+const clickMenuItem = name => fireEvent.click( screen.getByRole( 'menuitem', { name } ) );
 
 const CLASSIC_STATUS = {
 	is_block_theme: false,
@@ -93,6 +94,12 @@ describe( 'StyleSection on a classic theme', () => {
 		expect( screen.queryByRole( 'link', { name: 'Edit Styles' } ) ).toBeNull();
 		expect( screen.getByRole( 'button', { name: 'Text' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'button', { name: 'Background' } ) ).toBeInTheDocument();
+
+		// Each group offers its resets from an options menu, not a Reset button.
+		[ 'Color', 'Typography', 'Padding', 'Border', 'Border Radius' ].forEach( label =>
+			expect( screen.getByRole( 'button', { name: `${ label } options` } ) ).toBeInTheDocument()
+		);
+		expect( screen.queryByRole( 'button', { name: 'Reset' } ) ).toBeNull();
 	} );
 
 	it( 'opens a color palette in a popover from a color row', () => {
@@ -107,7 +114,7 @@ describe( 'StyleSection on a classic theme', () => {
 		expect( screen.queryByRole( 'listbox', { name: 'Background' } ) ).toBeNull();
 	} );
 
-	it( 'shows Reset only for groups holding an override, and reset clears the group', () => {
+	it( 'offers a reset only for the item holding an override, and clears just that item', () => {
 		const onChangeStyles = jest.fn();
 		render(
 			<StyleSection
@@ -118,10 +125,32 @@ describe( 'StyleSection on a classic theme', () => {
 			/>
 		);
 
-		const resets = screen.getAllByRole( 'button', { name: 'Reset' } );
-		expect( resets ).toHaveLength( 1 );
-		resets[ 0 ].click();
+		openPanelMenu( 'Color' );
+
+		// Text holds no override, so it is listed as an unset default control.
+		expect( screen.queryByRole( 'menuitem', { name: 'Reset Text' } ) ).toBeNull();
+		expect( screen.getByRole( 'menuitemcheckbox', { name: 'Text' } ) ).toBeInTheDocument();
+
+		clickMenuItem( 'Reset Background' );
 		expect( onChangeStyles ).toHaveBeenCalledWith( {} );
+	} );
+
+	it( 'clears every color in the group from Reset all, leaving other groups alone', () => {
+		const onChangeStyles = jest.fn();
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ { color: { text: '#111111', background: '#123456' }, border: { radius: '4px' } } }
+				inFlight={ false }
+				onChangeStyles={ onChangeStyles }
+			/>
+		);
+
+		openPanelMenu( 'Color' );
+		clickMenuItem( 'Reset all' );
+
+		// The whole object goes back, since the REST layer replaces it wholesale.
+		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { radius: '4px' } } );
 	} );
 
 	it( 'prunes the parent node when a nested override is reset', () => {
@@ -135,8 +164,8 @@ describe( 'StyleSection on a classic theme', () => {
 			/>
 		);
 
-		expect( screen.getAllByRole( 'button', { name: 'Reset' } ) ).toHaveLength( 1 );
-		groupReset( 'Padding' ).click();
+		openPanelMenu( 'Padding' );
+		clickMenuItem( 'Reset Padding' );
 		expect( onChangeStyles ).toHaveBeenCalledWith( {} );
 	} );
 
@@ -151,8 +180,42 @@ describe( 'StyleSection on a classic theme', () => {
 			/>
 		);
 
-		groupReset( 'Border' ).click();
+		// The radius is its own group, so resetting the border leaves it behind.
+		openPanelMenu( 'Border' );
+		clickMenuItem( 'Reset Border' );
 		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { radius: '4px' } } );
+	} );
+
+	it( 'keeps the border radius when the whole border group is reset', () => {
+		const onChangeStyles = jest.fn();
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ { border: { radius: '4px', width: '1px' } } }
+				inFlight={ false }
+				onChangeStyles={ onChangeStyles }
+			/>
+		);
+
+		openPanelMenu( 'Border' );
+		clickMenuItem( 'Reset all' );
+		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { radius: '4px' } } );
+	} );
+
+	it( 'resets only the radius from the Border Radius group', () => {
+		const onChangeStyles = jest.fn();
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ { border: { radius: '4px', width: '1px' } } }
+				inFlight={ false }
+				onChangeStyles={ onChangeStyles }
+			/>
+		);
+
+		openPanelMenu( 'Border Radius' );
+		clickMenuItem( 'Reset Radius' );
+		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { width: '1px' } } );
 	} );
 
 	it( 'disables the controls that take a disabled prop while a save is in flight', () => {
@@ -162,7 +225,6 @@ describe( 'StyleSection on a classic theme', () => {
 
 		// The pickers rely on the inert wrapper, which jsdom does not honor, so this
 		// covers the controls that receive a real `disabled` prop.
-		expect( groupReset( 'Color' ) ).toBeDisabled();
 		expect( screen.getByRole( 'button', { name: 'Text' } ) ).toBeDisabled();
 		expect( screen.getByLabelText( 'Radius' ) ).toBeDisabled();
 		expect( screen.getByRole( 'slider', { name: 'Border radius' } ) ).toBeDisabled();

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -64,6 +64,10 @@ const CONTRAST_WARNING = 'This color combination may be hard for people to read.
 // in the document, so the queries below are scoped to the rendered notice.
 const NOTICE_CONTENT = '.components-notice__content';
 
+// Every group renders its Reset beside its own heading, so a group can be reset by
+// name while other groups also hold an override.
+const groupReset = label => screen.getByRole( 'heading', { name: label, level: 3 } ).parentElement.querySelector( 'button' );
+
 const CLASSIC_STATUS = {
 	is_block_theme: false,
 	style_defaults: {
@@ -106,6 +110,49 @@ describe( 'StyleSection on a classic theme', () => {
 		expect( resets ).toHaveLength( 1 );
 		resets[ 0 ].click();
 		expect( onChangeStyles ).toHaveBeenCalledWith( {} );
+	} );
+
+	it( 'prunes the parent node when a nested override is reset', () => {
+		const onChangeStyles = jest.fn();
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ { spacing: { padding: { top: '1px' } } } }
+				inFlight={ false }
+				onChangeStyles={ onChangeStyles }
+			/>
+		);
+
+		expect( screen.getAllByRole( 'button', { name: 'Reset' } ) ).toHaveLength( 1 );
+		groupReset( 'Padding' ).click();
+		expect( onChangeStyles ).toHaveBeenCalledWith( {} );
+	} );
+
+	it( 'keeps the border radius when the border group is reset', () => {
+		const onChangeStyles = jest.fn();
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ { border: { radius: '4px', width: '1px' } } }
+				inFlight={ false }
+				onChangeStyles={ onChangeStyles }
+			/>
+		);
+
+		groupReset( 'Border' ).click();
+		expect( onChangeStyles ).toHaveBeenCalledWith( { border: { radius: '4px' } } );
+	} );
+
+	it( 'disables the controls that take a disabled prop while a save is in flight', () => {
+		render(
+			<StyleSection status={ CLASSIC_STATUS } styles={ { color: { background: '#123456' } } } inFlight={ true } onChangeStyles={ () => {} } />
+		);
+
+		// The pickers rely on the inert wrapper, which jsdom does not honor, so this
+		// covers the controls that receive a real `disabled` prop.
+		expect( groupReset( 'Color' ) ).toBeDisabled();
+		expect( screen.getByLabelText( 'Radius' ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Unlink Corners' } ) ).toBeDisabled();
 	} );
 
 	it( 'warns on a low-contrast pair', () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -91,8 +91,20 @@ describe( 'StyleSection on a classic theme', () => {
 		render( <StyleSection status={ CLASSIC_STATUS } styles={ {} } inFlight={ false } onChangeStyles={ () => {} } /> );
 
 		expect( screen.queryByRole( 'link', { name: 'Edit Styles' } ) ).toBeNull();
-		expect( screen.getByText( 'Background' ) ).toBeInTheDocument();
-		expect( screen.getByText( 'Text' ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Text' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'button', { name: 'Background' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'opens a color palette in a popover from a color row', () => {
+		render( <StyleSection status={ CLASSIC_STATUS } styles={ {} } inFlight={ false } onChangeStyles={ () => {} } /> );
+
+		expect( screen.queryByRole( 'listbox', { name: 'Text' } ) ).toBeNull();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Text' } ) );
+
+		expect( screen.getByRole( 'listbox', { name: 'Text' } ) ).toBeInTheDocument();
+		expect( screen.getByRole( 'option', { name: 'Accent' } ) ).toBeInTheDocument();
+		expect( screen.queryByRole( 'listbox', { name: 'Background' } ) ).toBeNull();
 	} );
 
 	it( 'shows Reset only for groups holding an override, and reset clears the group', () => {
@@ -151,6 +163,7 @@ describe( 'StyleSection on a classic theme', () => {
 		// The pickers rely on the inert wrapper, which jsdom does not honor, so this
 		// covers the controls that receive a real `disabled` prop.
 		expect( groupReset( 'Color' ) ).toBeDisabled();
+		expect( screen.getByRole( 'button', { name: 'Text' } ) ).toBeDisabled();
 		expect( screen.getByLabelText( 'Radius' ) ).toBeDisabled();
 		expect( screen.getByRole( 'button', { name: 'Unlink Corners' } ) ).toBeDisabled();
 	} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -1,6 +1,7 @@
 /**
  * Contextual Prompts Style section: on a block theme it only offers the handoff
- * to the Site Editor's Styles panel, with no site-wide style controls.
+ * to the Site Editor's Styles panel, with no site-wide style controls; on a
+ * classic theme it renders the site-wide style control groups.
  */
 
 /**
@@ -55,5 +56,74 @@ describe( 'StyleSection on a block theme', () => {
 				data: expect.objectContaining( { destinationUrl: BLOCK_THEME_STATUS.site_editor_styles_url } ),
 			} )
 		);
+	} );
+} );
+
+const CONTRAST_WARNING = 'This color combination may be hard for people to read.';
+// A Notice announces itself into the a11y-speak region, which duplicates its text
+// in the document, so the queries below are scoped to the rendered notice.
+const NOTICE_CONTENT = '.components-notice__content';
+
+const CLASSIC_STATUS = {
+	is_block_theme: false,
+	style_defaults: {
+		color: { background: '#f7f7f7' },
+		border: { radius: '10px' },
+		spacing: { padding: { top: '20px', right: '20px', bottom: '20px', left: '20px' } },
+	},
+	style_palette: [
+		{ name: 'Accent', slug: 'accent', color: '#178f15' },
+		{ name: 'Base', slug: 'base', color: '#ffffff' },
+	],
+	style_font_sizes: [
+		{ name: 'Small', slug: 'small', size: '14px' },
+		{ name: 'Medium', slug: 'medium', size: '18px' },
+	],
+	site_editor_styles_url: 'https://example.test/wp-admin/site-editor.php?p=%2Fstyles',
+};
+
+describe( 'StyleSection on a classic theme', () => {
+	it( 'renders control groups and no handoff button', () => {
+		render( <StyleSection status={ CLASSIC_STATUS } styles={ {} } inFlight={ false } onChangeStyles={ () => {} } /> );
+
+		expect( screen.queryByRole( 'link', { name: 'Edit Styles' } ) ).toBeNull();
+		expect( screen.getByText( 'Background' ) ).toBeInTheDocument();
+		expect( screen.getByText( 'Text' ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows Reset only for groups holding an override, and reset clears the group', () => {
+		const onChangeStyles = jest.fn();
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ { color: { background: '#123456' } } }
+				inFlight={ false }
+				onChangeStyles={ onChangeStyles }
+			/>
+		);
+
+		const resets = screen.getAllByRole( 'button', { name: 'Reset' } );
+		expect( resets ).toHaveLength( 1 );
+		resets[ 0 ].click();
+		expect( onChangeStyles ).toHaveBeenCalledWith( {} );
+	} );
+
+	it( 'warns on a low-contrast pair', () => {
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ { color: { background: '#777777', text: '#888888' } } }
+				inFlight={ false }
+				onChangeStyles={ () => {} }
+			/>
+		);
+		expect( screen.getByText( CONTRAST_WARNING, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
+	} );
+
+	it( 'does not warn when only one color resolves', () => {
+		render( <StyleSection status={ CLASSIC_STATUS } styles={ { color: { text: '#888888' } } } inFlight={ false } onChangeStyles={ () => {} } /> );
+		// Default background #f7f7f7 vs #888888 is below 4.5 too, so the warning
+		// must consider defaults: expect it present.
+		expect( screen.getByText( CONTRAST_WARNING, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.js
@@ -28,7 +28,9 @@ const luminance = channels => {
 };
 
 // WCAG relative luminance, which the contrast ratio rests on: null when the
-// value is not a color this module can read.
+// value is not a color this module can read. Exported for the tests alone, which
+// use it to pin where it diverges from the perceived brightness the suggestion
+// below follows.
 export const relativeLuminance = value => {
 	const channels = parseHex( value );
 	return channels ? luminance( channels ) : null;

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.js
@@ -27,6 +27,13 @@ const luminance = channels => {
 	return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 };
 
+// WCAG relative luminance, for deciding which way a low-contrast pair should
+// move: null when the value is not a color this module can read.
+export const relativeLuminance = value => {
+	const channels = parseHex( value );
+	return channels ? luminance( channels ) : null;
+};
+
 export const contrastRatio = ( a, b ) => {
 	const channelsA = parseHex( a );
 	const channelsB = parseHex( b );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.js
@@ -1,0 +1,59 @@
+/**
+ * Style helpers for the Contextual Prompts Style section.
+ */
+
+const parseHex = value => {
+	if ( 'string' !== typeof value ) {
+		return null;
+	}
+	let hex = value.trim().replace( /^#/, '' );
+	if ( 3 === hex.length ) {
+		hex = hex
+			.split( '' )
+			.map( c => c + c )
+			.join( '' );
+	}
+	if ( ! /^[0-9a-f]{6}$/i.test( hex ) ) {
+		return null;
+	}
+	return [ parseInt( hex.slice( 0, 2 ), 16 ), parseInt( hex.slice( 2, 4 ), 16 ), parseInt( hex.slice( 4, 6 ), 16 ) ];
+};
+
+const luminance = channels => {
+	const [ r, g, b ] = channels.map( channel => {
+		const srgb = channel / 255;
+		return srgb <= 0.03928 ? srgb / 12.92 : Math.pow( ( srgb + 0.055 ) / 1.055, 2.4 );
+	} );
+	return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+};
+
+export const contrastRatio = ( a, b ) => {
+	const channelsA = parseHex( a );
+	const channelsB = parseHex( b );
+	if ( ! channelsA || ! channelsB ) {
+		return null;
+	}
+	const lumA = luminance( channelsA );
+	const lumB = luminance( channelsB );
+	const [ darker, lighter ] = lumA < lumB ? [ lumA, lumB ] : [ lumB, lumA ];
+	return ( lighter + 0.05 ) / ( darker + 0.05 );
+};
+
+const PRESET_COLOR_PREFIX = 'var:preset|color|';
+
+export const resolveColor = ( value, palette ) => {
+	if ( 'string' !== typeof value || ! value ) {
+		return null;
+	}
+	if ( value.startsWith( PRESET_COLOR_PREFIX ) ) {
+		const slug = value.slice( PRESET_COLOR_PREFIX.length );
+		const entry = ( palette || [] ).find( color => color.slug === slug );
+		return entry ? entry.color : null;
+	}
+	return parseHex( value ) ? value : null;
+};
+
+export const presetRefForColor = ( hex, palette ) => {
+	const entry = ( palette || [] ).find( color => color.color?.toLowerCase() === hex?.toLowerCase() );
+	return entry ? PRESET_COLOR_PREFIX + entry.slug : hex;
+};

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.js
@@ -27,11 +27,23 @@ const luminance = channels => {
 	return 0.2126 * r + 0.7152 * g + 0.0722 * b;
 };
 
-// WCAG relative luminance, for deciding which way a low-contrast pair should
-// move: null when the value is not a color this module can read.
+// WCAG relative luminance, which the contrast ratio rests on: null when the
+// value is not a color this module can read.
 export const relativeLuminance = value => {
 	const channels = parseHex( value );
 	return channels ? luminance( channels ) : null;
+};
+
+// Perceived brightness, the metric core's ContrastChecker orders a pair by when
+// it picks which way to move them. It disagrees with relative luminance on
+// saturated hues, so the editor's suggestion follows this one.
+export const perceivedBrightness = value => {
+	const channels = parseHex( value );
+	if ( ! channels ) {
+		return null;
+	}
+	const [ r, g, b ] = channels;
+	return ( 299 * r + 587 * g + 114 * b ) / 1000;
 };
 
 export const contrastRatio = ( a, b ) => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.test.js
@@ -1,0 +1,45 @@
+/**
+ * Internal dependencies
+ */
+import { contrastRatio, presetRefForColor, resolveColor } from './style-utils';
+
+const PALETTE = [
+	{ name: 'Accent', slug: 'accent', color: '#178f15' },
+	{ name: 'Base', slug: 'base', color: '#ffffff' },
+];
+
+describe( 'contrastRatio', () => {
+	it( 'computes the WCAG ratio for black on white', () => {
+		expect( contrastRatio( '#000000', '#ffffff' ) ).toBeCloseTo( 21, 0 );
+	} );
+	it( 'is symmetric', () => {
+		expect( contrastRatio( '#ffffff', '#000000' ) ).toBeCloseTo( 21, 0 );
+	} );
+	it( 'flags a low-contrast pair below 4.5', () => {
+		expect( contrastRatio( '#777777', '#888888' ) ).toBeLessThan( 4.5 );
+	} );
+	it( 'returns null for unparseable input', () => {
+		expect( contrastRatio( 'nope', '#ffffff' ) ).toBeNull();
+	} );
+} );
+
+describe( 'resolveColor', () => {
+	it( 'resolves a preset reference against the palette', () => {
+		expect( resolveColor( 'var:preset|color|accent', PALETTE ) ).toBe( '#178f15' );
+	} );
+	it( 'passes hex through', () => {
+		expect( resolveColor( '#123456', PALETTE ) ).toBe( '#123456' );
+	} );
+	it( 'returns null for an unknown slug', () => {
+		expect( resolveColor( 'var:preset|color|missing', PALETTE ) ).toBeNull();
+	} );
+} );
+
+describe( 'presetRefForColor', () => {
+	it( 'returns the preset ref for a palette color', () => {
+		expect( presetRefForColor( '#178F15', PALETTE ) ).toBe( 'var:preset|color|accent' );
+	} );
+	it( 'returns the raw hex for a custom color', () => {
+		expect( presetRefForColor( '#123456', PALETTE ) ).toBe( '#123456' );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { contrastRatio, presetRefForColor, relativeLuminance, resolveColor } from './style-utils';
+import { contrastRatio, perceivedBrightness, presetRefForColor, relativeLuminance, resolveColor } from './style-utils';
 
 const PALETTE = [
 	{ name: 'Accent', slug: 'accent', color: '#178f15' },
@@ -28,11 +28,32 @@ describe( 'relativeLuminance', () => {
 		expect( relativeLuminance( '#000000' ) ).toBe( 0 );
 		expect( relativeLuminance( '#ffffff' ) ).toBeCloseTo( 1, 5 );
 	} );
-	it( 'orders a pair, which is what picks the contrast suggestion', () => {
-		expect( relativeLuminance( '#777777' ) ).toBeLessThan( relativeLuminance( '#888888' ) );
-	} );
 	it( 'returns null for unparseable input', () => {
 		expect( relativeLuminance( 'var:preset|color|accent' ) ).toBeNull();
+	} );
+} );
+
+describe( 'perceivedBrightness', () => {
+	it( 'runs from black to white on the 0-255 scale', () => {
+		expect( perceivedBrightness( '#000000' ) ).toBe( 0 );
+		expect( perceivedBrightness( '#ffffff' ) ).toBeCloseTo( 255, 5 );
+	} );
+	it( 'weights the channels as core does', () => {
+		// Pure green: 587 * 255 / 1000.
+		expect( perceivedBrightness( '#00ff00' ) ).toBeCloseTo( 149.685, 3 );
+	} );
+	it( 'orders a plain pair the same way relative luminance does', () => {
+		expect( perceivedBrightness( '#777777' ) ).toBeLessThan( perceivedBrightness( '#888888' ) );
+		expect( relativeLuminance( '#777777' ) ).toBeLessThan( relativeLuminance( '#888888' ) );
+	} );
+	it( 'disagrees with relative luminance on a saturated hue, which is why it picks the suggestion', () => {
+		// Green (149.7) reads darker than light gray (204) by brightness, while by
+		// WCAG luminance it is the lighter of the two (0.715 vs 0.604).
+		expect( perceivedBrightness( '#00ff00' ) ).toBeLessThan( perceivedBrightness( '#cccccc' ) );
+		expect( relativeLuminance( '#00ff00' ) ).toBeGreaterThan( relativeLuminance( '#cccccc' ) );
+	} );
+	it( 'returns null for unparseable input', () => {
+		expect( perceivedBrightness( 'var:preset|color|accent' ) ).toBeNull();
 	} );
 } );
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.test.js
@@ -1,7 +1,7 @@
 /**
  * Internal dependencies
  */
-import { contrastRatio, presetRefForColor, resolveColor } from './style-utils';
+import { contrastRatio, presetRefForColor, relativeLuminance, resolveColor } from './style-utils';
 
 const PALETTE = [
 	{ name: 'Accent', slug: 'accent', color: '#178f15' },
@@ -20,6 +20,19 @@ describe( 'contrastRatio', () => {
 	} );
 	it( 'returns null for unparseable input', () => {
 		expect( contrastRatio( 'nope', '#ffffff' ) ).toBeNull();
+	} );
+} );
+
+describe( 'relativeLuminance', () => {
+	it( 'runs from black to white', () => {
+		expect( relativeLuminance( '#000000' ) ).toBe( 0 );
+		expect( relativeLuminance( '#ffffff' ) ).toBeCloseTo( 1, 5 );
+	} );
+	it( 'orders a pair, which is what picks the contrast suggestion', () => {
+		expect( relativeLuminance( '#777777' ) ).toBeLessThan( relativeLuminance( '#888888' ) );
+	} );
+	it( 'returns null for unparseable input', () => {
+		expect( relativeLuminance( 'var:preset|color|accent' ) ).toBeNull();
 	} );
 } );
 

--- a/plugins/newspack-plugin/src/wizards/handoff-banner/index.js
+++ b/plugins/newspack-plugin/src/wizards/handoff-banner/index.js
@@ -7,7 +7,7 @@ import '../../shared/js/public-path';
 /**
  * WordPress dependencies.
  */
-import { createElement, render, useState } from '@wordpress/element';
+import { createElement, render, useEffect, useRef, useState } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 
 /**
@@ -16,16 +16,55 @@ import { __ } from '@wordpress/i18n';
 import { Button } from '../../../packages/components/src';
 import './style.scss';
 
-const HandoffBanner = ( {
+const VISIBLE_CLASS = 'newspack-handoff-banner-visible';
+const HEIGHT_PROPERTY = '--newspack-handoff-banner-height';
+
+/**
+ * Stop advertising the banner height. Pages that reserve room for the banner
+ * fall back to a zero offset.
+ */
+const clearBannerHeight = () => {
+	document.documentElement.classList.remove( VISIBLE_CLASS );
+	document.documentElement.style.removeProperty( HEIGHT_PROPERTY );
+};
+
+export const HandoffBanner = ( {
 	bodyText = __( 'Return to Newspack after completing configuration', 'newspack-plugin' ),
 	primaryButtonText = __( 'Back to Newspack', 'newspack-plugin' ),
 	dismissButtonText = __( 'Dismiss', 'newspack-plugin' ),
 	primaryButtonURL = '/wp-admin/admin.php?page=newspack-dashboard',
 } ) => {
 	const [ visibility, setVisibility ] = useState( true );
+	const bannerRef = useRef( null );
+
+	// Full-screen editors lay themselves out against the viewport and ignore the
+	// banner's place in the document flow. Publish the measured height so their
+	// scoped CSS can reserve the space, and take it back when the banner goes.
+	useEffect( () => {
+		const banner = bannerRef.current;
+		if ( ! visibility || ! banner ) {
+			clearBannerHeight();
+			return;
+		}
+		const updateHeight = () => {
+			document.documentElement.classList.add( VISIBLE_CLASS );
+			document.documentElement.style.setProperty( HEIGHT_PROPERTY, `${ banner.offsetHeight }px` );
+		};
+		updateHeight();
+		if ( typeof window.ResizeObserver !== 'function' ) {
+			return clearBannerHeight;
+		}
+		const observer = new window.ResizeObserver( updateHeight );
+		observer.observe( banner );
+		return () => {
+			observer.disconnect();
+			clearBannerHeight();
+		};
+	}, [ visibility ] );
+
 	return (
 		visibility && (
-			<div className="newspack-handoff-banner">
+			<div className="newspack-handoff-banner" ref={ bannerRef }>
 				<div className="newspack-handoff-banner__text">{ bodyText }</div>
 				<div className="newspack-handoff-banner__buttons">
 					<Button variant="tertiary" isSmall onClick={ () => setVisibility( false ) }>

--- a/plugins/newspack-plugin/src/wizards/handoff-banner/index.js
+++ b/plugins/newspack-plugin/src/wizards/handoff-banner/index.js
@@ -20,8 +20,8 @@ const VISIBLE_CLASS = 'newspack-handoff-banner-visible';
 const HEIGHT_PROPERTY = '--newspack-handoff-banner-height';
 
 /**
- * Stop advertising the banner height. Pages that reserve room for the banner
- * fall back to a zero offset.
+ * Stop advertising the space the banner takes. Pages that reserve room for the
+ * banner fall back to a zero offset.
  */
 const clearBannerHeight = () => {
 	document.documentElement.classList.remove( VISIBLE_CLASS );
@@ -38,8 +38,13 @@ export const HandoffBanner = ( {
 	const bannerRef = useRef( null );
 
 	// Full-screen editors lay themselves out against the viewport and ignore the
-	// banner's place in the document flow. Publish the measured height so their
-	// scoped CSS can reserve the space, and take it back when the banner goes.
+	// banner's place in the document flow. Publish the measured space their scoped
+	// CSS has to reserve, and take it back when the banner goes.
+	//
+	// The measurement is the banner's distance from the top of the viewport, not
+	// its own height: anything stacked above it in the flow — the admin bar
+	// padding `html.wp-toolbar` keeps even where the bar itself is hidden, the
+	// WooCommerce header offset below — has to be cleared too.
 	useEffect( () => {
 		const banner = bannerRef.current;
 		if ( ! visibility || ! banner ) {
@@ -48,7 +53,7 @@ export const HandoffBanner = ( {
 		}
 		const updateHeight = () => {
 			document.documentElement.classList.add( VISIBLE_CLASS );
-			document.documentElement.style.setProperty( HEIGHT_PROPERTY, `${ banner.offsetHeight }px` );
+			document.documentElement.style.setProperty( HEIGHT_PROPERTY, `${ Math.ceil( banner.getBoundingClientRect().bottom ) }px` );
 		};
 		updateHeight();
 		if ( typeof window.ResizeObserver !== 'function' ) {

--- a/plugins/newspack-plugin/src/wizards/handoff-banner/index.js
+++ b/plugins/newspack-plugin/src/wizards/handoff-banner/index.js
@@ -23,7 +23,7 @@ const HEIGHT_PROPERTY = '--newspack-handoff-banner-height';
  * Stop advertising the space the banner takes. Pages that reserve room for the
  * banner fall back to a zero offset.
  */
-const clearBannerHeight = () => {
+const clearBannerOffset = () => {
 	document.documentElement.classList.remove( VISIBLE_CLASS );
 	document.documentElement.style.removeProperty( HEIGHT_PROPERTY );
 };
@@ -41,29 +41,35 @@ export const HandoffBanner = ( {
 	// banner's place in the document flow. Publish the measured space their scoped
 	// CSS has to reserve, and take it back when the banner goes.
 	//
-	// The measurement is the banner's distance from the top of the viewport, not
+	// The measurement is the banner's distance from the top of the document, not
 	// its own height: anything stacked above it in the flow — the admin bar
 	// padding `html.wp-toolbar` keeps even where the bar itself is hidden, the
-	// WooCommerce header offset below — has to be cleared too.
+	// WooCommerce header offset below — has to be cleared too. Adding `scrollY`
+	// back keeps the value at rest: the admin document behind a fixed editor can
+	// scroll, and a viewport-relative reading taken mid-scroll would shrink (or
+	// go negative) and drag the editor up under the banner.
 	useEffect( () => {
 		const banner = bannerRef.current;
 		if ( ! visibility || ! banner ) {
-			clearBannerHeight();
+			clearBannerOffset();
 			return;
 		}
-		const updateHeight = () => {
+		const updateOffset = () => {
 			document.documentElement.classList.add( VISIBLE_CLASS );
-			document.documentElement.style.setProperty( HEIGHT_PROPERTY, `${ Math.ceil( banner.getBoundingClientRect().bottom ) }px` );
+			document.documentElement.style.setProperty(
+				HEIGHT_PROPERTY,
+				`${ Math.ceil( banner.getBoundingClientRect().bottom + window.scrollY ) }px`
+			);
 		};
-		updateHeight();
+		updateOffset();
 		if ( typeof window.ResizeObserver !== 'function' ) {
-			return clearBannerHeight;
+			return clearBannerOffset;
 		}
-		const observer = new window.ResizeObserver( updateHeight );
+		const observer = new window.ResizeObserver( updateOffset );
 		observer.observe( banner );
 		return () => {
 			observer.disconnect();
-			clearBannerHeight();
+			clearBannerOffset();
 		};
 	}, [ visibility ] );
 

--- a/plugins/newspack-plugin/src/wizards/handoff-banner/index.js
+++ b/plugins/newspack-plugin/src/wizards/handoff-banner/index.js
@@ -28,6 +28,16 @@ const clearBannerOffset = () => {
 	document.documentElement.style.removeProperty( HEIGHT_PROPERTY );
 };
 
+// The mounted banner's measurement, held at module scope so code outside the
+// component can ask for a fresh reading. Null while no banner is mounted.
+let measureBannerOffset = null;
+
+/**
+ * Publish a fresh offset. Anything that moves the banner without resizing it —
+ * the ResizeObserver below never sees that — has to call this.
+ */
+export const remeasureBannerOffset = () => measureBannerOffset?.();
+
 export const HandoffBanner = ( {
 	bodyText = __( 'Return to Newspack after completing configuration', 'newspack-plugin' ),
 	primaryButtonText = __( 'Back to Newspack', 'newspack-plugin' ),
@@ -61,15 +71,20 @@ export const HandoffBanner = ( {
 				`${ Math.ceil( banner.getBoundingClientRect().bottom + window.scrollY ) }px`
 			);
 		};
+		measureBannerOffset = updateOffset;
 		updateOffset();
+		const cleanUp = () => {
+			measureBannerOffset = null;
+			clearBannerOffset();
+		};
 		if ( typeof window.ResizeObserver !== 'function' ) {
-			return clearBannerOffset;
+			return cleanUp;
 		}
 		const observer = new window.ResizeObserver( updateOffset );
 		observer.observe( banner );
 		return () => {
 			observer.disconnect();
-			clearBannerOffset();
+			cleanUp();
 		};
 	}, [ visibility ] );
 
@@ -107,6 +122,9 @@ if ( el ) {
 			const wooHeader = document.querySelector( '.woocommerce-layout__header' );
 			if ( wooHeader && wpbody.style.marginTop ) {
 				el.style.marginTop = wpbody.style.marginTop;
+				// The margin pushes the banner down without changing its size, so
+				// the published offset has to be taken again. A no-op before mount.
+				remeasureBannerOffset();
 				return true;
 			}
 			return false;

--- a/plugins/newspack-plugin/src/wizards/handoff-banner/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/handoff-banner/index.test.js
@@ -29,19 +29,42 @@ const mockRect = ( { top, height } ) => {
 	};
 };
 
+/**
+ * Scroll the document, which jsdom otherwise pins at 0.
+ *
+ * @param {number} value Pixels scrolled from the top of the document.
+ * @return {Function} Restores the original descriptor.
+ */
+const mockScrollY = value => {
+	const original = Object.getOwnPropertyDescriptor( window, 'scrollY' );
+	Object.defineProperty( window, 'scrollY', { configurable: true, value } );
+	return () => {
+		if ( original ) {
+			Object.defineProperty( window, 'scrollY', original );
+		} else {
+			delete window.scrollY;
+		}
+	};
+};
+
 describe( 'HandoffBanner', () => {
 	let restoreRect;
+	let restoreScrollY;
 
 	afterEach( () => {
 		if ( restoreRect ) {
 			restoreRect();
 			restoreRect = null;
 		}
+		if ( restoreScrollY ) {
+			restoreScrollY();
+			restoreScrollY = null;
+		}
 		document.documentElement.classList.remove( VISIBLE_CLASS );
 		document.documentElement.style.removeProperty( HEIGHT_PROPERTY );
 	} );
 
-	it( "publishes the banner's viewport bottom on the document element", () => {
+	it( "publishes the banner's bottom edge on the document element", () => {
 		restoreRect = mockRect( { top: 0, height: 56 } );
 
 		render( <HandoffBanner /> );
@@ -52,6 +75,17 @@ describe( 'HandoffBanner', () => {
 
 	it( 'covers whatever sits above the banner, e.g. the admin bar padding', () => {
 		restoreRect = mockRect( { top: 32, height: 56 } );
+
+		render( <HandoffBanner /> );
+
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '88px' );
+	} );
+
+	it( 'stays at rest when the document behind a fixed editor is scrolled', () => {
+		// Scrolled 294px, the banner's viewport bottom has gone negative; the
+		// offset a fixed editor needs is still the same 88px it is at the top.
+		restoreScrollY = mockScrollY( 294 );
+		restoreRect = mockRect( { top: -262, height: 56 } );
 
 		render( <HandoffBanner /> );
 

--- a/plugins/newspack-plugin/src/wizards/handoff-banner/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/handoff-banner/index.test.js
@@ -1,0 +1,114 @@
+/**
+ * External dependencies.
+ */
+import { render, fireEvent, screen } from '@testing-library/react';
+
+/**
+ * Internal dependencies.
+ */
+import { HandoffBanner } from './index';
+
+const VISIBLE_CLASS = 'newspack-handoff-banner-visible';
+const HEIGHT_PROPERTY = '--newspack-handoff-banner-height';
+
+/**
+ * Give every element a stable measurable height, the way a browser would.
+ *
+ * @param {number} height Height in pixels reported by `offsetHeight`.
+ * @return {Function} Restores the original descriptor.
+ */
+const mockOffsetHeight = height => {
+	const original = Object.getOwnPropertyDescriptor( window.HTMLElement.prototype, 'offsetHeight' );
+	Object.defineProperty( window.HTMLElement.prototype, 'offsetHeight', {
+		configurable: true,
+		get: () => height,
+	} );
+	return () => {
+		if ( original ) {
+			Object.defineProperty( window.HTMLElement.prototype, 'offsetHeight', original );
+		} else {
+			delete window.HTMLElement.prototype.offsetHeight;
+		}
+	};
+};
+
+describe( 'HandoffBanner', () => {
+	let restoreOffsetHeight;
+
+	afterEach( () => {
+		if ( restoreOffsetHeight ) {
+			restoreOffsetHeight();
+			restoreOffsetHeight = null;
+		}
+		document.documentElement.classList.remove( VISIBLE_CLASS );
+		document.documentElement.style.removeProperty( HEIGHT_PROPERTY );
+	} );
+
+	it( 'publishes the measured banner height on the document element', () => {
+		restoreOffsetHeight = mockOffsetHeight( 56 );
+
+		render( <HandoffBanner /> );
+
+		expect( document.documentElement.classList.contains( VISIBLE_CLASS ) ).toBe( true );
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '56px' );
+	} );
+
+	it( 're-measures when the banner is resized, e.g. when the text wraps', () => {
+		let resizeCallback;
+		const originalResizeObserver = window.ResizeObserver;
+		window.ResizeObserver = class {
+			constructor( callback ) {
+				resizeCallback = callback;
+			}
+			observe() {}
+			unobserve() {}
+			disconnect() {}
+		};
+		restoreOffsetHeight = mockOffsetHeight( 56 );
+
+		render( <HandoffBanner /> );
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '56px' );
+
+		restoreOffsetHeight();
+		restoreOffsetHeight = mockOffsetHeight( 92 );
+		resizeCallback();
+
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '92px' );
+
+		window.ResizeObserver = originalResizeObserver;
+	} );
+
+	it( 'still publishes a height without ResizeObserver support', () => {
+		const originalResizeObserver = window.ResizeObserver;
+		delete window.ResizeObserver;
+		restoreOffsetHeight = mockOffsetHeight( 56 );
+
+		render( <HandoffBanner /> );
+
+		expect( document.documentElement.classList.contains( VISIBLE_CLASS ) ).toBe( true );
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '56px' );
+
+		window.ResizeObserver = originalResizeObserver;
+	} );
+
+	it( 'clears the class and the height when dismissed', () => {
+		restoreOffsetHeight = mockOffsetHeight( 56 );
+
+		render( <HandoffBanner /> );
+		fireEvent.click( screen.getByText( 'Dismiss' ) );
+
+		expect( screen.queryByText( 'Back to Newspack' ) ).toBeNull();
+		expect( document.documentElement.classList.contains( VISIBLE_CLASS ) ).toBe( false );
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '' );
+	} );
+
+	it( 'clears the class and the height on unmount', () => {
+		restoreOffsetHeight = mockOffsetHeight( 56 );
+
+		const { unmount } = render( <HandoffBanner /> );
+		unmount();
+
+		expect( document.documentElement.classList.contains( VISIBLE_CLASS ) ).toBe( false );
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '' );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/handoff-banner/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/handoff-banner/index.test.js
@@ -6,7 +6,7 @@ import { render, fireEvent, screen } from '@testing-library/react';
 /**
  * Internal dependencies.
  */
-import { HandoffBanner } from './index';
+import { HandoffBanner, remeasureBannerOffset } from './index';
 
 const VISIBLE_CLASS = 'newspack-handoff-banner-visible';
 const HEIGHT_PROPERTY = '--newspack-handoff-banner-height';
@@ -123,6 +123,33 @@ describe( 'HandoffBanner', () => {
 		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '124px' );
 
 		window.ResizeObserver = originalResizeObserver;
+	} );
+
+	it( 're-measures when the banner is moved after mount, e.g. the WooCommerce header offset', () => {
+		restoreRect = mockRect( { top: 32, height: 56 } );
+
+		render( <HandoffBanner /> );
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '88px' );
+
+		// The bootstrap's WooCommerce offset can land up to five seconds after
+		// mount: the margin moves the banner without resizing it, so nothing but
+		// this call refreshes the published value.
+		restoreRect();
+		restoreRect = mockRect( { top: 92, height: 56 } );
+		remeasureBannerOffset();
+
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '148px' );
+	} );
+
+	it( 'ignores a re-measure once the banner is gone', () => {
+		restoreRect = mockRect( { top: 32, height: 56 } );
+
+		const { unmount } = render( <HandoffBanner /> );
+		unmount();
+		remeasureBannerOffset();
+
+		expect( document.documentElement.classList.contains( VISIBLE_CLASS ) ).toBe( false );
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '' );
 	} );
 
 	it( 'still publishes a value without ResizeObserver support', () => {

--- a/plugins/newspack-plugin/src/wizards/handoff-banner/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/handoff-banner/index.test.js
@@ -12,45 +12,58 @@ const VISIBLE_CLASS = 'newspack-handoff-banner-visible';
 const HEIGHT_PROPERTY = '--newspack-handoff-banner-height';
 
 /**
- * Give every element a stable measurable height, the way a browser would.
+ * Place every element at a known spot in the viewport, the way a browser would.
  *
- * @param {number} height Height in pixels reported by `offsetHeight`.
- * @return {Function} Restores the original descriptor.
+ * @param {Object} rect        Geometry to report.
+ * @param {number} rect.top    Distance from the top of the viewport.
+ * @param {number} rect.height Height in pixels.
+ * @return {Function} Restores the original method.
  */
-const mockOffsetHeight = height => {
-	const original = Object.getOwnPropertyDescriptor( window.HTMLElement.prototype, 'offsetHeight' );
-	Object.defineProperty( window.HTMLElement.prototype, 'offsetHeight', {
-		configurable: true,
-		get: () => height,
-	} );
+const mockRect = ( { top, height } ) => {
+	const original = window.Element.prototype.getBoundingClientRect;
+	window.Element.prototype.getBoundingClientRect = function () {
+		return { top, bottom: top + height, height, left: 0, right: 0, width: 0, x: 0, y: top };
+	};
 	return () => {
-		if ( original ) {
-			Object.defineProperty( window.HTMLElement.prototype, 'offsetHeight', original );
-		} else {
-			delete window.HTMLElement.prototype.offsetHeight;
-		}
+		window.Element.prototype.getBoundingClientRect = original;
 	};
 };
 
 describe( 'HandoffBanner', () => {
-	let restoreOffsetHeight;
+	let restoreRect;
 
 	afterEach( () => {
-		if ( restoreOffsetHeight ) {
-			restoreOffsetHeight();
-			restoreOffsetHeight = null;
+		if ( restoreRect ) {
+			restoreRect();
+			restoreRect = null;
 		}
 		document.documentElement.classList.remove( VISIBLE_CLASS );
 		document.documentElement.style.removeProperty( HEIGHT_PROPERTY );
 	} );
 
-	it( 'publishes the measured banner height on the document element', () => {
-		restoreOffsetHeight = mockOffsetHeight( 56 );
+	it( "publishes the banner's viewport bottom on the document element", () => {
+		restoreRect = mockRect( { top: 0, height: 56 } );
 
 		render( <HandoffBanner /> );
 
 		expect( document.documentElement.classList.contains( VISIBLE_CLASS ) ).toBe( true );
 		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '56px' );
+	} );
+
+	it( 'covers whatever sits above the banner, e.g. the admin bar padding', () => {
+		restoreRect = mockRect( { top: 32, height: 56 } );
+
+		render( <HandoffBanner /> );
+
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '88px' );
+	} );
+
+	it( 'rounds a fractional bottom up so no sliver is left uncovered', () => {
+		restoreRect = mockRect( { top: 32, height: 56.5 } );
+
+		render( <HandoffBanner /> );
+
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '89px' );
 	} );
 
 	it( 're-measures when the banner is resized, e.g. when the text wraps', () => {
@@ -64,35 +77,35 @@ describe( 'HandoffBanner', () => {
 			unobserve() {}
 			disconnect() {}
 		};
-		restoreOffsetHeight = mockOffsetHeight( 56 );
+		restoreRect = mockRect( { top: 32, height: 56 } );
 
 		render( <HandoffBanner /> );
-		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '56px' );
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '88px' );
 
-		restoreOffsetHeight();
-		restoreOffsetHeight = mockOffsetHeight( 92 );
+		restoreRect();
+		restoreRect = mockRect( { top: 32, height: 92 } );
 		resizeCallback();
 
-		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '92px' );
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '124px' );
 
 		window.ResizeObserver = originalResizeObserver;
 	} );
 
-	it( 'still publishes a height without ResizeObserver support', () => {
+	it( 'still publishes a value without ResizeObserver support', () => {
 		const originalResizeObserver = window.ResizeObserver;
 		delete window.ResizeObserver;
-		restoreOffsetHeight = mockOffsetHeight( 56 );
+		restoreRect = mockRect( { top: 32, height: 56 } );
 
 		render( <HandoffBanner /> );
 
 		expect( document.documentElement.classList.contains( VISIBLE_CLASS ) ).toBe( true );
-		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '56px' );
+		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '88px' );
 
 		window.ResizeObserver = originalResizeObserver;
 	} );
 
-	it( 'clears the class and the height when dismissed', () => {
-		restoreOffsetHeight = mockOffsetHeight( 56 );
+	it( 'clears the class and the value when dismissed', () => {
+		restoreRect = mockRect( { top: 32, height: 56 } );
 
 		render( <HandoffBanner /> );
 		fireEvent.click( screen.getByText( 'Dismiss' ) );
@@ -102,8 +115,8 @@ describe( 'HandoffBanner', () => {
 		expect( document.documentElement.style.getPropertyValue( HEIGHT_PROPERTY ) ).toBe( '' );
 	} );
 
-	it( 'clears the class and the height on unmount', () => {
-		restoreOffsetHeight = mockOffsetHeight( 56 );
+	it( 'clears the class and the value on unmount', () => {
+		restoreRect = mockRect( { top: 32, height: 56 } );
 
 		const { unmount } = render( <HandoffBanner /> );
 		unmount();

--- a/plugins/newspack-plugin/src/wizards/handoff-banner/style.scss
+++ b/plugins/newspack-plugin/src/wizards/handoff-banner/style.scss
@@ -49,9 +49,11 @@
 /*
  * The site editor pins `.edit-site` to the viewport (`position: fixed`, top 0,
  * `100vh` tall), so the banner would sit underneath it instead of pushing it
- * down. `newspack-handoff-banner-visible` and the measured height come from the
- * banner component; shift the editor down and shrink it by that much. The
- * offsets are scoped to this screen, so nothing else reacts to the class.
+ * down. `newspack-handoff-banner-visible` and the measured offset come from the
+ * banner component — the space to clear at the top of the document, which is the
+ * banner plus anything above it, not just its own height. Shift the editor down
+ * and shrink it by that much. The offsets are scoped to this screen, so nothing
+ * else reacts to the class.
  */
 $banner-height: var(--newspack-handoff-banner-height, 0px);
 

--- a/plugins/newspack-plugin/src/wizards/handoff-banner/style.scss
+++ b/plugins/newspack-plugin/src/wizards/handoff-banner/style.scss
@@ -45,3 +45,27 @@
 		gap: wp-vars.$grid-unit-10;
 	}
 }
+
+/*
+ * The site editor pins `.edit-site` to the viewport (`position: fixed`, top 0,
+ * `100vh` tall), so the banner would sit underneath it instead of pushing it
+ * down. `newspack-handoff-banner-visible` and the measured height come from the
+ * banner component; shift the editor down and shrink it by that much. The
+ * offsets are scoped to this screen, so nothing else reacts to the class.
+ */
+$banner-height: var(--newspack-handoff-banner-height, 0px);
+
+.newspack-handoff-banner-visible body.site-editor-php {
+	.edit-site {
+		height: calc(100vh - #{$banner-height});
+		min-height: calc(100vh - #{$banner-height});
+		top: $banner-height;
+	}
+
+	// In full-canvas mode the sidebar region is fixed to the viewport rather
+	// than to `.edit-site`, so it needs the same treatment.
+	.edit-site-layout.is-full-canvas .edit-site-layout__sidebar-region {
+		height: calc(100vh - #{$banner-height});
+		top: $banner-height;
+	}
+}

--- a/plugins/newspack-popups/includes/class-newspack-popups-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-api.php
@@ -197,7 +197,7 @@ final class Newspack_Popups_API {
 			'style_defaults'         => Newspack_Popups_Contextual_Prompt_Styles::get_defaults(),
 			'style_palette'          => self::flatten_global_settings_presets( wp_get_global_settings( [ 'color', 'palette' ] ) ),
 			'style_font_sizes'       => self::flatten_global_settings_presets( wp_get_global_settings( [ 'typography', 'fontSizes' ] ) ),
-			'site_editor_styles_url' => admin_url( 'site-editor.php?p=%2Fstyles' ),
+			'site_editor_styles_url' => admin_url( 'site-editor.php?p=%2Fstyles&section=' . rawurlencode( '/blocks/' . rawurlencode( Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ) ) ),
 		];
 	}
 

--- a/plugins/newspack-popups/includes/class-newspack-popups-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-api.php
@@ -200,10 +200,30 @@ final class Newspack_Popups_API {
 			'is_block_theme'         => wp_is_block_theme(),
 			'styles'                 => empty( $styles ) ? (object) [] : $styles,
 			'style_defaults'         => Newspack_Popups_Contextual_Prompt_Styles::get_defaults(),
-			'style_palette'          => self::merge_global_settings_presets( wp_get_global_settings( [ 'color', 'palette' ] ) ),
+			'style_palette'          => self::get_palette_presets(),
 			'style_font_sizes'       => self::normalize_preset_font_sizes( $font_sizes ),
 			'site_editor_styles_url' => admin_url( 'site-editor.php?p=%2Fstyles&section=' . rawurlencode( '/blocks/' . rawurlencode( Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ) ) ),
 		];
+	}
+
+	/**
+	 * The color presets the wizard's pickers offer, merged across origins. Core's
+	 * `color.defaultPalette` setting decides whether the editor shows the default
+	 * origin at all — it is false whenever a classic theme registers an
+	 * `editor-color-palette`, as newspack-theme does — so the wizard drops that
+	 * origin when the editor would, rather than offering colors the editor does not.
+	 *
+	 * @return array Flat preset list.
+	 */
+	private static function get_palette_presets() {
+		$palette = wp_get_global_settings( [ 'color', 'palette' ] );
+		// A missing settings path hands back the whole settings tree, so an absent
+		// `defaultPalette` reads as truthy and the defaults stay, as core's own
+		// default for the setting has them.
+		if ( is_array( $palette ) && isset( $palette['default'] ) && ! wp_get_global_settings( [ 'color', 'defaultPalette' ] ) ) {
+			unset( $palette['default'] );
+		}
+		return self::merge_global_settings_presets( $palette );
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-api.php
@@ -190,7 +190,8 @@ final class Newspack_Popups_API {
 		// Styles are a keyed object to every client, so no overrides has to travel
 		// as `{}`: an empty PHP array would serialize as `[]` and a client
 		// comparing it against an object it built would never see them as equal.
-		$styles = Newspack_Popups_Contextual_Prompt_Styles::get_styles();
+		$styles     = Newspack_Popups_Contextual_Prompt_Styles::get_styles();
+		$font_sizes = self::flatten_global_settings_presets( wp_get_global_settings( [ 'typography', 'fontSizes' ] ) );
 		return [
 			'enabled'                => Newspack_Popups_Settings::is_ai_copy_assistant_enabled(),
 			'can_manage'             => current_user_can( 'manage_options' ),
@@ -200,29 +201,72 @@ final class Newspack_Popups_API {
 			'styles'                 => empty( $styles ) ? (object) [] : $styles,
 			'style_defaults'         => Newspack_Popups_Contextual_Prompt_Styles::get_defaults(),
 			'style_palette'          => self::flatten_global_settings_presets( wp_get_global_settings( [ 'color', 'palette' ] ) ),
-			'style_font_sizes'       => self::flatten_global_settings_presets( wp_get_global_settings( [ 'typography', 'fontSizes' ] ) ),
+			'style_font_sizes'       => self::normalize_preset_font_sizes( $font_sizes ),
 			'site_editor_styles_url' => admin_url( 'site-editor.php?p=%2Fstyles&section=' . rawurlencode( '/blocks/' . rawurlencode( Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ) ) ),
 		];
 	}
 
 	/**
-	 * Global-settings presets come keyed by origin (custom > theme > default);
-	 * the wizard wants one flat list, first non-empty origin wins.
+	 * Global-settings presets come keyed by origin, each origin holding its own
+	 * list; the wizard wants one flat list. Merge the origins, custom beating theme
+	 * beating default on a shared slug: every origin gets a CSS custom property, so
+	 * a lower-precedence preset is still usable and dropping it would hide it from
+	 * the wizard for no reason. Anything not origin-keyed and not already a flat
+	 * list is not a preset list at all, and yields nothing.
+	 *
+	 * Public so the merge can be exercised directly in tests.
 	 *
 	 * @param mixed $presets Origin-keyed presets, or already-flat array.
-	 * @return array
+	 * @return array Flat preset list, empty when there is nothing to offer.
 	 */
-	private static function flatten_global_settings_presets( $presets ) {
+	public static function flatten_global_settings_presets( $presets ) {
 		if ( ! is_array( $presets ) ) {
 			return [];
 		}
+		// Not origin-keyed: already a flat preset list.
+		if ( wp_is_numeric_array( $presets ) ) {
+			return array_values( $presets );
+		}
+		$flat  = [];
+		$slugs = [];
 		foreach ( [ 'custom', 'theme', 'default' ] as $origin ) {
-			if ( ! empty( $presets[ $origin ] ) && is_array( $presets[ $origin ] ) ) {
-				return array_values( $presets[ $origin ] );
+			if ( empty( $presets[ $origin ] ) || ! is_array( $presets[ $origin ] ) ) {
+				continue;
+			}
+			foreach ( $presets[ $origin ] as $preset ) {
+				if ( ! is_array( $preset ) ) {
+					continue;
+				}
+				$slug = isset( $preset['slug'] ) ? (string) $preset['slug'] : '';
+				if ( '' !== $slug ) {
+					if ( isset( $slugs[ $slug ] ) ) {
+						continue;
+					}
+					$slugs[ $slug ] = true;
+				}
+				$flat[] = $preset;
 			}
 		}
-		// Not origin-keyed: already a flat preset list.
-		return array_values( $presets );
+		return $flat;
+	}
+
+	/**
+	 * Font size presets can carry a plain number: core unit-izes the ones a theme
+	 * registers with `add_theme_support( 'editor-font-sizes' )`, but not the ones a
+	 * theme.json declares. The wizard stores CSS strings and the style sanitizer
+	 * keeps string leaves only, so a numeric size would be offered in the picker
+	 * and dropped on save. Deliver every size in px, as core's own back-compat does.
+	 *
+	 * @param array $presets Flat font size presets.
+	 * @return array
+	 */
+	private static function normalize_preset_font_sizes( $presets ) {
+		foreach ( $presets as $index => $preset ) {
+			if ( is_array( $preset ) && isset( $preset['size'] ) && is_numeric( $preset['size'] ) ) {
+				$presets[ $index ]['size'] = $preset['size'] . 'px';
+			}
+		}
+		return $presets;
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-api.php
@@ -160,6 +160,10 @@ final class Newspack_Popups_API {
 							'required' => true,
 							'type'     => 'object',
 						],
+						'styles' => [
+							'required' => false,
+							'type'     => 'object',
+						],
 					],
 				]
 			);
@@ -178,17 +182,43 @@ final class Newspack_Popups_API {
 
 	/**
 	 * The Contextual Prompts status payload: opt-in state, whether the user can
-	 * manage it, and the publisher-profile fields.
+	 * manage it, the publisher-profile fields, and the block's style data.
 	 *
 	 * @return array
 	 */
 	private static function contextual_prompt_status() {
 		return [
-			'enabled'         => Newspack_Popups_Settings::is_ai_copy_assistant_enabled(),
-			'can_manage'      => current_user_can( 'manage_options' ),
-			'fields'          => Newspack_Popups_Settings::get_ai_copy_assistant_fields(),
-			'override_active' => Newspack_Popups_Settings::is_override_active(),
+			'enabled'                => Newspack_Popups_Settings::is_ai_copy_assistant_enabled(),
+			'can_manage'             => current_user_can( 'manage_options' ),
+			'fields'                 => Newspack_Popups_Settings::get_ai_copy_assistant_fields(),
+			'override_active'        => Newspack_Popups_Settings::is_override_active(),
+			'is_block_theme'         => wp_is_block_theme(),
+			'styles'                 => Newspack_Popups_Contextual_Prompt_Styles::get_styles(),
+			'style_defaults'         => Newspack_Popups_Contextual_Prompt_Styles::get_defaults(),
+			'style_palette'          => self::flatten_global_settings_presets( wp_get_global_settings( [ 'color', 'palette' ] ) ),
+			'style_font_sizes'       => self::flatten_global_settings_presets( wp_get_global_settings( [ 'typography', 'fontSizes' ] ) ),
+			'site_editor_styles_url' => admin_url( 'site-editor.php?p=%2Fstyles' ),
 		];
+	}
+
+	/**
+	 * Global-settings presets come keyed by origin (custom > theme > default);
+	 * the wizard wants one flat list, first non-empty origin wins.
+	 *
+	 * @param mixed $presets Origin-keyed presets, or already-flat array.
+	 * @return array
+	 */
+	private static function flatten_global_settings_presets( $presets ) {
+		if ( ! is_array( $presets ) ) {
+			return [];
+		}
+		foreach ( [ 'custom', 'theme', 'default' ] as $origin ) {
+			if ( ! empty( $presets[ $origin ] ) && is_array( $presets[ $origin ] ) ) {
+				return array_values( $presets[ $origin ] );
+			}
+		}
+		// Not origin-keyed: already a flat preset list.
+		return array_values( $presets );
 	}
 
 	/**
@@ -204,6 +234,9 @@ final class Newspack_Popups_API {
 		}
 
 		Newspack_Popups_Settings::save_ai_copy_assistant_fields( (array) $request['fields'] );
+		if ( isset( $request['styles'] ) ) {
+			Newspack_Popups_Contextual_Prompt_Styles::save_styles( (array) $request['styles'] );
+		}
 		return rest_ensure_response( self::contextual_prompt_status() );
 	}
 

--- a/plugins/newspack-popups/includes/class-newspack-popups-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-api.php
@@ -187,13 +187,17 @@ final class Newspack_Popups_API {
 	 * @return array
 	 */
 	private static function contextual_prompt_status() {
+		// Styles are a keyed object to every client, so no overrides has to travel
+		// as `{}`: an empty PHP array would serialize as `[]` and a client
+		// comparing it against an object it built would never see them as equal.
+		$styles = Newspack_Popups_Contextual_Prompt_Styles::get_styles();
 		return [
 			'enabled'                => Newspack_Popups_Settings::is_ai_copy_assistant_enabled(),
 			'can_manage'             => current_user_can( 'manage_options' ),
 			'fields'                 => Newspack_Popups_Settings::get_ai_copy_assistant_fields(),
 			'override_active'        => Newspack_Popups_Settings::is_override_active(),
 			'is_block_theme'         => wp_is_block_theme(),
-			'styles'                 => Newspack_Popups_Contextual_Prompt_Styles::get_styles(),
+			'styles'                 => empty( $styles ) ? (object) [] : $styles,
 			'style_defaults'         => Newspack_Popups_Contextual_Prompt_Styles::get_defaults(),
 			'style_palette'          => self::flatten_global_settings_presets( wp_get_global_settings( [ 'color', 'palette' ] ) ),
 			'style_font_sizes'       => self::flatten_global_settings_presets( wp_get_global_settings( [ 'typography', 'fontSizes' ] ) ),

--- a/plugins/newspack-popups/includes/class-newspack-popups-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-api.php
@@ -200,40 +200,71 @@ final class Newspack_Popups_API {
 			'is_block_theme'         => wp_is_block_theme(),
 			'styles'                 => empty( $styles ) ? (object) [] : $styles,
 			'style_defaults'         => Newspack_Popups_Contextual_Prompt_Styles::get_defaults(),
-			'style_palette'          => self::flatten_global_settings_presets( wp_get_global_settings( [ 'color', 'palette' ] ) ),
+			'style_palette'          => self::merge_global_settings_presets( wp_get_global_settings( [ 'color', 'palette' ] ) ),
 			'style_font_sizes'       => self::normalize_preset_font_sizes( $font_sizes ),
 			'site_editor_styles_url' => admin_url( 'site-editor.php?p=%2Fstyles&section=' . rawurlencode( '/blocks/' . rawurlencode( Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ) ) ),
 		];
 	}
 
 	/**
-	 * Global-settings presets come keyed by origin, each origin holding its own
-	 * list; the wizard wants one flat list. Merge the origins, custom beating theme
-	 * beating default on a shared slug: every origin gets a CSS custom property, so
-	 * a lower-precedence preset is still usable and dropping it would hide it from
-	 * the wizard for no reason. Anything not origin-keyed and not already a flat
-	 * list is not a preset list at all, and yields nothing.
+	 * The preset lists that hold something, highest precedence first. Global
+	 * settings key presets by origin (custom > theme > default), each origin holding
+	 * its own list; an already-flat list stands in as its own single origin. Neither
+	 * shape means it is not a preset list at all — a missing settings path hands back
+	 * the whole settings tree — so it offers nothing.
+	 *
+	 * @param mixed $presets Origin-keyed presets, or already-flat array.
+	 * @return array List of preset lists, empty when there is nothing to offer.
+	 */
+	private static function preset_origin_lists( $presets ) {
+		if ( ! is_array( $presets ) ) {
+			return [];
+		}
+		// Not origin-keyed: already a flat preset list.
+		if ( wp_is_numeric_array( $presets ) ) {
+			return empty( $presets ) ? [] : [ array_values( $presets ) ];
+		}
+		$lists = [];
+		foreach ( [ 'custom', 'theme', 'default' ] as $origin ) {
+			if ( ! empty( $presets[ $origin ] ) && is_array( $presets[ $origin ] ) ) {
+				$lists[] = array_values( $presets[ $origin ] );
+			}
+		}
+		return $lists;
+	}
+
+	/**
+	 * One flat preset list, taking the highest origin that holds anything. This is
+	 * how the editor resolves a preset list it offers as a single set — font sizes,
+	 * where `custom ?? theme ?? default` decides — so the wizard offers the same
+	 * sizes its picker does.
+	 *
+	 * Public so the flattening can be exercised directly in tests.
+	 *
+	 * @param mixed $presets Origin-keyed presets, or already-flat array.
+	 * @return array Flat preset list, empty when there is nothing to offer.
+	 */
+	public static function flatten_global_settings_presets( $presets ) {
+		$lists = self::preset_origin_lists( $presets );
+		return empty( $lists ) ? [] : $lists[0];
+	}
+
+	/**
+	 * One flat preset list holding every origin, custom beating theme beating
+	 * default on a shared slug. The editor's color panel shows each origin as its
+	 * own section rather than picking one, and every origin gets a CSS custom
+	 * property, so dropping the lower ones would hide usable colors.
 	 *
 	 * Public so the merge can be exercised directly in tests.
 	 *
 	 * @param mixed $presets Origin-keyed presets, or already-flat array.
 	 * @return array Flat preset list, empty when there is nothing to offer.
 	 */
-	public static function flatten_global_settings_presets( $presets ) {
-		if ( ! is_array( $presets ) ) {
-			return [];
-		}
-		// Not origin-keyed: already a flat preset list.
-		if ( wp_is_numeric_array( $presets ) ) {
-			return array_values( $presets );
-		}
+	public static function merge_global_settings_presets( $presets ) {
 		$flat  = [];
 		$slugs = [];
-		foreach ( [ 'custom', 'theme', 'default' ] as $origin ) {
-			if ( empty( $presets[ $origin ] ) || ! is_array( $presets[ $origin ] ) ) {
-				continue;
-			}
-			foreach ( $presets[ $origin ] as $preset ) {
+		foreach ( self::preset_origin_lists( $presets ) as $list ) {
+			foreach ( $list as $preset ) {
 				if ( ! is_array( $preset ) ) {
 					continue;
 				}

--- a/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
@@ -37,6 +37,18 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 	const SHORTHAND_PATHS = [ 'border.radius' ];
 
 	/**
+	 * Color shapes the wizard can read for its contrast check: a hex value or a
+	 * preset reference.
+	 */
+	const WIZARD_COLOR_PATTERN = '/^(?:#[0-9a-fA-F]{3}|#[0-9a-fA-F]{6}|var:preset\|color\|[a-zA-Z0-9_-]+)\z/';
+
+	/**
+	 * The CSS initial text color, used when the site's global text color is
+	 * missing or in a shape the wizard cannot read.
+	 */
+	const INITIAL_TEXT_COLOR = '#000000';
+
+	/**
 	 * Register hooks. Classic themes only: on block themes Global Styles owns
 	 * the block's styles and this class must stay inert.
 	 */
@@ -196,7 +208,37 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 			[ 'blocks', Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ],
 			[ 'transforms' => [ 'resolve-variables' ] ]
 		);
-		return is_array( $defaults ) ? $defaults : [];
+		$defaults = is_array( $defaults ) ? $defaults : [];
+		if ( ! isset( $defaults['color'] ) || ! is_array( $defaults['color'] ) ) {
+			$defaults['color'] = [];
+		}
+		// The block's default design carries no text color, so a background chosen
+		// in the wizard would have nothing to be checked against. Stand in the
+		// color the prompt actually renders with.
+		if ( empty( $defaults['color']['text'] ) ) {
+			$defaults['color']['text'] = self::get_inherited_text_color();
+		}
+		return $defaults;
+	}
+
+	/**
+	 * The text color a prompt inherits from the site, in a shape the wizard can
+	 * read. Global styles resolve preset references to `var()` lookups, which the
+	 * wizard cannot resolve, so anything unreadable falls back to the CSS initial
+	 * text color.
+	 *
+	 * @return string
+	 */
+	private static function get_inherited_text_color() {
+		// A missing path hands back the whole styles tree, hence the string check.
+		$text = wp_get_global_styles( [ 'color', 'text' ], [ 'transforms' => [ 'resolve-variables' ] ] );
+		if ( is_string( $text ) ) {
+			$text = trim( $text );
+			if ( '' !== $text && preg_match( self::WIZARD_COLOR_PATTERN, $text ) ) {
+				return $text;
+			}
+		}
+		return self::INITIAL_TEXT_COLOR;
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
@@ -223,9 +223,10 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 
 	/**
 	 * The text color a prompt inherits from the site, in a shape the wizard can
-	 * read. Global styles resolve preset references to `var()` lookups, which the
-	 * wizard cannot resolve, so anything unreadable falls back to the CSS initial
-	 * text color.
+	 * read. The resolve-variables transform hands back a concrete color for a
+	 * preset reference, whichever origin defines the preset; a `var()` lookup only
+	 * survives it when the slug is in no palette, so anything still unreadable here
+	 * falls back to the CSS initial text color.
 	 *
 	 * @return string
 	 */

--- a/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Contextual Prompt block default styles.
+ *
+ * Publisher-set defaults for the Contextual Prompt block, edited in the
+ * Contextual Prompts wizard on classic themes (block themes use Global Styles
+ * directly). Stored as a block-supports-shaped object, rendered to CSS by the
+ * style engine, and delivered at :root :where() specificity AFTER the block's
+ * theme.json default design so it overrides the default while any per-block
+ * style still wins.
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Contextual Prompt styles class.
+ */
+final class Newspack_Popups_Contextual_Prompt_Styles {
+	const OPTION_NAME = 'newspack_popups_contextual_prompt_styles';
+
+	/**
+	 * Leaf values: CSS-safe fragments only. Permits hex/named colors, units,
+	 * var:preset|…|… refs and var() lookups; rejects anything that could close
+	 * a declaration or rule.
+	 */
+	const VALUE_PATTERN = '/^[a-zA-Z0-9 #%().,\/|:_-]+$/';
+
+	/**
+	 * Register hooks. Classic themes only: on block themes Global Styles owns
+	 * the block's styles and this class must stay inert.
+	 */
+	public static function init() {
+		if ( wp_is_block_theme() ) {
+			return;
+		}
+		// Same hook and priority as core's wp_enqueue_global_styles on classic
+		// themes, registered later so it runs after: the inline CSS then lands
+		// behind the block's default design in the same handle.
+		add_action( 'wp_footer', [ __CLASS__, 'enqueue_front_end_styles' ], 1 );
+		add_filter( 'block_editor_settings_all', [ __CLASS__, 'filter_block_editor_settings' ] );
+	}
+
+	/**
+	 * The saved style overrides.
+	 *
+	 * @return array
+	 */
+	public static function get_styles() {
+		$styles = get_option( self::OPTION_NAME, [] );
+		return is_array( $styles ) ? $styles : [];
+	}
+
+	/**
+	 * Sanitize and persist style overrides. An empty result removes the option.
+	 *
+	 * @param array $styles Block-supports-shaped style object.
+	 */
+	public static function save_styles( $styles ) {
+		$sanitized = self::sanitize( (array) $styles );
+		if ( empty( $sanitized ) ) {
+			delete_option( self::OPTION_NAME );
+			return;
+		}
+		update_option( self::OPTION_NAME, $sanitized );
+	}
+
+	/**
+	 * Allowlist filter for the stored shape. Anything not explicitly allowed is
+	 * dropped; any leaf failing the value pattern drops its whole branch.
+	 *
+	 * @param array $styles Raw style object.
+	 * @return array Sanitized style object.
+	 */
+	public static function sanitize( $styles ) {
+		$side_schema = [
+			'color' => true,
+			'width' => true,
+			'style' => true,
+		];
+		$schema      = [
+			'color'      => [
+				'background' => true,
+				'text'       => true,
+			],
+			'typography' => [ 'fontSize' => true ],
+			'spacing'    => [
+				'padding' => [
+					'top'    => true,
+					'right'  => true,
+					'bottom' => true,
+					'left'   => true,
+				],
+			],
+			'border'     => array_merge(
+				$side_schema,
+				[
+					'radius' => [
+						'topLeft'     => true,
+						'topRight'    => true,
+						'bottomLeft'  => true,
+						'bottomRight' => true,
+					],
+					'top'    => $side_schema,
+					'right'  => $side_schema,
+					'bottom' => $side_schema,
+					'left'   => $side_schema,
+				]
+			),
+		];
+
+		return self::sanitize_node( $styles, $schema );
+	}
+
+	/**
+	 * Recursively apply a schema node: keys must exist in the schema; leaves
+	 * must be pattern-safe strings. A schema of `true` accepts a string leaf; a
+	 * schema array accepts either a string leaf (border.radius shorthand) or a
+	 * matching sub-object.
+	 *
+	 * @param mixed $node   Incoming value.
+	 * @param mixed $schema Schema node.
+	 * @return array Sanitized node (possibly empty).
+	 */
+	private static function sanitize_node( $node, $schema ) {
+		$clean = [];
+		if ( ! is_array( $node ) ) {
+			return $clean;
+		}
+		foreach ( $node as $key => $value ) {
+			if ( ! isset( $schema[ $key ] ) ) {
+				continue;
+			}
+			if ( is_string( $value ) ) {
+				if ( preg_match( self::VALUE_PATTERN, $value ) ) {
+					$clean[ $key ] = $value;
+				}
+				continue;
+			}
+			if ( is_array( $schema[ $key ] ) && is_array( $value ) ) {
+				$sub = self::sanitize_node( $value, $schema[ $key ] );
+				if ( ! empty( $sub ) ) {
+					$clean[ $key ] = $sub;
+				}
+			}
+		}
+		return $clean;
+	}
+
+	/**
+	 * The overrides as a single CSS rule, or an empty string.
+	 *
+	 * @return string
+	 */
+	public static function get_css() {
+		$styles = self::get_styles();
+		if ( empty( $styles ) ) {
+			return '';
+		}
+		$result = wp_style_engine_get_styles(
+			$styles,
+			[ 'selector' => ':root :where(.wp-block-newspack-popups-contextual-prompt)' ]
+		);
+		return isset( $result['css'] ) ? $result['css'] : '';
+	}
+
+	/**
+	 * The block's effective default styles (theme.json cascade, presets
+	 * resolved), for display in the wizard. Never includes this class's own
+	 * overrides: they live in an option, not in theme.json data.
+	 *
+	 * @return array
+	 */
+	public static function get_defaults() {
+		$defaults = wp_get_global_styles(
+			[ 'blocks', Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ],
+			[ 'transforms' => [ 'resolve-variables' ] ]
+		);
+		return is_array( $defaults ) ? $defaults : [];
+	}
+
+	/**
+	 * Front end: append the CSS to the global-styles handle so it prints after
+	 * the block's default design. Falls back to a standalone handle when core
+	 * has not registered global-styles, or has already printed it — inline CSS
+	 * added to a printed handle is silently dropped.
+	 */
+	public static function enqueue_front_end_styles() {
+		$css = self::get_css();
+		if ( '' === $css ) {
+			return;
+		}
+		if ( wp_style_is( 'global-styles', 'enqueued' ) && ! wp_style_is( 'global-styles', 'done' ) ) {
+			wp_add_inline_style( 'global-styles', $css );
+			return;
+		}
+		$handle = 'newspack-popups-contextual-prompt-styles';
+		wp_register_style( $handle, false ); // phpcs:ignore WordPress.WP.EnqueuedResourceParameters.MissingVersion -- Inline styles only, no source file to version.
+		wp_enqueue_style( $handle );
+		wp_add_inline_style( $handle, $css );
+	}
+
+	/**
+	 * Editor: append the CSS to the canvas styles, after the entries core added
+	 * from theme.json, so order decides at equal specificity.
+	 *
+	 * @param array $settings Block editor settings.
+	 * @return array
+	 */
+	public static function filter_block_editor_settings( $settings ) {
+		$css = self::get_css();
+		if ( '' === $css ) {
+			return $settings;
+		}
+		if ( ! isset( $settings['styles'] ) || ! is_array( $settings['styles'] ) ) {
+			$settings['styles'] = [];
+		}
+		$settings['styles'][] = [ 'css' => $css ];
+		return $settings;
+	}
+}

--- a/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
@@ -25,7 +25,16 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 	 * var:preset|…|… refs and var() lookups; rejects anything that could close
 	 * a declaration or rule.
 	 */
-	const VALUE_PATTERN = '/^[a-zA-Z0-9 #%().,\/|:_-]+$/';
+	const VALUE_PATTERN = '/^[a-zA-Z0-9 #%().,\/|:_-]+\z/';
+
+	/**
+	 * Object-schema nodes that also accept a string leaf, as dot paths into the
+	 * schema. `border.radius` is either a shorthand or a per-corner object;
+	 * everywhere else a string would emit a shorthand declaration nobody
+	 * allowlisted (`spacing.padding: '10px'` becoming `padding`), so it is
+	 * dropped.
+	 */
+	const SHORTHAND_PATHS = [ 'border.radius' ];
 
 	/**
 	 * Register hooks. Classic themes only: on block themes Global Styles owns
@@ -33,6 +42,13 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 	 */
 	public static function init() {
 		if ( wp_is_block_theme() ) {
+			return;
+		}
+		// The rollout flag gates the call to this method; the admin opt-in is an
+		// option, so it is read here — the same point the render-time block strip
+		// reads it. With the opt-in withdrawn no prompt markup renders, so there is
+		// nothing for this CSS to style.
+		if ( ! Newspack_Popups_Settings::is_ai_copy_assistant_enabled() ) {
 			return;
 		}
 		// Same hook and priority as core's wp_enqueue_global_styles on classic
@@ -116,14 +132,15 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 	/**
 	 * Recursively apply a schema node: keys must exist in the schema; leaves
 	 * must be pattern-safe strings. A schema of `true` accepts a string leaf; a
-	 * schema array accepts either a string leaf (border.radius shorthand) or a
-	 * matching sub-object.
+	 * schema array accepts a matching sub-object, plus a string leaf only at the
+	 * paths in SHORTHAND_PATHS.
 	 *
-	 * @param mixed $node   Incoming value.
-	 * @param mixed $schema Schema node.
+	 * @param mixed  $node   Incoming value.
+	 * @param mixed  $schema Schema node.
+	 * @param string $path   Dot path to $node, for the shorthand allowlist.
 	 * @return array Sanitized node (possibly empty).
 	 */
-	private static function sanitize_node( $node, $schema ) {
+	private static function sanitize_node( $node, $schema, $path = '' ) {
 		$clean = [];
 		if ( ! is_array( $node ) ) {
 			return $clean;
@@ -132,14 +149,16 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 			if ( ! isset( $schema[ $key ] ) ) {
 				continue;
 			}
+			$key_path = '' === $path ? (string) $key : $path . '.' . $key;
 			if ( is_string( $value ) ) {
-				if ( preg_match( self::VALUE_PATTERN, $value ) ) {
+				$accepts_string = true === $schema[ $key ] || in_array( $key_path, self::SHORTHAND_PATHS, true );
+				if ( $accepts_string && preg_match( self::VALUE_PATTERN, $value ) ) {
 					$clean[ $key ] = $value;
 				}
 				continue;
 			}
 			if ( is_array( $schema[ $key ] ) && is_array( $value ) ) {
-				$sub = self::sanitize_node( $value, $schema[ $key ] );
+				$sub = self::sanitize_node( $value, $schema[ $key ], $key_path );
 				if ( ! empty( $sub ) ) {
 					$clean[ $key ] = $sub;
 				}

--- a/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
@@ -43,8 +43,14 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 	const WIZARD_COLOR_PATTERN = '/^(?:#[0-9a-fA-F]{3}|#[0-9a-fA-F]{6}|var:preset\|color\|[a-zA-Z0-9_-]+)\z/';
 
 	/**
-	 * The CSS initial text color, used when the site's global text color is
-	 * missing or in a shape the wizard cannot read.
+	 * An `rgb()`/`rgba()` color with integer channels, the one other shape
+	 * theme.json data hands back for a color. Alpha is matched only to be dropped.
+	 */
+	const RGB_COLOR_PATTERN = '/^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,[^)]*)?\)\z/i';
+
+	/**
+	 * The CSS initial text color, used when the site sets no global text color at
+	 * all.
 	 */
 	const INITIAL_TEXT_COLOR = '#000000';
 
@@ -214,32 +220,66 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 		}
 		// The block's default design carries no text color, so a background chosen
 		// in the wizard would have nothing to be checked against. Stand in the
-		// color the prompt actually renders with.
+		// color the prompt actually renders with, when that is one the wizard can
+		// read.
 		if ( empty( $defaults['color']['text'] ) ) {
-			$defaults['color']['text'] = self::get_inherited_text_color();
+			$inherited = self::get_inherited_text_color();
+			if ( null !== $inherited ) {
+				$defaults['color']['text'] = $inherited;
+			}
 		}
 		return $defaults;
 	}
 
 	/**
 	 * The text color a prompt inherits from the site, in a shape the wizard can
-	 * read. The resolve-variables transform hands back a concrete color for a
-	 * preset reference, whichever origin defines the preset; a `var()` lookup only
-	 * survives it when the slug is in no palette, so anything still unreadable here
-	 * falls back to the CSS initial text color.
+	 * read: a hex value, a preset reference, or an `rgb()` color as hex. The
+	 * resolve-variables transform hands back a concrete color for a preset
+	 * reference, whichever origin defines the preset; a `var()` lookup only
+	 * survives it when the slug is in no palette.
 	 *
-	 * @return string
+	 * A color in none of those shapes hands back nothing rather than a stand-in:
+	 * the wizard would check a chosen background against the wrong color, and a
+	 * contrast warning pointing the wrong way is worse than no warning. Only a site
+	 * with no global text color at all gets the CSS initial one.
+	 *
+	 * @return string|null Hex value or preset reference, null when unreadable.
 	 */
 	private static function get_inherited_text_color() {
 		// A missing path hands back the whole styles tree, hence the string check.
 		$text = wp_get_global_styles( [ 'color', 'text' ], [ 'transforms' => [ 'resolve-variables' ] ] );
-		if ( is_string( $text ) ) {
-			$text = trim( $text );
-			if ( '' !== $text && preg_match( self::WIZARD_COLOR_PATTERN, $text ) ) {
-				return $text;
-			}
+		$text = is_string( $text ) ? trim( $text ) : '';
+		if ( '' === $text ) {
+			return self::INITIAL_TEXT_COLOR;
 		}
-		return self::INITIAL_TEXT_COLOR;
+		if ( preg_match( self::WIZARD_COLOR_PATTERN, $text ) ) {
+			return $text;
+		}
+		return self::rgb_to_hex( $text );
+	}
+
+	/**
+	 * An `rgb()`/`rgba()` color as a hex string, alpha dropped: the wizard reads
+	 * hex, and a contrast ratio has no use for alpha. Only the comma-separated
+	 * integer form is handled — the percentage and space-separated CSS Color 4
+	 * forms are not what theme.json data carries.
+	 *
+	 * @param string $value CSS color value.
+	 * @return string|null Hex value, null when this is not such a color.
+	 */
+	private static function rgb_to_hex( $value ) {
+		if ( ! preg_match( self::RGB_COLOR_PATTERN, $value, $matches ) ) {
+			return null;
+		}
+		$hex = '#';
+		foreach ( array_slice( $matches, 1, 3 ) as $channel ) {
+			$channel = (int) $channel;
+			if ( 255 < $channel ) {
+				return null;
+			}
+			$hex .= str_pad( dechex( $channel ), 2, '0', STR_PAD_LEFT );
+		}
+		return $hex;
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups.php
@@ -114,6 +114,10 @@ final class Newspack_Popups {
 		if ( self::is_contextual_prompts_enabled() ) {
 			Newspack_Popups_Contextual_Prompt_Block::init();
 		}
+		include_once __DIR__ . '/class-newspack-popups-contextual-prompt-styles.php';
+		if ( self::is_contextual_prompts_enabled() ) {
+			Newspack_Popups_Contextual_Prompt_Styles::init();
+		}
 		// Feature off — rollout flag absent OR admin opt-in withdrawn: strip any
 		// stored Contextual Prompt markup so it never reaches the front end as an
 		// orphaned call to action (or keeps a stale site-wide override alive).

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
@@ -33,7 +33,9 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 		$data     = $response->get_data();
 
 		$this->assertArrayHasKey( 'is_block_theme', $data );
-		$this->assertSame( [], $data['styles'] );
+		// No overrides travels as an empty object, never an empty array.
+		$this->assertEquals( (object) [], $data['styles'] );
+		$this->assertSame( '{}', wp_json_encode( $data['styles'] ) );
 		$this->assertSame( '#f7f7f7', $data['style_defaults']['color']['background'] );
 		$this->assertNotEmpty( $data['style_palette'] );
 		$this->assertArrayHasKey( 'color', $data['style_palette'][0] );

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
@@ -99,11 +99,11 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Presets are merged across origins: a shared slug is taken from the highest
+	 * The palette is merged across origins: a shared slug is taken from the highest
 	 * origin defining it, and a slug only a lower origin defines still travels.
 	 */
-	public function test_presets_merge_across_origins() {
-		$merged = Newspack_Popups_API::flatten_global_settings_presets(
+	public function test_palette_presets_merge_across_origins() {
+		$merged = Newspack_Popups_API::merge_global_settings_presets(
 			[
 				'default' => [
 					[
@@ -142,35 +142,63 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Font sizes are not merged: the editor's picker offers a single origin, the
+	 * highest one holding anything, so the wizard offers the same set.
+	 */
+	public function test_font_size_presets_take_the_highest_origin() {
+		$presets = [
+			'default' => [
+				[
+					'slug' => 'medium',
+					'size' => '20px',
+				],
+			],
+			'theme'   => [
+				[
+					'slug' => 'normal',
+					'size' => '20px',
+				],
+				[
+					'slug' => 'huge',
+					'size' => '44px',
+				],
+			],
+		];
+
+		$this->assertSame( $presets['theme'], Newspack_Popups_API::flatten_global_settings_presets( $presets ) );
+
+		// With that origin empty the next one down stands in.
+		$presets['theme'] = [];
+		$this->assertSame( $presets['default'], Newspack_Popups_API::flatten_global_settings_presets( $presets ) );
+	}
+
+	/**
 	 * Nothing to offer travels as an empty list, never as a list of junk. An
-	 * already-flat list passes through untouched.
+	 * already-flat list passes through untouched. Both shapes are read the same way
+	 * whether the presets are merged or taken from one origin.
 	 */
 	public function test_presets_edge_shapes() {
-		$this->assertSame(
-			[],
-			Newspack_Popups_API::flatten_global_settings_presets(
-				[
-					'default' => [],
-					'theme'   => [],
-					'custom'  => [],
-				]
-			)
-		);
+		$empty_origins = [
+			'default' => [],
+			'theme'   => [],
+			'custom'  => [],
+		];
 		// A missing settings path hands back the whole settings tree, which is not a
 		// preset list.
-		$this->assertSame(
-			[],
-			Newspack_Popups_API::flatten_global_settings_presets( [ 'typography' => [ 'fontSizes' => [] ] ] )
-		);
-		$this->assertSame( [], Newspack_Popups_API::flatten_global_settings_presets( 'not an array' ) );
-
-		$flat = [
+		$settings_tree = [ 'typography' => [ 'fontSizes' => [] ] ];
+		$flat          = [
 			[
 				'slug' => 'small',
 				'size' => '13px',
 			],
 		];
-		$this->assertSame( $flat, Newspack_Popups_API::flatten_global_settings_presets( $flat ) );
+
+		foreach ( [ 'flatten_global_settings_presets', 'merge_global_settings_presets' ] as $method ) {
+			$this->assertSame( [], Newspack_Popups_API::$method( $empty_origins ), $method );
+			$this->assertSame( [], Newspack_Popups_API::$method( $settings_tree ), $method );
+			$this->assertSame( [], Newspack_Popups_API::$method( 'not an array' ), $method );
+			$this->assertSame( $flat, Newspack_Popups_API::$method( $flat ), $method );
+		}
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
@@ -1,0 +1,92 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class Contextual Prompt Styles API Test
+ *
+ * The wizard's Style section rides the existing status/profile endpoints:
+ * status carries the style payload, profile save carries optional overrides.
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Contextual Prompt styles API test case.
+ */
+class ContextualPromptStylesApiTest extends WP_UnitTestCase {
+	/**
+	 * Admin user, feature opted in, routes registered.
+	 */
+	public function set_up() {
+		parent::set_up();
+		update_option( Newspack_Popups_Settings::AI_COPY_ASSISTANT_ENABLED_OPTION, true );
+		delete_option( Newspack_Popups_Contextual_Prompt_Styles::OPTION_NAME );
+		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
+		global $wp_rest_server;
+		$wp_rest_server = new WP_REST_Server(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+		do_action( 'rest_api_init' );
+	}
+
+	/**
+	 * Status carries the style payload.
+	 */
+	public function test_status_includes_style_payload() {
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/newspack-popups/v1/contextual-prompt/status' ) );
+		$data     = $response->get_data();
+
+		$this->assertArrayHasKey( 'is_block_theme', $data );
+		$this->assertSame( [], $data['styles'] );
+		$this->assertSame( '#f7f7f7', $data['style_defaults']['color']['background'] );
+		$this->assertNotEmpty( $data['style_palette'] );
+		$this->assertArrayHasKey( 'color', $data['style_palette'][0] );
+		$this->assertNotEmpty( $data['style_font_sizes'] );
+		$this->assertArrayHasKey( 'size', $data['style_font_sizes'][0] );
+		$this->assertStringContainsString( 'site-editor.php', $data['site_editor_styles_url'] );
+	}
+
+	/**
+	 * Profile save with styles persists them and echoes them in the response.
+	 */
+	public function test_save_profile_with_styles() {
+		$request = new WP_REST_Request( 'POST', '/newspack-popups/v1/contextual-prompt/profile' );
+		$request->set_body_params(
+			[
+				'fields' => [],
+				'styles' => [
+					'color' => [ 'background' => '#123456' ],
+					'evil'  => [ 'x' => 'y' ],
+				],
+			]
+		);
+		$response = rest_do_request( $request );
+		$data     = $response->get_data();
+
+		$this->assertSame( '#123456', $data['styles']['color']['background'] );
+		$this->assertArrayNotHasKey( 'evil', $data['styles'] );
+		$this->assertSame(
+			[ 'color' => [ 'background' => '#123456' ] ],
+			Newspack_Popups_Contextual_Prompt_Styles::get_styles()
+		);
+	}
+
+	/**
+	 * Omitting styles leaves the stored option untouched; an explicit empty
+	 * object clears it.
+	 */
+	public function test_save_profile_styles_semantics() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_styles( [ 'color' => [ 'text' => '#fedcba' ] ] );
+
+		$request = new WP_REST_Request( 'POST', '/newspack-popups/v1/contextual-prompt/profile' );
+		$request->set_body_params( [ 'fields' => [] ] );
+		rest_do_request( $request );
+		$this->assertNotEmpty( Newspack_Popups_Contextual_Prompt_Styles::get_styles() );
+
+		$request = new WP_REST_Request( 'POST', '/newspack-popups/v1/contextual-prompt/profile' );
+		$request->set_body_params(
+			[
+				'fields' => [],
+				'styles' => [],
+			]
+		);
+		rest_do_request( $request );
+		$this->assertSame( [], Newspack_Popups_Contextual_Prompt_Styles::get_styles() );
+	}
+}

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
@@ -26,11 +26,13 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A test's theme.json data is cached for the whole request, so drop it.
+	 * A test's theme.json data is cached for the whole request — resolved settings
+	 * in the theme_json cache group too — so drop all of it.
 	 */
 	public function tear_down() {
 		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'add_numeric_font_size_preset' ] );
-		WP_Theme_JSON_Resolver::clean_cached_data();
+		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'disable_default_palette' ] );
+		wp_clean_theme_json_cache();
 		parent::tear_down();
 	}
 
@@ -61,7 +63,7 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 	 */
 	public function test_status_normalizes_numeric_font_size_presets() {
 		add_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'add_numeric_font_size_preset' ] );
-		WP_Theme_JSON_Resolver::clean_cached_data();
+		wp_clean_theme_json_cache();
 
 		// The premise: the number does survive into the global settings.
 		$settings = wp_get_global_settings( [ 'typography', 'fontSizes' ] );
@@ -139,6 +141,44 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 		$this->assertSame( '#123456', $by_slug['accent'] );
 		$this->assertSame( '#fefefe', $by_slug['base'] );
 		$this->assertSame( '#000000', $by_slug['contrast'] );
+	}
+
+	/**
+	 * The default origin travels only while the editor shows it: core turns
+	 * `color.defaultPalette` off for any classic theme registering an
+	 * editor-color-palette, and the wizard must not offer colors the editor hides.
+	 */
+	public function test_palette_drops_the_default_origin_when_the_editor_hides_it() {
+		$default_slugs = wp_list_pluck( wp_get_global_settings( [ 'color', 'palette' ] )['default'], 'slug' );
+		$this->assertNotEmpty( $default_slugs );
+
+		$palette = rest_do_request( new WP_REST_Request( 'GET', '/newspack-popups/v1/contextual-prompt/status' ) )->get_data()['style_palette'];
+		$this->assertNotEmpty( array_intersect( $default_slugs, wp_list_pluck( $palette, 'slug' ) ) );
+
+		add_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'disable_default_palette' ] );
+		wp_clean_theme_json_cache();
+		// The premise: the presets are still there, the editor just hides them.
+		$this->assertFalse( wp_get_global_settings( [ 'color', 'defaultPalette' ] ) );
+		$this->assertNotEmpty( wp_get_global_settings( [ 'color', 'palette' ] )['default'] );
+
+		$palette = rest_do_request( new WP_REST_Request( 'GET', '/newspack-popups/v1/contextual-prompt/status' ) )->get_data()['style_palette'];
+		$this->assertSame( [], array_intersect( $default_slugs, wp_list_pluck( $palette, 'slug' ) ) );
+	}
+
+	/**
+	 * Hide the default color palette, as core does for a classic theme that
+	 * registers its own.
+	 *
+	 * @param WP_Theme_JSON_Data $theme_json Theme JSON data.
+	 * @return WP_Theme_JSON_Data
+	 */
+	public static function disable_default_palette( $theme_json ) {
+		return $theme_json->update_with(
+			[
+				'version'  => 2,
+				'settings' => [ 'color' => [ 'defaultPalette' => false ] ],
+			]
+		);
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
@@ -26,6 +26,15 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A test's theme.json data is cached for the whole request, so drop it.
+	 */
+	public function tear_down() {
+		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'add_numeric_font_size_preset' ] );
+		WP_Theme_JSON_Resolver::clean_cached_data();
+		parent::tear_down();
+	}
+
+	/**
 	 * Status carries the style payload.
 	 */
 	public function test_status_includes_style_payload() {
@@ -42,6 +51,126 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 		$this->assertNotEmpty( $data['style_font_sizes'] );
 		$this->assertArrayHasKey( 'size', $data['style_font_sizes'][0] );
 		$this->assertStringContainsString( 'site-editor.php', $data['site_editor_styles_url'] );
+	}
+
+	/**
+	 * A theme.json font size preset may be a bare number; core only unit-izes the
+	 * ones registered through add_theme_support. The payload must carry strings
+	 * either way: the picker hands back the shape it was given, and the style
+	 * sanitizer drops anything that is not a string.
+	 */
+	public function test_status_normalizes_numeric_font_size_presets() {
+		add_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'add_numeric_font_size_preset' ] );
+		WP_Theme_JSON_Resolver::clean_cached_data();
+
+		// The premise: the number does survive into the global settings.
+		$settings = wp_get_global_settings( [ 'typography', 'fontSizes' ] );
+		$this->assertSame( 21, $settings['theme'][0]['size'] );
+
+		$response = rest_do_request( new WP_REST_Request( 'GET', '/newspack-popups/v1/contextual-prompt/status' ) );
+		$sizes    = wp_list_pluck( $response->get_data()['style_font_sizes'], 'size', 'slug' );
+
+		$this->assertSame( '21px', $sizes['numeric'] );
+	}
+
+	/**
+	 * Add a font size preset carrying a number rather than a CSS string.
+	 *
+	 * @param WP_Theme_JSON_Data $theme_json Theme JSON data.
+	 * @return WP_Theme_JSON_Data
+	 */
+	public static function add_numeric_font_size_preset( $theme_json ) {
+		return $theme_json->update_with(
+			[
+				'version'  => 2,
+				'settings' => [
+					'typography' => [
+						'fontSizes' => [
+							[
+								'name' => 'Numeric',
+								'slug' => 'numeric',
+								'size' => 21,
+							],
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * Presets are merged across origins: a shared slug is taken from the highest
+	 * origin defining it, and a slug only a lower origin defines still travels.
+	 */
+	public function test_presets_merge_across_origins() {
+		$merged = Newspack_Popups_API::flatten_global_settings_presets(
+			[
+				'default' => [
+					[
+						'slug'  => 'base',
+						'color' => '#ffffff',
+					],
+					[
+						'slug'  => 'contrast',
+						'color' => '#000000',
+					],
+				],
+				'theme'   => [
+					[
+						'slug'  => 'base',
+						'color' => '#fefefe',
+					],
+					[
+						'slug'  => 'accent',
+						'color' => '#178f15',
+					],
+				],
+				'custom'  => [
+					[
+						'slug'  => 'accent',
+						'color' => '#123456',
+					],
+				],
+			]
+		);
+		$by_slug = wp_list_pluck( $merged, 'color', 'slug' );
+
+		$this->assertCount( 3, $merged );
+		$this->assertSame( '#123456', $by_slug['accent'] );
+		$this->assertSame( '#fefefe', $by_slug['base'] );
+		$this->assertSame( '#000000', $by_slug['contrast'] );
+	}
+
+	/**
+	 * Nothing to offer travels as an empty list, never as a list of junk. An
+	 * already-flat list passes through untouched.
+	 */
+	public function test_presets_edge_shapes() {
+		$this->assertSame(
+			[],
+			Newspack_Popups_API::flatten_global_settings_presets(
+				[
+					'default' => [],
+					'theme'   => [],
+					'custom'  => [],
+				]
+			)
+		);
+		// A missing settings path hands back the whole settings tree, which is not a
+		// preset list.
+		$this->assertSame(
+			[],
+			Newspack_Popups_API::flatten_global_settings_presets( [ 'typography' => [ 'fontSizes' => [] ] ] )
+		);
+		$this->assertSame( [], Newspack_Popups_API::flatten_global_settings_presets( 'not an array' ) );
+
+		$flat = [
+			[
+				'slug' => 'small',
+				'size' => '13px',
+			],
+		];
+		$this->assertSame( $flat, Newspack_Popups_API::flatten_global_settings_presets( $flat ) );
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
@@ -216,4 +216,22 @@ class ContextualPromptStylesTest extends WP_UnitTestCase {
 		// Preset spacing must come back resolved, not as a var:preset reference.
 		$this->assertStringNotContainsString( 'var:preset', (string) $defaults['spacing']['padding']['top'] );
 	}
+
+	/**
+	 * The block node carries no text color, so defaults stand in the color the
+	 * prompt inherits: without it the wizard has nothing to check a chosen
+	 * background against.
+	 */
+	public function test_get_defaults_fills_in_the_inherited_text_color() {
+		$block_node = wp_get_global_styles(
+			[ 'blocks', Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ],
+			[ 'transforms' => [ 'resolve-variables' ] ]
+		);
+		$this->assertArrayNotHasKey( 'text', $block_node['color'] );
+
+		$defaults = Newspack_Popups_Contextual_Prompt_Styles::get_defaults();
+		// This theme sets no global text color either, so the fallback is the CSS
+		// initial one.
+		$this->assertSame( '#000000', $defaults['color']['text'] );
+	}
 }

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
@@ -15,12 +15,55 @@
  */
 class ContextualPromptStylesTest extends WP_UnitTestCase {
 	/**
+	 * The global text color add_global_text_color() declares.
+	 *
+	 * @var string
+	 */
+	private static $global_text_color = '';
+
+	/**
 	 * The styles class is inert without the admin opt-in.
 	 */
 	public function set_up() {
 		parent::set_up();
 		update_option( Newspack_Popups_Settings::AI_COPY_ASSISTANT_ENABLED_OPTION, true );
 		delete_option( Newspack_Popups_Contextual_Prompt_Styles::OPTION_NAME );
+	}
+
+	/**
+	 * A test's theme.json data is cached for the whole request, so drop it.
+	 */
+	public function tear_down() {
+		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'add_global_text_color' ] );
+		wp_clean_theme_json_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * Give the site a global text color for the rest of the test.
+	 *
+	 * @param string $color CSS color value.
+	 */
+	private function set_global_text_color( $color ) {
+		self::$global_text_color = $color;
+		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'add_global_text_color' ] );
+		add_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'add_global_text_color' ] );
+		wp_clean_theme_json_cache();
+	}
+
+	/**
+	 * Declare a global text color in the theme's theme.json data.
+	 *
+	 * @param WP_Theme_JSON_Data $theme_json Theme JSON data.
+	 * @return WP_Theme_JSON_Data
+	 */
+	public static function add_global_text_color( $theme_json ) {
+		return $theme_json->update_with(
+			[
+				'version' => 2,
+				'styles'  => [ 'color' => [ 'text' => self::$global_text_color ] ],
+			]
+		);
 	}
 
 	/**
@@ -233,5 +276,31 @@ class ContextualPromptStylesTest extends WP_UnitTestCase {
 		// This theme sets no global text color either, so the fallback is the CSS
 		// initial one.
 		$this->assertSame( '#000000', $defaults['color']['text'] );
+	}
+
+	/**
+	 * An `rgb()`/`rgba()` global text color is handed over as hex, alpha dropped:
+	 * the wizard's contrast check reads hex.
+	 */
+	public function test_get_defaults_converts_an_rgb_inherited_text_color() {
+		$this->set_global_text_color( 'rgb(18,52,86)' );
+		$this->assertSame( '#123456', Newspack_Popups_Contextual_Prompt_Styles::get_defaults()['color']['text'] );
+
+		$this->set_global_text_color( 'rgba( 18, 52, 86, 0.5 )' );
+		$this->assertSame( '#123456', Newspack_Popups_Contextual_Prompt_Styles::get_defaults()['color']['text'] );
+	}
+
+	/**
+	 * A global text color the wizard cannot read stands nothing in: a contrast
+	 * check run against the wrong color would warn the wrong way, which is worse
+	 * than the warning simply being absent for that pairing.
+	 */
+	public function test_get_defaults_omits_an_unreadable_inherited_text_color() {
+		$this->set_global_text_color( 'rebeccapurple' );
+
+		$defaults = Newspack_Popups_Contextual_Prompt_Styles::get_defaults();
+
+		$this->assertSame( '#f7f7f7', $defaults['color']['background'] );
+		$this->assertArrayNotHasKey( 'text', $defaults['color'] );
 	}
 }

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
@@ -98,6 +98,42 @@ class ContextualPromptStylesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A string where the schema expects an object is dropped: only the paths in
+	 * SHORTHAND_PATHS (border.radius) take a shorthand, so nothing can smuggle a
+	 * `padding` or `border-top` declaration past the leaf allowlist.
+	 */
+	public function test_sanitize_rejects_unlisted_shorthands() {
+		$sanitized = Newspack_Popups_Contextual_Prompt_Styles::sanitize(
+			[
+				'spacing' => [ 'padding' => '10px' ],
+				'border'  => [ 'top' => '1px' ],
+			]
+		);
+
+		$this->assertSame( [], $sanitized );
+	}
+
+	/**
+	 * Withdrawing the admin opt-in stops the CSS shipping: init registers no
+	 * output hooks at all.
+	 */
+	public function test_init_requires_the_opt_in() {
+		if ( wp_is_block_theme() ) {
+			$this->markTestSkipped( 'Block themes keep the class inert regardless of the opt-in.' );
+		}
+		$callback = [ 'Newspack_Popups_Contextual_Prompt_Styles', 'enqueue_front_end_styles' ];
+		remove_action( 'wp_footer', $callback, 1 );
+
+		delete_option( Newspack_Popups_Settings::AI_COPY_ASSISTANT_ENABLED_OPTION );
+		Newspack_Popups_Contextual_Prompt_Styles::init();
+		$this->assertFalse( has_action( 'wp_footer', $callback ) );
+
+		update_option( Newspack_Popups_Settings::AI_COPY_ASSISTANT_ENABLED_OPTION, true );
+		Newspack_Popups_Contextual_Prompt_Styles::init();
+		$this->assertSame( 1, has_action( 'wp_footer', $callback ) );
+	}
+
+	/**
 	 * Values that could break out of a declaration are rejected wholesale.
 	 */
 	public function test_sanitize_rejects_css_injection() {

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
@@ -1,0 +1,183 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Class Contextual Prompt Styles Test
+ *
+ * Covers the wizard-set default styles for the Contextual Prompt block:
+ * allowlist sanitization, style-engine CSS output, and the editor delivery
+ * path. The CSS must sit at :root :where() specificity so the block's
+ * theme.json default design loses by order and per-block styles still win.
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Contextual Prompt styles test case.
+ */
+class ContextualPromptStylesTest extends WP_UnitTestCase {
+	/**
+	 * The styles class is inert without the admin opt-in.
+	 */
+	public function set_up() {
+		parent::set_up();
+		update_option( Newspack_Popups_Settings::AI_COPY_ASSISTANT_ENABLED_OPTION, true );
+		delete_option( Newspack_Popups_Contextual_Prompt_Styles::OPTION_NAME );
+	}
+
+	/**
+	 * Unknown properties are stripped; known ones survive.
+	 */
+	public function test_sanitize_allowlist() {
+		$sanitized = Newspack_Popups_Contextual_Prompt_Styles::sanitize(
+			[
+				'color'      => [
+					'background' => '#123456',
+					'text'       => 'var:preset|color|accent',
+					'gradient'   => 'linear-gradient(red, blue)',
+				],
+				'typography' => [
+					'fontSize'   => '18px',
+					'fontFamily' => 'serif',
+				],
+				'spacing'    => [
+					'padding' => [
+						'top'    => '10px',
+						'right'  => '20px',
+						'bottom' => '10px',
+						'left'   => '20px',
+						'inline' => '5px',
+					],
+					'margin'  => [ 'top' => '10px' ],
+				],
+				'border'     => [
+					'color'  => '#00ff00',
+					'width'  => '2px',
+					'style'  => 'dashed',
+					'radius' => [
+						'topLeft'     => '4px',
+						'topRight'    => '4px',
+						'bottomLeft'  => '4px',
+						'bottomRight' => '4px',
+					],
+				],
+				'evil'       => [ 'anything' => 'x' ],
+			]
+		);
+
+		$this->assertSame( '#123456', $sanitized['color']['background'] );
+		$this->assertSame( 'var:preset|color|accent', $sanitized['color']['text'] );
+		$this->assertArrayNotHasKey( 'gradient', $sanitized['color'] );
+		$this->assertSame( '18px', $sanitized['typography']['fontSize'] );
+		$this->assertArrayNotHasKey( 'fontFamily', $sanitized['typography'] );
+		$this->assertArrayNotHasKey( 'inline', $sanitized['spacing']['padding'] );
+		$this->assertArrayNotHasKey( 'margin', $sanitized['spacing'] );
+		$this->assertSame( '4px', $sanitized['border']['radius']['topLeft'] );
+		$this->assertArrayNotHasKey( 'evil', $sanitized );
+	}
+
+	/**
+	 * Per-side border objects are allowed with the same leaf allowlist.
+	 */
+	public function test_sanitize_split_borders() {
+		$sanitized = Newspack_Popups_Contextual_Prompt_Styles::sanitize(
+			[
+				'border' => [
+					'top'    => [
+						'color' => '#111111',
+						'width' => '1px',
+						'style' => 'solid',
+						'evil'  => 'x',
+					],
+					'radius' => '6px',
+				],
+			]
+		);
+
+		$this->assertSame( '1px', $sanitized['border']['top']['width'] );
+		$this->assertArrayNotHasKey( 'evil', $sanitized['border']['top'] );
+		$this->assertSame( '6px', $sanitized['border']['radius'] );
+	}
+
+	/**
+	 * Values that could break out of a declaration are rejected wholesale.
+	 */
+	public function test_sanitize_rejects_css_injection() {
+		$sanitized = Newspack_Popups_Contextual_Prompt_Styles::sanitize(
+			[
+				'color' => [
+					'background' => 'red;}body{display:none',
+					'text'       => "#fff\0",
+				],
+			]
+		);
+
+		$this->assertSame( [], $sanitized );
+	}
+
+	/**
+	 * CSS output: style engine declarations inside the zero-plus-root wrapper,
+	 * preset refs converted to CSS custom property lookups.
+	 */
+	public function test_get_css() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_styles(
+			[
+				'color'   => [ 'background' => 'var:preset|color|accent' ],
+				'spacing' => [ 'padding' => [ 'top' => '11px' ] ],
+				'border'  => [ 'radius' => '9px' ],
+			]
+		);
+		$css = Newspack_Popups_Contextual_Prompt_Styles::get_css();
+
+		$this->assertStringStartsWith( ':root :where(.wp-block-newspack-popups-contextual-prompt){', $css );
+		$this->assertStringContainsString( 'background-color:var(--wp--preset--color--accent)', $css );
+		$this->assertStringContainsString( 'padding-top:11px', $css );
+		$this->assertStringContainsString( 'border-radius:9px', $css );
+	}
+
+	/**
+	 * No saved styles means no CSS and no editor payload.
+	 */
+	public function test_empty_option_produces_nothing() {
+		$this->assertSame( '', Newspack_Popups_Contextual_Prompt_Styles::get_css() );
+
+		$settings = Newspack_Popups_Contextual_Prompt_Styles::filter_block_editor_settings( [ 'styles' => [] ] );
+		$this->assertSame( [], $settings['styles'] );
+	}
+
+	/**
+	 * Saving an empty object clears the option entirely.
+	 */
+	public function test_save_empty_deletes_option() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_styles( [ 'color' => [ 'background' => '#123456' ] ] );
+		$this->assertNotEmpty( get_option( Newspack_Popups_Contextual_Prompt_Styles::OPTION_NAME ) );
+
+		Newspack_Popups_Contextual_Prompt_Styles::save_styles( [] );
+		$this->assertFalse( get_option( Newspack_Popups_Contextual_Prompt_Styles::OPTION_NAME ) );
+	}
+
+	/**
+	 * Editor delivery: the CSS is appended AFTER whatever core put in settings.styles,
+	 * so it wins the cascade against the default-layer design at equal specificity.
+	 */
+	public function test_editor_settings_append() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_styles( [ 'color' => [ 'text' => '#fedcba' ] ] );
+
+		$settings = Newspack_Popups_Contextual_Prompt_Styles::filter_block_editor_settings(
+			[ 'styles' => [ [ 'css' => 'body{}' ] ] ]
+		);
+
+		$this->assertCount( 2, $settings['styles'] );
+		$this->assertStringContainsString( 'color:#fedcba', end( $settings['styles'] )['css'] );
+	}
+
+	/**
+	 * Defaults surface the block's theme.json default design, presets resolved.
+	 */
+	public function test_get_defaults_resolves_block_design() {
+		$defaults = Newspack_Popups_Contextual_Prompt_Styles::get_defaults();
+
+		$this->assertSame( '#f7f7f7', $defaults['color']['background'] );
+		$this->assertSame( '10px', $defaults['border']['radius'] );
+		// Preset spacing must come back resolved, not as a var:preset reference.
+		$this->assertStringNotContainsString( 'var:preset', (string) $defaults['spacing']['padding']['top'] );
+	}
+}

--- a/themes/newspack-theme/newspack-theme/sass/blocks/_blocks.scss
+++ b/themes/newspack-theme/newspack-theme/sass/blocks/_blocks.scss
@@ -388,6 +388,18 @@ p.has-background {
 	}
 }
 
+//! Newspack Contextual Prompt Block
+.wp-block-newspack-popups-contextual-prompt {
+	// The card's padding owns the vertical rhythm at its edges.
+	> *:first-child {
+		margin-top: 0 !important; // !important to override inline styles from child block attributes.
+	}
+
+	> *:last-child {
+		margin-bottom: 0 !important; // !important to override inline styles from child block attributes.
+	}
+}
+
 //! Columns
 .wp-block-columns {
 	.wp-block-cover,

--- a/themes/newspack-theme/newspack-theme/sass/style-editor-base.scss
+++ b/themes/newspack-theme/newspack-theme/sass/style-editor-base.scss
@@ -1502,6 +1502,21 @@ ul.wp-block-list {
 	font-family: var(--newspack-theme-font-heading);
 }
 
+/** === Contextual Prompt Block === */
+// Core's classic.css gives every `.wp-block` a 28px vertical margin in the
+// canvas; the card's padding owns the vertical rhythm at its edges.
+.wp-block-newspack-popups-contextual-prompt {
+	> * {
+		&:first-child {
+			margin-top: 0 !important; // !important to override inline styles.
+		}
+
+		&:last-child {
+			margin-bottom: 0 !important; // !important to override inline styles.
+		}
+	}
+}
+
 /** === Ad Unit Block === */
 .wp-block-newspack-ads-blocks-ad-unit {
 	> div {


### PR DESCRIPTION
## Description

Adds a third section, Style, to the Contextual Prompts wizard, giving publishers a Global Styles equivalent for the Contextual Prompt block.

**Block themes** get a handoff: an Edit Styles button that deep-links into the Site Editor's Styles panel with the Contextual Prompt block's own panel open, with the return banner to come back to the wizard. The banner now measures itself and offsets the site editor's fixed layout by a CSS custom property, so it pushes the editor down instead of overlaying it.

**Classic themes** get controls replicating the block's Global Styles surface: Color (editor-style swatch rows with popover palettes and the core contrast warning), Typography (font size), Padding, Border, and Border Radius. Values are stored in a popups option shaped like a block-supports style object, sanitized against a property allowlist, rendered through the style engine, and emitted at `:root :where()` specificity after the block's default design on both the front end and the editor canvas, so per-block styles always win. Controls initialize to the block's effective defaults (resolved from the theme.json cascade) and each group resets back to default. Values ride the existing single Save flow and dirty tracking.

Also includes a newspack-theme rule (front end + editor twin) zeroing the first child's top margin and last child's bottom margin inside the block, so the card's padding owns its edges.

## How to test

1. On a classic theme, open Audience > Campaigns > Contextual Prompts and scroll to Style: controls show the block defaults (background #f7f7f7, radius 10px, padding 1.5rem). Set a background and text color; a low-contrast pair shows the warning. Save, then check a story with a prompt: the front end and the editor canvas both reflect the defaults, and styling the block directly still overrides them.
2. Reset a group and save: the override clears back to the default.
3. On a block theme, the section shows only Edit Styles; it lands on the Campaigns: Contextual Prompt panel in Styles with the return banner pushing the editor down, and Back to Newspack returns to the wizard.