### PR TITLE
prototype: make Audience Management an explicit prerequisite for Access Control

### DIFF
--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-content-gates.php
@@ -95,12 +95,18 @@ class Audience_Content_Gates extends Wizard {
 			'newspack-wizards',
 			'newspackAudienceContentGates',
 			[
-				'api'                     => '/' . NEWSPACK_API_NAMESPACE . '/wizard/' . $this->slug,
-				'available_access_rules'  => Access_Rules::get_access_rules(),
-				'available_content_rules' => Content_Rules::get_content_rules(),
-				'edit_gate_layout_url'    => Content_Gate::get_edit_gate_layout_url(),
-				'presave_checks_enabled'  => Content_Gate::get_presave_checks_enabled(),
-				'default_gate_status'     => Content_Gate::get_default_new_gate_status(),
+				'api'                         => '/' . NEWSPACK_API_NAMESPACE . '/wizard/' . $this->slug,
+				'available_access_rules'      => Access_Rules::get_access_rules(),
+				'available_content_rules'     => Content_Rules::get_content_rules(),
+				'edit_gate_layout_url'        => Content_Gate::get_edit_gate_layout_url(),
+				'presave_checks_enabled'      => Content_Gate::get_presave_checks_enabled(),
+				'default_gate_status'         => Content_Gate::get_default_new_gate_status(),
+				// NPPD-1846: Audience Management is a prerequisite for Access
+				// Control. Without it there is no reader registration, magic
+				// link login, account email or My Account page for a gate to
+				// hand off to.
+				'audience_management_enabled' => Reader_Activation::is_enabled(),
+				'audience_management_url'     => admin_url( 'admin.php?page=newspack-audience' ),
 			]
 		);
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/audience-management-required.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/audience-management-required.tsx
@@ -1,0 +1,46 @@
+/**
+ * Audience Management prerequisite state for Access Control.
+ */
+
+/**
+ * WordPress dependencies.
+ */
+import { __ } from '@wordpress/i18n';
+import { ExternalLink, __experimentalVStack as VStack } from '@wordpress/components'; // eslint-disable-line @wordpress/no-unsafe-wp-apis
+import { people } from '@wordpress/icons';
+
+/**
+ * Internal dependencies
+ */
+import { Button, Grid, SectionHeader } from '../../../../../packages/components/src';
+
+const AudienceManagementRequired = () => {
+	const audienceManagementUrl = window.newspackAudienceContentGates?.audience_management_url || '';
+
+	return (
+		<Grid columns={ 4 } noMargin>
+			<VStack start={ 2 } end={ 4 } spacing={ 8 }>
+				<SectionHeader
+					icon={ people }
+					title={ __( 'Set up Audience Management first', 'newspack-plugin' ) }
+					description={ __(
+						'Access Control needs reader accounts, sign-in and account emails. Audience Management provides them.',
+						'newspack-plugin'
+					) }
+					pageHeader
+					noMargin
+				/>
+				<VStack alignment="center" spacing={ 4 }>
+					<Button variant="primary" href={ audienceManagementUrl }>
+						{ __( 'Set up Audience Management', 'newspack-plugin' ) }
+					</Button>
+					<ExternalLink href="https://help.newspack.com/engagement/reader-activation-system/">
+						{ __( 'Learn more', 'newspack-plugin' ) }
+					</ExternalLink>
+				</VStack>
+			</VStack>
+		</Grid>
+	);
+};
+
+export default AudienceManagementRequired;

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates.tsx
@@ -17,6 +17,7 @@ import { Divider, Grid } from '../../../../../packages/components/src';
 import { useWizardData } from '../../../../../packages/components/src/wizard/store/utils';
 import { useWizardApiFetch } from '../../../hooks/use-wizard-api-fetch';
 import { WIZARD_STORE_NAMESPACE } from '../../../../../packages/components/src/wizard/store';
+import AudienceManagementRequired from './audience-management-required';
 import ContentGatesOnboarding from './content-gates-onboarding';
 import ContentGatesPriority from './content-gates-priority';
 import ContentGateSettings from './content-gate-settings';
@@ -36,12 +37,16 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 	const config = ( wizardData?.config || {} ) as GateSettings;
 	const hasMetering = gates.some( gate => gate.registration?.metering?.enabled || gate.custom_access?.metering?.enabled );
 	const hasInstitutions = !! config.has_institutions;
