### PR TITLE
chore: address vipwpcs 3.1.0 posts_per_page sniff errors (NPPM-3055)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=8.0"
 	},
 	"require-dev": {
-		"automattic/vipwpcs": "~3.0.1",
+		"automattic/vipwpcs": "^3.0",
 		"wp-coding-standards/wpcs": "^3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",

--- a/plugins/newspack-ads/includes/providers/gam/class-gam-model.php
+++ b/plugins/newspack-ads/includes/providers/gam/class-gam-model.php
@@ -418,7 +418,7 @@ final class GAM_Model {
 		$query           = new \WP_Query(
 			[
 				'post_type'      => self::$custom_post_type,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Legacy ad-unit CPT; config-scale.
 				'post_status'    => [ 'publish' ],
 			]
 		);

--- a/plugins/newspack-listings/tests/test-blocks.php
+++ b/plugins/newspack-listings/tests/test-blocks.php
@@ -23,7 +23,7 @@ class BlocksTest extends WP_UnitTestCase {
 
 		// Set default block options for Curated List.
 		$block_json = json_decode(
-			file_get_contents( NEWSPACK_LISTINGS_PLUGIN_FILE . '/src/blocks/curated-list/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents
+			file_get_contents( NEWSPACK_LISTINGS_PLUGIN_FILE . '/src/blocks/curated-list/block.json' ), // phpcs:ignore WordPress.WP.AlternativeFunctions.file_get_contents_file_get_contents, WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown -- Reads the block's bundled block.json from the local filesystem.
 			true
 		);
 		foreach ( $block_json['attributes'] as $attribute => $options ) {

--- a/plugins/newspack-network/includes/cli/backfillers/class-membership-plan-updated.php
+++ b/plugins/newspack-network/includes/cli/backfillers/class-membership-plan-updated.php
@@ -45,7 +45,7 @@ class Membership_Plan_Updated extends Abstract_Backfiller {
 			[
 				'post_type'   => Memberships_Admin::MEMBERSHIP_PLANS_CPT,
 				'post_status' => 'any',
-				'numberposts' => -1,
+				'numberposts' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Operator-run CLI command; unbounded by design.
 				'date_query'  => [
 					'column'    => 'post_modified_gmt',
 					'after'     => $this->start,

--- a/plugins/newspack-network/includes/cli/backfillers/class-product-updated.php
+++ b/plugins/newspack-network/includes/cli/backfillers/class-product-updated.php
@@ -41,7 +41,7 @@ class Product_Updated extends Abstract_Backfiller {
 			[
 				'post_type'   => 'product',
 				'post_status' => 'any',
-				'numberposts' => -1,
+				'numberposts' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Operator-run CLI command; unbounded by design.
 				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					[
 						'key'     => Product_Admin::NETWORK_ID_META_KEY,

--- a/plugins/newspack-network/includes/cli/backfillers/class-woocommerce-membership-updated.php
+++ b/plugins/newspack-network/includes/cli/backfillers/class-woocommerce-membership-updated.php
@@ -38,7 +38,7 @@ class Woocommerce_Membership_Updated extends Abstract_Backfiller {
 			[
 				'post_type'   => 'wc_user_membership',
 				'post_status' => 'any',
-				'numberposts' => -1,
+				'numberposts' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Operator-run CLI command; unbounded by design.
 				'fields'      => 'ids',
 				'date_query'  => [
 					'column'    => 'post_modified_gmt',

--- a/plugins/newspack-network/includes/cli/class-product-network-ids.php
+++ b/plugins/newspack-network/includes/cli/class-product-network-ids.php
@@ -857,7 +857,7 @@ class Product_Network_Ids {
 			[
 				'post_type'   => Memberships_Admin::MEMBERSHIP_PLANS_CPT,
 				'post_status' => 'any',
-				'numberposts' => -1,
+				'numberposts' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Operator-run CLI command; unbounded by design.
 				'fields'      => 'ids',
 			]
 		);
@@ -998,7 +998,7 @@ class Product_Network_Ids {
 			[
 				'post_type'   => 'product',
 				'post_status' => 'any',
-				'numberposts' => -1,
+				'numberposts' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Operator-run CLI command; unbounded by design.
 				'fields'      => 'ids',
 				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					[

--- a/plugins/newspack-network/includes/content-distribution/class-distributor-migrator.php
+++ b/plugins/newspack-network/includes/content-distribution/class-distributor-migrator.php
@@ -230,7 +230,7 @@ class Distributor_Migrator {
 		return get_posts(
 			[
 				'post_type'      => 'dt_subscription',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- One-time migration over the Distributor subscription CPT.
 				'fields'         => 'ids',
 			]
 		);

--- a/plugins/newspack-network/includes/hub/admin/class-woo.php
+++ b/plugins/newspack-network/includes/hub/admin/class-woo.php
@@ -60,7 +60,7 @@ abstract class Woo {
 			add_filter( 'disable_formats_dropdown', [ __CLASS__, 'disable_restrict_manage_posts' ], 10, 2 );
 
 			add_action( 'restrict_manage_posts', [ __CLASS__, 'restrict_manage_posts' ], 10, 2 );
-			add_filter( 'pre_get_posts', [ __CLASS__, 'pre_get_posts' ] );
+			add_action( 'pre_get_posts', [ __CLASS__, 'pre_get_posts' ] );
 		}
 	}
 

--- a/plugins/newspack-network/includes/hub/class-nodes.php
+++ b/plugins/newspack-network/includes/hub/class-nodes.php
@@ -69,7 +69,7 @@ class Nodes {
 		$nodes  = get_posts(
 			[
 				'post_type'      => self::POST_TYPE_SLUG,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Network nodes CPT; a network has a handful of nodes.
 				'fields'         => 'ids',
 			]
 		);

--- a/plugins/newspack-newsletters/includes/ads/class-ads-placements.php
+++ b/plugins/newspack-newsletters/includes/ads/class-ads-placements.php
@@ -79,7 +79,7 @@ final class Ads_Placements {
 		$placement_ads = get_posts(
 			[
 				'post_type'      => Ads::CPT,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Newsletter ads CPT; config-scale.
 				'tax_query'      => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 					[
 						'taxonomy' => self::TAXONOMY,

--- a/plugins/newspack-newsletters/includes/ads/class-ads.php
+++ b/plugins/newspack-newsletters/includes/ads/class-ads.php
@@ -592,7 +592,7 @@ final class Ads {
 		$all_ads = get_posts(
 			[
 				'post_type'      => self::CPT,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Newsletter ads CPT; config-scale.
 			]
 		);
 		$ads     = [];

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-layouts.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-layouts.php
@@ -353,7 +353,7 @@ final class Newspack_Newsletters_Layouts {
 		$layouts_query = new WP_Query(
 			[
 				'post_type'      => self::NEWSPACK_NEWSLETTERS_LAYOUT_CPT,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Newsletter layout CPT; config-scale.
 			]
 		);
 		$author_cache  = [];

--- a/plugins/newspack-newsletters/includes/class-subscription-lists.php
+++ b/plugins/newspack-newsletters/includes/class-subscription-lists.php
@@ -405,7 +405,7 @@ class Subscription_Lists {
 		$posts   = get_posts(
 			[
 				'post_type'      => self::CPT,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Subscription-list CPT; config-scale.
 				'post_status'    => 'any',
 			]
 		);

--- a/plugins/newspack-newsletters/tests/test-ads-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-ads-list-rest.php
@@ -5,6 +5,8 @@
  * @package Newspack_Newsletters
  */
 
+// phpcs:disable WordPressVIPMinimum.Performance.NoPaging -- Unbounded queries are acceptable in tests.
+
 use Newspack\Newsletters\Admin\Ads_List_REST;
 use Newspack_Newsletters\Ads;
 

--- a/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
@@ -5,6 +5,8 @@
  * @package Newspack_Newsletters
  */
 
+// phpcs:disable WordPressVIPMinimum.Performance.NoPaging -- Unbounded queries are acceptable in tests.
+
 use Newspack\Newsletters\Admin\Newsletters_List_REST;
 
 /**

--- a/plugins/newspack-plugin/includes/class-donations.php
+++ b/plugins/newspack-plugin/includes/class-donations.php
@@ -326,7 +326,7 @@ class Donations {
 			[
 				'post_type'      => 'product',
 				'post_status'    => 'any',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Donation-flagged products only; small meta-filtered set.
 				'fields'         => 'ids',
 				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					[

--- a/plugins/newspack-plugin/includes/class-starter-content.php
+++ b/plugins/newspack-plugin/includes/class-starter-content.php
@@ -197,7 +197,7 @@ class Starter_Content {
 		$file = wp_upload_bits(
 			'newspack-logomark.png',
 			null,
-			file_get_contents( NEWSPACK_ABSPATH . 'includes/raw_assets/images/newspack-logomark.png' )
+			file_get_contents( NEWSPACK_ABSPATH . 'includes/raw_assets/images/newspack-logomark.png' ) // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown -- Reads a bundled plugin asset from the local filesystem.
 		);
 
 		if ( ! $file || empty( $file['file'] ) ) {

--- a/plugins/newspack-plugin/includes/cli/class-co-authors-plus.php
+++ b/plugins/newspack-plugin/includes/cli/class-co-authors-plus.php
@@ -148,7 +148,7 @@ class Co_Authors_Plus {
 
 		$get_posts_args = [
 			'post_type'      => 'guest-author',
-			'posts_per_page' => -1,
+			'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Operator-run CLI command; unbounded by design.
 			'post_status'    => 'any',
 		];
 		if ( self::$guest_author_ids !== false && is_array( self::$guest_author_ids ) ) {
@@ -365,7 +365,7 @@ class Co_Authors_Plus {
 		$linked_guest_authors = get_posts(
 			[
 				'post_type'      => 'guest-author',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Operator-run CLI command; unbounded by design.
 				'post_status'    => 'any',
 				'meta_query'     => [ $meta_query ], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			]

--- a/plugins/newspack-plugin/includes/cli/class-teams-for-memberships-diagnostics.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-for-memberships-diagnostics.php
@@ -178,7 +178,7 @@ class Teams_For_Memberships_Diagnostics {
 				[
 					'post_type'      => 'wc_memberships_team',
 					'post_status'    => 'any',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Operator-run CLI command; unbounded by design.
 					'author'         => $target->post_author,
 				]
 			);
@@ -762,7 +762,7 @@ class Teams_For_Memberships_Diagnostics {
 		$query_args = [
 			'post_type'      => 'wc_memberships_team',
 			'post_status'    => 'any',
-			'posts_per_page' => -1,
+			'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Operator-run CLI command; unbounded by design.
 		];
 		if ( self::$team_id ) {
 			$query_args['p'] = self::$team_id;

--- a/plugins/newspack-plugin/includes/cli/class-teams-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-migration.php
@@ -4,8 +4,10 @@
  * Newspack Access Control group subscriptions, plus a backfill for group managers.
  *
  * Ported from the standalone `migrate-memberships` drop-in so the tooling ships
- * with the plugin (CLI classes load only under WP_CLI, so there is no web-request
- * cost) and writes through the real Group_Subscription data layer.
+ * with the plugin and writes through the real Group_Subscription data layer. Note
+ * that CLI\Initializer::init() includes this file on every request; only the
+ * WP_CLI::add_command() registration is gated behind WP_CLI, so nothing here should
+ * assume a CLI-only execution context.
  *
  * Member and manager writes go through update_members()/add_manager(), which fire
  * only the group cache-reset hook — no data events, ESP sync, or emails. WooCommerce

--- a/plugins/newspack-plugin/includes/cli/class-teams-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-migration.php
@@ -17,6 +17,8 @@
  * @package Newspack
  */
 
+// phpcs:disable WordPressVIPMinimum.Performance.NoPaging -- Operator-run CLI command; unbounded by design.
+
 namespace Newspack\CLI;
 
 use Newspack\Group_Subscription;

--- a/plugins/newspack-plugin/includes/collections/class-query-helper.php
+++ b/plugins/newspack-plugin/includes/collections/class-query-helper.php
@@ -299,7 +299,7 @@ class Query_Helper {
 			[
 				'post_type'      => 'post',
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Posts in a single collection; bounded editorial set.
 				'tax_query'      => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 					[
 						'taxonomy' => Collection_Taxonomy::get_taxonomy(),

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -1694,7 +1694,7 @@ class Content_Gate {
 			[
 				'post_type'      => $post_type,
 				'post_status'    => $post_status ? $post_status : self::get_post_statuses(),
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Content-gate CPT; config-scale.
 				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					[
 						'key'     => 'is_newsletter',

--- a/plugins/newspack-plugin/includes/content-gate/class-institution.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-institution.php
@@ -136,7 +136,7 @@ class Institution {
 			[
 				'post_type'      => self::POST_TYPE,
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Institution CPT; config-scale.
 				'orderby'        => 'title',
 				'order'          => 'ASC',
 			]
@@ -188,7 +188,7 @@ class Institution {
 			[
 				'post_type'      => self::POST_TYPE,
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Institution CPT; config-scale.
 			]
 		);
 		$institutions = [];

--- a/plugins/newspack-plugin/includes/corrections/class-corrections.php
+++ b/plugins/newspack-plugin/includes/corrections/class-corrections.php
@@ -313,7 +313,7 @@ class Corrections {
 	public static function get_corrections( $post_id ) {
 		$corrections = get_posts( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
 			[
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Corrections attached to a single post; per-post bounded.
 				'post_type'      => self::POST_TYPE,
 				'post_status'    => 'any',
 				'meta_key'       => self::CORRECTION_POST_ID_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key

--- a/plugins/newspack-plugin/includes/emails/class-emails.php
+++ b/plugins/newspack-plugin/includes/emails/class-emails.php
@@ -372,7 +372,7 @@ class Emails {
 		$templates = get_posts(
 			[
 				'post_type'      => self::POST_TYPE,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- One-time migration over a handful of email templates.
 				'post_status'    => 'publish',
 			]
 		);
@@ -1320,7 +1320,7 @@ class Emails {
 			$templates = get_posts(
 				[
 					'post_type'      => self::POST_TYPE,
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Email-template CPT; config-scale.
 					'post_status'    => 'publish',
 				]
 			);

--- a/plugins/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php
+++ b/plugins/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php
@@ -305,7 +305,7 @@ class Memberships {
 			[
 				'post_type'      => self::GATE_CPT,
 				'post_status'    => [ 'publish', 'draft', 'trash', 'pending', 'future' ],
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Content-gate CPT; config-scale.
 			]
 		);
 		foreach ( $gates as $gate ) {

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-renewal.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-renewal.php
@@ -31,7 +31,7 @@ class Renewal {
 		add_action( 'init', [ __CLASS__, 'add_renewal_endpoint' ] );
 		if ( ! is_admin() ) {
 			add_filter( 'woocommerce_get_query_vars', [ __CLASS__, 'add_renewal_query_var' ] );
-			add_filter( 'pre_get_posts', [ __CLASS__, 'maybe_redirect_renewal_endpoint' ] );
+			add_action( 'pre_get_posts', [ __CLASS__, 'maybe_redirect_renewal_endpoint' ] );
 		}
 	}
 
@@ -81,7 +81,7 @@ class Renewal {
 	 *
 	 * @param \WP_Query $query Query object.
 	 */
-	public static function maybe_redirect_renewal_endpoint( $query ) { // phpcs:ignore WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.VoidReturn, WordPressVIPMinimum.Hooks.AlwaysReturnInFilter.MissingReturnStatement
+	public static function maybe_redirect_renewal_endpoint( $query ) {
 		if (
 			! $query->is_main_query() ||
 			! isset( $query->query_vars[ self::RENEWAL_ENDPOINT ] )

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -856,7 +856,7 @@ class Group_Subscription_Settings {
 		$product_ids = \get_posts( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
 			[
 				'post_type'      => [ 'product', 'product_variation' ],
-				'posts_per_page' => -1, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
+				'posts_per_page' => -1, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page, WordPressVIPMinimum.Performance.NoPaging -- Group-subscription-enabled products only; small meta-filtered set.
 				'fields'         => 'ids',
 				'meta_key'       => $meta_key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value'     => 'yes', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value

--- a/plugins/newspack-plugin/includes/starter_content/class-starter-content-generated.php
+++ b/plugins/newspack-plugin/includes/starter_content/class-starter-content-generated.php
@@ -252,7 +252,7 @@ class Starter_Content_Generated extends Starter_Content_Provider {
 	 */
 	public static function generate_title( $post_index = 0 ) {
 		if ( Starter_Content::is_e2e() ) {
-			return $post_index . ' ' . file_get_contents( NEWSPACK_ABSPATH . 'includes/raw_assets/markup/title.txt' );
+			return $post_index . ' ' . file_get_contents( NEWSPACK_ABSPATH . 'includes/raw_assets/markup/title.txt' ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown -- Reads a bundled plugin asset from the local filesystem.
 		}
 		$title = self::get_lipsum( 'words', wp_rand( 7, 14 ) );
 		$title = ucfirst( strtolower( str_replace( '.', '', $title ) ) ); // Remove periods, convert to sentence case.
@@ -397,7 +397,7 @@ class Starter_Content_Generated extends Starter_Content_Provider {
 	 */
 	public static function get_lipsum( $type, $amount ) {
 		if ( Starter_Content::is_e2e() ) {
-			return file_get_contents( NEWSPACK_ABSPATH . 'includes/raw_assets/markup/body.txt' );
+			return file_get_contents( NEWSPACK_ABSPATH . 'includes/raw_assets/markup/body.txt' ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown -- Reads a bundled plugin asset from the local filesystem.
 		}
 		if ( 'paras' === $type ) {
 			return implode( PHP_EOL, self::lipsum_paragraphs( $amount ) );

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscription-products.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscription-products.php
@@ -1591,7 +1591,7 @@ class Audience_Subscription_Products extends Wizard {
 			[
 				'post_type'      => Content_Gate::get_gate_post_types(),
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Content-gate CPT; config-scale (result is cached).
 			]
 		);
 

--- a/plugins/newspack-plugin/tests/unit-tests/collections/class-test-post-type.php
+++ b/plugins/newspack-plugin/tests/unit-tests/collections/class-test-post-type.php
@@ -237,7 +237,7 @@ class Test_Post_Type extends WP_UnitTestCase {
 				'post_type'      => Post_Type::get_post_type(),
 				'orderby'        => self::$order_column_name,
 				'order'          => 'ASC',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Unbounded queries are acceptable in tests.
 			]
 		);
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
@@ -2990,7 +2990,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 				[
 					'post_type'      => Content_Gate::GATE_LAYOUT_CPT,
 					'post_status'    => 'any',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Unbounded queries are acceptable in tests.
 					'fields'         => 'ids',
 				]
 			);

--- a/plugins/newspack-plugin/tests/unit-tests/webhooks.php
+++ b/plugins/newspack-plugin/tests/unit-tests/webhooks.php
@@ -5,6 +5,8 @@
  * @package Newspack\Tests
  */
 
+// phpcs:disable WordPressVIPMinimum.Performance.NoPaging -- Unbounded queries are acceptable in tests.
+
 use Newspack\Data_Events;
 
 /**

--- a/plugins/newspack-popups/includes/class-newspack-popups-expiry.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-expiry.php
@@ -121,7 +121,7 @@ final class Newspack_Popups_Expiry {
 			[
 				'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Prompt CPT; config-scale.
 				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					'relation' => 'AND',
 					[

--- a/plugins/newspack-popups/includes/class-newspack-popups-model.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-model.php
@@ -110,7 +110,7 @@ final class Newspack_Popups_Model {
 				[
 					'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 					'post_status'    => 'publish',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Prompt CPT; config-scale.
 				]
 			),
 			true

--- a/plugins/newspack-popups/includes/class-newspack-popups-model.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-model.php
@@ -110,7 +110,7 @@ final class Newspack_Popups_Model {
 				[
 					'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 					'post_status'    => 'publish',
-					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Prompt CPT; config-scale.
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Prompt CPT; accepted cost. Unlike retrieve_popups() above this is frontend-reachable, so a cap would change which prompts render and is left to a follow-up.
 				]
 			),
 			true

--- a/plugins/newspack-popups/includes/class-newspack-popups-settings.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-settings.php
@@ -246,7 +246,10 @@ class Newspack_Popups_Settings {
 				'post_type'      => 'page',
 				'post_status'    => 'publish',
 				'post_parent'    => 0,
-				'posts_per_page' => 1000, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Deliberate cap to keep the query bounded on sites with very many top-level pages.
+				// This list doubles as the save allow-list in update_setting(), so a cap would make
+				// pages outside the window silently unsaveable. Left unbounded until the setting
+				// moves to an autocomplete field and stops enumerating pages.
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- See above; bounding this changes behavior, not just cost.
 			]
 		);
 		// Remove the query filter so we don't unintentionally affect other queries.

--- a/plugins/newspack-popups/includes/class-newspack-popups-settings.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-settings.php
@@ -246,7 +246,7 @@ class Newspack_Popups_Settings {
 				'post_type'      => 'page',
 				'post_status'    => 'publish',
 				'post_parent'    => 0,
-				'posts_per_page' => -1,
+				'posts_per_page' => 1000, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page -- Deliberate cap to keep the query bounded on sites with very many top-level pages.
 			]
 		);
 		// Remove the query filter so we don't unintentionally affect other queries.

--- a/plugins/newspack-popups/includes/class-newspack-popups.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups.php
@@ -1280,7 +1280,7 @@ final class Newspack_Popups {
 				'fields'           => 'ids',
 				'post_status'      => 'any',
 				'post_type'        => self::NEWSPACK_POPUPS_CPT,
-				'posts_per_page'   => -1,
+				'posts_per_page'   => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Prompt CPT; config-scale.
 			]
 		);
 

--- a/plugins/newspack-popups/includes/class-newspack-segments-model.php
+++ b/plugins/newspack-popups/includes/class-newspack-segments-model.php
@@ -439,7 +439,7 @@ final class Newspack_Segments_Model {
 			[
 				'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 				'fields'         => 'ids',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Prompt IDs for a single segment; config-scale.
 				'tax_query'      => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 					[
 						'taxonomy' => self::TAX_SLUG,

--- a/plugins/newspack-story-budget/includes/class-api.php
+++ b/plugins/newspack-story-budget/includes/class-api.php
@@ -578,7 +578,7 @@ class API {
 		$query_args = [
 			'story_budget_search' => true,
 			'fields'              => 'ids',
-			'posts_per_page'      => -1,
+			'posts_per_page'      => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Tax-scoped to active budgets; bounded editorial set.
 			's'                   => $request->get_param( 's' ) ?? '',
 		];
 
@@ -932,7 +932,7 @@ class API {
 		$query_args = [
 			'story_budget_search' => true,
 			'fields'              => 'ids',
-			'posts_per_page'      => -1,
+			'posts_per_page'      => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Tax-scoped to active budgets; bounded editorial set.
 			's'                   => $request->get_param( 's' ) ?? '',
 		];
 

--- a/plugins/newspack-story-budget/includes/class-api.php
+++ b/plugins/newspack-story-budget/includes/class-api.php
@@ -578,7 +578,7 @@ class API {
 		$query_args = [
 			'story_budget_search' => true,
 			'fields'              => 'ids',
-			'posts_per_page'      => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Tax-scoped to active budgets; bounded editorial set.
+			'posts_per_page'      => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Accepted cost on an authenticated editorial screen: the story_budget_search shape (postmeta JOIN + leading-wildcard LIKE) is the expense here, not the row count. Capping is a behavior change left to a follow-up.
 			's'                   => $request->get_param( 's' ) ?? '',
 		];
 
@@ -932,7 +932,7 @@ class API {
 		$query_args = [
 			'story_budget_search' => true,
 			'fields'              => 'ids',
-			'posts_per_page'      => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Tax-scoped to active budgets; bounded editorial set.
+			'posts_per_page'      => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Accepted cost on an authenticated editorial screen: the story_budget_search shape (postmeta JOIN + leading-wildcard LIKE) is the expense here, not the row count. Capping is a behavior change left to a follow-up.
 			's'                   => $request->get_param( 's' ) ?? '',
 		];
 

--- a/plugins/newspack-story-budget/includes/class-budgets.php
+++ b/plugins/newspack-story-budget/includes/class-budgets.php
@@ -171,7 +171,7 @@ class Budgets {
 			[
 				'post_type'      => self::get_post_types(),
 				'post_status'    => [ 'publish', 'pending', 'draft', 'future', 'private' ],
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging -- Tax-scoped to active budgets; bounded editorial set.
 			]
 		);
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`vipwpcs 3.1.0` added a check that flags `posts_per_page`/`numberposts` set to `-1` as an error ([Automattic/VIP-Coding-Standards#882](https://github.com/Automattic/VIP-Coding-Standards/pull/882)), which turned CI red for every PR that lints an affected plugin (`release` was unblocked by pinning to `~3.0.1` in #740; `main` is unpinned and still red). This addresses all **66 occurrences** across the workspace — the audit and per-bucket decisions are on NPPM-3055 — so `main` lints clean against the current standards, and the `release` pin can be reverted once this is promoted:

- **Test files (26) and WP-CLI commands (14):** dismissed via `phpcs:ignore`/file-level `phpcs:disable` — not production code, and CLI commands are intentionally unbounded operator tooling. Files with three or more occurrences (two newsletters REST test files, the webhooks tests, the teams-migration CLI) use a file-level disable; the rest are inline.
- **Runtime queries against bounded, config-scale CPTs (25):** inline `phpcs:ignore` with a one-line justification each (gates, prompts, ad units, newsletter layouts, subscription lists, network nodes, email templates, per-post corrections, meta-flagged product sets, budget-scoped stories). One line extends an existing ignore: the old `WordPress.WP.PostsPerPage` code does not suppress the new sniff.
- **No behavior changes.** An earlier revision capped the Campaigns donor-landing-page query at 1000; review showed that list doubles as the server-side save allow-list, so a cap made pages outside the window silently unsaveable. It is back to `-1` with a comment explaining why bounding it is not a cost-only change. Moving that setting to an autocomplete field — which removes the enumeration, the allow-list and the query together — is a separate follow-up, as are optional caps on `retrieve_active_popups()` and the two Story Budget typeahead queries.
- **Unpin:** reverts the interim `~3.0.1` pin from #740 (which reached `main` via the post-release branch sync) back to `^3.0`, so the unpin lands alongside the fixes it depends on. Verified end-state: a fresh `composer install` on this branch resolves vipwpcs 3.1.0 and the full lint scope passes.

The new standards also surface warnings, which fail CI the same as errors. Those are addressed too:

- **WCS renewal redirect (`AlwaysReturnInFilter.TerminatingInsteadOfReturn`):** fixed in code rather than dismissed. `pre_get_posts` is a core **action**, but the redirect callback was registered with `add_filter`, which is what put it in the sniff's scope (and had already accumulated two suppressions for related messages). Registering with `add_action` — the same registry call, zero behavior change — resolves the new warning at the root and allowed **removing** the two pre-existing ignores on the callback.
- **Starter content (3) and a listings test (1) `FetchingRemoteData.FileGetContentsUnknown`:** dismissed with justifications — all four read bundled plugin assets from the local filesystem (setup-time starter content and a test fixture), not remote URLs.

The only findings left anywhere in the workspace lint scope are two `DuplicateClassName` warnings in popups test mocks that fire solely in whole-workspace scans (the mock shadows a newsletters class, and per-package CI never scans both plugins together) — invisible to CI, left alone.

Closes NPPM-3055. Promotion to `release` carries the unpin there — no separate revert needed.

### How to test the changes in this Pull Request:

1. CI on this PR is the primary test: with the pin reverted, the PHPCS jobs for all six touched plugins re-resolve the latest standards (vipwpcs 3.1.0) and must pass.
2. Locally: `composer install` at the workspace root on this branch (resolves vipwpcs 3.1.0), then `vendor/bin/phpcs --standard=phpcs.xml --sniffs=WordPressVIPMinimum.Performance.NoPaging` — zero errors (was 66).
3. Per-package, exactly as CI invokes it: `composer phpcs -- "$PWD/plugins/<name>"` for each of the seven touched plugins — all exit 0. A whole-workspace `vendor/bin/phpcs --standard=phpcs.xml` reports only 2 `DuplicateClassName` warnings in popups test mocks, which fire solely in cross-plugin scans and are invisible to per-package CI.
4. Campaigns → Settings → Donor landing page (behavior unchanged by this PR): the field is a text input, and saving a valid published top-level page ID still succeeds — including the oldest pages on a site with many of them.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (n/a — lint annotations + a query cap; existing suites pass: newspack-popups 253 tests OK, newspack-plugin full suite OK)
* [x] Have you successfully run tests with your changes locally?

