### PR TITLE
test(scripts): include .ts/.tsx sources in jest coverage

### DIFF
--- a/packages/scripts/scripts/test.js
+++ b/packages/scripts/scripts/test.js
@@ -41,7 +41,7 @@ const JEST_CONFIG = {
 	},
 	modulePaths: [ path.resolve( modules.rootDirectory, 'node_modules' ), path.resolve( __dirname, '../node_modules' ) ],
 	testEnvironment: 'jsdom',
-	collectCoverageFrom: [ '**/*.{js,jsx}', '!**/node_modules/**', '!**/dist/**', '!**/vendor/**' ],
+	collectCoverageFrom: [ '**/*.{js,jsx,ts,tsx}', '!**/*.d.ts', '!**/node_modules/**', '!**/dist/**', '!**/vendor/**' ],
 };
 
 args.push( '--config', JSON.stringify( JEST_CONFIG ) );


### PR DESCRIPTION
## What this does and why

Follow-up to #762. That PR fixed `testMatch` so `.test.ts` / `.test.tsx` files are collected and run; this one makes their **source** count toward coverage. `collectCoverageFrom` still globbed only `{js,jsx}`, so a `--coverage` run reported nothing for TypeScript files even when they were exercised.

## Changes proposed

```diff
- collectCoverageFrom: [ '**/*.{js,jsx}', '!**/node_modules/**', '!**/dist/**', '!**/vendor/**' ],
+ collectCoverageFrom: [ '**/*.{js,jsx,ts,tsx}', '!**/*.d.ts', '!**/node_modules/**', '!**/dist/**', '!**/vendor/**' ],
```

Two parts:
- Add `ts`/`tsx` to the glob so TypeScript sources are instrumented.
- Exclude `**/*.d.ts`. Ambient type declarations (43 in the monorepo today) carry no executable code; without the exclusion each one lands in the report as a 0%-covered row — noise that drags the aggregate down.

The change is additive for `.js`/`.jsx` (their collection is unchanged). No coverage threshold is configured anywhere, and CI does not run Jest with `--coverage`, so this only affects the report a developer sees on an opt-in `--coverage` run.

## How to test

Run a Jest coverage pass that exercises a TypeScript file, e.g. the content-gate editor tests, and inspect the coverage table.

Verified locally (coverage scoped to `plugins/newspack-plugin/src/content-gate/editor`, running `block-visibility.test.ts`):
- **Before:** TypeScript source absent from the report.
- **After:** `block-visibility.tsx` is measured; the sibling `.js` files still appear; `index.d.ts` is excluded. Toggling the `!**/*.d.ts` rule confirms it is what removes the declaration file (present without it, gone with it).

Refs [NPPM-3057](https://linear.app/a8c/issue/NPPM-3057).