+	// Audience Management is a hard prerequisite: without it there is no reader
+	// registration, login, account email or account page for a gate to hand off
+	// to. wp_localize_script() stringifies booleans, so '' means off.
+	const hasAudienceManagement = Boolean( window.newspackAudienceContentGates?.audience_management_enabled );
 
 	useEffect( () => {
 		if ( isFetching ) {
 			return;
 		}
-		if ( ! gates?.length ) {
+		if ( ! hasAudienceManagement || ! gates?.length ) {
 			resetHeaderData();
 			return;
 		}
@@ -82,7 +87,7 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 			sectionMenu,
 			sectionSecondaryAction: hasInstitutions ? institutionsLink : undefined,
 		} );
-	}, [ isFetching, gates, hasInstitutions ] );
+	}, [ isFetching, gates, hasInstitutions, hasAudienceManagement ] );
 
 	const toggleCountdownBanner = useRef< () => void >();
 	const handleToggleCountdownBanner = () => {
@@ -160,6 +165,10 @@ const ContentGates = ( { updateGatesData }: { updateGatesData: ( gates: Gate[] )
 			} );
 		}
 	}, [ errorMessage ] );
+
+	if ( ! hasAudienceManagement ) {
+		return <AudienceManagementRequired />;
+	}
 
 	if ( ! gates?.length ) {
 		return <ContentGatesOnboarding />;

--- a/plugins/newspack-plugin/src/wizards/types/window.d.ts
+++ b/plugins/newspack-plugin/src/wizards/types/window.d.ts
@@ -81,6 +81,10 @@ declare global {
 			// wp_localize_script() stringifies booleans ('1'/''); the wizard writes real booleans back.
 			presave_checks_enabled: boolean | string;
 			default_gate_status: GateStatus;
+			// NPPD-1846: Audience Management prerequisite. Stringified by
+			// wp_localize_script(), so '' means off.
+			audience_management_enabled: boolean | string;
+			audience_management_url: string;
 		};
 	}
 }


### PR DESCRIPTION
**Prototype, not an implementation.** Do not merge. This exists so the design can be seen running, and so the code can be lifted into a proper implementation.

Linear: [NPPD-1846](https://linear.app/a8c/issue/NPPD-1846/make-audience-management-dependency-explicit-for-access-control)

## The problem

Access Control appears whenever `NEWSPACK_CONTENT_GATES` is defined, and never checks Reader Activation. The ticket describes the symptom as broken UI in `/my-account`, but that undersells it. With Audience Management off, all of these bail out:

| What | Where |
| --- | --- |
| Reader registration hooks | `class-reader-registration.php:28` |
| Magic links (passwordless login) | `class-magic-link.php`, 7 guards |
| Newspack My Account shell | `class-my-account.php:116` |
| Auth / account emails | `class-reader-activation-emails.php:39` |
| Reader session hydration | `class-session-hydration.php:102` |
| ESP contact sync | `sync/class-sync.php:76` |
| `has_reader_activation` for blocks | `class-blocks.php:71` |

Meanwhile `class-content-gate.php` has no Reader Activation dependency at all, so gates happily restrict content. A registration wall built without Audience Management locks readers out and gives them no way in.

## What this does

Blocks the Access Control screen when Audience Management is off, replacing it with a prerequisite state that links into the Audience Management setup flow.

The submenu item deliberately stays visible. Hiding it would make the dependency invisible again, which is the opposite of what the ticket asks for.

## Why one screen is enough

Gate creation is the only door. The other candidate entry points are all downstream of a gate already existing:

- **Editor sidebar panel** returns early at `class-content-gate.php:474` when `count( self::get_gates() ) === 0`.
- **Gate layout editor** is reached through a nonce'd `newspack_edit_gate_layout` action from the wizard, so it is not a standalone entry point.
- **Newspack Dashboard** does not link to Access Control.

## Deliberately not included

1. **REST route guard.** `register_api_endpoints()` guards on `is_feature_enabled()` only. The same Audience Management check belongs beside it, otherwise a stale tab can still POST a gate into existence. The design assumes this exists.
2. **Orphaned gates.** Gates published while Audience Management was off keep restricting content, and once this ships nobody can reach them to unpublish. Needs its own decision, likely a product call rather than a design one.
3. **The help doc.** [help.newspack.com/access-control](https://help.newspack.com/access-control/) still does not list Audience Management as a dependency, which was the original question that started the thread. Not a code change, still unowned.

## Verified

Both directions checked on a local site: Audience Management off shows the prerequisite state with no "Add Content Gate" action, Audience Management on still renders the gate list with its header action intact. ESLint and PHPCS clean.