### PR TITLE
ci: pin vipwpcs to ~3.0.1 until posts_per_page audit (NPPM-3055)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=8.0"
 	},
 	"require-dev": {
-		"automattic/vipwpcs": "^3.0",
+		"automattic/vipwpcs": "~3.0.1",
 		"wp-coding-standards/wpcs": "^3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Every PHPCS CI run that lints `newspack-plugin` started failing today on files untouched by the PRs being checked. The PHPCS job installs the coding standards fresh on each run (there is no committed `composer.lock`, and the root `composer.json` allows `automattic/vipwpcs: ^3.0`), and `vipwpcs 3.1.0` — released today — added a new check ([Automattic/VIP-Coding-Standards#882](https://github.com/Automattic/VIP-Coding-Standards/pull/882)) that flags `posts_per_page => -1` as an error. The repo has ~15 pre-existing usages, so CI is red for every PR that lints the plugin, on both `main`- and `release`-based branches.

This pins `automattic/vipwpcs` to `~3.0.1` so CI resolves the last known-good version and PRs unblock immediately. It's deliberately an interim measure: the real work in NPPM-3055 — auditing the `posts_per_page => -1` usages and either fixing the query args or annotating intentional unbounded queries — can then land calmly, after which the pin can be relaxed.

Verified by reproducing the CI job's exact steps locally on this branch: a fresh `composer install` (no lockfile) resolves `vipwpcs 3.0.1` alongside the still-floating `wpcs 3.4.1` (the same combination as this morning's green runs), and `composer phpcs -- plugins/newspack-plugin` exits 0.

Part of NPPM-3055 (interim unblock — the underlying `posts_per_page` audit stays open).

### How to test the changes in this Pull Request:

1. Confirm the PHPCS / newspack check on this PR is green (it runs the exact code path this change fixes).
2. Locally: at the workspace root on this branch, remove `vendor/` and any `composer.lock`, run `composer install`, and confirm the output locks `automattic/vipwpcs (3.0.1)`.
3. Run `composer phpcs -- plugins/newspack-plugin` — exits 0 with no `WordPressVIPMinimum.Performance.NoPaging` errors.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (n/a — CI dependency pin)
* [x] Have you successfully run tests with your changes locally?
