### PR TITLE
fix(env): match loopback aliases whole, not as a substring

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -438,12 +438,33 @@ jobs:
           retention-days: 14
 
   # ----------------------------------------------------------------------------
+  shell-tests:
+    name: Shell specs
+    # Not gated on changed-packages: these cover bin/ and `n`, which belong to no
+    # package, so a tooling-only PR would otherwise run nothing at all.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: bin/tests
+        run: |
+          shopt -s nullglob
+          specs=(bin/tests/*.sh)
+          if [ ${#specs[@]} -eq 0 ]; then
+            echo "No shell specs found in bin/tests/."
+            exit 1
+          fi
+          for spec in "${specs[@]}"; do
+            echo "--- $spec"
+            bash "$spec"
+          done
+
+  # ----------------------------------------------------------------------------
   ci-ok:
     name: CI OK
     # `install` is in the needs list so a `--frozen-lockfile` failure on a
     # root-deps-only PR (empty js/php matrices) is treated as a CI failure
     # rather than masked by the skipped matrix jobs.
-    needs: [install, js, php-lint, php-lint-non-workspace, php-test, build-zips, bundle-zips]
+    needs: [install, js, php-lint, php-lint-non-workspace, php-test, build-zips, bundle-zips, shell-tests]
     if: always()
     runs-on: ubuntu-latest
     steps:

--- a/bin/_common.sh
+++ b/bin/_common.sh
@@ -1,6 +1,11 @@
 #!/bin/bash
 
-NABSPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+# Derived unless the caller already set it to a real workspace root: `n` resolves
+# symlinks with `pwd -P` and that form has to survive being sourced here. An
+# inherited value is checked rather than trusted — bin/worktree.sh removes trees
+# under $NABSPATH, so a root arriving from the environment would delete elsewhere.
+[[ -n "${NABSPATH:-}" && -f "$NABSPATH/n" ]] ||
+    NABSPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 
 validate_name() {
     if [[ ! "$1" =~ ^[a-zA-Z0-9._/-]+$ ]] || [[ "$1" == *..* ]] || [[ "$1" == /* ]]; then
@@ -29,6 +34,18 @@ validate_port() {
         echo "Error: invalid port '$1' (must be a number between 1 and 65535)"
         exit 1
     fi
+}
+
+# Is this loopback alias up on lo0? (macOS only — Linux routes all 127.x.x.x by
+# default.) The address is compared whole, as a field of its own: loopback
+# addresses are prefixes of each other (127.0.0.2 sits inside 127.0.0.24) and the
+# low ones are recycled while higher envs stay up, so a substring test reports a
+# free address as already aliased — and the env then dies binding a port on an
+# address the host does not have. Returns 0 (shell true) when the address is up;
+# `found` is unset, and so awk-numeric 0, when it is not. An unreadable lo0 is
+# therefore reported absent, which makes the caller create the alias.
+lo0_alias_exists() {
+    ifconfig lo0 2>/dev/null | awk -v ip="$1" '$1 == "inet" && $2 == ip { found = 1 } END { exit !found }'
 }
 
 # Logging helpers — mirror the colored output used by bin/site-setup.sh.

--- a/bin/env.sh
+++ b/bin/env.sh
@@ -323,7 +323,7 @@ networks:
 YAML
         echo "Created $compose_file (db: $db_name, domain: $domain, ip: $ip)"
         # Check networking prerequisites (macOS only — Linux routes all 127.x.x.x by default).
-        if [[ "$(uname)" == "Darwin" ]] && ! ifconfig lo0 2>/dev/null | grep -q "$ip"; then
+        if [[ "$(uname)" == "Darwin" ]] && ! lo0_alias_exists "$ip"; then
             if command -v newspack-manage-host >/dev/null 2>&1; then
                 sudo newspack-manage-host alias-add "$ip"
             else
@@ -440,7 +440,7 @@ MIGRATE
         # Re-read domain after potential migration.
         domain=$(domain_for_env "$compose_file")
         # Ensure loopback alias exists (macOS only — Linux routes all 127.x.x.x by default).
-        if [[ "$(uname)" == "Darwin" && -n "$ip" && "$ip" != "127.0.0.1" ]] && ! ifconfig lo0 | grep -q "$ip"; then
+        if [[ "$(uname)" == "Darwin" && -n "$ip" && "$ip" != "127.0.0.1" ]] && ! lo0_alias_exists "$ip"; then
             if command -v newspack-manage-host >/dev/null 2>&1; then
                 sudo newspack-manage-host alias-add "$ip"
             else

--- a/bin/repos.sh
+++ b/bin/repos.sh
@@ -75,10 +75,11 @@ get_standalone_repo_host_path() {
 # Prints nothing; returns 0 when standalone, 1 otherwise. Needs $NABSPATH.
 #
 # Both toplevels are taken from git (physical, symlink-resolved paths) so the
-# comparison holds even when $NABSPATH reaches the workspace through a symlink
-# (bin/_common.sh derives it with a plain `pwd`, which keeps symlinks). A raw
-# string compare against $NABSPATH would misclassify an unzipped plugin as
-# standalone in that case.
+# comparison holds even when $NABSPATH reaches the workspace through a symlink,
+# which it can: bin/_common.sh derives it with a plain `pwd`, which keeps
+# symlinks, unless the caller set it first (`n` resolves them with `pwd -P`).
+# Against a symlinked $NABSPATH a raw string compare would misclassify an
+# unzipped plugin as standalone.
 is_standalone_git_repo() {
 	local host_path="$1"
 	local dir="$NABSPATH/$host_path"

--- a/bin/tests/test-lo0-alias-exists.sh
+++ b/bin/tests/test-lo0-alias-exists.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+#
+# test-lo0-alias-exists.sh
+#
+# Self-proving spec for lo0_alias_exists (_common.sh): the address is matched
+# whole, never as a substring.
+#
+# Loopback addresses are prefixes of each other — 127.0.0.2 sits inside
+# 127.0.0.24 — and the aliases are recycled, so the low ones come free again
+# while high ones stay up. A substring test therefore reports 127.0.0.2 present
+# the moment any 127.0.0.2X exists, `n env create` / `n env up` skip creating
+# the alias, and Docker fails the env with "can't assign requested address"
+# binding a port on an address nothing listens on.
+#
+# Run: bash bin/tests/test-lo0-alias-exists.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../_common.sh
+. "$SCRIPT_DIR/../_common.sh"
+
+WORK=$(mktemp -d -t lo0-alias-XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+
+# Stub ifconfig with a host whose low aliases have been recycled away: .11 and
+# .24-.26 are up, .2-.10 are not. macOS always follows the address with a
+# netmask; the trailing .30 is synthetic, pinning the case where the address
+# ends its line.
+cat > "$WORK/ifconfig" <<'STUB'
+#!/usr/bin/env bash
+cat <<'OUT'
+lo0: flags=8049<UP,LOOPBACK,RUNNING,MULTICAST> mtu 16384
+	options=1203<RXCSUM,TXCSUM,TXSTATUS,SW_TIMESTAMP>
+	inet 127.0.0.1 netmask 0xff000000
+	inet6 ::1 prefixlen 128
+	inet6 fe80::1%lo0 prefixlen 64 scopeid 0x1
+	inet 127.0.0.11 netmask 0xff000000
+	inet 127.0.0.24 netmask 0xff000000
+	inet 127.0.0.25 netmask 0xff000000
+	inet 127.0.0.26 netmask 0xff000000
+	inet 127.0.0.30
+OUT
+STUB
+chmod +x "$WORK/ifconfig"
+PATH="$WORK:$PATH"
+
+failures=0
+assert_alias() {
+	local ip="$1" want="$2" desc="$3" got
+	if lo0_alias_exists "$ip"; then got=present; else got=absent; fi
+	if [[ "$got" == "$want" ]]; then
+		echo "  ok: $desc"
+	else
+		echo "  FAIL: $desc — want $want, got $got"
+		failures=$((failures + 1))
+	fi
+}
+
+echo "lo0_alias_exists:"
+assert_alias 127.0.0.24 present "an alias that is up reads present"
+assert_alias 127.0.0.5 absent "an alias that was never created reads absent"
+assert_alias 127.0.0.2 absent "a recycled alias reads absent though 127.0.0.24 is up"
+assert_alias 127.0.0.3 absent "a recycled alias reads absent though 127.0.0.30 is up"
+assert_alias 127.0.0.1 present "a prefix that is itself up still reads present"
+assert_alias 127.0.0.30 present "an address ending its line reads present"
+
+# The fail-safe direction. An unreadable lo0 must read absent, so the caller
+# creates the alias; a wrong "present" is the shape of the bug above — skip the
+# creation, then fail to bind a port on an address the host does not have.
+mkdir -p "$WORK/broken"
+cat > "$WORK/broken/ifconfig" <<'STUB'
+#!/usr/bin/env bash
+echo "ifconfig: interface lo0 does not exist" >&2
+exit 1
+STUB
+chmod +x "$WORK/broken/ifconfig"
+if ( PATH="$WORK/broken:$PATH"; lo0_alias_exists 127.0.0.24 ); then
+	echo "  FAIL: an unreadable lo0 must read absent — got present"
+	failures=$((failures + 1))
+else
+	echo "  ok: an unreadable lo0 reads absent, so the caller creates the alias"
+fi
+
+if [[ "$failures" -gt 0 ]]; then
+	echo "$failures assertion(s) failed"
+	exit 1
+fi
+echo "All assertions passed."

--- a/n
+++ b/n
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 NABSPATH="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd -P)"
+source "$(dirname "${BASH_SOURCE[0]}")/bin/_common.sh"
 source "$(dirname "${BASH_SOURCE[0]}")/bin/repos.sh"
 
 # Use -it flags only when TTY is available
@@ -180,10 +181,9 @@ start() {
     # These don't survive reboots, so this runs on every start.
     if [[ "$(uname)" == "Darwin" ]]; then
         missing_aliases=()
-        lo0_addrs=$(ifconfig lo0 2>/dev/null)
         for octet in $(seq 2 100); do
             ip="127.0.0.$octet"
-            if ! echo "$lo0_addrs" | grep -qE "inet $ip( |$)"; then
+            if ! lo0_alias_exists "$ip"; then
                 missing_aliases+=("$ip")
             fi
         done


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`n env create` and `n env up` tested for an existing lo0 alias with an unanchored substring grep:

```sh
! ifconfig lo0 2>/dev/null | grep -q "$ip"
```

Loopback addresses are prefixes of each other, and the low ones get recycled while higher-numbered envs stay up. So on a machine holding `127.0.0.11` and `127.0.0.24`–`127.0.0.58`, asking about `127.0.0.2` matched the substring inside a live `inet 127.0.0.24`. Both commands concluded the alias already existed, skipped `newspack-manage-host alias-add`, and Docker then failed the env:

```
Error response from daemon: ports are not available: exposing port TCP 127.0.0.2:443 ->
127.0.0.1:0: listen tcp4 127.0.0.2:443: bind: can't assign requested address
```

The `/etc/hosts` entry was still written, since that step has no such check — which is what pins the diagnosis to the alias step alone. It fires on exactly the recycled low addresses (`127.0.0.2`–`127.0.0.5` are all prefixes of live aliases), so it gets commoner as a fleet ages.

**The check is now one helper**, `lo0_alias_exists` in `bin/_common.sh`, comparing the address as a whole `awk` field. All three call sites use it — `bin/env.sh` twice, and `n start`'s pre-allocation loop, **whose own copy was already correct**. That is the point of routing it through one definition: the correct form existed in the repo and simply wasn't used where it mattered, and two definitions of one predicate is how that survived.

`n` now sources `bin/_common.sh`. It sets `NABSPATH` *before* doing so, and `_common.sh` derives `NABSPATH` only when the caller has not already set it to a real workspace root — so `n`'s symlink-resolved `pwd -P` form survives, an inherited value is validated rather than trusted, and the ordering is enforced by the code instead of by a comment. Behaviour is unchanged for the other three scripts that source it.

`bin/tests/test-lo0-alias-exists.sh` is a new self-contained spec pinning the whole-field match and the fail-safe direction (an unreadable `lo0` must read *absent*, so the caller creates the alias — a wrong "present" is the shape of this bug). A new `shell-tests` CI job runs everything in `bin/tests/`, so the spec cannot rot; it is deliberately **not** gated on `changed-packages`, because `bin/` and `n` belong to no package and a tooling-only PR would otherwise run nothing at all.

### How to test the changes in this Pull Request:

1. Reproduce the false positive on any machine with a high loopback alias up. With `127.0.0.24` aliased and `127.0.0.2` not:
   ```sh
   ifconfig lo0 | grep -q "127.0.0.2" && echo "old check: present (wrong)"
   source bin/_common.sh && { lo0_alias_exists 127.0.0.2 && echo present || echo "new check: absent (correct)"; }
   ```
2. Run the spec — 7/7 pass: `bash bin/tests/test-lo0-alias-exists.sh`
3. Confirm it genuinely regresses the bug: swap the helper body back to `ifconfig lo0 2>/dev/null | grep -q "$1"` and re-run. It fails 2 assertions (the two recycled-alias cases) and exits 1.
4. End-to-end: `n env create` an env that lands on a recycled low address, then `n env up` it. Before this change the container fails to start with `can't assign requested address`; after it, the alias is created and the env serves.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Verified end-to-end on a real stuck env: the alias was created, `n env up` reported the env ready, `curl` returned HTTP 200, and Docker bound `127.0.0.2:80/443`. The `awk` form was also measured against the loop it replaces in `n start` — it is *faster* (~0.34s vs ~0.88s for 99 addresses), since the previous form forked `echo | grep` per iteration.
