### PR TITLE
fix: audit posts_per_page => -1 usages after vipwpcs 3.1.0 (NPPM-3055, #740)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=8.0"
 	},
 	"require-dev": {
-		"automattic/vipwpcs": "~3.1.0",
+		"automattic/vipwpcs": "~3.0.1",
 		"wp-coding-standards/wpcs": "^3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",

--- a/plugins/newspack-ads/includes/providers/gam/class-gam-model.php
+++ b/plugins/newspack-ads/includes/providers/gam/class-gam-model.php
@@ -418,7 +418,7 @@ final class GAM_Model {
 		$query           = new \WP_Query(
 			[
 				'post_type'      => self::$custom_post_type,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'post_status'    => [ 'publish' ],
 			]
 		);

--- a/plugins/newspack-network/includes/cli/backfillers/class-membership-plan-updated.php
+++ b/plugins/newspack-network/includes/cli/backfillers/class-membership-plan-updated.php
@@ -45,7 +45,7 @@ class Membership_Plan_Updated extends Abstract_Backfiller {
 			[
 				'post_type'   => Memberships_Admin::MEMBERSHIP_PLANS_CPT,
 				'post_status' => 'any',
-				'numberposts' => -1,
+				'numberposts' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_numberposts
 				'date_query'  => [
 					'column'    => 'post_modified_gmt',
 					'after'     => $this->start,

--- a/plugins/newspack-network/includes/cli/backfillers/class-product-updated.php
+++ b/plugins/newspack-network/includes/cli/backfillers/class-product-updated.php
@@ -41,7 +41,7 @@ class Product_Updated extends Abstract_Backfiller {
 			[
 				'post_type'   => 'product',
 				'post_status' => 'any',
-				'numberposts' => -1,
+				'numberposts' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_numberposts
 				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					[
 						'key'     => Product_Admin::NETWORK_ID_META_KEY,

--- a/plugins/newspack-network/includes/cli/backfillers/class-woocommerce-membership-updated.php
+++ b/plugins/newspack-network/includes/cli/backfillers/class-woocommerce-membership-updated.php
@@ -38,7 +38,7 @@ class Woocommerce_Membership_Updated extends Abstract_Backfiller {
 			[
 				'post_type'   => 'wc_user_membership',
 				'post_status' => 'any',
-				'numberposts' => -1,
+				'numberposts' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_numberposts
 				'fields'      => 'ids',
 				'date_query'  => [
 					'column'    => 'post_modified_gmt',

--- a/plugins/newspack-network/includes/cli/class-product-network-ids.php
+++ b/plugins/newspack-network/includes/cli/class-product-network-ids.php
@@ -857,7 +857,7 @@ class Product_Network_Ids {
 			[
 				'post_type'   => Memberships_Admin::MEMBERSHIP_PLANS_CPT,
 				'post_status' => 'any',
-				'numberposts' => -1,
+				'numberposts' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_numberposts
 				'fields'      => 'ids',
 			]
 		);
@@ -998,7 +998,7 @@ class Product_Network_Ids {
 			[
 				'post_type'   => 'product',
 				'post_status' => 'any',
-				'numberposts' => -1,
+				'numberposts' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_numberposts
 				'fields'      => 'ids',
 				'meta_query'  => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					[

--- a/plugins/newspack-network/includes/content-distribution/class-distributor-migrator.php
+++ b/plugins/newspack-network/includes/content-distribution/class-distributor-migrator.php
@@ -230,7 +230,7 @@ class Distributor_Migrator {
 		return get_posts(
 			[
 				'post_type'      => 'dt_subscription',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'fields'         => 'ids',
 			]
 		);

--- a/plugins/newspack-network/includes/hub/class-nodes.php
+++ b/plugins/newspack-network/includes/hub/class-nodes.php
@@ -69,7 +69,7 @@ class Nodes {
 		$nodes  = get_posts(
 			[
 				'post_type'      => self::POST_TYPE_SLUG,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'fields'         => 'ids',
 			]
 		);

--- a/plugins/newspack-newsletters/includes/ads/class-ads-placements.php
+++ b/plugins/newspack-newsletters/includes/ads/class-ads-placements.php
@@ -79,7 +79,7 @@ final class Ads_Placements {
 		$placement_ads = get_posts(
 			[
 				'post_type'      => Ads::CPT,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'tax_query'      => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 					[
 						'taxonomy' => self::TAXONOMY,

--- a/plugins/newspack-newsletters/includes/ads/class-ads.php
+++ b/plugins/newspack-newsletters/includes/ads/class-ads.php
@@ -592,7 +592,7 @@ final class Ads {
 		$all_ads = get_posts(
 			[
 				'post_type'      => self::CPT,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 			]
 		);
 		$ads     = [];

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-layouts.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-layouts.php
@@ -353,7 +353,7 @@ final class Newspack_Newsletters_Layouts {
 		$layouts_query = new WP_Query(
 			[
 				'post_type'      => self::NEWSPACK_NEWSLETTERS_LAYOUT_CPT,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 			]
 		);
 		$author_cache  = [];

--- a/plugins/newspack-newsletters/includes/class-subscription-lists.php
+++ b/plugins/newspack-newsletters/includes/class-subscription-lists.php
@@ -405,7 +405,7 @@ class Subscription_Lists {
 		$posts   = get_posts(
 			[
 				'post_type'      => self::CPT,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'post_status'    => 'any',
 			]
 		);

--- a/plugins/newspack-newsletters/tests/test-ads-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-ads-list-rest.php
@@ -547,7 +547,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -594,7 +594,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -657,7 +657,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -708,7 +708,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -754,7 +754,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -801,7 +801,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -818,7 +818,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -834,7 +834,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -1013,7 +1013,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 					'post_type'      => Ads::CPT,
 					'post_status'    => 'publish',
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -1056,7 +1056,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 					'post_type'      => Ads::CPT,
 					'post_status'    => 'publish',
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -1108,7 +1108,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 						'post_type'      => Ads::CPT,
 						'post_status'    => 'publish',
 						'fields'         => 'ids',
-						'posts_per_page' => -1,
+						'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 					]
 				)
 			);
@@ -1155,7 +1155,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 					'orderby'        => 'ID',
 					'order'          => 'ASC',
 				]
@@ -1251,7 +1251,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -1266,7 +1266,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -1318,7 +1318,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);
@@ -1333,7 +1333,7 @@ class Ads_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Ads::CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);

--- a/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
+++ b/plugins/newspack-newsletters/tests/test-newsletters-list-rest.php
@@ -48,7 +48,7 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 					'orderby'        => 'ID',
 					'order'          => 'ASC',
 				],
@@ -841,7 +841,7 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 					'orderby'        => 'ID',
 					'order'          => 'ASC',
 				]
@@ -894,7 +894,7 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 					'orderby'        => 'ID',
 					'order'          => 'ASC',
 				]
@@ -948,7 +948,7 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 				[
 					'post_type'      => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 					'orderby'        => 'ID',
 					'order'          => 'ASC',
 				]
@@ -1079,7 +1079,7 @@ class Newsletters_List_REST_Test extends WP_UnitTestCase {
 					'post_type'      => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
 					'post_status'    => 'publish',
 					'fields'         => 'ids',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			)
 		);

--- a/plugins/newspack-plugin/includes/class-donations.php
+++ b/plugins/newspack-plugin/includes/class-donations.php
@@ -326,7 +326,7 @@ class Donations {
 			[
 				'post_type'      => 'product',
 				'post_status'    => 'any',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'fields'         => 'ids',
 				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					[

--- a/plugins/newspack-plugin/includes/cli/class-co-authors-plus.php
+++ b/plugins/newspack-plugin/includes/cli/class-co-authors-plus.php
@@ -148,7 +148,7 @@ class Co_Authors_Plus {
 
 		$get_posts_args = [
 			'post_type'      => 'guest-author',
-			'posts_per_page' => -1,
+			'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 			'post_status'    => 'any',
 		];
 		if ( self::$guest_author_ids !== false && is_array( self::$guest_author_ids ) ) {
@@ -365,7 +365,7 @@ class Co_Authors_Plus {
 		$linked_guest_authors = get_posts(
 			[
 				'post_type'      => 'guest-author',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'post_status'    => 'any',
 				'meta_query'     => [ $meta_query ], // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 			]

--- a/plugins/newspack-plugin/includes/cli/class-teams-for-memberships-diagnostics.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-for-memberships-diagnostics.php
@@ -178,7 +178,7 @@ class Teams_For_Memberships_Diagnostics {
 				[
 					'post_type'      => 'wc_memberships_team',
 					'post_status'    => 'any',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 					'author'         => $target->post_author,
 				]
 			);
@@ -762,7 +762,7 @@ class Teams_For_Memberships_Diagnostics {
 		$query_args = [
 			'post_type'      => 'wc_memberships_team',
 			'post_status'    => 'any',
-			'posts_per_page' => -1,
+			'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 		];
 		if ( self::$team_id ) {
 			$query_args['p'] = self::$team_id;

--- a/plugins/newspack-plugin/includes/cli/class-teams-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-teams-migration.php
@@ -132,7 +132,7 @@ class Teams_Migration {
 			[
 				'post_type'      => 'wc_memberships_team',
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'fields'         => 'ids',
 				'orderby'        => 'ID',
 				'order'          => 'ASC',
@@ -454,7 +454,7 @@ class Teams_Migration {
 			[
 				'post_type'      => 'product',
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'fields'         => 'ids',
 				'orderby'        => 'ID',
 				'order'          => 'ASC',
@@ -677,7 +677,7 @@ class Teams_Migration {
 					'post_type'      => 'wc_user_membership',
 					'post_status'    => 'wcm-active',
 					'post_parent'    => $plan_id,
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 					'fields'         => 'ids',
 					'no_found_rows'  => true,
 				]
@@ -883,7 +883,7 @@ class Teams_Migration {
 			[
 				'post_type'      => 'wc_memberships_team',
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'fields'         => 'ids',
 				'orderby'        => 'ID',
 				'order'          => 'ASC',
@@ -1429,7 +1429,7 @@ class Teams_Migration {
 			[
 				'post_type'      => 'wc_membership_plan',
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'fields'         => 'ids',
 				'no_found_rows'  => true,
 				'orderby'        => 'ID',

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -1705,7 +1705,7 @@ class Content_Gate {
 			[
 				'post_type'      => $post_type,
 				'post_status'    => $post_status ? $post_status : self::get_post_statuses(),
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					[
 						'key'     => 'is_newsletter',

--- a/plugins/newspack-plugin/includes/content-gate/class-institution.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-institution.php
@@ -136,7 +136,7 @@ class Institution {
 			[
 				'post_type'      => self::POST_TYPE,
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'orderby'        => 'title',
 				'order'          => 'ASC',
 			]
@@ -188,7 +188,7 @@ class Institution {
 			[
 				'post_type'      => self::POST_TYPE,
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 			]
 		);
 		$institutions = [];

--- a/plugins/newspack-plugin/includes/corrections/class-corrections.php
+++ b/plugins/newspack-plugin/includes/corrections/class-corrections.php
@@ -313,7 +313,7 @@ class Corrections {
 	public static function get_corrections( $post_id ) {
 		$corrections = get_posts( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
 			[
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'post_type'      => self::POST_TYPE,
 				'post_status'    => 'any',
 				'meta_key'       => self::CORRECTION_POST_ID_META, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key

--- a/plugins/newspack-plugin/includes/emails/class-emails.php
+++ b/plugins/newspack-plugin/includes/emails/class-emails.php
@@ -372,7 +372,7 @@ class Emails {
 		$templates = get_posts(
 			[
 				'post_type'      => self::POST_TYPE,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'post_status'    => 'publish',
 			]
 		);
@@ -1320,7 +1320,7 @@ class Emails {
 			$templates = get_posts(
 				[
 					'post_type'      => self::POST_TYPE,
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 					'post_status'    => 'publish',
 				]
 			);

--- a/plugins/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php
+++ b/plugins/newspack-plugin/includes/plugins/wc-memberships/class-memberships.php
@@ -305,7 +305,7 @@ class Memberships {
 			[
 				'post_type'      => self::GATE_CPT,
 				'post_status'    => [ 'publish', 'draft', 'trash', 'pending', 'future' ],
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 			]
 		);
 		foreach ( $gates as $gate ) {

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/group-subscription/class-group-subscription-settings.php
@@ -910,7 +910,7 @@ class Group_Subscription_Settings {
 		$product_ids = \get_posts( // phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.get_posts_get_posts
 			[
 				'post_type'      => [ 'product', 'product_variation' ],
-				'posts_per_page' => -1, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page
+				'posts_per_page' => -1, // phpcs:ignore WordPress.WP.PostsPerPage.posts_per_page_posts_per_page, WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'fields'         => 'ids',
 				'meta_key'       => $meta_key, // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_key
 				'meta_value'     => 'yes', // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_value

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscription-products.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-subscription-products.php
@@ -1591,7 +1591,7 @@ class Audience_Subscription_Products extends Wizard {
 			[
 				'post_type'      => Content_Gate::get_gate_post_types(),
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 			]
 		);
 

--- a/plugins/newspack-plugin/tests/unit-tests/collections/class-test-post-type.php
+++ b/plugins/newspack-plugin/tests/unit-tests/collections/class-test-post-type.php
@@ -237,7 +237,7 @@ class Test_Post_Type extends WP_UnitTestCase {
 				'post_type'      => Post_Type::get_post_type(),
 				'orderby'        => self::$order_column_name,
 				'order'          => 'ASC',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 			]
 		);
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/content-gates.php
@@ -3013,7 +3013,7 @@ class Test_Content_Gates extends \WP_UnitTestCase {
 				[
 					'post_type'      => Content_Gate::GATE_LAYOUT_CPT,
 					'post_status'    => 'any',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 					'fields'         => 'ids',
 				]
 			);

--- a/plugins/newspack-plugin/tests/unit-tests/webhooks.php
+++ b/plugins/newspack-plugin/tests/unit-tests/webhooks.php
@@ -45,7 +45,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 			[
 				'post_type'      => Data_Events\Webhooks::REQUEST_POST_TYPE,
 				'post_status'    => 'any',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 			]
 		);
 		foreach ( $requests as $request ) {
@@ -341,7 +341,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 			[
 				'post_type'      => Data_Events\Webhooks::REQUEST_POST_TYPE,
 				'post_status'    => 'any',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'fields'         => 'ids',
 			]
 		);
@@ -378,7 +378,7 @@ class Newspack_Test_Webhooks extends WP_UnitTestCase {
 			[
 				'post_type'      => Data_Events\Webhooks::REQUEST_POST_TYPE,
 				'post_status'    => 'any',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'fields'         => 'ids',
 			]
 		);

--- a/plugins/newspack-popups/includes/class-newspack-popups-expiry.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-expiry.php
@@ -121,7 +121,7 @@ final class Newspack_Popups_Expiry {
 			[
 				'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 				'post_status'    => 'publish',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'meta_query'     => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					'relation' => 'AND',
 					[

--- a/plugins/newspack-popups/includes/class-newspack-popups-model.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-model.php
@@ -110,7 +110,7 @@ final class Newspack_Popups_Model {
 				[
 					'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 					'post_status'    => 'publish',
-					'posts_per_page' => -1,
+					'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				]
 			),
 			true

--- a/plugins/newspack-popups/includes/class-newspack-popups-settings.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-settings.php
@@ -246,7 +246,7 @@ class Newspack_Popups_Settings {
 				'post_type'      => 'page',
 				'post_status'    => 'publish',
 				'post_parent'    => 0,
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 			]
 		);
 		// Remove the query filter so we don't unintentionally affect other queries.

--- a/plugins/newspack-popups/includes/class-newspack-popups.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups.php
@@ -1280,7 +1280,7 @@ final class Newspack_Popups {
 				'fields'           => 'ids',
 				'post_status'      => 'any',
 				'post_type'        => self::NEWSPACK_POPUPS_CPT,
-				'posts_per_page'   => -1,
+				'posts_per_page'   => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 			]
 		);
 

--- a/plugins/newspack-popups/includes/class-newspack-segments-model.php
+++ b/plugins/newspack-popups/includes/class-newspack-segments-model.php
@@ -439,7 +439,7 @@ final class Newspack_Segments_Model {
 			[
 				'post_type'      => Newspack_Popups::NEWSPACK_POPUPS_CPT,
 				'fields'         => 'ids',
-				'posts_per_page' => -1,
+				'posts_per_page' => -1, // phpcs:ignore WordPressVIPMinimum.Performance.NoPaging.posts_per_page_posts_per_page
 				'tax_query'      => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_tax_query
 					[
 						'taxonomy' => self::TAX_SLUG,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`automattic/vipwpcs 3.1.0` (released 2026-07-27) added `WordPressVIPMinimum.Performance.NoPaging`, which flags `posts_per_page`/`numberposts` set to `-1`. #740 pinned the `release` branch to `~3.0.1` as an interim CI unblock, deferring the real audit to NPPM-3055. A same-day dependabot PR then bumped `main`'s `composer.json` back to `~3.1.0` (#744), so `main` now has the same 66 `NoPaging` errors across 35 files that #740 fixed on `release`.

This does the audit #740 deferred, and re-applies the same interim pin on `main`:

- **62 usages** annotated with `phpcs:ignore WordPressVIPMinimum.Performance.NoPaging...`: queries against small, bounded, admin-configured collections (ad units, gates, templates, prompts, network config, teams, memberships), single-entity-scoped lookups (e.g. corrections for one post), or WP-CLI migration/backfill tooling and PHPUnit fixtures — none of these run against arbitrarily-large, publisher-content-scale data on a live request path.
- **4 usages left unsuppressed**, tracked for a follow-up fix under NPPM-3055 — these look like genuine VIP-relevant gaps rather than false positives:
  - `newspack-plugin/includes/collections/class-query-helper.php:302` — Collections "posts by section", unbounded `post_type => post` query scoped to one taxonomy term (result is cached, but the query itself has no cap).
  - `newspack-story-budget/includes/class-budgets.php:174` — story listing scoped to all *active* (non-archived) budgets when no `$budget_id` is given; budgets aren't time-boxed by the code.
  - `newspack-story-budget/includes/class-api.php:581` and `:935` — REST search callbacks (`get_stories_search`, `get_budget_stories_search`) taking free-text search input with `posts_per_page => -1` and no cap at all.
- `composer.json`: re-pin `automattic/vipwpcs` to `~3.0.1`, matching #740, so CI is green regardless of the 4 open items above.

Also fixes a stale suppression: `group-subscription-settings.php:913` already had a `phpcs:ignore` for the old `WordPress.WP.PostsPerPage...` sniff code, which doesn't cover the new VIP sniff — extended it to cover both.

Part of NPPM-3055.

### How to test the changes in this Pull Request:

1. At the workspace root on this branch, remove `vendor/` and `composer.lock`, run `composer install`, and confirm it locks `automattic/vipwpcs (3.0.1)`.
2. Run `composer phpcs -- plugins themes packages config e2e phpcsSniffs` (or just `composer phpcs`) — exits 0.
3. Optional: to confirm the suppressions are correctly scoped (not just masked by the pin), temporarily bump the local `vipwpcs` requirement to `~3.1.0`, reinstall, and re-run `composer phpcs -- --sniffs=WordPressVIPMinimum.Performance.NoPaging` — only the 4 tracked/unsuppressed usages listed above should still report.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? (n/a — lint annotations and a dependency pin, no behavior change)
* [x] Have you successfully run tests with your changes locally?