### PR TITLE
ci: restore vipwpcs pin to ~3.0.1 (NPPM-3055)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -22,6 +22,13 @@ updates:
       interval: "weekly"
     labels:
       - "dependencies"
+    ignore:
+      # The root composer.json pins vipwpcs to ~3.0.1 on purpose: 3.1.0 widened
+      # WordPressVIPMinimum.Performance.NoPaging to flag posts_per_page and
+      # numberposts set to -1, which is 66 errors across six plugins and reddens
+      # CI for every PR. Dependabot raised the constraint anyway (#744), undoing
+      # the pin from #740. Lift this ignore once NPPM-3055 lands the audit.
+      - dependency-name: "automattic/vipwpcs"
 
   # GitHub Actions.
   - package-ecosystem: "github-actions"

--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,7 @@
 		"php": ">=8.0"
 	},
 	"require-dev": {
-		"automattic/vipwpcs": "~3.1.0",
+		"automattic/vipwpcs": "~3.0.1",
 		"wp-coding-standards/wpcs": "^3.0",
 		"phpcompatibility/phpcompatibility-wp": "^2.1",
 		"dealerdirect/phpcodesniffer-composer-installer": "^1.0",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

There **is** a related open PR and it should be read alongside this one: **#741** (`chore: address vipwpcs 3.1.0 posts_per_page sniff errors`, NPPM-3055) fixes the flagged call sites properly. This PR does not overlap with it or replace it — it changes only the dependency constraint and the Dependabot config, and touches none of the files #741 touches. See "Relationship to #741" below.

### Changes proposed in this Pull Request:

Restores the root `automattic/vipwpcs` constraint to `~3.0.1` and tells Dependabot to leave it alone until the audit lands.

**Why.** #740 pinned vipwpcs to `~3.0.1` on 27 Jul, deliberately, "until posts_per_page audit (NPPM-3055)". The next day #744 raised it to `~3.1.0`, undoing that pin. `main` has been failing CI ever since, and so has every open PR against it.

vipwpcs 3.1.0 rewrote `WordPressVIPMinimum.Performance.NoPaging`. Under 3.0.1 it flagged high or infinite `posts_per_page`; under 3.1.0 it also flags `posts_per_page` and `numberposts` set to `-1`. That is 66 new errors:

| plugin | hits |
| --- | --- |
| newspack-plugin | 25 |
| newspack-newsletters | 25 |
| newspack-network | 7 |
| newspack-popups | 5 |
| newspack-story-budget | 3 |
| newspack-ads | 1 |

Roughly 40 of those sit in `tests/` or `includes/cli/`. Alongside them come 4 `FetchingRemoteData.FileGetContentsUnknown` and 1 `AlwaysReturnInFilter.TerminatingInsteadOfReturn`, for 71 in total. None are regressions in our code; the rule got broader.

**What changed.**

- `composer.json`: `automattic/vipwpcs` from `~3.1.0` back to `~3.0.1`, restoring #740.
- `.github/dependabot.yml`: adds an `ignore` entry for `automattic/vipwpcs` on the root composer ecosystem, with a comment pointing at NPPM-3055. Without it Dependabot raises the constraint again and we are back here next week. The file had no ignore rules at all before this.

`wp-coding-standards/wpcs` is untouched and stays at 3.4.1, so the CVE-2026-45293 fix landing in #758 is unaffected.

**Relationship to #741.** #741 is the real fix and this is a stopgap. #741 is currently conflicting with `main` and carries a changes-requested review flagging a HIGH release risk, so it is not landing immediately. Rather than leave every PR in the repo red until it does, this restores the pin that was already agreed in #740. Once NPPM-3055 lands, drop the `ignore` block and let Dependabot raise the constraint again.

Tracked internally as NPPM-3055. There is no GitHub issue to close.

### How to test the changes in this Pull Request:

1. Reproduce the breakage on `main` first. From a clean checkout of `main`, remove any root `vendor/` and `composer.lock` (the root lock is gitignored and never committed, so CI always resolves fresh), then:
   ```
   composer install
   composer show automattic/vipwpcs      # 3.1.0
   composer phpcs -- plugins/newspack-listings
   ```
   Expect `NoPaging` errors and a non-zero exit.
2. Check out this branch, again removing root `vendor/` and `composer.lock`, and run `composer install`. Confirm `composer show automattic/vipwpcs` reports **3.0.1** and `composer show wp-coding-standards/wpcs` reports **3.4.1**.
3. Run phpcs the way CI runs it, for each affected package:
   ```
   for p in newspack-listings newspack-network newspack-story-budget \
            newspack-plugin newspack-newsletters newspack-popups newspack-ads; do
     composer phpcs -- "plugins/$p"; echo "$p exit=$?"
   done
   ```
   Every package should exit 0 with no violations.
4. Confirm Dependabot will not undo it again: `.github/dependabot.yml` should parse as valid YAML with an `ignore` entry for `automattic/vipwpcs` under the root composer ecosystem.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — not applicable; this changes a dependency constraint and CI configuration, not product code.
* [x] Have you successfully run tests with your changes locally?

On that last box, what I actually ran: a fresh root `composer install` reproducing CI's resolution exactly, then `composer phpcs` per package for all seven affected plugins (all exit 0, zero violations), plus a YAML parse of the modified `dependabot.yml`. I did not run PHPUnit, since no PHP changed.

One caveat a reviewer should not be misled by: **this PR's own green CI does not demonstrate the fix.** Because it changes no plugin package, `Detect changed packages` finds nothing and the PHPCS matrix skips. The evidence is the local run in step 3 above; the real confirmation is that #758 and other open PRs go green once this merges.

For contrast, a full-ruleset run on this branch reports only 2 `Generic.Classes.DuplicateClassName` warnings, on newspack-popups test mocks that redeclare newspack-newsletters classes. Those predate this change and only surface when both plugins are linted in a single invocation, which CI never does.
