### PR TITLE
fix: prompt style defaults follow the theme and editor parity fixes

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -178,6 +178,11 @@ const SpacingRow = ( { icon, label, steps, value, onChange, disabled } ) => {
 		}
 	}, [ preset, step ] );
 
+	// While no step represents the value, the row stays on its input: the slider
+	// would sit at None with that value still standing, and a drag from there would
+	// overwrite it from a position that was never true.
+	const isStepless = null === step && undefined !== preset && '' !== preset;
+
 	// Core marks every step but the two ends, which the slider's own stops carry.
 	const marks = steps.slice( 1, steps.length - 1 ).map( ( _step, index ) => ( { value: index + 1 } ) );
 
@@ -221,7 +226,7 @@ const SpacingRow = ( { icon, label, steps, value, onChange, disabled } ) => {
 					isPressed={ isCustom }
 					label={ isCustom ? __( 'Use preset', 'newspack-plugin' ) : __( 'Set custom value', 'newspack-plugin' ) }
 					onClick={ () => setIsCustom( ! isCustom ) }
-					disabled={ disabled }
+					disabled={ disabled || isStepless }
 				/>
 			) }
 		</HStack>

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -30,6 +30,7 @@ import {
 	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanelItem as ToolsPanelItem, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalUnitControl as UnitControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
+	__experimentalUseCustomUnits as useCustomUnits, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
 import { useEffect, useState } from '@wordpress/element';
@@ -70,6 +71,9 @@ const ICON_SIZE = 24;
 // The radius slider works in the value's own number space, capped where core's
 // BorderControl caps its width slider.
 const RADIUS_SLIDER_MAX = 100;
+// The units a custom padding value may be given in while the site declares none,
+// which is the fallback core's own spacing controls carry for the same setting.
+const DEFAULT_SPACING_UNITS = [ 'px', 'em', 'rem', 'vh', 'vw', '%' ];
 
 const getPath = ( source, path ) => path.reduce( ( node, key ) => node?.[ key ], source );
 
@@ -163,20 +167,23 @@ const ColorRow = ( { label, colorValue, disabled, children } ) => (
 // spacing presets or, behind the settings toggle, a custom value. Mirrors the
 // editor's spacing row — @wordpress/block-editor owns SpacingSizesControl and is
 // not loaded on the wizard page.
-const SpacingRow = ( { icon, label, steps, value, onChange, disabled } ) => {
+const SpacingRow = ( { icon, label, steps, units, allowCustom, value, onChange, disabled } ) => {
 	// A resolved default lands on the step it came from; anything else is custom.
 	const preset = spacingPresetOf( value, steps );
 	const step = spacingStepOf( preset, steps );
 	const hasPresets = 1 < steps.length;
-	const [ isCustom, setIsCustom ] = useState( () => ! hasPresets || ( undefined !== preset && null === step ) );
+	// A site turning `spacing.customSpacingSize` off leaves the row preset-only, as
+	// it leaves the editor's own row: no way into an input, so a value no step
+	// represents shows the slider at None until an edit replaces it.
+	const [ isCustom, setIsCustom ] = useState( () => allowCustom && ( ! hasPresets || ( undefined !== preset && null === step ) ) );
 
 	// A value the slider cannot land on — a custom default, or one a reset brings
 	// back — moves the row to the input, as the editor's row does.
 	useEffect( () => {
-		if ( undefined !== preset && null === step ) {
+		if ( allowCustom && undefined !== preset && null === step ) {
 			setIsCustom( true );
 		}
-	}, [ preset, step ] );
+	}, [ allowCustom, preset, step ] );
 
 	// While no step represents the value, the row stays on its input: the slider
 	// would sit at None with that value still standing, and a drag from there would
@@ -195,6 +202,7 @@ const SpacingRow = ( { icon, label, steps, value, onChange, disabled } ) => {
 					hideLabelFromVision
 					value={ spacingValueOf( preset, steps ) }
 					onChange={ next => onChange( next || undefined ) }
+					units={ units }
 					min={ 0 }
 					disabled={ disabled }
 					__next40pxDefaultSize
@@ -218,7 +226,7 @@ const SpacingRow = ( { icon, label, steps, value, onChange, disabled } ) => {
 					__next40pxDefaultSize
 				/>
 			) }
-			{ hasPresets && (
+			{ allowCustom && hasPresets && (
 				<Button
 					size="small"
 					icon={ settings }
@@ -235,7 +243,7 @@ const SpacingRow = ( { icon, label, steps, value, onChange, disabled } ) => {
 
 // Sides move in pairs until the sides are unlinked, which is how the editor
 // opens whenever the two axes each hold one value.
-const PaddingControl = ( { steps, values, onChange, disabled } ) => {
+const PaddingControl = ( { steps, units, allowCustom, values, onChange, disabled } ) => {
 	const [ isLinked, setIsLinked ] = useState( () => values.top === values.bottom && values.left === values.right );
 	const axialRows = [
 		{ key: 'vertical', sides: [ 'top', 'bottom' ], icon: sidesVertical, label: __( 'Vertical padding', 'newspack-plugin' ) },
@@ -269,6 +277,8 @@ const PaddingControl = ( { steps, values, onChange, disabled } ) => {
 						icon={ icon }
 						label={ label }
 						steps={ steps }
+						units={ units }
+						allowCustom={ allowCustom }
 						value={ values[ sides[ 0 ] ] }
 						onChange={ next => onChange( sides, next ) }
 						disabled={ disabled }
@@ -287,6 +297,8 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 		style_palette: stylePalette,
 		style_font_sizes: styleFontSizes,
 		style_spacing_sizes: styleSpacingSizes,
+		style_spacing_custom: styleSpacingCustom = true,
+		style_spacing_units: styleSpacingUnits,
 	} = status;
 
 	const defaults = styleDefaults || {};
@@ -296,6 +308,9 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 	const paletteColors = palette.map( ( { name, slug, color } ) => ( { name, slug, color } ) );
 	const fontSizes = ( styleFontSizes || [] ).map( ( { name, slug, size } ) => ( { name, slug, size: withPixelUnit( size ) } ) );
 	const paddingSteps = spacingSteps( styleSpacingSizes, __( 'None', 'newspack-plugin' ) );
+	// A custom padding value is offered in the units the site allows, filtered the
+	// way core's own spacing controls filter theirs.
+	const paddingUnits = useCustomUnits( { availableUnits: styleSpacingUnits || DEFAULT_SPACING_UNITS } );
 	const effective = path => getPath( styles, path ) ?? getPath( defaults, path );
 
 	const radius = effective( [ 'border', 'radius' ] );
@@ -427,7 +442,14 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 							onDeselect={ clearPadding }
 							isShownByDefault
 						>
-							<PaddingControl steps={ paddingSteps } values={ paddingValues } onChange={ setPaddingSides } disabled={ inFlight } />
+							<PaddingControl
+								steps={ paddingSteps }
+								units={ paddingUnits }
+								allowCustom={ styleSpacingCustom }
+								values={ paddingValues }
+								onChange={ setPaddingSides }
+								disabled={ inFlight }
+							/>
 						</ToolsPanelItem>
 					</StylePanel>
 					<StylePanel

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -25,7 +25,6 @@ import {
 	Notice,
 	RangeControl,
 	__experimentalBorderBoxControl as BorderBoxControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
-	__experimentalBoxControl as BoxControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalToolsPanel as ToolsPanel, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -33,19 +32,41 @@ import {
 	__experimentalUnitControl as UnitControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalVStack as VStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 } from '@wordpress/components';
-import { Icon, cornerAll } from '@wordpress/icons';
+import { useEffect, useState } from '@wordpress/element';
+import {
+	Icon,
+	cornerAll,
+	link,
+	linkOff,
+	settings,
+	sidesBottom,
+	sidesHorizontal,
+	sidesLeft,
+	sidesRight,
+	sidesTop,
+	sidesVertical,
+} from '@wordpress/icons';
 
 /**
  * Internal dependencies
  */
 import { Button, Grid, Handoff, SectionHeader } from '../../../../../../packages/components/src';
-import { contrastRatio, perceivedBrightness, presetRefForColor, resolveColor } from './style-utils';
+import {
+	contrastRatio,
+	perceivedBrightness,
+	presetRefForColor,
+	resolveColor,
+	spacingPresetOf,
+	spacingRefForStep,
+	spacingStepOf,
+	spacingSteps,
+	spacingValueOf,
+} from './style-utils';
 import './style-section.scss';
 
 const MIN_CONTRAST_RATIO = 4.5;
 // The size the editor gives the icon in front of a dimension input.
 const ICON_SIZE = 24;
-const PADDING_SIDES = [ 'top', 'right', 'bottom', 'left' ];
 // The radius slider works in the value's own number space, capped where core's
 // BorderControl caps its width slider.
 const RADIUS_SLIDER_MAX = 100;
@@ -53,6 +74,10 @@ const RADIUS_SLIDER_MAX = 100;
 const getPath = ( source, path ) => path.reduce( ( node, key ) => node?.[ key ], source );
 
 const hasKeys = value => !! value && 0 < Object.keys( value ).length;
+
+// Per-side padding only. A theme.json may carry the shorthand string instead,
+// which no per-side row can read, so it stands in as nothing.
+const asSides = value => ( !! value && 'object' === typeof value ? value : {} );
 
 // Immutable deep-set that deletes the key when the value is undefined and prunes
 // nodes left empty: the REST layer replaces the whole object, and an all-empty
@@ -134,6 +159,121 @@ const ColorRow = ( { label, colorValue, disabled, children } ) => (
 	/>
 );
 
+// One padding row: the axis or side icon, then either a slider over the site's
+// spacing presets or, behind the settings toggle, a custom value. Mirrors the
+// editor's spacing row — @wordpress/block-editor owns SpacingSizesControl and is
+// not loaded on the wizard page.
+const SpacingRow = ( { icon, label, steps, value, onChange, disabled } ) => {
+	// A resolved default lands on the step it came from; anything else is custom.
+	const preset = spacingPresetOf( value, steps );
+	const step = spacingStepOf( preset, steps );
+	const hasPresets = 1 < steps.length;
+	const [ isCustom, setIsCustom ] = useState( () => ! hasPresets || ( undefined !== preset && null === step ) );
+
+	// A value the slider cannot land on — a custom default, or one a reset brings
+	// back — moves the row to the input, as the editor's row does.
+	useEffect( () => {
+		if ( undefined !== preset && null === step ) {
+			setIsCustom( true );
+		}
+	}, [ preset, step ] );
+
+	// Core marks every step but the two ends, which the slider's own stops carry.
+	const marks = steps.slice( 1, steps.length - 1 ).map( ( _step, index ) => ( { value: index + 1 } ) );
+
+	return (
+		<HStack className="newspack-prompt-style-padding__row" spacing={ 2 }>
+			<Icon className="newspack-prompt-style-padding__icon" icon={ icon } size={ ICON_SIZE } />
+			{ isCustom ? (
+				<UnitControl
+					label={ label }
+					hideLabelFromVision
+					value={ spacingValueOf( preset, steps ) }
+					onChange={ next => onChange( next || undefined ) }
+					min={ 0 }
+					disabled={ disabled }
+					__next40pxDefaultSize
+				/>
+			) : (
+				<RangeControl
+					label={ label }
+					hideLabelFromVision
+					value={ step ?? 0 }
+					onChange={ next => onChange( spacingRefForStep( next, steps ) ) }
+					min={ 0 }
+					max={ steps.length - 1 }
+					step={ 1 }
+					marks={ marks }
+					initialPosition={ 0 }
+					withInputField={ false }
+					aria-valuetext={ steps[ step ?? 0 ]?.name }
+					renderTooltipContent={ next => steps[ next ]?.name }
+					disabled={ disabled }
+					__nextHasNoMarginBottom
+					__next40pxDefaultSize
+				/>
+			) }
+			{ hasPresets && (
+				<Button
+					size="small"
+					icon={ settings }
+					iconSize={ ICON_SIZE }
+					isPressed={ isCustom }
+					label={ isCustom ? __( 'Use preset', 'newspack-plugin' ) : __( 'Set custom value', 'newspack-plugin' ) }
+					onClick={ () => setIsCustom( ! isCustom ) }
+					disabled={ disabled }
+				/>
+			) }
+		</HStack>
+	);
+};
+
+// Sides move in pairs until the sides are unlinked, which is how the editor
+// opens whenever the two axes each hold one value.
+const PaddingControl = ( { steps, values, onChange, disabled } ) => {
+	const [ isLinked, setIsLinked ] = useState( () => values.top === values.bottom && values.left === values.right );
+	const axialRows = [
+		{ key: 'vertical', sides: [ 'top', 'bottom' ], icon: sidesVertical, label: __( 'Vertical padding', 'newspack-plugin' ) },
+		{ key: 'horizontal', sides: [ 'left', 'right' ], icon: sidesHorizontal, label: __( 'Horizontal padding', 'newspack-plugin' ) },
+	];
+	// The editor's order for the unlinked sides, which is not the CSS shorthand's.
+	const sideRows = [
+		{ key: 'top', sides: [ 'top' ], icon: sidesTop, label: __( 'Top padding', 'newspack-plugin' ) },
+		{ key: 'bottom', sides: [ 'bottom' ], icon: sidesBottom, label: __( 'Bottom padding', 'newspack-plugin' ) },
+		{ key: 'left', sides: [ 'left' ], icon: sidesLeft, label: __( 'Left padding', 'newspack-plugin' ) },
+		{ key: 'right', sides: [ 'right' ], icon: sidesRight, label: __( 'Right padding', 'newspack-plugin' ) },
+	];
+
+	return (
+		<fieldset className="newspack-prompt-style-padding">
+			<HStack className="newspack-prompt-style-padding__header">
+				<BaseControl.VisualLabel as="legend">{ __( 'Padding', 'newspack-plugin' ) }</BaseControl.VisualLabel>
+				<Button
+					size="small"
+					icon={ isLinked ? link : linkOff }
+					iconSize={ ICON_SIZE }
+					label={ isLinked ? __( 'Unlink sides', 'newspack-plugin' ) : __( 'Link sides', 'newspack-plugin' ) }
+					onClick={ () => setIsLinked( ! isLinked ) }
+					disabled={ disabled }
+				/>
+			</HStack>
+			<VStack spacing={ 1 }>
+				{ ( isLinked ? axialRows : sideRows ).map( ( { key, sides, icon, label } ) => (
+					<SpacingRow
+						key={ key }
+						icon={ icon }
+						label={ label }
+						steps={ steps }
+						value={ values[ sides[ 0 ] ] }
+						onChange={ next => onChange( sides, next ) }
+						disabled={ disabled }
+					/>
+				) ) }
+			</VStack>
+		</fieldset>
+	);
+};
+
 const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 	const {
 		is_block_theme: isBlockTheme,
@@ -141,6 +281,7 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 		style_defaults: styleDefaults,
 		style_palette: stylePalette,
 		style_font_sizes: styleFontSizes,
+		style_spacing_sizes: styleSpacingSizes,
 	} = status;
 
 	const defaults = styleDefaults || {};
@@ -149,6 +290,7 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 	// controls only take the shapes they document.
 	const paletteColors = palette.map( ( { name, slug, color } ) => ( { name, slug, color } ) );
 	const fontSizes = ( styleFontSizes || [] ).map( ( { name, slug, size } ) => ( { name, slug, size: withPixelUnit( size ) } ) );
+	const paddingSteps = spacingSteps( styleSpacingSizes, __( 'None', 'newspack-plugin' ) );
 	const effective = path => getPath( styles, path ) ?? getPath( defaults, path );
 
 	const radius = effective( [ 'border', 'radius' ] );
@@ -166,14 +308,24 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 
 	const setFontSize = value => onChangeStyles( setPath( styles, [ 'typography', 'fontSize' ], value ? withPixelUnit( value ) : undefined ) );
 
-	const setPadding = value => {
-		const sides = {};
-		PADDING_SIDES.forEach( side => {
-			if ( undefined !== value?.[ side ] ) {
-				sides[ side ] = value[ side ];
+	// Each side reads its own effective value, so overriding one leaves the others
+	// showing the default they still render with.
+	const paddingValues = { ...asSides( defaults.spacing?.padding ), ...asSides( styles.spacing?.padding ) };
+
+	const clearPadding = () => onChangeStyles( setPath( styles, [ 'spacing', 'padding' ], undefined ) );
+
+	// Only the sides the row owns are written: the rest keep whatever they had,
+	// default included, so the override stays as small as the edit.
+	const setPaddingSides = ( sides, value ) => {
+		const next = { ...asSides( styles.spacing?.padding ) };
+		sides.forEach( side => {
+			if ( undefined === value ) {
+				delete next[ side ];
+			} else {
+				next[ side ] = value;
 			}
 		} );
-		onChangeStyles( setPath( styles, [ 'spacing', 'padding' ], hasKeys( sides ) ? sides : undefined ) );
+		onChangeStyles( setPath( styles, [ 'spacing', 'padding' ], hasKeys( next ) ? next : undefined ) );
 	};
 
 	const borderOverride = withoutRadius( styles.border );
@@ -263,24 +415,14 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 							/>
 						</ToolsPanelItem>
 					</StylePanel>
-					<StylePanel
-						label={ __( 'Padding', 'newspack-plugin' ) }
-						resetAll={ () => onChangeStyles( setPath( styles, [ 'spacing', 'padding' ], undefined ) ) }
-					>
+					<StylePanel label={ __( 'Padding', 'newspack-plugin' ) } resetAll={ clearPadding }>
 						<ToolsPanelItem
 							label={ __( 'Padding', 'newspack-plugin' ) }
 							hasValue={ () => undefined !== styles.spacing?.padding }
-							onDeselect={ () => setPadding() }
+							onDeselect={ clearPadding }
 							isShownByDefault
 						>
-							<BoxControl
-								label={ __( 'Padding', 'newspack-plugin' ) }
-								values={ effective( [ 'spacing', 'padding' ] ) }
-								onChange={ setPadding }
-								splitOnAxis={ false }
-								allowReset={ false }
-								__next40pxDefaultSize
-							/>
+							<PaddingControl steps={ paddingSteps } values={ paddingValues } onChange={ setPaddingSides } disabled={ inFlight } />
 						</ToolsPanelItem>
 					</StylePanel>
 					<StylePanel

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -531,7 +531,12 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 			/>
 			{ isBlockTheme ? (
 				<VStack spacing={ 6 } alignment="start">
-					<Handoff url={ siteEditorStylesUrl } __next40pxDefaultSize>
+					<Handoff
+						url={ siteEditorStylesUrl }
+						bannerText={ __( 'Return to Contextual Prompts after editing the block styles', 'newspack-plugin' ) }
+						bannerButtonText={ __( 'Back to Contextual Prompts', 'newspack-plugin' ) }
+						size="compact"
+					>
 						{ __( 'Edit Styles', 'newspack-plugin' ) }
 					</Handoff>
 				</VStack>

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -81,6 +81,32 @@
 		}
 	}
 
+	// The padding rows follow the editor's spacing control: a legend paired with
+	// the link toggle, then one row per axis or side, each led by its icon and
+	// closed by the custom-value toggle, with the control between them.
+	.newspack-prompt-style-padding {
+		border: 0;
+		margin: 0;
+		padding: 0;
+
+		&__header {
+			margin-bottom: wp-vars.$grid-unit-10;
+			min-height: wp-vars.$grid-unit-30;
+		}
+
+		&__icon {
+			fill: currentcolor;
+			flex: none;
+		}
+
+		&__row {
+			.components-range-control,
+			.components-unit-control-wrapper {
+				flex: 1;
+			}
+		}
+	}
+
 	// Split the radius row the way core's BorderControl splits its width row: the
 	// corners icon, then the input, then the slider taking the rest.
 	.newspack-prompt-style-radius {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -309,6 +309,65 @@ describe( 'StyleSection on a classic theme', () => {
 		expect( paddingRow( 1 ).getByRole( 'button', { name: 'Use preset' } ) ).toBeEnabled();
 	} );
 
+	it( 'leaves the padding rows preset-only when the site allows no custom spacing value', () => {
+		const onChangeStyles = jest.fn();
+		render(
+			<StyleSection
+				status={ { ...CLASSIC_STATUS, style_spacing_custom: false } }
+				styles={ {} }
+				inFlight={ false }
+				onChangeStyles={ onChangeStyles }
+			/>
+		);
+
+		// No way into an input, in either direction.
+		expect( screen.queryByRole( 'button', { name: 'Set custom value' } ) ).toBeNull();
+		expect( screen.queryByRole( 'button', { name: 'Use preset' } ) ).toBeNull();
+
+		// The sliders still write their steps.
+		fireEvent.change( screen.getByRole( 'slider', { name: 'Vertical padding' } ), { target: { value: '1' } } );
+
+		expect( onChangeStyles ).toHaveBeenCalledWith( {
+			spacing: { padding: { top: 'var:preset|spacing|30', bottom: 'var:preset|spacing|30' } },
+		} );
+	} );
+
+	it( 'shows a value no step represents at None while the site is preset-only', () => {
+		render(
+			<StyleSection
+				status={ { ...CLASSIC_STATUS, style_spacing_custom: false } }
+				styles={ { spacing: { padding: { top: '7px', bottom: '7px' } } } }
+				inFlight={ false }
+				onChangeStyles={ () => {} }
+			/>
+		);
+
+		// With no input to fall back on, the row sits at the first step until an edit
+		// replaces the stored value — which is the policy's own answer for it.
+		expect( screen.getByRole( 'slider', { name: 'Vertical padding' } ) ).toHaveValue( '0' );
+		expect( screen.getByRole( 'slider', { name: 'Horizontal padding' } ) ).toHaveValue( '2' );
+	} );
+
+	it( 'offers a custom padding value only in the units the site allows', () => {
+		render(
+			<StyleSection
+				status={ { ...CLASSIC_STATUS, style_spacing_units: [ 'px', 'em' ] } }
+				styles={ {} }
+				inFlight={ false }
+				onChangeStyles={ () => {} }
+			/>
+		);
+
+		fireEvent.click( screen.getAllByRole( 'button', { name: 'Set custom value' } )[ 0 ] );
+
+		const unitSelect = paddingRow( 0 ).getByRole( 'combobox', { name: 'Select unit' } );
+		expect( Array.from( unitSelect.options ).map( option => option.value ) ).toEqual( [ 'px', 'em' ] );
+
+		// The radius keeps its own units: the spacing policy is not its policy.
+		const radiusUnits = within( document.querySelector( '.newspack-prompt-style-radius' ) ).getByRole( 'combobox', { name: 'Select unit' } );
+		expect( radiusUnits.options.length ).toBeGreaterThan( 2 );
+	} );
+
 	it( 'keeps the border radius when the border group is reset', () => {
 		const onChangeStyles = jest.fn();
 		render(

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -77,6 +77,9 @@ const clickMenuItem = name => fireEvent.click( screen.getByRole( 'menuitem', { n
 // The Border group's own link toggle carries the same label as the padding one,
 // as it does in the editor, so padding queries are scoped to its fieldset.
 const padding = () => within( document.querySelector( '.newspack-prompt-style-padding' ) );
+// Every padding row carries the same toggle labels, so a row is queried by its
+// position: the vertical axis leads, then the horizontal one.
+const paddingRow = index => within( document.querySelectorAll( '.newspack-prompt-style-padding__row' )[ index ] );
 
 const CLASSIC_STATUS = {
 	is_block_theme: false,
@@ -278,6 +281,32 @@ describe( 'StyleSection on a classic theme', () => {
 
 		expect( screen.queryByRole( 'slider', { name: 'Vertical padding' } ) ).toBeNull();
 		expect( screen.getByLabelText( 'Vertical padding' ) ).toHaveValue( 13 );
+	} );
+
+	it( 'holds a row on its input while no step represents its value', () => {
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ { spacing: { padding: { top: '7px', bottom: '7px' } } } }
+				inFlight={ false }
+				onChangeStyles={ () => {} }
+			/>
+		);
+
+		// The vertical axis holds a value off the scale, so the way out of its input is
+		// closed: the slider would sit at None with that value still standing, and a
+		// drag from there would overwrite it from a position that was never true.
+		expect( screen.getByLabelText( 'Vertical padding' ) ).toHaveValue( 7 );
+		expect( paddingRow( 0 ).getByRole( 'button', { name: 'Use preset' } ) ).toBeDisabled();
+
+		// The horizontal axis sits on a step, so its own toggle works as before.
+		const toggle = paddingRow( 1 ).getByRole( 'button', { name: 'Set custom value' } );
+		expect( toggle ).toBeEnabled();
+
+		fireEvent.click( toggle );
+
+		expect( screen.queryByRole( 'slider', { name: 'Horizontal padding' } ) ).toBeNull();
+		expect( paddingRow( 1 ).getByRole( 'button', { name: 'Use preset' } ) ).toBeEnabled();
 	} );
 
 	it( 'keeps the border radius when the border group is reset', () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -7,7 +7,7 @@
 /**
  * External dependencies
  */
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import '@testing-library/jest-dom';
 
 /**
@@ -74,6 +74,10 @@ const NOTICE_CONTENT = '.components-notice__content';
 const openPanelMenu = label => fireEvent.click( screen.getByRole( 'button', { name: `${ label } options` } ) );
 const clickMenuItem = name => fireEvent.click( screen.getByRole( 'menuitem', { name } ) );
 
+// The Border group's own link toggle carries the same label as the padding one,
+// as it does in the editor, so padding queries are scoped to its fieldset.
+const padding = () => within( document.querySelector( '.newspack-prompt-style-padding' ) );
+
 const CLASSIC_STATUS = {
 	is_block_theme: false,
 	style_defaults: {
@@ -88,6 +92,13 @@ const CLASSIC_STATUS = {
 	style_font_sizes: [
 		{ name: 'Small', slug: 'small', size: '14px' },
 		{ name: 'Medium', slug: 'medium', size: '18px' },
+	],
+	// Core's default spacing scale, trimmed: the default padding above resolves to
+	// the `40` step, so the sliders open on a preset rather than a custom value.
+	style_spacing_sizes: [
+		{ name: 'Small', slug: '30', size: '10px' },
+		{ name: 'Medium', slug: '40', size: '20px' },
+		{ name: 'Large', slug: '50', size: '30px' },
 	],
 	site_editor_styles_url: 'https://example.test/wp-admin/site-editor.php?p=%2Fstyles',
 };
@@ -176,6 +187,99 @@ describe( 'StyleSection on a classic theme', () => {
 		expect( onChangeStyles ).toHaveBeenCalledWith( {} );
 	} );
 
+	it( 'opens the padding as a linked axial pair, each row on its preset step', () => {
+		render( <StyleSection status={ CLASSIC_STATUS } styles={ {} } inFlight={ false } onChangeStyles={ () => {} } /> );
+
+		// The default padding arrives resolved (20px), which is the third step of the
+		// scale: None, Small, Medium, Large.
+		expect( screen.getByRole( 'slider', { name: 'Vertical padding' } ) ).toHaveValue( '2' );
+		expect( screen.getByRole( 'slider', { name: 'Horizontal padding' } ) ).toHaveValue( '2' );
+		expect( screen.queryByRole( 'slider', { name: 'Top padding' } ) ).toBeNull();
+		// Each row marks the steps between the two ends, as the editor marks them.
+		expect( document.querySelectorAll( '.newspack-prompt-style-padding__row' ) ).toHaveLength( 2 );
+		expect( document.querySelectorAll( '.newspack-prompt-style-padding__row:first-child .components-range-control__mark' ) ).toHaveLength( 2 );
+	} );
+
+	it( 'stores a slider step as a spacing preset on both sides of the axis', () => {
+		const onChangeStyles = jest.fn();
+		render( <StyleSection status={ CLASSIC_STATUS } styles={ {} } inFlight={ false } onChangeStyles={ onChangeStyles } /> );
+
+		fireEvent.change( screen.getByRole( 'slider', { name: 'Vertical padding' } ), { target: { value: '3' } } );
+
+		expect( onChangeStyles ).toHaveBeenCalledWith( {
+			spacing: { padding: { top: 'var:preset|spacing|50', bottom: 'var:preset|spacing|50' } },
+		} );
+
+		// The other axis writes its own pair, leaving the sides it does not own to
+		// the default they still render with.
+		fireEvent.change( screen.getByRole( 'slider', { name: 'Horizontal padding' } ), { target: { value: '1' } } );
+
+		expect( onChangeStyles ).toHaveBeenLastCalledWith( {
+			spacing: { padding: { left: 'var:preset|spacing|30', right: 'var:preset|spacing|30' } },
+		} );
+	} );
+
+	it( 'stores the first step as a plain zero, the way the editor does', () => {
+		const onChangeStyles = jest.fn();
+		render( <StyleSection status={ CLASSIC_STATUS } styles={ {} } inFlight={ false } onChangeStyles={ onChangeStyles } /> );
+
+		// No preset defines it, and clearing instead would only snap the row back to
+		// the default padding.
+		fireEvent.change( screen.getByRole( 'slider', { name: 'Vertical padding' } ), { target: { value: '0' } } );
+
+		expect( onChangeStyles ).toHaveBeenCalledWith( { spacing: { padding: { top: '0', bottom: '0' } } } );
+	} );
+
+	it( 'unlinks the axes into one row per side', () => {
+		render( <StyleSection status={ CLASSIC_STATUS } styles={ {} } inFlight={ false } onChangeStyles={ () => {} } /> );
+
+		fireEvent.click( padding().getByRole( 'button', { name: 'Unlink sides' } ) );
+
+		[ 'Top padding', 'Bottom padding', 'Left padding', 'Right padding' ].forEach( name =>
+			expect( screen.getByRole( 'slider', { name } ) ).toBeInTheDocument()
+		);
+		expect( screen.queryByRole( 'slider', { name: 'Vertical padding' } ) ).toBeNull();
+		expect( padding().getByRole( 'button', { name: 'Link sides' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'writes one side on its own once the sides are unlinked', () => {
+		const onChangeStyles = jest.fn();
+		render( <StyleSection status={ CLASSIC_STATUS } styles={ {} } inFlight={ false } onChangeStyles={ onChangeStyles } /> );
+
+		fireEvent.click( padding().getByRole( 'button', { name: 'Unlink sides' } ) );
+		fireEvent.change( screen.getByRole( 'slider', { name: 'Left padding' } ), { target: { value: '1' } } );
+
+		expect( onChangeStyles ).toHaveBeenCalledWith( { spacing: { padding: { left: 'var:preset|spacing|30' } } } );
+	} );
+
+	it( 'swaps a padding row for an input that writes a raw value', () => {
+		const onChangeStyles = jest.fn();
+		render( <StyleSection status={ CLASSIC_STATUS } styles={ {} } inFlight={ false } onChangeStyles={ onChangeStyles } /> );
+
+		// One toggle per row; the vertical axis leads.
+		fireEvent.click( screen.getAllByRole( 'button', { name: 'Set custom value' } )[ 0 ] );
+
+		expect( screen.queryByRole( 'slider', { name: 'Vertical padding' } ) ).toBeNull();
+		// The input starts from the step the row was on, and its unit stays in play.
+		const input = screen.getByLabelText( 'Vertical padding' );
+		expect( input ).toHaveValue( 20 );
+
+		fireEvent.change( input, { target: { value: '7' } } );
+
+		expect( onChangeStyles ).toHaveBeenCalledWith( { spacing: { padding: { top: '7px', bottom: '7px' } } } );
+	} );
+
+	it( 'starts a row in its input when the value matches no step', () => {
+		const status = {
+			...CLASSIC_STATUS,
+			style_defaults: { ...CLASSIC_STATUS.style_defaults, spacing: { padding: { top: '13px', right: '13px', bottom: '13px', left: '13px' } } },
+		};
+		render( <StyleSection status={ status } styles={ {} } inFlight={ false } onChangeStyles={ () => {} } /> );
+
+		expect( screen.queryByRole( 'slider', { name: 'Vertical padding' } ) ).toBeNull();
+		expect( screen.getByLabelText( 'Vertical padding' ) ).toHaveValue( 13 );
+	} );
+
 	it( 'keeps the border radius when the border group is reset', () => {
 		const onChangeStyles = jest.fn();
 		render(
@@ -235,6 +339,8 @@ describe( 'StyleSection on a classic theme', () => {
 		expect( screen.getByRole( 'button', { name: 'Text' } ) ).toBeDisabled();
 		expect( screen.getByLabelText( 'Radius' ) ).toBeDisabled();
 		expect( screen.getByRole( 'slider', { name: 'Border radius' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'slider', { name: 'Vertical padding' } ) ).toBeDisabled();
+		expect( padding().getByRole( 'button', { name: 'Unlink sides' } ) ).toBeDisabled();
 	} );
 
 	it( 'offers one border radius input paired with a slider', () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -53,7 +53,12 @@ describe( 'StyleSection on a block theme', () => {
 			expect.objectContaining( {
 				path: '/newspack/v1/handoff',
 				method: 'POST',
-				data: expect.objectContaining( { destinationUrl: BLOCK_THEME_STATUS.site_editor_styles_url } ),
+				data: expect.objectContaining( {
+					destinationUrl: BLOCK_THEME_STATUS.site_editor_styles_url,
+					// The banner the Site Editor shows carries the way back here.
+					bannerText: 'Return to Contextual Prompts after editing the block styles',
+					bannerButtonText: 'Back to Contextual Prompts',
+				} ),
 			} )
 		);
 	} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-utils.js
@@ -78,3 +78,48 @@ export const presetRefForColor = ( hex, palette ) => {
 	const entry = ( palette || [] ).find( color => color.color?.toLowerCase() === hex?.toLowerCase() );
 	return entry ? PRESET_COLOR_PREFIX + entry.slug : hex;
 };
+
+const PRESET_SPACING_PREFIX = 'var:preset|spacing|';
+// Step 0 of the spacing scale. Core stores it as the bare string, not a preset
+// reference, since no preset defines it.
+export const SPACING_NONE = '0';
+
+// The spacing steps a slider offers: None, then the site's presets in order, as
+// core's own spacing control builds them.
+export const spacingSteps = ( presets, noneLabel ) => [
+	{ name: noneLabel, slug: SPACING_NONE, size: 0 },
+	...( presets || [] ).map( ( { name, slug, size } ) => ( { name, slug, size } ) ),
+];
+
+export const isSpacingPreset = value => SPACING_NONE === value || ( 'string' === typeof value && value.includes( PRESET_SPACING_PREFIX ) );
+
+// A stored value as a step index, or null when it is a custom value the slider
+// cannot represent.
+export const spacingStepOf = ( value, steps ) => {
+	if ( undefined === value || '' === value ) {
+		return null;
+	}
+	const slug = SPACING_NONE === value ? SPACING_NONE : String( value ).replace( PRESET_SPACING_PREFIX, '' );
+	const index = steps.findIndex( step => String( step.slug ) === slug );
+	return -1 === index ? null : index;
+};
+
+// What a step writes back: None is the bare zero, every other step the preset
+// reference, so the value tracks the preset if the theme redefines it.
+export const spacingRefForStep = ( step, steps ) => ( 0 === step ? SPACING_NONE : `${ PRESET_SPACING_PREFIX }${ steps[ step ]?.slug }` );
+
+// A resolved value (`1.5rem`) as the preset reference it came from, so a default
+// the wizard receives already resolved still lands on its own slider step.
+export const spacingPresetOf = ( value, steps ) => {
+	if ( undefined === value || isSpacingPreset( value ) ) {
+		return value;
+	}
+	const match = steps.find( step => String( step.size ).trim() === String( value ).trim() );
+	return match ? spacingRefForStep( steps.indexOf( match ), steps ) : value;
+};
+
+// The concrete CSS value behind a step, for the custom input to start from.
+export const spacingValueOf = ( value, steps ) => {
+	const step = spacingStepOf( value, steps );
+	return null === step ? value : steps[ step ].size;
+};

--- a/plugins/newspack-popups/includes/class-newspack-popups-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-api.php
@@ -190,8 +190,11 @@ final class Newspack_Popups_API {
 		// Styles are a keyed object to every client, so no overrides has to travel
 		// as `{}`: an empty PHP array would serialize as `[]` and a client
 		// comparing it against an object it built would never see them as equal.
-		$styles     = Newspack_Popups_Contextual_Prompt_Styles::get_styles();
-		$font_sizes = self::flatten_global_settings_presets( wp_get_global_settings( [ 'typography', 'fontSizes' ] ) );
+		$styles = Newspack_Popups_Contextual_Prompt_Styles::get_styles();
+		// Both lists take the highest origin holding anything, which is how the
+		// editor resolves the single set its own controls offer.
+		$font_sizes    = self::flatten_global_settings_presets( wp_get_global_settings( [ 'typography', 'fontSizes' ] ) );
+		$spacing_sizes = self::flatten_global_settings_presets( wp_get_global_settings( [ 'spacing', 'spacingSizes' ] ) );
 		return [
 			'enabled'                => Newspack_Popups_Settings::is_ai_copy_assistant_enabled(),
 			'can_manage'             => current_user_can( 'manage_options' ),
@@ -201,7 +204,8 @@ final class Newspack_Popups_API {
 			'styles'                 => empty( $styles ) ? (object) [] : $styles,
 			'style_defaults'         => Newspack_Popups_Contextual_Prompt_Styles::get_defaults(),
 			'style_palette'          => self::get_palette_presets(),
-			'style_font_sizes'       => self::normalize_preset_font_sizes( $font_sizes ),
+			'style_font_sizes'       => self::normalize_preset_sizes( $font_sizes ),
+			'style_spacing_sizes'    => self::normalize_preset_sizes( $spacing_sizes ),
 			'site_editor_styles_url' => admin_url( 'site-editor.php?p=%2Fstyles&section=' . rawurlencode( '/blocks/' . rawurlencode( Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ) ) ),
 		];
 	}
@@ -302,16 +306,16 @@ final class Newspack_Popups_API {
 	}
 
 	/**
-	 * Font size presets can carry a plain number: core unit-izes the ones a theme
+	 * Size presets can carry a plain number: core unit-izes the font sizes a theme
 	 * registers with `add_theme_support( 'editor-font-sizes' )`, but not the ones a
 	 * theme.json declares. The wizard stores CSS strings and the style sanitizer
-	 * keeps string leaves only, so a numeric size would be offered in the picker
-	 * and dropped on save. Deliver every size in px, as core's own back-compat does.
+	 * keeps string leaves only, so a numeric size would be offered in a control and
+	 * dropped on save. Deliver every size in px, as core's own back-compat does.
 	 *
-	 * @param array $presets Flat font size presets.
+	 * @param array $presets Flat font size or spacing size presets.
 	 * @return array
 	 */
-	private static function normalize_preset_font_sizes( $presets ) {
+	private static function normalize_preset_sizes( $presets ) {
 		foreach ( $presets as $index => $preset ) {
 			if ( is_array( $preset ) && isset( $preset['size'] ) && is_numeric( $preset['size'] ) ) {
 				$presets[ $index ]['size'] = $preset['size'] . 'px';

--- a/plugins/newspack-popups/includes/class-newspack-popups-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-api.php
@@ -207,6 +207,8 @@ final class Newspack_Popups_API {
 			'style_palette'          => self::get_palette_presets(),
 			'style_font_sizes'       => self::normalize_preset_sizes( $font_sizes ),
 			'style_spacing_sizes'    => self::normalize_preset_sizes( $spacing_sizes ),
+			'style_spacing_custom'   => self::is_custom_spacing_size_allowed(),
+			'style_spacing_units'    => self::get_spacing_units(),
 			'site_editor_styles_url' => admin_url( 'site-editor.php?p=%2Fstyles&section=' . rawurlencode( '/blocks/' . rawurlencode( Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ) ) ),
 		];
 	}
@@ -249,6 +251,38 @@ final class Newspack_Popups_API {
 			unset( $sizes['default'] );
 		}
 		return self::sort_spacing_size_presets( self::merge_global_settings_presets( $sizes ) );
+	}
+
+	/**
+	 * Whether the padding rows may offer a custom value at all. `spacing.customSpacingSize`
+	 * is the setting core turns into the editor's `disableCustomSpacingSizes`, which
+	 * leaves its spacing rows preset-only, so the wizard's rows honor the same policy.
+	 *
+	 * @return bool
+	 */
+	private static function is_custom_spacing_size_allowed() {
+		// As with the palette, a missing settings path hands back the whole settings
+		// tree, so an absent `customSpacingSize` reads as truthy and custom values
+		// stay, as core's own default for the setting allows them.
+		return (bool) wp_get_global_settings( [ 'spacing', 'customSpacingSize' ] );
+	}
+
+	/**
+	 * The units a custom padding value may be given in. `spacing.units` is what
+	 * core's own spacing control filters its unit list by, and a classic theme
+	 * declaring `custom-units` support narrows it, so the wizard offers no unit the
+	 * editor would refuse.
+	 *
+	 * @return array List of unit strings.
+	 */
+	private static function get_spacing_units() {
+		$units = wp_get_global_settings( [ 'spacing', 'units' ] );
+		// A missing settings path hands back the whole settings tree, so anything but
+		// a flat list falls back to core's own default for the setting.
+		if ( ! is_array( $units ) || ! wp_is_numeric_array( $units ) ) {
+			return [ 'px', 'em', 'rem', 'vh', 'vw', '%' ];
+		}
+		return array_values( array_filter( $units, 'is_string' ) );
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-api.php
@@ -194,7 +194,7 @@ final class Newspack_Popups_API {
 		// Font sizes take the highest origin holding anything, which is how the
 		// editor's picker resolves the single set it offers; spacing sizes are one
 		// scale built from every origin, as core's own spacing control builds it.
-		$font_sizes    = self::flatten_global_settings_presets( wp_get_global_settings( [ 'typography', 'fontSizes' ] ) );
+		$font_sizes    = self::flatten_global_settings_presets( self::get_style_setting( [ 'typography', 'fontSizes' ] ) );
 		$spacing_sizes = self::get_spacing_size_presets();
 		return [
 			'enabled'                => Newspack_Popups_Settings::is_ai_copy_assistant_enabled(),
@@ -214,6 +214,45 @@ final class Newspack_Popups_API {
 	}
 
 	/**
+	 * A style setting resolved the way the editor resolves it for a block: the
+	 * block's own `settings.blocks.<block>` value when it has one, the global value
+	 * otherwise. Core's `wp_get_global_settings()` does not do that fallback — given
+	 * a block context it reads the block path alone, and a missing path hands back
+	 * the whole settings tree — so the block path is read from the settings tree and
+	 * only stands in when it is set. Block settings keep the same origin-keyed preset
+	 * shape as global ones, so the flatten/merge helpers read either.
+	 *
+	 * @param array $path Settings path, e.g. `[ 'color', 'palette' ]`.
+	 * @return mixed The setting, or whatever the global lookup hands back.
+	 */
+	private static function get_style_setting( $path ) {
+		$block_path  = array_merge( [ 'blocks', Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ], $path );
+		$block_value = self::settings_path_value( wp_get_global_settings(), $block_path );
+		// A block setting of `false` is a setting, as the editor treats it: only an
+		// unset one falls back to the global scope.
+		return null === $block_value ? wp_get_global_settings( $path ) : $block_value;
+	}
+
+	/**
+	 * The value a settings tree holds at a path, or null when the path is not there.
+	 * `wp_get_global_settings()` hands the whole tree back for a missing path, which
+	 * cannot answer whether the path is set at all; this can.
+	 *
+	 * @param mixed $settings Settings tree.
+	 * @param array $path     Settings path.
+	 * @return mixed|null The value, or null when the path is unset.
+	 */
+	private static function settings_path_value( $settings, $path ) {
+		foreach ( $path as $key ) {
+			if ( ! is_array( $settings ) || ! isset( $settings[ $key ] ) ) {
+				return null;
+			}
+			$settings = $settings[ $key ];
+		}
+		return $settings;
+	}
+
+	/**
 	 * The color presets the wizard's pickers offer, merged across origins. Core's
 	 * `color.defaultPalette` setting decides whether the editor shows the default
 	 * origin at all — it is false whenever a classic theme registers an
@@ -223,11 +262,11 @@ final class Newspack_Popups_API {
 	 * @return array Flat preset list.
 	 */
 	private static function get_palette_presets() {
-		$palette = wp_get_global_settings( [ 'color', 'palette' ] );
+		$palette = self::get_style_setting( [ 'color', 'palette' ] );
 		// A missing settings path hands back the whole settings tree, so an absent
 		// `defaultPalette` reads as truthy and the defaults stay, as core's own
 		// default for the setting has them.
-		if ( is_array( $palette ) && isset( $palette['default'] ) && ! wp_get_global_settings( [ 'color', 'defaultPalette' ] ) ) {
+		if ( is_array( $palette ) && isset( $palette['default'] ) && ! self::get_style_setting( [ 'color', 'defaultPalette' ] ) ) {
 			unset( $palette['default'] );
 		}
 		return self::merge_global_settings_presets( $palette );
@@ -243,11 +282,11 @@ final class Newspack_Popups_API {
 	 * @return array Flat preset list.
 	 */
 	private static function get_spacing_size_presets() {
-		$sizes = wp_get_global_settings( [ 'spacing', 'spacingSizes' ] );
+		$sizes = self::get_style_setting( [ 'spacing', 'spacingSizes' ] );
 		// As with the palette, a missing settings path hands back the whole settings
 		// tree, so an absent `defaultSpacingSizes` reads as truthy and the defaults
 		// stay, as core's own default for the setting has them.
-		if ( is_array( $sizes ) && isset( $sizes['default'] ) && ! wp_get_global_settings( [ 'spacing', 'defaultSpacingSizes' ] ) ) {
+		if ( is_array( $sizes ) && isset( $sizes['default'] ) && ! self::get_style_setting( [ 'spacing', 'defaultSpacingSizes' ] ) ) {
 			unset( $sizes['default'] );
 		}
 		return self::sort_spacing_size_presets( self::merge_global_settings_presets( $sizes ) );
@@ -264,7 +303,7 @@ final class Newspack_Popups_API {
 		// As with the palette, a missing settings path hands back the whole settings
 		// tree, so an absent `customSpacingSize` reads as truthy and custom values
 		// stay, as core's own default for the setting allows them.
-		return (bool) wp_get_global_settings( [ 'spacing', 'customSpacingSize' ] );
+		return (bool) self::get_style_setting( [ 'spacing', 'customSpacingSize' ] );
 	}
 
 	/**
@@ -276,7 +315,7 @@ final class Newspack_Popups_API {
 	 * @return array List of unit strings.
 	 */
 	private static function get_spacing_units() {
-		$units = wp_get_global_settings( [ 'spacing', 'units' ] );
+		$units = self::get_style_setting( [ 'spacing', 'units' ] );
 		// A missing settings path hands back the whole settings tree, so anything but
 		// a flat list falls back to core's own default for the setting.
 		if ( ! is_array( $units ) || ! wp_is_numeric_array( $units ) ) {

--- a/plugins/newspack-popups/includes/class-newspack-popups-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-api.php
@@ -191,10 +191,11 @@ final class Newspack_Popups_API {
 		// as `{}`: an empty PHP array would serialize as `[]` and a client
 		// comparing it against an object it built would never see them as equal.
 		$styles = Newspack_Popups_Contextual_Prompt_Styles::get_styles();
-		// Both lists take the highest origin holding anything, which is how the
-		// editor resolves the single set its own controls offer.
+		// Font sizes take the highest origin holding anything, which is how the
+		// editor's picker resolves the single set it offers; spacing sizes are one
+		// scale built from every origin, as core's own spacing control builds it.
 		$font_sizes    = self::flatten_global_settings_presets( wp_get_global_settings( [ 'typography', 'fontSizes' ] ) );
-		$spacing_sizes = self::flatten_global_settings_presets( wp_get_global_settings( [ 'spacing', 'spacingSizes' ] ) );
+		$spacing_sizes = self::get_spacing_size_presets();
 		return [
 			'enabled'                => Newspack_Popups_Settings::is_ai_copy_assistant_enabled(),
 			'can_manage'             => current_user_can( 'manage_options' ),
@@ -228,6 +229,55 @@ final class Newspack_Popups_API {
 			unset( $palette['default'] );
 		}
 		return self::merge_global_settings_presets( $palette );
+	}
+
+	/**
+	 * The spacing presets the wizard's padding rows step through. Core's
+	 * `SpacingSizesControl` builds one scale out of the custom, theme and default
+	 * origins rather than picking one, and `spacing.defaultSpacingSizes` decides
+	 * whether the default origin belongs in it — core turns that off for a theme
+	 * registering its own scale — so the wizard offers the steps the editor offers.
+	 *
+	 * @return array Flat preset list.
+	 */
+	private static function get_spacing_size_presets() {
+		$sizes = wp_get_global_settings( [ 'spacing', 'spacingSizes' ] );
+		// As with the palette, a missing settings path hands back the whole settings
+		// tree, so an absent `defaultSpacingSizes` reads as truthy and the defaults
+		// stay, as core's own default for the setting has them.
+		if ( is_array( $sizes ) && isset( $sizes['default'] ) && ! wp_get_global_settings( [ 'spacing', 'defaultSpacingSizes' ] ) ) {
+			unset( $sizes['default'] );
+		}
+		return self::sort_spacing_size_presets( self::merge_global_settings_presets( $sizes ) );
+	}
+
+	/**
+	 * Spacing presets in the order core's control shows them: by slug, compared as
+	 * numbers, and only while every slug starts with a digit — core leaves a scale
+	 * holding a named step in its origin order rather than sorting it. The step core
+	 * adds for no padding carries the `0` slug, so leaving it out of the list asks
+	 * the same question of it.
+	 *
+	 * Public so the ordering can be exercised directly in tests.
+	 *
+	 * @param array $presets Flat spacing size presets.
+	 * @return array
+	 */
+	public static function sort_spacing_size_presets( $presets ) {
+		foreach ( $presets as $preset ) {
+			$slug = is_array( $preset ) && isset( $preset['slug'] ) ? (string) $preset['slug'] : '';
+			if ( ! preg_match( '/^[0-9]/', $slug ) ) {
+				return $presets;
+			}
+		}
+		// usort is stable, so two slugs comparing equal keep their origin order.
+		usort(
+			$presets,
+			function ( $a, $b ) {
+				return strnatcmp( (string) $a['slug'], (string) $b['slug'] );
+			}
+		);
+		return $presets;
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-block.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-block.php
@@ -268,9 +268,14 @@ final class Newspack_Popups_Contextual_Prompt_Block {
 				'styles'  => [
 					'blocks' => [
 						self::BLOCK_NAME => [
-							'border'  => [ 'radius' => '10px' ],
-							'color'   => [ 'background' => '#f7f7f7' ],
-							'spacing' => [
+							'border'     => [ 'radius' => '10px' ],
+							'color'      => [ 'background' => '#f7f7f7' ],
+							// Body copy size. Block themes define `medium` themselves;
+							// classic themes resolve it from core's default set, which
+							// stays available even where the theme's own sizes replace
+							// it in the editor's picker.
+							'typography' => [ 'fontSize' => 'var:preset|font-size|medium' ],
+							'spacing'    => [
 								'padding'  => [
 									'top'    => 'var:preset|spacing|50',
 									'right'  => 'var:preset|spacing|50',

--- a/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
@@ -49,10 +49,22 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 	const RGB_COLOR_PATTERN = '/^rgba?\(\s*(\d{1,3})\s*,\s*(\d{1,3})\s*,\s*(\d{1,3})\s*(?:,[^)]*)?\)\z/i';
 
 	/**
-	 * The CSS initial text color, used when the site sets no global text color at
-	 * all.
+	 * The CSS initial text color, the last resort when the site sets no global
+	 * text color at all.
 	 */
 	const INITIAL_TEXT_COLOR = '#000000';
+
+	/**
+	 * The classic Newspack theme's template. Its style variations are child
+	 * themes, so they all report this one.
+	 */
+	const NEWSPACK_THEME_TEMPLATE = 'newspack-theme';
+
+	/**
+	 * The body text color the classic Newspack theme renders with. It lives in
+	 * the theme's stylesheet, which the global styles data cannot see.
+	 */
+	const NEWSPACK_THEME_TEXT_COLOR = '#111111';
 
 	/**
 	 * Register hooks. Classic themes only: on block themes Global Styles owns
@@ -241,7 +253,7 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 	 * A color in none of those shapes hands back nothing rather than a stand-in:
 	 * the wizard would check a chosen background against the wrong color, and a
 	 * contrast warning pointing the wrong way is worse than no warning. Only a site
-	 * with no global text color at all gets the CSS initial one.
+	 * with no global text color at all gets the assumed default.
 	 *
 	 * @return string|null Hex value or preset reference, null when unreadable.
 	 */
@@ -250,12 +262,33 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 		$text = wp_get_global_styles( [ 'color', 'text' ], [ 'transforms' => [ 'resolve-variables' ] ] );
 		$text = is_string( $text ) ? trim( $text ) : '';
 		if ( '' === $text ) {
-			return self::INITIAL_TEXT_COLOR;
+			return self::get_assumed_text_color();
 		}
 		if ( preg_match( self::WIZARD_COLOR_PATTERN, $text ) ) {
 			return $text;
 		}
 		return self::rgb_to_hex( $text );
+	}
+
+	/**
+	 * The text color to assume when the site declares no global one. A classic
+	 * theme states its body color in CSS, out of the global styles data's reach,
+	 * so the Newspack theme's is named here and other classic themes supply
+	 * theirs through the filter.
+	 *
+	 * @return string Hex value.
+	 */
+	private static function get_assumed_text_color() {
+		$color = self::NEWSPACK_THEME_TEMPLATE === get_template() ? self::NEWSPACK_THEME_TEXT_COLOR : self::INITIAL_TEXT_COLOR;
+
+		/**
+		 * Filters the text color a Contextual Prompt is assumed to inherit when the
+		 * site declares no global text color. Read by the wizard's contrast check,
+		 * so it must be a hex value.
+		 *
+		 * @param string $color Hex color value.
+		 */
+		return apply_filters( 'newspack_popups_contextual_prompt_inherited_text_color', $color );
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
@@ -33,6 +33,7 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'add_numeric_font_size_preset' ] );
 		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'disable_default_palette' ] );
 		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'disable_default_spacing_sizes' ] );
+		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'restrict_spacing_policy' ] );
 		wp_clean_theme_json_cache();
 		parent::tear_down();
 	}
@@ -60,6 +61,52 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 			$this->assertArrayHasKey( $key, $data['style_spacing_sizes'][0] );
 		}
 		$this->assertStringContainsString( 'site-editor.php', $data['site_editor_styles_url'] );
+	}
+
+	/**
+	 * The padding rows also carry the site's spacing policy: whether a custom value
+	 * may be given at all, and in which units. Core's own spacing control leaves its
+	 * rows preset-only when `spacing.customSpacingSize` is off and filters its unit
+	 * list by `spacing.units`, so the wizard's rows can honor the same policy.
+	 */
+	public function test_status_carries_the_spacing_policy() {
+		$data = rest_do_request( new WP_REST_Request( 'GET', '/newspack-popups/v1/contextual-prompt/status' ) )->get_data();
+
+		// Core's own defaults for both settings: custom values allowed, offered in the
+		// units core's theme.json declares.
+		$this->assertTrue( $data['style_spacing_custom'] );
+		$this->assertContains( 'px', $data['style_spacing_units'] );
+		// A flat list of unit strings, which is all a unit control can read.
+		$this->assertSame( array_values( $data['style_spacing_units'] ), $data['style_spacing_units'] );
+		$this->assertSame( $data['style_spacing_units'], array_filter( $data['style_spacing_units'], 'is_string' ) );
+
+		add_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'restrict_spacing_policy' ] );
+		wp_clean_theme_json_cache();
+
+		$data = rest_do_request( new WP_REST_Request( 'GET', '/newspack-popups/v1/contextual-prompt/status' ) )->get_data();
+
+		$this->assertFalse( $data['style_spacing_custom'] );
+		$this->assertSame( [ 'px', 'em' ], $data['style_spacing_units'] );
+	}
+
+	/**
+	 * Turn custom spacing values off and narrow the units, as a theme.json may.
+	 *
+	 * @param WP_Theme_JSON_Data $theme_json Theme JSON data.
+	 * @return WP_Theme_JSON_Data
+	 */
+	public static function restrict_spacing_policy( $theme_json ) {
+		return $theme_json->update_with(
+			[
+				'version'  => 2,
+				'settings' => [
+					'spacing' => [
+						'customSpacingSize' => false,
+						'units'             => [ 'px', 'em' ],
+					],
+				],
+			]
+		);
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
@@ -32,6 +32,7 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 	public function tear_down() {
 		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'add_numeric_font_size_preset' ] );
 		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'disable_default_palette' ] );
+		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'disable_default_spacing_sizes' ] );
 		wp_clean_theme_json_cache();
 		parent::tear_down();
 	}
@@ -216,6 +217,115 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 		// With that origin empty the next one down stands in.
 		$presets['theme'] = [];
 		$this->assertSame( $presets['default'], Newspack_Popups_API::flatten_global_settings_presets( $presets ) );
+	}
+
+	/**
+	 * Spacing sizes are one scale built from every origin, custom beating theme
+	 * beating default on a shared slug, and ordered by slug as numbers rather than
+	 * by the origin that happened to define each step.
+	 */
+	public function test_spacing_presets_combine_origins_in_slug_order() {
+		$presets = [
+			'default' => [
+				[
+					'slug' => '70',
+					'size' => '5.06rem',
+				],
+				[
+					'slug' => '80',
+					'size' => '6.75rem',
+				],
+			],
+			'theme'   => [
+				[
+					'slug' => '20',
+					'size' => '10px',
+				],
+				[
+					'slug' => '40',
+					'size' => '20px',
+				],
+			],
+			'custom'  => [
+				[
+					'slug' => '40',
+					'size' => '24px',
+				],
+				[
+					'slug' => '60',
+					'size' => '30px',
+				],
+			],
+		];
+
+		$sizes = Newspack_Popups_API::sort_spacing_size_presets( Newspack_Popups_API::merge_global_settings_presets( $presets ) );
+
+		$this->assertSame( [ '20', '40', '60', '70', '80' ], wp_list_pluck( $sizes, 'slug' ) );
+		$this->assertSame( '24px', wp_list_pluck( $sizes, 'size', 'slug' )['40'] );
+
+		// A named step leaves the scale in its origin order, which is what core's own
+		// control does rather than sorting a slug that carries no number.
+		$presets['theme'][] = [
+			'slug' => 'huge',
+			'size' => '9rem',
+		];
+		$sizes              = Newspack_Popups_API::sort_spacing_size_presets( Newspack_Popups_API::merge_global_settings_presets( $presets ) );
+
+		$this->assertSame( [ '40', '60', '20', 'huge', '70', '80' ], wp_list_pluck( $sizes, 'slug' ) );
+	}
+
+	/**
+	 * The default origin travels only while the editor shows it: core turns
+	 * `spacing.defaultSpacingSizes` off for a theme registering its own scale, and
+	 * the wizard must not offer steps the editor hides.
+	 */
+	public function test_spacing_presets_drop_the_default_origin_when_the_editor_hides_it() {
+		$default_slugs = wp_list_pluck( wp_get_global_settings( [ 'spacing', 'spacingSizes' ] )['default'], 'slug' );
+		$this->assertNotEmpty( $default_slugs );
+
+		$sizes = rest_do_request( new WP_REST_Request( 'GET', '/newspack-popups/v1/contextual-prompt/status' ) )->get_data()['style_spacing_sizes'];
+		$this->assertNotEmpty( array_intersect( $default_slugs, wp_list_pluck( $sizes, 'slug' ) ) );
+
+		add_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'disable_default_spacing_sizes' ] );
+		wp_clean_theme_json_cache();
+		// The premise: the presets are still there, the editor just hides them.
+		$this->assertFalse( wp_get_global_settings( [ 'spacing', 'defaultSpacingSizes' ] ) );
+		$this->assertNotEmpty( wp_get_global_settings( [ 'spacing', 'spacingSizes' ] )['default'] );
+
+		$sizes = rest_do_request( new WP_REST_Request( 'GET', '/newspack-popups/v1/contextual-prompt/status' ) )->get_data()['style_spacing_sizes'];
+		$slugs = wp_list_pluck( $sizes, 'slug' );
+
+		$this->assertSame( [], array_intersect( $default_slugs, $slugs ) );
+		// The theme's own step stands, so the scale is hidden defaults rather than
+		// nothing at all.
+		$this->assertSame( [ '15' ], $slugs );
+	}
+
+	/**
+	 * Hide the default spacing scale behind a theme's own, as core does for a theme
+	 * registering spacing sizes of its own.
+	 *
+	 * @param WP_Theme_JSON_Data $theme_json Theme JSON data.
+	 * @return WP_Theme_JSON_Data
+	 */
+	public static function disable_default_spacing_sizes( $theme_json ) {
+		return $theme_json->update_with(
+			[
+				'version'  => 2,
+				'settings' => [
+					'spacing' => [
+						'defaultSpacingSizes' => false,
+						'spacingSizes'        => [
+							[
+								'name' => 'Tiny',
+								'slug' => '15',
+								'size' => '4px',
+							],
+						],
+					],
+				],
+			]
+		);
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
@@ -52,6 +52,12 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'color', $data['style_palette'][0] );
 		$this->assertNotEmpty( $data['style_font_sizes'] );
 		$this->assertArrayHasKey( 'size', $data['style_font_sizes'][0] );
+		// The padding rows step through the site's spacing presets, so they travel
+		// with the name each step shows and the size a resolved default matches on.
+		$this->assertNotEmpty( $data['style_spacing_sizes'] );
+		foreach ( [ 'name', 'slug', 'size' ] as $key ) {
+			$this->assertArrayHasKey( $key, $data['style_spacing_sizes'][0] );
+		}
 		$this->assertStringContainsString( 'site-editor.php', $data['site_editor_styles_url'] );
 	}
 

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
@@ -34,6 +34,8 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'disable_default_palette' ] );
 		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'disable_default_spacing_sizes' ] );
 		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'restrict_spacing_policy' ] );
+		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'scope_spacing_policy_to_the_block' ] );
+		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'scope_palette_to_the_block' ] );
 		wp_clean_theme_json_cache();
 		parent::tear_down();
 	}
@@ -103,6 +105,109 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 					'spacing' => [
 						'customSpacingSize' => false,
 						'units'             => [ 'px', 'em' ],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * The policy is read for the block, not just for the site: the editor resolves
+	 * `settings.blocks.<block>` first and falls back to the global scope, so a theme
+	 * scoping a spacing policy to the Contextual Prompt block is the policy the
+	 * payload carries.
+	 */
+	public function test_status_carries_a_block_scoped_spacing_policy() {
+		add_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'scope_spacing_policy_to_the_block' ] );
+		wp_clean_theme_json_cache();
+
+		// The premise: the two scopes disagree, and the block scope really is there.
+		$block_context = [ 'block_name' => Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ];
+		$this->assertTrue( wp_get_global_settings( [ 'spacing', 'customSpacingSize' ] ) );
+		$this->assertFalse( wp_get_global_settings( [ 'spacing', 'customSpacingSize' ], $block_context ) );
+
+		$data = rest_do_request( new WP_REST_Request( 'GET', '/newspack-popups/v1/contextual-prompt/status' ) )->get_data();
+
+		$this->assertFalse( $data['style_spacing_custom'] );
+		$this->assertSame( [ 'rem' ], $data['style_spacing_units'] );
+	}
+
+	/**
+	 * Turn custom spacing values off and narrow the units for the block alone, while
+	 * the site keeps allowing both.
+	 *
+	 * @param WP_Theme_JSON_Data $theme_json Theme JSON data.
+	 * @return WP_Theme_JSON_Data
+	 */
+	public static function scope_spacing_policy_to_the_block( $theme_json ) {
+		return $theme_json->update_with(
+			[
+				'version'  => 2,
+				'settings' => [
+					'spacing' => [
+						'customSpacingSize' => true,
+						'units'             => [ 'px', 'em' ],
+					],
+					'blocks'  => [
+						Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME => [
+							'spacing' => [
+								'customSpacingSize' => false,
+								'units'             => [ 'rem' ],
+							],
+						],
+					],
+				],
+			]
+		);
+	}
+
+	/**
+	 * A palette scoped to the block stands in for the site's, as the editor's own
+	 * pickers resolve it for the block first.
+	 */
+	public function test_status_carries_a_block_scoped_palette() {
+		add_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'scope_palette_to_the_block' ] );
+		wp_clean_theme_json_cache();
+
+		$palette = rest_do_request( new WP_REST_Request( 'GET', '/newspack-popups/v1/contextual-prompt/status' ) )->get_data()['style_palette'];
+		$by_slug = wp_list_pluck( $palette, 'color', 'slug' );
+
+		$this->assertSame( '#0a0a0a', $by_slug['prompt-only'] );
+		$this->assertArrayNotHasKey( 'site-only', $by_slug );
+	}
+
+	/**
+	 * Give the block its own color preset while the site registers another.
+	 *
+	 * @param WP_Theme_JSON_Data $theme_json Theme JSON data.
+	 * @return WP_Theme_JSON_Data
+	 */
+	public static function scope_palette_to_the_block( $theme_json ) {
+		return $theme_json->update_with(
+			[
+				'version'  => 2,
+				'settings' => [
+					'color'  => [
+						'palette' => [
+							[
+								'name'  => 'Site only',
+								'slug'  => 'site-only',
+								'color' => '#f0f0f0',
+							],
+						],
+					],
+					'blocks' => [
+						Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME => [
+							'color' => [
+								'palette' => [
+									[
+										'name'  => 'Prompt only',
+										'slug'  => 'prompt-only',
+										'color' => '#0a0a0a',
+									],
+								],
+							],
+						],
 					],
 				],
 			]

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
@@ -256,8 +256,11 @@ class ContextualPromptStylesTest extends WP_UnitTestCase {
 
 		$this->assertSame( '#f7f7f7', $defaults['color']['background'] );
 		$this->assertSame( '10px', $defaults['border']['radius'] );
-		// Preset spacing must come back resolved, not as a var:preset reference.
+		// Preset spacing and font size must come back resolved, not as var:preset
+		// references: the wizard's controls read concrete CSS values.
 		$this->assertStringNotContainsString( 'var:preset', (string) $defaults['spacing']['padding']['top'] );
+		$this->assertNotEmpty( $defaults['typography']['fontSize'] );
+		$this->assertStringNotContainsString( 'var:', (string) $defaults['typography']['fontSize'] );
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
@@ -213,6 +213,34 @@ class ContextualPromptStylesTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The padding rows store a spacing preset reference, or a plain zero for the
+	 * scale's first step. Both survive the allowlist and reach the style engine,
+	 * which turns the reference into the preset's custom property.
+	 */
+	public function test_spacing_presets_survive_into_the_css() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_styles(
+			[
+				'spacing' => [
+					'padding' => [
+						'top'    => 'var:preset|spacing|50',
+						'bottom' => 'var:preset|spacing|50',
+						'left'   => '0',
+					],
+				],
+			]
+		);
+		$stored = Newspack_Popups_Contextual_Prompt_Styles::get_styles();
+
+		$this->assertSame( 'var:preset|spacing|50', $stored['spacing']['padding']['top'] );
+		$this->assertSame( '0', $stored['spacing']['padding']['left'] );
+
+		$css = Newspack_Popups_Contextual_Prompt_Styles::get_css();
+
+		$this->assertStringContainsString( 'padding-top:var(--wp--preset--spacing--50)', $css );
+		$this->assertStringContainsString( 'padding-left:0', $css );
+	}
+
+	/**
 	 * No saved styles means no CSS and no editor payload.
 	 */
 	public function test_empty_option_produces_nothing() {

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
@@ -273,9 +273,44 @@ class ContextualPromptStylesTest extends WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'text', $block_node['color'] );
 
 		$defaults = Newspack_Popups_Contextual_Prompt_Styles::get_defaults();
-		// This theme sets no global text color either, so the fallback is the CSS
-		// initial one.
+		// This theme sets no global text color either, and is not the Newspack
+		// theme, so the fallback is the CSS initial color.
 		$this->assertSame( '#000000', $defaults['color']['text'] );
+	}
+
+	/**
+	 * On the classic Newspack theme the assumed color is the one its stylesheet
+	 * renders body text with, not the CSS initial black: the theme declares it in
+	 * CSS, where the global styles data cannot see it.
+	 */
+	public function test_get_defaults_assumes_the_newspack_theme_text_color() {
+		$original = get_option( 'template' );
+		update_option( 'template', Newspack_Popups_Contextual_Prompt_Styles::NEWSPACK_THEME_TEMPLATE );
+		$text = Newspack_Popups_Contextual_Prompt_Styles::get_defaults()['color']['text'];
+		update_option( 'template', $original );
+		wp_clean_theme_json_cache();
+
+		$this->assertSame( '#111111', $text );
+	}
+
+	/**
+	 * Another classic theme supplies its own body text color through the filter.
+	 */
+	public function test_get_defaults_lets_a_filter_set_the_assumed_text_color() {
+		add_filter( 'newspack_popups_contextual_prompt_inherited_text_color', [ __CLASS__, 'return_custom_text_color' ] );
+		$text = Newspack_Popups_Contextual_Prompt_Styles::get_defaults()['color']['text'];
+		remove_filter( 'newspack_popups_contextual_prompt_inherited_text_color', [ __CLASS__, 'return_custom_text_color' ] );
+
+		$this->assertSame( '#333333', $text );
+	}
+
+	/**
+	 * A theme's own body text color, for the filter test.
+	 *
+	 * @return string
+	 */
+	public static function return_custom_text_color() {
+		return '#333333';
 	}
 
 	/**

--- a/themes/newspack-theme/newspack-theme/sass/style-editor-base.scss
+++ b/themes/newspack-theme/newspack-theme/sass/style-editor-base.scss
@@ -29,9 +29,9 @@ body {
 	color: var(--newspack-theme-color-text-main);
 }
 
+// No font-size here: the base size is inherited from the canvas, as on the front
+// end, so a styled container's font-size reaches its paragraphs.
 p {
-	font-size: var(--newspack-theme-font-size-base);
-
 	&.has-background {
 		padding: 20px 30px;
 	}


### PR DESCRIPTION
## Description

Follow-ups to the Contextual Prompts Style section from live testing:

- The wizard's inherited Text color default now assumes the classic newspack-theme's real body color (#111111) instead of the CSS initial black, with a filter (`newspack_popups_contextual_prompt_inherited_text_color`) for other classic themes.
- The theme's editor stylesheet no longer forces a paragraph font size, so font sizes set on containers (including the prompt's) inherit in the canvas exactly as they do on the front end.
- The block's default design now includes the medium font-size preset, on both theme types.
- The wizard's Padding control steps through the site's spacing presets like the editor's Dimensions panel: axial vertical/horizontal sliders with preset marks and names, link/unlink to four sides, and a custom-value toggle per row. Presets store as `var:preset|spacing|<slug>` references.

## How to test

1. Classic theme: the Style section's Text swatch defaults to the theme text color (#111), Typography defaults to M (20px), and Padding shows preset sliders at Medium; setting a font size now updates the prompt in the editor canvas, not just the front end.
2. Unlink Padding, set a side to a custom value, save, and confirm the front end applies the preset variables.
3. Block theme: Global Styles shows the prompt's default font size as Medium.