### PR TITLE
feat(campaigns): move classic prompt styles into an Edit Styles drawer

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/contextual-prompts-settings.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/contextual-prompts-settings.js
@@ -2,10 +2,10 @@
  * Contextual Prompts settings content.
  *
  * Presentational: the parent tab owns the fetched status/values and the header
- * Save/Disable actions. When the feature is off this renders an empty state with
- * an admin opt-in (AI-use disclosure modal); when on, the publisher-profile and
- * site-wide override sections in the branch's grid/divider layout, plus the
- * style section on a classic theme.
+ * Save/Disable actions, along with the style editing both theme kinds get from
+ * the header. When the feature is off this renders an empty state with an admin
+ * opt-in (AI-use disclosure modal); when on, the publisher-profile and
+ * site-wide override sections in the branch's grid/divider layout.
  */
 
 /**
@@ -30,7 +30,6 @@ import { megaphone } from '@wordpress/icons';
  */
 import { Button, Divider, Grid, Modal, SectionHeader } from '../../../../../../packages/components/src';
 import WizardsTab from '../../../../wizards-tab';
-import StyleSection from './style-section';
 
 const DISCLOSURE = __(
 	"Contextual Prompts lets editors draft donation call-to-action copy with AI. The story's content is sent to a third-party AI provider, which retains it for up to 30 days for abuse monitoring and never uses it to train AI models or in other AI products. Every suggestion is a draft an editor reviews and approves; nothing is published automatically.",
@@ -50,7 +49,7 @@ const OVERRIDE_ENABLED_KEY = 'newspack_contextual_prompts_override_enabled';
 const OVERRIDE_CTA_KEY = 'newspack_contextual_prompts_override_cta';
 const OVERRIDE_BUTTON_KEYS = [ 'newspack_contextual_prompts_override_label', 'newspack_contextual_prompts_override_url' ];
 
-const ContextualPromptsSettings = ( { status, values, blockStyles, error, inFlight, onSetValue, onChangeStyles, onEnable } ) => {
+const ContextualPromptsSettings = ( { status, values, error, inFlight, onSetValue, onEnable } ) => {
 	const [ modalOpen, setModalOpen ] = useState( false );
 	const { enabled, can_manage: canManage, fields } = status;
 
@@ -138,11 +137,6 @@ const ContextualPromptsSettings = ( { status, values, blockStyles, error, inFlig
 	const hasCtaToggle = ( fields || [] ).some( field => OVERRIDE_CTA_KEY === field.key );
 	const effectiveCta = hasCtaToggle ? values[ OVERRIDE_CTA_KEY ] || 'form' : 'button';
 	const overrideEnabled = !! values[ OVERRIDE_ENABLED_KEY ];
-	// The Style section needs the style payload newspack-popups only started
-	// sending alongside it. Against an older one its controls would render empty
-	// and every save would be silently dropped, so the section stays out. Block
-	// themes have no section at all: the header hands off to the Site Editor.
-	const hasStylePayload = 'is_block_theme' in status;
 
 	// Fields are grouped by section server-side so the override controls can sit
 	// under their own heading rather than trailing the publisher profile.
@@ -235,12 +229,6 @@ const ContextualPromptsSettings = ( { status, values, blockStyles, error, inFlig
 				/>
 				<VStack spacing={ 6 }>{ renderFields( 'override' ) }</VStack>
 			</Grid>
-			{ hasStylePayload && ! status.is_block_theme && (
-				<>
-					<Divider alignment="full-width" variant="tertiary" />
-					<StyleSection status={ status } styles={ blockStyles } inFlight={ inFlight } onChangeStyles={ onChangeStyles } />
-				</>
-			) }
 		</WizardsTab>
 	);
 };

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/contextual-prompts-settings.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/contextual-prompts-settings.test.js
@@ -32,9 +32,9 @@ const TOGGLE_FIELD = {
 const LABEL_FIELD = { ...FIELD_DEFAULTS, key: 'newspack_contextual_prompts_override_label', label: 'Override button label', type: 'text' };
 const URL_FIELD = { ...FIELD_DEFAULTS, key: 'newspack_contextual_prompts_override_url', label: 'Override button URL', type: 'text' };
 
-// The style keys the status payload carries, on a classic theme; the Style
-// section itself is covered in style-section.test.js, so the heading is enough to
-// see the section render at all.
+// The style keys the status payload carries, on a classic theme; the settings
+// body must ignore them, since styles are edited from the wizard header (the
+// drawer or the Site Editor handoff, both owned by the parent tab).
 const STYLE_PAYLOAD = {
 	is_block_theme: false,
 	style_defaults: {},
@@ -101,7 +101,7 @@ describe( 'ContextualPromptsSettings empty state', () => {
 } );
 
 describe( 'ContextualPromptsSettings enabled body', () => {
-	it( 'renders the two settings sections, plus Style on a classic theme', () => {
+	it( 'renders the two settings sections and no Style section, style payload or not', () => {
 		render(
 			<ContextualPromptsSettings
 				status={ { enabled: true, can_manage: true, fields: [ ENABLE_FIELD ], ...STYLE_PAYLOAD } }
@@ -115,45 +115,8 @@ describe( 'ContextualPromptsSettings enabled body', () => {
 
 		expect( screen.getByRole( 'heading', { name: 'Publisher Profile' } ) ).toBeInTheDocument();
 		expect( screen.getByRole( 'heading', { name: 'Site-Wide Override' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'heading', { name: 'Style' } ) ).toBeInTheDocument();
-	} );
-
-	// A block theme's styles live in the Site Editor, which the wizard header hands
-	// off to, so the section has nothing left to render.
-	it( 'leaves out the Style section on a block theme', () => {
-		render(
-			<ContextualPromptsSettings
-				status={ { enabled: true, can_manage: true, fields: [ ENABLE_FIELD ], ...STYLE_PAYLOAD, is_block_theme: true } }
-				values={ fieldsToValues( [ ENABLE_FIELD ] ) }
-				error={ null }
-				inFlight={ false }
-				onSetValue={ () => {} }
-				onEnable={ () => Promise.resolve() }
-			/>
-		);
-
-		expect( screen.getByRole( 'heading', { name: 'Site-Wide Override' } ) ).toBeInTheDocument();
 		expect( screen.queryByRole( 'heading', { name: 'Style' } ) ).not.toBeInTheDocument();
 		expect( screen.queryByRole( 'button', { name: 'Background' } ) ).toBeNull();
-	} );
-
-	// An older newspack-popups answers the status endpoint without the style keys:
-	// the section's controls would render empty and its saves would be dropped.
-	it( 'leaves out the Style section when the payload carries no style keys', () => {
-		render(
-			<ContextualPromptsSettings
-				status={ { enabled: true, can_manage: true, fields: [ ENABLE_FIELD ] } }
-				values={ fieldsToValues( [ ENABLE_FIELD ] ) }
-				error={ null }
-				inFlight={ false }
-				onSetValue={ () => {} }
-				onEnable={ () => Promise.resolve() }
-			/>
-		);
-
-		expect( screen.getByRole( 'heading', { name: 'Publisher Profile' } ) ).toBeInTheDocument();
-		expect( screen.getByRole( 'heading', { name: 'Site-Wide Override' } ) ).toBeInTheDocument();
-		expect( screen.queryByRole( 'heading', { name: 'Style' } ) ).not.toBeInTheDocument();
 	} );
 
 	it( 'shows only the enable toggle while the override is off', () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
@@ -157,6 +157,28 @@ const ContextualPrompts = props => {
 		}
 		return request( PROFILE_PATH, data ).then( () => setSnackbar( __( 'Settings saved.', 'newspack-plugin' ) ) );
 	};
+	// The endpoint requires fields, so the drawer sends the saved snapshot: a
+	// no-op for the profile that leaves local field edits both unsaved and
+	// intact, since this path never refreshes values from the response.
+	const saveStyles = () => {
+		setInFlight( true );
+		setError( null );
+		return apiFetch( { path: PROFILE_PATH, method: 'POST', data: { fields: savedValuesRef.current, styles: blockStyles } } )
+			.then( next => {
+				statusRequestRef.current++;
+				setStatus( next );
+				const nextStyles = normalizeStyles( next.styles );
+				setBlockStyles( nextStyles );
+				savedStylesRef.current = nextStyles;
+				setSnackbar( __( 'Styles saved.', 'newspack-plugin' ) );
+				return next;
+			} )
+			.catch( err => {
+				setError( err );
+				throw err;
+			} )
+			.finally( () => setInFlight( false ) );
+	};
 	const onSave = () => saveProfile().catch( () => {} );
 	const setValue = ( key, value ) => setValues( previous => ( { ...previous, [ key ]: value } ) );
 
@@ -181,11 +203,12 @@ const ContextualPrompts = props => {
 		if ( stylesDirty ) {
 			requestConfirm( discardStyles );
 		} else {
+			setError( null );
 			setEditingStyles( false );
 		}
 	};
 	const onStyleDrawerSave = () =>
-		saveProfile()
+		saveStyles()
 			.then( () => setEditingStyles( false ) )
 			.catch( () => {} );
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
@@ -171,6 +171,7 @@ const ContextualPrompts = props => {
 	// block would catch and answer with a prompt of its own.
 	const discardStyles = () => {
 		setBlockStyles( savedStylesRef.current );
+		setError( null );
 		setEditingStyles( false );
 	};
 	const onStyleDrawerClose = () => {
@@ -193,6 +194,8 @@ const ContextualPrompts = props => {
 	// separate confirm dialog would fight this one's navigation block.
 	const disable = () => {
 		setDisabling( true );
+		// A drawer left open would come back with the feature on re-enable.
+		setEditingStyles( false );
 		return setEnabled( false )
 			.then( () => setSnackbar( __( 'Contextual Prompts disabled.', 'newspack-plugin' ) ) )
 			.catch( () => {} )
@@ -233,7 +236,16 @@ const ContextualPrompts = props => {
 				</Handoff>
 			) }
 			{ showStyleDrawer && (
-				<Button variant="secondary" onClick={ () => setEditingStyles( true ) }>
+				<Button
+					variant="secondary"
+					onClick={ () => {
+						// The page and the drawer share the error state, so a notice
+						// left over from the page must not follow the drawer in.
+						setError( null );
+						setEditingStyles( true );
+					} }
+					disabled={ inFlight }
+				>
 					{ __( 'Edit Styles', 'newspack-plugin' ) }
 				</Button>
 			) }
@@ -277,7 +289,7 @@ const ContextualPrompts = props => {
 		<ContextualPromptsScreen { ...props } headerActions={ headerActions }>
 			{ confirmDialog }
 			{ content }
-			{ editingStyles && status && (
+			{ editingStyles && showStyleDrawer && (
 				<StyleDrawer
 					status={ status }
 					styles={ blockStyles }

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
@@ -281,6 +281,7 @@ const ContextualPrompts = props => {
 				<StyleDrawer
 					status={ status }
 					styles={ blockStyles }
+					error={ error }
 					inFlight={ inFlight }
 					isDirty={ stylesDirty }
 					onChangeStyles={ setBlockStyles }

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
@@ -157,13 +157,13 @@ const ContextualPrompts = props => {
 		}
 		return request( PROFILE_PATH, data ).then( () => setSnackbar( __( 'Settings saved.', 'newspack-plugin' ) ) );
 	};
-	// The endpoint requires fields, so the drawer sends the saved snapshot: a
-	// no-op for the profile that leaves local field edits both unsaved and
-	// intact, since this path never refreshes values from the response.
+	// The endpoint requires fields but only writes the keys it is given, so the
+	// drawer sends an empty object: no profile write at all, and local field
+	// edits stay unsaved and intact, since this path never refreshes values.
 	const saveStyles = () => {
 		setInFlight( true );
 		setError( null );
-		return apiFetch( { path: PROFILE_PATH, method: 'POST', data: { fields: savedValuesRef.current, styles: blockStyles } } )
+		return apiFetch( { path: PROFILE_PATH, method: 'POST', data: { fields: {}, styles: blockStyles } } )
 			.then( next => {
 				statusRequestRef.current++;
 				setStatus( next );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
@@ -22,6 +22,7 @@ import { moreVertical } from '@wordpress/icons';
  */
 import { withWizardScreen, Button, Handoff, Notice, Waiting, useUnsavedChangesDialog } from '../../../../../../packages/components/src';
 import ContextualPromptsSettings from './contextual-prompts-settings';
+import StyleDrawer from './style-drawer';
 
 const STATUS_PATH = '/newspack-popups/v1/contextual-prompt/status';
 const ENABLE_PATH = '/newspack-popups/v1/contextual-prompt/enable';
@@ -55,6 +56,8 @@ const ContextualPrompts = props => {
 	const [ error, setError ] = useState( null );
 	const [ loaded, setLoaded ] = useState( false );
 	const [ disabling, setDisabling ] = useState( false );
+	// Whether the Edit Styles drawer is open (classic themes only).
+	const [ editingStyles, setEditingStyles ] = useState( false );
 	// The legacy campaigns wizard has no store snackbar outlet, so success feedback
 	// is a local Snackbar (as the advertising placements screen does).
 	const [ snackbar, setSnackbar ] = useState( null );
@@ -152,16 +155,38 @@ const ContextualPrompts = props => {
 		if ( stylesDirty ) {
 			data.styles = blockStyles;
 		}
-		return request( PROFILE_PATH, data )
-			.then( () => setSnackbar( __( 'Settings saved.', 'newspack-plugin' ) ) )
-			.catch( () => {} );
+		return request( PROFILE_PATH, data ).then( () => setSnackbar( __( 'Settings saved.', 'newspack-plugin' ) ) );
 	};
+	const onSave = () => saveProfile().catch( () => {} );
 	const setValue = ( key, value ) => setValues( previous => ( { ...previous, [ key ]: value } ) );
 
 	const isDirty = ! valuesEqual( values, savedValuesRef.current ) || stylesDirty;
 	// Guard stays active during an in-flight save: the edits are only safe once
 	// a successful response has refreshed the saved snapshot.
 	const { confirmDialog, requestConfirm } = useUnsavedChangesDialog( { when: isDirty } );
+
+	// Closing the drawer with style edits standing goes through the same dialog
+	// as Disable and navigation. A second dialog instance would fight this one:
+	// dismissing it replaces the history location, which the guard's own active
+	// block would catch and answer with a prompt of its own.
+	const discardStyles = () => {
+		setBlockStyles( savedStylesRef.current );
+		setEditingStyles( false );
+	};
+	const onStyleDrawerClose = () => {
+		if ( inFlight ) {
+			return;
+		}
+		if ( stylesDirty ) {
+			requestConfirm( discardStyles );
+		} else {
+			setEditingStyles( false );
+		}
+	};
+	const onStyleDrawerSave = () =>
+		saveProfile()
+			.then( () => setEditingStyles( false ) )
+			.catch( () => {} );
 
 	// Disabling refreshes state from the response, discarding local edits, so route
 	// it through the same unsaved-changes guard: it confirms only when dirty, and a
@@ -176,10 +201,14 @@ const ContextualPrompts = props => {
 	const onDisable = () => requestConfirm( disable );
 	const onEnable = () => setEnabled( true ).then( () => setSnackbar( __( 'Contextual Prompts enabled.', 'newspack-plugin' ) ) );
 
-	// Block themes have no Style section: their block styles live in the Site
-	// Editor, so the header hands off to it. The style payload newspack-popups
-	// only started sending carries the theme flag, so an older one gets nothing.
-	const showStyleHandoff = status?.enabled && 'is_block_theme' in status && status.is_block_theme;
+	// Styles are edited from the header on both theme kinds: a block theme hands
+	// off to the Site Editor, where its block styles live, and a classic theme
+	// opens the drawer hosting the wizard's own controls. The style payload
+	// newspack-popups only started sending carries the theme flag, so an older
+	// one gets neither button.
+	const hasStylePayload = status?.enabled && 'is_block_theme' in status;
+	const showStyleHandoff = hasStylePayload && status.is_block_theme;
+	const showStyleDrawer = hasStylePayload && ! status.is_block_theme;
 
 	const headerActions = status?.enabled ? (
 		<>
@@ -203,7 +232,12 @@ const ContextualPrompts = props => {
 					{ __( 'Edit Styles', 'newspack-plugin' ) }
 				</Handoff>
 			) }
-			<Button variant="primary" onClick={ saveProfile } disabled={ inFlight || ! isDirty }>
+			{ showStyleDrawer && (
+				<Button variant="secondary" onClick={ () => setEditingStyles( true ) }>
+					{ __( 'Edit Styles', 'newspack-plugin' ) }
+				</Button>
+			) }
+			<Button variant="primary" onClick={ onSave } disabled={ inFlight || ! isDirty }>
 				{ __( 'Save', 'newspack-plugin' ) }
 			</Button>
 		</>
@@ -222,11 +256,9 @@ const ContextualPrompts = props => {
 			<ContextualPromptsSettings
 				status={ status }
 				values={ values }
-				blockStyles={ blockStyles }
 				error={ error }
 				inFlight={ inFlight }
 				onSetValue={ setValue }
-				onChangeStyles={ setBlockStyles }
 				onEnable={ onEnable }
 			/>
 		);
@@ -245,6 +277,17 @@ const ContextualPrompts = props => {
 		<ContextualPromptsScreen { ...props } headerActions={ headerActions }>
 			{ confirmDialog }
 			{ content }
+			{ editingStyles && status && (
+				<StyleDrawer
+					status={ status }
+					styles={ blockStyles }
+					inFlight={ inFlight }
+					isDirty={ stylesDirty }
+					onChangeStyles={ setBlockStyles }
+					onRequestClose={ onStyleDrawerClose }
+					onSave={ onStyleDrawerSave }
+				/>
+			) }
 			{ snackbar &&
 				createPortal(
 					<div className="newspack-wizard__snackbar-list">

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
@@ -279,7 +279,7 @@ describe( 'ContextualPrompts tab', () => {
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
 		const { data } = apiFetch.mock.calls[ 1 ][ 0 ];
 		expect( data.styles ).toEqual( { color: { background: '#123456' }, border: { radius: '4px' } } );
-		expect( data.fields ).toEqual( { [ PROFILE_FIELD.key ]: '' } );
+		expect( data.fields ).toEqual( {} );
 		await waitFor( () => expect( drawerElement() ).toBeNull() );
 	} );
 
@@ -296,11 +296,11 @@ describe( 'ContextualPrompts tab', () => {
 		apiFetch.mockResolvedValueOnce( styledStatus() );
 		fireEvent.click( drawer().getByRole( 'button', { name: 'Save' } ) );
 
-		// The drawer commits styles only: the fields it has to send are the saved
-		// snapshot, not the edits standing in the page behind it.
+		// The drawer commits styles only: the required fields argument goes out
+		// empty, never carrying the edits standing in the page behind it.
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
 		const { data } = apiFetch.mock.calls[ 1 ][ 0 ];
-		expect( data.fields ).toEqual( { [ PROFILE_FIELD.key ]: '' } );
+		expect( data.fields ).toEqual( {} );
 
 		await waitFor( () => expect( drawerElement() ).toBeNull() );
 		expect( screen.getByRole( 'textbox', { name: 'Publisher name' } ) ).toHaveValue( 'Newsroom X' );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
@@ -1,10 +1,11 @@
 /**
  * Contextual Prompts tab: a failed initial status fetch surfaces an error with a
  * Retry that re-runs the fetch, profile fields lock while a save is pending, and
- * on a block theme the header hands off to the Site Editor's Styles panel.
+ * the header's Edit Styles action opens the drawer on a classic theme or hands
+ * off to the Site Editor's Styles panel on a block theme.
  */
 
-import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor, within } from '@testing-library/react';
 import { MemoryRouter } from 'react-router-dom';
 import '@testing-library/jest-dom';
 import apiFetch from '@wordpress/api-fetch';
@@ -39,7 +40,7 @@ const PROFILE_FIELD = {
 // the other in place, so the payload assertion also covers "send the full object".
 const SAVED_STYLES = { color: { background: '#123456' }, border: { radius: '4px', width: '1px' } };
 
-// Classic theme, so the Style section renders its controls rather than the handoff.
+// Classic theme, so the header's Edit Styles opens the drawer rather than the handoff.
 const styledStatus = () => ( {
 	enabled: true,
 	can_manage: true,
@@ -55,14 +56,24 @@ const styledStatus = () => ( {
 // With nothing stored, PHP hands back an empty JSON array rather than an object.
 const unstyledStatus = () => ( { ...styledStatus(), styles: [] } );
 
-// Block theme, so the styles live in the Site Editor: no Style section, and the
-// header carries the handoff to it instead.
+// Block theme, so the styles live in the Site Editor: no drawer, and the header
+// carries the handoff to it instead.
 const blockThemeStatus = () => ( { ...styledStatus(), is_block_theme: true } );
 
 // Each style group resets from the options menu in its ToolsPanel header.
 const resetStyleItem = ( panel, item ) => {
 	fireEvent.click( screen.getByRole( 'button', { name: `${ panel } options` } ) );
 	fireEvent.click( screen.getByRole( 'menuitem', { name: `Reset ${ item }` } ) );
+};
+
+// The drawer and the header both carry Save/Cancel-named buttons, so drawer
+// queries are scoped to its frame (a portal, hence the document lookup).
+const drawerElement = () => document.querySelector( '.newspack-prompt-style-drawer' );
+const drawer = () => within( drawerElement() );
+
+const openDrawer = async () => {
+	await waitFor( () => expect( screen.getByRole( 'button', { name: 'Edit Styles' } ) ).toBeInTheDocument() );
+	fireEvent.click( screen.getByRole( 'button', { name: 'Edit Styles' } ) );
 };
 
 describe( 'ContextualPrompts tab', () => {
@@ -130,12 +141,55 @@ describe( 'ContextualPrompts tab', () => {
 		expect( screen.getByRole( 'textbox', { name: 'Publisher name' } ) ).toHaveValue( 'Newsroom X' );
 	} );
 
-	it( 'renders the Style section when enabled', async () => {
+	it( 'opens the Edit Styles drawer from the header on a classic theme, with no in-page section', async () => {
 		apiFetch.mockResolvedValueOnce( styledStatus() );
 		renderTab();
 
-		await waitFor( () => expect( screen.getByRole( 'heading', { name: 'Style', level: 2 } ) ).toBeInTheDocument() );
-		expect( screen.getByText( 'Background' ) ).toBeInTheDocument();
+		await waitFor( () => expect( screen.getByRole( 'button', { name: 'Edit Styles' } ) ).toBeInTheDocument() );
+		// The tab body carries no style controls: the drawer owns them now.
+		expect( screen.queryByRole( 'heading', { name: 'Style' } ) ).toBeNull();
+		expect( screen.queryByRole( 'button', { name: 'Background' } ) ).toBeNull();
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Edit Styles' } ) );
+		expect( screen.getByRole( 'heading', { name: 'Edit Styles', level: 2 } ) ).toBeInTheDocument();
+		expect( drawer().getByRole( 'button', { name: 'Background' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'closes the drawer without a prompt when the styles are untouched', async () => {
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		renderTab();
+		await openDrawer();
+
+		fireEvent.click( drawer().getByRole( 'button', { name: 'Cancel' } ) );
+		await waitFor( () => expect( drawerElement() ).toBeNull() );
+		expect( screen.queryByText( /unsaved changes that will be lost/i ) ).toBeNull();
+	} );
+
+	it( 'confirms before Cancel discards style edits, keeping the drawer when the prompt is cancelled', async () => {
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		renderTab();
+		await openDrawer();
+
+		resetStyleItem( 'Border', 'Border' );
+
+		// Cancelling with a style edit standing prompts instead of closing.
+		fireEvent.click( drawer().getByRole( 'button', { name: 'Cancel' } ) );
+		await screen.findByText( /unsaved changes that will be lost/i );
+
+		// Keeping the changes leaves the drawer open with the edit in place. The
+		// text query dodges the dialog's X button, which is also named Cancel.
+		fireEvent.click( within( document.querySelector( '.newspack-modal' ) ).getByText( 'Cancel' ) );
+		expect( drawerElement() ).not.toBeNull();
+
+		// Discarding closes the drawer, reverts the edit and saves nothing: the
+		// reopened drawer's Save has nothing to send.
+		await waitFor( () => fireEvent.click( drawer().getByRole( 'button', { name: 'Cancel' } ) ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Discard Changes' } ) );
+		await waitFor( () => expect( drawerElement() ).toBeNull() );
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+
+		fireEvent.click( screen.getByRole( 'button', { name: 'Edit Styles' } ) );
+		expect( drawer().getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
 	} );
 
 	it( 'omits styles from the save payload when they are untouched', async () => {
@@ -158,37 +212,39 @@ describe( 'ContextualPrompts tab', () => {
 	it( 'goes clean again when a style edit is undone from an empty array payload', async () => {
 		apiFetch.mockResolvedValueOnce( unstyledStatus() );
 		renderTab();
+		await openDrawer();
 
-		await waitFor( () => expect( screen.getByRole( 'button', { name: 'Text' } ) ).toBeInTheDocument() );
-		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+		expect( drawer().getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
 
-		fireEvent.click( screen.getByRole( 'button', { name: 'Text' } ) );
+		fireEvent.click( drawer().getByRole( 'button', { name: 'Text' } ) );
 		fireEvent.click( screen.getByRole( 'option', { name: 'Accent' } ) );
-		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
+		expect( drawer().getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
 
 		// Clicking the selected swatch clears it, leaving no overrides at all: the
 		// saved snapshot has to compare equal to that, empty array payload or not.
 		fireEvent.click( screen.getByRole( 'option', { name: 'Accent' } ) );
-		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+		expect( drawer().getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
 	} );
 
-	it( 'includes the whole style object in the save payload when a style is edited', async () => {
+	it( 'includes the whole style object in the drawer save payload and closes on success', async () => {
 		apiFetch.mockResolvedValueOnce( styledStatus() );
 		renderTab();
+		await openDrawer();
 
-		await waitFor( () => expect( screen.getByRole( 'heading', { name: 'Border', level: 3 } ) ).toBeInTheDocument() );
-		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+		expect( screen.getByRole( 'heading', { name: 'Border', level: 3 } ) ).toBeInTheDocument();
+		expect( drawer().getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
 
 		resetStyleItem( 'Border', 'Border' );
-		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
+		expect( drawer().getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
 
 		apiFetch.mockResolvedValueOnce( styledStatus() );
-		fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+		fireEvent.click( drawer().getByRole( 'button', { name: 'Save' } ) );
 
 		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
 		const { data } = apiFetch.mock.calls[ 1 ][ 0 ];
 		expect( data.styles ).toEqual( { color: { background: '#123456' }, border: { radius: '4px' } } );
 		expect( data.fields ).toEqual( { [ PROFILE_FIELD.key ]: '' } );
+		await waitFor( () => expect( drawerElement() ).toBeNull() );
 	} );
 
 	describe( 'on a block theme', () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
@@ -283,6 +283,30 @@ describe( 'ContextualPrompts tab', () => {
 		await waitFor( () => expect( drawerElement() ).toBeNull() );
 	} );
 
+	it( 'leaves dirty profile fields unsaved and intact when the drawer saves', async () => {
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		renderTab();
+
+		await waitFor( () => expect( screen.getByRole( 'textbox', { name: 'Publisher name' } ) ).toBeInTheDocument() );
+		fireEvent.change( screen.getByRole( 'textbox', { name: 'Publisher name' } ), { target: { value: 'Newsroom X' } } );
+
+		await openDrawer();
+		resetStyleItem( 'Border', 'Border' );
+
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		fireEvent.click( drawer().getByRole( 'button', { name: 'Save' } ) );
+
+		// The drawer commits styles only: the fields it has to send are the saved
+		// snapshot, not the edits standing in the page behind it.
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+		const { data } = apiFetch.mock.calls[ 1 ][ 0 ];
+		expect( data.fields ).toEqual( { [ PROFILE_FIELD.key ]: '' } );
+
+		await waitFor( () => expect( drawerElement() ).toBeNull() );
+		expect( screen.getByRole( 'textbox', { name: 'Publisher name' } ) ).toHaveValue( 'Newsroom X' );
+		expect( screen.getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
+	} );
+
 	it( 'keeps the drawer open and shows the error when the drawer save fails', async () => {
 		apiFetch.mockResolvedValueOnce( styledStatus() );
 		renderTab();

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
@@ -116,6 +116,19 @@ describe( 'ContextualPrompts tab', () => {
 		await waitFor( () => expect( screen.getByRole( 'textbox', { name: 'Publisher name' } ) ).toBeDisabled() );
 	} );
 
+	it( 'locks the Edit Styles action while a save is pending', async () => {
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		renderTab();
+
+		await waitFor( () => expect( screen.getByRole( 'textbox', { name: 'Publisher name' } ) ).toBeInTheDocument() );
+		fireEvent.change( screen.getByRole( 'textbox', { name: 'Publisher name' } ), { target: { value: 'Newsroom X' } } );
+
+		// The drawer must not open onto state a pending save is about to replace.
+		apiFetch.mockReturnValueOnce( new Promise( () => {} ) );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Save' } ) );
+		await waitFor( () => expect( screen.getByRole( 'button', { name: 'Edit Styles' } ) ).toBeDisabled() );
+	} );
+
 	it( 'confirms before Disable discards unsaved edits, and cancelling keeps state', async () => {
 		const nameField = {
 			key: 'newspack_contextual_prompts_publisher_name',
@@ -190,6 +203,29 @@ describe( 'ContextualPrompts tab', () => {
 
 		fireEvent.click( screen.getByRole( 'button', { name: 'Edit Styles' } ) );
 		expect( drawer().getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+	} );
+
+	it( 'vetoes Escape while style edits are unsaved', async () => {
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		renderTab();
+		await openDrawer();
+
+		resetStyleItem( 'Border', 'Border' );
+
+		// The frame's own handler vetoes the close and defers to the confirm.
+		fireEvent.keyDown( drawerElement(), { key: 'Escape' } );
+		await screen.findByText( /unsaved changes that will be lost/i );
+		expect( drawerElement() ).not.toBeNull();
+	} );
+
+	it( 'closes on Escape without a prompt when styles are untouched', async () => {
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		renderTab();
+		await openDrawer();
+
+		fireEvent.keyDown( drawerElement(), { key: 'Escape' } );
+		await waitFor( () => expect( drawerElement() ).toBeNull() );
+		expect( screen.queryByText( /unsaved changes that will be lost/i ) ).toBeNull();
 	} );
 
 	it( 'omits styles from the save payload when they are untouched', async () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
@@ -247,6 +247,24 @@ describe( 'ContextualPrompts tab', () => {
 		await waitFor( () => expect( drawerElement() ).toBeNull() );
 	} );
 
+	it( 'keeps the drawer open and shows the error when the drawer save fails', async () => {
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		renderTab();
+		await openDrawer();
+
+		resetStyleItem( 'Border', 'Border' );
+
+		apiFetch.mockRejectedValueOnce( new Error( 'Save failed.' ) );
+		fireEvent.click( drawer().getByRole( 'button', { name: 'Save' } ) );
+
+		// The edits are still there to retry, with the reason in reach of them.
+		await waitFor( () => {
+			expect( apiFetch ).toHaveBeenCalledTimes( 2 );
+			expect( drawerElement() ).not.toBeNull();
+			expect( drawer().getByText( 'Save failed.' ) ).toBeInTheDocument();
+		} );
+	} );
+
 	describe( 'on a block theme', () => {
 		const HANDOFF_LINK = 'https://example.test/wp-admin/site-editor.php?handoff=1';
 		const RETURN_URL = 'https://example.test/wp-admin/admin.php?page=newspack-audience';

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-drawer.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-drawer.js
@@ -11,7 +11,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { Modal, Popover, SlotFillProvider, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { Modal, Notice, Popover, SlotFillProvider, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
 import { close } from '@wordpress/icons';
 
 /**
@@ -20,11 +20,16 @@ import { close } from '@wordpress/icons';
 import { Button } from '../../../../../../packages/components/src';
 import StyleSection from './style-section';
 
-const StyleDrawer = ( { status, styles, inFlight, isDirty, onChangeStyles, onRequestClose, onSave } ) => {
-	// Close through the Modal's own Escape handler so the slide-out (exit)
-	// animation runs; calling onRequestClose directly unmounts the panel with no
-	// animation, since the Modal only animates closes that it initiates.
+const StyleDrawer = ( { status, styles, error, inFlight, isDirty, onChangeStyles, onRequestClose, onSave } ) => {
+	// Veto first: a close the parent answers with a confirm must reach it without
+	// the exit animation replaying, so only closes that really unmount go through
+	// the Modal's own Escape handler, which is what animates them. The overlay
+	// click is the accepted exception: it animates before the confirm appears.
 	const requestClose = event => {
+		if ( isDirty || inFlight ) {
+			onRequestClose();
+			return;
+		}
 		const frame = event.currentTarget.closest( '.components-modal__frame' );
 		if ( frame ) {
 			frame.dispatchEvent( new window.KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } ) );
@@ -36,6 +41,15 @@ const StyleDrawer = ( { status, styles, inFlight, isDirty, onChangeStyles, onReq
 		<Modal
 			__experimentalHideHeader
 			onRequestClose={ onRequestClose }
+			// Escape on a dirty or in-flight drawer is vetoed here, before the
+			// Modal's own handler animates the close. Popovers inside the drawer
+			// preventDefault their own Escape, so those are left alone.
+			onKeyDown={ event => {
+				if ( 'Escape' === event.key && ! event.defaultPrevented && ( isDirty || inFlight ) ) {
+					event.preventDefault();
+					onRequestClose();
+				}
+			} }
 			className="newspack-prompt-style-drawer"
 			overlayClassName="newspack-prompt-style-drawer__overlay"
 			contentLabel={ __( 'Edit Styles', 'newspack-plugin' ) }
@@ -53,6 +67,11 @@ const StyleDrawer = ( { status, styles, inFlight, isDirty, onChangeStyles, onReq
 				<div className="newspack-prompt-style-drawer__content">
 					<StyleSection status={ status } styles={ styles } inFlight={ inFlight } onChangeStyles={ onChangeStyles } />
 				</div>
+				{ error && (
+					<Notice status="error" isDismissible={ false } className="newspack-prompt-style-drawer__notice">
+						{ error.message }
+					</Notice>
+				) }
 				<HStack className="newspack-prompt-style-drawer__footer" spacing={ 2 } justify="flex-end">
 					<Button variant="tertiary" onClick={ requestClose } disabled={ inFlight } __next40pxDefaultSize>
 						{ __( 'Cancel', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-drawer.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-drawer.js
@@ -1,0 +1,70 @@
+/**
+ * Contextual Prompts Edit Styles drawer.
+ *
+ * A right-edge slide-in panel hosting the classic-theme style controls, opened
+ * from the wizard header. The parent owns the styles state and the close/save
+ * flows: closing with unsaved style edits is confirmed there before the local
+ * edits are discarded.
+ */
+
+/**
+ * WordPress dependencies
+ */
+import { __ } from '@wordpress/i18n';
+import { Modal, Popover, SlotFillProvider, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { close } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { Button } from '../../../../../../packages/components/src';
+import StyleSection from './style-section';
+
+const StyleDrawer = ( { status, styles, inFlight, isDirty, onChangeStyles, onRequestClose, onSave } ) => {
+	// Close through the Modal's own Escape handler so the slide-out (exit)
+	// animation runs; calling onRequestClose directly unmounts the panel with no
+	// animation, since the Modal only animates closes that it initiates.
+	const requestClose = event => {
+		const frame = event.currentTarget.closest( '.components-modal__frame' );
+		if ( frame ) {
+			frame.dispatchEvent( new window.KeyboardEvent( 'keydown', { key: 'Escape', bubbles: true } ) );
+		} else {
+			onRequestClose();
+		}
+	};
+	return (
+		<Modal
+			__experimentalHideHeader
+			onRequestClose={ onRequestClose }
+			className="newspack-prompt-style-drawer"
+			overlayClassName="newspack-prompt-style-drawer__overlay"
+			contentLabel={ __( 'Edit Styles', 'newspack-plugin' ) }
+		>
+			{ /* Without a slot in the dialog, the controls' popovers (palettes, panel
+			     menus) portal to a body-level container the Modal may already hold
+			     aria-hidden, dropping them from the accessibility tree. In the slot
+			     they stay inside the dialog; being `position: fixed`, they still
+			     escape the content area's overflow. */ }
+			<SlotFillProvider>
+				<HStack className="newspack-prompt-style-drawer__header" spacing={ 2 } alignment="center">
+					<h2 className="newspack-prompt-style-drawer__title">{ __( 'Edit Styles', 'newspack-plugin' ) }</h2>
+					<Button icon={ close } size="small" label={ __( 'Close', 'newspack-plugin' ) } onClick={ requestClose } disabled={ inFlight } />
+				</HStack>
+				<div className="newspack-prompt-style-drawer__content">
+					<StyleSection status={ status } styles={ styles } inFlight={ inFlight } onChangeStyles={ onChangeStyles } />
+				</div>
+				<HStack className="newspack-prompt-style-drawer__footer" spacing={ 2 } justify="flex-end">
+					<Button variant="tertiary" onClick={ requestClose } disabled={ inFlight } __next40pxDefaultSize>
+						{ __( 'Cancel', 'newspack-plugin' ) }
+					</Button>
+					<Button variant="primary" onClick={ onSave } disabled={ inFlight || ! isDirty } isBusy={ inFlight } __next40pxDefaultSize>
+						{ __( 'Save', 'newspack-plugin' ) }
+					</Button>
+				</HStack>
+				<Popover.Slot />
+			</SlotFillProvider>
+		</Modal>
+	);
+};
+
+export default StyleDrawer;

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-drawer.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-drawer.js
@@ -73,10 +73,10 @@ const StyleDrawer = ( { status, styles, error, inFlight, isDirty, onChangeStyles
 					</Notice>
 				) }
 				<HStack className="newspack-prompt-style-drawer__footer" spacing={ 2 } justify="flex-end">
-					<Button variant="tertiary" onClick={ requestClose } disabled={ inFlight } __next40pxDefaultSize>
+					<Button variant="secondary" onClick={ requestClose } disabled={ inFlight }>
 						{ __( 'Cancel', 'newspack-plugin' ) }
 					</Button>
-					<Button variant="primary" onClick={ onSave } disabled={ inFlight || ! isDirty } isBusy={ inFlight } __next40pxDefaultSize>
+					<Button variant="primary" onClick={ onSave } disabled={ inFlight || ! isDirty } isBusy={ inFlight }>
 						{ __( 'Save', 'newspack-plugin' ) }
 					</Button>
 				</HStack>

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-drawer.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-drawer.js
@@ -12,7 +12,7 @@
  */
 import { __ } from '@wordpress/i18n';
 import { Modal, Notice, Popover, SlotFillProvider, __experimentalHStack as HStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
-import { close } from '@wordpress/icons';
+import { Icon, close, styles as stylesIcon } from '@wordpress/icons';
 
 /**
  * Internal dependencies
@@ -61,6 +61,7 @@ const StyleDrawer = ( { status, styles, error, inFlight, isDirty, onChangeStyles
 			     escape the content area's overflow. */ }
 			<SlotFillProvider>
 				<HStack className="newspack-prompt-style-drawer__header" spacing={ 2 } alignment="center">
+					<Icon className="newspack-prompt-style-drawer__icon" icon={ stylesIcon } size={ 24 } />
 					<h2 className="newspack-prompt-style-drawer__title">{ __( 'Edit Styles', 'newspack-plugin' ) }</h2>
 					<Button icon={ close } size="small" label={ __( 'Close', 'newspack-plugin' ) } onClick={ requestClose } disabled={ inFlight } />
 				</HStack>

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -1,10 +1,9 @@
 /**
- * Contextual Prompts Style section.
+ * Contextual Prompts style controls.
  *
  * Controls that write site-wide defaults for the Contextual Prompt block on a
- * classic theme. Block themes get no section: the wizard header hands off to the
- * Site Editor's Styles panel instead, so the parent renders this for classic
- * themes alone.
+ * classic theme, hosted in the Edit Styles drawer. Block themes get no controls:
+ * the wizard header hands off to the Site Editor's Styles panel instead.
  */
 
 /**
@@ -53,7 +52,7 @@ import {
 /**
  * Internal dependencies
  */
-import { Button, Grid, SectionHeader } from '../../../../../../packages/components/src';
+import { Button } from '../../../../../../packages/components/src';
 import {
 	contrastRatio,
 	perceivedBrightness,
@@ -367,166 +366,149 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 
 	// ColorPalette, FontSizePicker, BoxControl and BorderBoxControl take no
 	// `disabled` prop, so the whole stack goes inert while a save is in flight.
-	const controls = (
-		<Disabled isDisabled={ !! inFlight }>
-			<HStack alignment="top" justify="flex-end">
-				<VStack spacing={ 0 } className="newspack-prompt-style-controls">
-					<StylePanel
-						label={ __( 'Color', 'newspack-plugin' ) }
-						className="newspack-prompt-style-panel--color"
-						resetAll={ () => onChangeStyles( setPath( styles, [ 'color' ], undefined ) ) }
-						__experimentalFirstVisibleItemClass="newspack-prompt-style-colors--first"
-						__experimentalLastVisibleItemClass="newspack-prompt-style-colors--last"
-					>
-						<ToolsPanelItem
-							className="newspack-prompt-style-colors"
-							label={ __( 'Text', 'newspack-plugin' ) }
-							hasValue={ () => undefined !== styles.color?.text }
-							onDeselect={ () => setColor( 'text' ) }
-							isShownByDefault
-						>
-							<ColorRow label={ __( 'Text', 'newspack-plugin' ) } colorValue={ text } disabled={ inFlight }>
-								<ColorPalette
-									aria-label={ __( 'Text', 'newspack-plugin' ) }
-									colors={ paletteColors }
-									value={ text ?? undefined }
-									onChange={ value => setColor( 'text', value ) }
-								/>
-							</ColorRow>
-						</ToolsPanelItem>
-						<ToolsPanelItem
-							className="newspack-prompt-style-colors"
-							label={ __( 'Background', 'newspack-plugin' ) }
-							hasValue={ () => undefined !== styles.color?.background }
-							onDeselect={ () => setColor( 'background' ) }
-							isShownByDefault
-						>
-							<ColorRow label={ __( 'Background', 'newspack-plugin' ) } colorValue={ background } disabled={ inFlight }>
-								<ColorPalette
-									aria-label={ __( 'Background', 'newspack-plugin' ) }
-									colors={ paletteColors }
-									value={ background ?? undefined }
-									onChange={ value => setColor( 'background', value ) }
-								/>
-							</ColorRow>
-						</ToolsPanelItem>
-						{ null !== ratio && ratio < MIN_CONTRAST_RATIO && (
-							<Notice status="warning" isDismissible={ false } className="newspack-prompt-style-notice">
-								{ contrastMessage( background, text ) }
-							</Notice>
-						) }
-					</StylePanel>
-					<StylePanel
-						label={ __( 'Typography', 'newspack-plugin' ) }
-						resetAll={ () => onChangeStyles( setPath( styles, [ 'typography' ], undefined ) ) }
-					>
-						<ToolsPanelItem
-							label={ __( 'Font Size', 'newspack-plugin' ) }
-							hasValue={ () => undefined !== styles.typography?.fontSize }
-							onDeselect={ () => setFontSize() }
-							isShownByDefault
-						>
-							<FontSizePicker
-								fontSizes={ fontSizes }
-								value={ effective( [ 'typography', 'fontSize' ] ) }
-								onChange={ setFontSize }
-								withReset={ false }
-								__next40pxDefaultSize
-							/>
-						</ToolsPanelItem>
-					</StylePanel>
-					<StylePanel label={ __( 'Padding', 'newspack-plugin' ) } resetAll={ clearPadding }>
-						<ToolsPanelItem
-							label={ __( 'Padding', 'newspack-plugin' ) }
-							hasValue={ () => undefined !== styles.spacing?.padding }
-							onDeselect={ clearPadding }
-							isShownByDefault
-						>
-							<PaddingControl
-								steps={ paddingSteps }
-								units={ paddingUnits }
-								allowCustom={ styleSpacingCustom }
-								values={ paddingValues }
-								onChange={ setPaddingSides }
-								disabled={ inFlight }
-							/>
-						</ToolsPanelItem>
-					</StylePanel>
-					<StylePanel
-						label={ __( 'Border', 'newspack-plugin' ) }
-						resetAll={ () => onChangeStyles( setPath( styles, [ 'border' ], undefined ) ) }
-					>
-						<ToolsPanelItem
-							label={ __( 'Border', 'newspack-plugin' ) }
-							hasValue={ () => hasKeys( borderOverride ) }
-							onDeselect={ clearBorder }
-							isShownByDefault
-						>
-							<BorderBoxControl
-								label={ __( 'Border', 'newspack-plugin' ) }
-								hideLabelFromVision
-								colors={ paletteColors }
-								value={ hasKeys( borderOverride ) ? borderOverride : withoutRadius( defaults.border ) }
-								onChange={ setBorder }
-								enableStyle
-								__next40pxDefaultSize
-							/>
-						</ToolsPanelItem>
-						<ToolsPanelItem
-							label={ __( 'Radius', 'newspack-plugin' ) }
-							hasValue={ () => undefined !== styles.border?.radius }
-							onDeselect={ () => setRadius() }
-							isShownByDefault
-						>
-							<VStack spacing={ 2 }>
-								<BaseControl.VisualLabel>{ __( 'Radius', 'newspack-plugin' ) }</BaseControl.VisualLabel>
-								<HStack spacing={ 4 } className="newspack-prompt-style-radius">
-									<Icon className="newspack-prompt-style-radius__icon" icon={ cornerAll } size={ ICON_SIZE } />
-									<UnitControl
-										label={ __( 'Radius', 'newspack-plugin' ) }
-										hideLabelFromVision
-										value={ radiusValue }
-										onChange={ setRadius }
-										min={ 0 }
-										disabled={ inFlight }
-										__next40pxDefaultSize
-									/>
-									<RangeControl
-										label={ __( 'Border radius', 'newspack-plugin' ) }
-										hideLabelFromVision
-										value={ radiusQuantity }
-										onChange={ setRadiusQuantity }
-										min={ 0 }
-										max={ RADIUS_SLIDER_MAX }
-										step={ 'px' === ( radiusUnit || 'px' ) || '%' === radiusUnit ? 1 : 0.1 }
-										initialPosition={ 0 }
-										withInputField={ false }
-										disabled={ inFlight }
-										__nextHasNoMarginBottom
-										__next40pxDefaultSize
-									/>
-								</HStack>
-							</VStack>
-						</ToolsPanelItem>
-					</StylePanel>
-				</VStack>
-			</HStack>
-		</Disabled>
-	);
-
 	return (
-		<Grid columns={ 2 } gutter={ 32 } noMargin>
-			<SectionHeader
-				heading={ 2 }
-				title={ __( 'Style', 'newspack-plugin' ) }
-				description={ __(
-					'Site-wide default styles for the Contextual Prompt block. Styles set on an individual block override these.',
-					'newspack-plugin'
-				) }
-				noMargin
-			/>
-			{ controls }
-		</Grid>
+		<Disabled isDisabled={ !! inFlight }>
+			<VStack spacing={ 0 } className="newspack-prompt-style-controls">
+				<StylePanel
+					label={ __( 'Color', 'newspack-plugin' ) }
+					className="newspack-prompt-style-panel--color"
+					resetAll={ () => onChangeStyles( setPath( styles, [ 'color' ], undefined ) ) }
+					__experimentalFirstVisibleItemClass="newspack-prompt-style-colors--first"
+					__experimentalLastVisibleItemClass="newspack-prompt-style-colors--last"
+				>
+					<ToolsPanelItem
+						className="newspack-prompt-style-colors"
+						label={ __( 'Text', 'newspack-plugin' ) }
+						hasValue={ () => undefined !== styles.color?.text }
+						onDeselect={ () => setColor( 'text' ) }
+						isShownByDefault
+					>
+						<ColorRow label={ __( 'Text', 'newspack-plugin' ) } colorValue={ text } disabled={ inFlight }>
+							<ColorPalette
+								aria-label={ __( 'Text', 'newspack-plugin' ) }
+								colors={ paletteColors }
+								value={ text ?? undefined }
+								onChange={ value => setColor( 'text', value ) }
+							/>
+						</ColorRow>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						className="newspack-prompt-style-colors"
+						label={ __( 'Background', 'newspack-plugin' ) }
+						hasValue={ () => undefined !== styles.color?.background }
+						onDeselect={ () => setColor( 'background' ) }
+						isShownByDefault
+					>
+						<ColorRow label={ __( 'Background', 'newspack-plugin' ) } colorValue={ background } disabled={ inFlight }>
+							<ColorPalette
+								aria-label={ __( 'Background', 'newspack-plugin' ) }
+								colors={ paletteColors }
+								value={ background ?? undefined }
+								onChange={ value => setColor( 'background', value ) }
+							/>
+						</ColorRow>
+					</ToolsPanelItem>
+					{ null !== ratio && ratio < MIN_CONTRAST_RATIO && (
+						<Notice status="warning" isDismissible={ false } className="newspack-prompt-style-notice">
+							{ contrastMessage( background, text ) }
+						</Notice>
+					) }
+				</StylePanel>
+				<StylePanel
+					label={ __( 'Typography', 'newspack-plugin' ) }
+					resetAll={ () => onChangeStyles( setPath( styles, [ 'typography' ], undefined ) ) }
+				>
+					<ToolsPanelItem
+						label={ __( 'Font Size', 'newspack-plugin' ) }
+						hasValue={ () => undefined !== styles.typography?.fontSize }
+						onDeselect={ () => setFontSize() }
+						isShownByDefault
+					>
+						<FontSizePicker
+							fontSizes={ fontSizes }
+							value={ effective( [ 'typography', 'fontSize' ] ) }
+							onChange={ setFontSize }
+							withReset={ false }
+							__next40pxDefaultSize
+						/>
+					</ToolsPanelItem>
+				</StylePanel>
+				<StylePanel label={ __( 'Padding', 'newspack-plugin' ) } resetAll={ clearPadding }>
+					<ToolsPanelItem
+						label={ __( 'Padding', 'newspack-plugin' ) }
+						hasValue={ () => undefined !== styles.spacing?.padding }
+						onDeselect={ clearPadding }
+						isShownByDefault
+					>
+						<PaddingControl
+							steps={ paddingSteps }
+							units={ paddingUnits }
+							allowCustom={ styleSpacingCustom }
+							values={ paddingValues }
+							onChange={ setPaddingSides }
+							disabled={ inFlight }
+						/>
+					</ToolsPanelItem>
+				</StylePanel>
+				<StylePanel
+					label={ __( 'Border', 'newspack-plugin' ) }
+					resetAll={ () => onChangeStyles( setPath( styles, [ 'border' ], undefined ) ) }
+				>
+					<ToolsPanelItem
+						label={ __( 'Border', 'newspack-plugin' ) }
+						hasValue={ () => hasKeys( borderOverride ) }
+						onDeselect={ clearBorder }
+						isShownByDefault
+					>
+						<BorderBoxControl
+							label={ __( 'Border', 'newspack-plugin' ) }
+							hideLabelFromVision
+							colors={ paletteColors }
+							value={ hasKeys( borderOverride ) ? borderOverride : withoutRadius( defaults.border ) }
+							onChange={ setBorder }
+							enableStyle
+							__next40pxDefaultSize
+						/>
+					</ToolsPanelItem>
+					<ToolsPanelItem
+						label={ __( 'Radius', 'newspack-plugin' ) }
+						hasValue={ () => undefined !== styles.border?.radius }
+						onDeselect={ () => setRadius() }
+						isShownByDefault
+					>
+						<VStack spacing={ 2 }>
+							<BaseControl.VisualLabel>{ __( 'Radius', 'newspack-plugin' ) }</BaseControl.VisualLabel>
+							<HStack spacing={ 4 } className="newspack-prompt-style-radius">
+								<Icon className="newspack-prompt-style-radius__icon" icon={ cornerAll } size={ ICON_SIZE } />
+								<UnitControl
+									label={ __( 'Radius', 'newspack-plugin' ) }
+									hideLabelFromVision
+									value={ radiusValue }
+									onChange={ setRadius }
+									min={ 0 }
+									disabled={ inFlight }
+									__next40pxDefaultSize
+								/>
+								<RangeControl
+									label={ __( 'Border radius', 'newspack-plugin' ) }
+									hideLabelFromVision
+									value={ radiusQuantity }
+									onChange={ setRadiusQuantity }
+									min={ 0 }
+									max={ RADIUS_SLIDER_MAX }
+									step={ 'px' === ( radiusUnit || 'px' ) || '%' === radiusUnit ? 1 : 0.1 }
+									initialPosition={ 0 }
+									withInputField={ false }
+									disabled={ inFlight }
+									__nextHasNoMarginBottom
+									__next40pxDefaultSize
+								/>
+							</HStack>
+						</VStack>
+					</ToolsPanelItem>
+				</StylePanel>
+			</VStack>
+		</Disabled>
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -231,6 +231,11 @@
 	padding: wp-vars.$grid-unit-15 wp-vars.$grid-unit-20;
 }
 
+.newspack-prompt-style-drawer__icon {
+	fill: currentcolor;
+	flex: none;
+}
+
 .newspack-prompt-style-drawer__title {
 	flex: 1;
 	font-size: inherit;

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -152,7 +152,17 @@
 	margin: 0;
 	max-height: none;
 	max-width: wp-vars.$sidebar-width;
+
+	// Core's frame carries a 350px floor, which would beat the cap above.
+	min-width: 0;
 	width: 100%;
+
+	// The wizard's modal styles blank every popover while a modal is open, to
+	// hide dropdowns left hanging behind one. The drawer's own popovers render
+	// into its slot inside this frame, so they are the one set meant to show.
+	.components-popover__content {
+		opacity: 1;
+	}
 
 	// Drop the modal's built-in content padding so the panels sit flush against
 	// the drawer's edges with only their own padding, and let the inner wrappers

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -1,23 +1,18 @@
 /**
- * Contextual Prompts Style section.
+ * Contextual Prompts style controls and the Edit Styles drawer hosting them.
  *
- * The style groups are core ToolsPanels, stacked into one ringed list the way the
- * editor's inspector stacks them. Color rows mirror the editor's color panel: a
- * bordered group of flat, full-width toggles, each showing a round indicator and
- * the color's name.
+ * The style groups are core ToolsPanels, stacked the way the editor's inspector
+ * stacks them: each panel carries its own top separator. Color rows mirror the
+ * editor's color panel: a bordered group of flat, full-width toggles, each
+ * showing a round indicator and the color's name.
  */
 
 @use "~@wordpress/base-styles/colors" as wp-colors;
 @use "~@wordpress/base-styles/variables" as wp-vars;
 
-// The controls column hugs the end of the section grid at the editor sidebar's
-// width, so the panels inside give their controls the width they have there. The
-// ring closes the stack off: the panels only carry the separators between them.
+// The panels fill the drawer at the editor sidebar's width, so the controls
+// inside get the width they have there; the drawer owns the chrome around them.
 .newspack-prompt-style-controls {
-	border-radius: wp-vars.$radius-small;
-	box-shadow: 0 0 0 wp-vars.$border-width wp-colors.$gray-300;
-	max-width: wp-vars.$sidebar-width;
-	overflow: hidden;
 	width: 100%;
 
 	// The color rows butt up against each other into a single bordered list
@@ -130,4 +125,115 @@
 .newspack-prompt-style-colors__popover.components-dropdown__content .components-popover__content {
 	padding: 16px;
 	width: 260px;
+}
+
+// Edit Styles drawer: a right-edge slide-in panel built on @wordpress/components
+// Modal with custom overlay/frame classes so it anchors to the right instead of
+// rendering centered. No overlay shim: the page stays visible, and the frame's
+// left border stands in for the ring the controls used to carry.
+.newspack-prompt-style-drawer__overlay {
+	align-items: stretch;
+	background: none;
+	justify-content: flex-end;
+	padding: 0;
+}
+
+// The slide-in deliberately carries no fill: its end state is the frame's
+// natural position, and a persisting transform would become the containing
+// block that fixed-position popovers inside the drawer anchor to.
+.components-modal__frame.newspack-prompt-style-drawer {
+	animation: 0.2s ease-out newspack-prompt-style-drawer-slide-in;
+	border-left: wp-vars.$border-width solid wp-colors.$gray-300;
+	border-radius: 0;
+	box-shadow: none;
+	display: flex;
+	flex-direction: column;
+	height: 100%;
+	margin: 0;
+	max-height: none;
+	max-width: wp-vars.$sidebar-width;
+	width: 100%;
+
+	// Drop the modal's built-in content padding so the panels sit flush against
+	// the drawer's edges with only their own padding, and let the inner wrappers
+	// flex so the content area scrolls within the full height.
+	.components-modal__content {
+		display: flex;
+		flex-direction: column;
+		padding: 0;
+	}
+
+	.components-modal__children-container {
+		display: flex;
+		flex: 1 1 auto;
+		flex-direction: column;
+		min-height: 0;
+	}
+}
+
+@keyframes newspack-prompt-style-drawer-slide-in {
+	from {
+		transform: translateX( 100% );
+	}
+
+	to {
+		transform: translateX( 0 );
+	}
+}
+
+@keyframes newspack-prompt-style-drawer-slide-out {
+	from {
+		transform: translateX( 0 );
+	}
+
+	to {
+		transform: translateX( 100% );
+	}
+}
+
+// Mirror the slide-in with a slide-out on close. @wp/components' Modal adds
+// `is-animating-out` and keeps the panel mounted until an animationend fires
+// (which bubbles up from the frame), so animating the frame is enough. Suppress
+// the overlay's default disappear animation so the motion stays a slide, not a
+// fade. The compound selector outweighs the base frame rule in the cascade.
+.components-modal__screen-overlay.newspack-prompt-style-drawer__overlay.is-animating-out {
+	animation: none;
+}
+
+.components-modal__screen-overlay.newspack-prompt-style-drawer__overlay.is-animating-out .components-modal__frame {
+	animation: 0.2s ease-in forwards newspack-prompt-style-drawer-slide-out;
+}
+
+@media ( prefers-reduced-motion: reduce ) {
+	.newspack-prompt-style-drawer__overlay,
+	.components-modal__frame.newspack-prompt-style-drawer,
+	.components-modal__screen-overlay.newspack-prompt-style-drawer__overlay.is-animating-out .components-modal__frame {
+		animation: none;
+	}
+}
+
+.newspack-prompt-style-drawer__header {
+	flex: 0 0 auto;
+	padding: wp-vars.$grid-unit-15 wp-vars.$grid-unit-20;
+}
+
+.newspack-prompt-style-drawer__title {
+	flex: 1;
+	font-size: inherit;
+	font-weight: wp-vars.$font-weight-medium;
+	margin: 0;
+}
+
+.newspack-prompt-style-drawer__content {
+	flex: 1 1 auto;
+	overflow-y: auto;
+
+	// The last panel's controls otherwise end flush against the footer's border.
+	padding-bottom: wp-vars.$grid-unit-20;
+}
+
+.newspack-prompt-style-drawer__footer {
+	border-top: wp-vars.$border-width solid wp-colors.$gray-300;
+	flex: 0 0 auto;
+	padding: wp-vars.$grid-unit-20;
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -241,9 +241,6 @@
 .newspack-prompt-style-drawer__content {
 	flex: 1 1 auto;
 	overflow-y: auto;
-
-	// The last panel's controls otherwise end flush against the footer's border.
-	padding-bottom: wp-vars.$grid-unit-20;
 }
 
 // The notice sits between the scrolling content and the footer, so it keeps its
@@ -254,7 +251,12 @@
 }
 
 .newspack-prompt-style-drawer__footer {
-	border-top: wp-vars.$border-width solid wp-colors.$gray-300;
 	flex: 0 0 auto;
 	padding: wp-vars.$grid-unit-20;
+
+	// The two actions split the row evenly.
+	.components-button {
+		flex: 1;
+		justify-content: center;
+	}
 }

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -202,10 +202,14 @@
 }
 
 // Mirror the slide-in with a slide-out on close. @wp/components' Modal adds
-// `is-animating-out` and keeps the panel mounted until an animationend fires
-// (which bubbles up from the frame), so animating the frame is enough. Suppress
-// the overlay's default disappear animation so the motion stays a slide, not a
-// fade. The compound selector outweighs the base frame rule in the cascade.
+// `is-animating-out` and keeps the panel mounted while it plays, but it only
+// listens for an animationend from its own `components-modal__disappear-animation`;
+// under a custom animation name every close instead resolves on its fallback
+// timeout, the core frame animation duration times 1.2 (200ms * 1.2 = 240ms).
+// The slide-out must therefore stay at or below that 200ms frame duration, or
+// the unmount cuts it short. Suppress the overlay's default disappear animation
+// so the motion stays a slide, not a fade. The compound selector outweighs the
+// base frame rule in the cascade.
 .components-modal__screen-overlay.newspack-prompt-style-drawer__overlay.is-animating-out {
 	animation: none;
 }
@@ -240,6 +244,13 @@
 
 	// The last panel's controls otherwise end flush against the footer's border.
 	padding-bottom: wp-vars.$grid-unit-20;
+}
+
+// The notice sits between the scrolling content and the footer, so it keeps its
+// own height instead of being squashed by the column's flex distribution.
+.newspack-prompt-style-drawer__notice {
+	flex: 0 0 auto;
+	margin: 0;
 }
 
 .newspack-prompt-style-drawer__footer {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -143,9 +143,12 @@
 // block that fixed-position popovers inside the drawer anchor to.
 .components-modal__frame.newspack-prompt-style-drawer {
 	animation: 0.2s ease-out newspack-prompt-style-drawer-slide-in;
-	border-left: wp-vars.$border-width solid wp-colors.$gray-300;
 	border-radius: 0;
-	box-shadow: none;
+
+	// The dividing line is a shadow rather than a border so it sits outside the
+	// box and the inside keeps the full 280px width. Also displaces core's
+	// default frame shadow.
+	box-shadow: -#{wp-vars.$border-width} 0 0 wp-colors.$gray-300;
 	display: flex;
 	flex-direction: column;
 	height: 100%;

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -1,7 +1,8 @@
 /**
- * Contextual Prompts Style section: the site-wide style control groups a classic
- * theme gets. Block themes have no section — the wizard header hands off to the
- * Site Editor instead, which index.test.js covers.
+ * Contextual Prompts style controls: the site-wide style control groups a
+ * classic theme gets, hosted in the Edit Styles drawer. Block themes have no
+ * controls — the wizard header hands off to the Site Editor instead. The drawer
+ * and handoff flows live in index.test.js.
  */
 
 /**


### PR DESCRIPTION
## What

On a classic theme, the Contextual Prompts wizard no longer renders a Style section in the tab body. Instead, the header gets the same treatment block themes already have: an **Edit Styles** secondary button between the ⋮ menu and Save. On a classic theme it opens a right-edge slide-in drawer (280px) hosting the existing style controls; on a block theme it keeps handing off to the Site Editor's Styles panel.

## Details

- `StyleSection` loses its Grid/SectionHeader wrapper chrome and now renders just the ringless controls stack; the drawer provides the width and border.
- New `StyleDrawer`: built on `@wordpress/components` Modal with custom overlay/frame classes (same approach as the subscribers-demo drawer), slide-in/out animation with `prefers-reduced-motion` handling, no overlay shim, and a `$gray-300` left border standing in for the ring the controls used to carry.
- The drawer carries its own Cancel/Save. Save posts the profile (styles included only when dirty) and closes on success. Cancel with unsaved style edits prompts through the tab's existing unsaved-changes dialog; a second dialog instance would fight the first one's history block, so they share it. Discard reverts to the last saved snapshot.
- Popovers inside the drawer (color palettes, panel menus) render into a `Popover.Slot` in the dialog. Without it they portal to a body-level container the Modal can hold `aria-hidden`, dropping them from the accessibility tree; the wizard's global `.modal-open` popover-hiding rule is also overridden inside the drawer only.
- Core's modal frame has a 350px `min-width` floor that would beat the 280px cap, so the drawer zeroes it.

## Testing

1. On a classic theme, open Audience → Campaigns → Contextual Prompts (feature enabled).
2. The tab body has no Style section; the header shows Edit Styles between ⋮ and Save.
3. Edit Styles slides the drawer in from the right with no dark overlay. All four panels (Color, Typography, Padding, Border) work, including the color palette popovers.
4. Edit a style, hit Cancel: one discard prompt. Cancel it → drawer stays with the edit; Discard Changes → drawer closes and the edit reverts.
5. Edit a style, hit the drawer's Save: saves, closes the drawer, persists after reload.
6. Escape and the X close the drawer, with the same discard prompt when dirty.
7. On a block theme, Edit Styles still hands off to the Site Editor.

Full jest suite passes (53 suites / 506 tests).