### PR TITLE
fix(reader-activation): don't sync generated display names (NPPM-3018)

### DIFF
--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
@@ -1333,6 +1333,19 @@ class Contact_Sync extends Sync {
 	}
 
 	/**
+	 * Whether WooCommerce customer data is available for building contact data.
+	 *
+	 * Wraps the class_exists() check so tests can simulate a site without
+	 * WooCommerce — the suite's WC mocks are loaded process-wide, which makes
+	 * the WooCommerce-less path below unreachable through class_exists() alone.
+	 *
+	 * @return bool
+	 */
+	protected static function is_woocommerce_available() {
+		return class_exists( '\WC_Customer' );
+	}
+
+	/**
 	 * Get contact data for syncing.
 	 *
 	 * @param int           $user_id The user ID.
@@ -1349,11 +1362,18 @@ class Contact_Sync extends Sync {
 
 		$contact = [
 			'email'    => $user->user_email,
-			'name'     => $user->display_name,
 			'metadata' => [],
 		];
 
-		if ( ! class_exists( '\WC_Customer' ) ) {
+		// A display name auto-generated from the email address (e.g. "jdoe" for
+		// jdoe@example.com) is not a real name — omit it so it can't reach the
+		// ESP as the contact name. Omitted rather than '': some ESP providers
+		// write empty first/last name fields whenever the name key is present.
+		if ( ! Reader_Activation::reader_has_generic_display_name( $user_id ) ) {
+			$contact['name'] = $user->display_name;
+		}
+
+		if ( ! static::is_woocommerce_available() ) {
 			return $contact;
 		}
 		$customer = new \WC_Customer( $user_id );

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync/class-test-contact-sync-name.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync/class-test-contact-sync-name.php
@@ -1,0 +1,97 @@
+<?php // phpcs:disable Squiz.Commenting.FunctionComment.Missing, Squiz.Commenting.ClassComment.Missing, Squiz.Commenting.FileComment.Missing
+/**
+ * Tests the contact-name gating in Contact_Sync::get_contact_data() (NPPM-3018).
+ *
+ * Readers who register without a name get a display name auto-generated from
+ * the email local part (Reader_Activation::canonize_user_data()). On sites
+ * without WooCommerce, get_contact_data() returns early with the display name
+ * as the contact name, so that slug used to sync to the ESP as the reader's
+ * name (merge tags rendering "Hi stephenberkeleysidetest").
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Reader_Activation;
+use Newspack\Reader_Activation\Contact_Sync;
+use Newspack\Reader_Activation\Sync\Metadata;
+
+require_once __DIR__ . '/class-woo-less-contact-sync.php';
+
+/**
+ * Contact name in Contact_Sync::get_contact_data().
+ *
+ * @group Contact_Sync_Name
+ */
+class Test_Contact_Sync_Name extends WP_UnitTestCase {
+
+	private function create_reader( $email, $display_name ) {
+		return $this->factory()->user->create(
+			[
+				'role'         => 'subscriber',
+				'user_email'   => $email,
+				'display_name' => $display_name,
+			]
+		);
+	}
+
+	public function test_generated_display_name_is_omitted_without_woocommerce() {
+		$email   = 'stephen+test@example.com';
+		$user_id = $this->create_reader( $email, Reader_Activation::generate_user_nicename( $email ) );
+
+		$contact = Woo_Less_Contact_Sync::get_contact_data( $user_id );
+
+		$this->assertSame( $email, $contact['email'] );
+		// Absent rather than '': some ESP providers write empty first/last name
+		// fields whenever the name key is present.
+		$this->assertArrayNotHasKey( 'name', $contact, 'An auto-generated display name must not be synced as the contact name.' );
+	}
+
+	public function test_legacy_generated_display_name_is_omitted_without_woocommerce() {
+		$email = 'stephen+test@example.com';
+		// Legacy generated construction: the raw email local part.
+		$user_id = $this->create_reader( $email, Reader_Activation::strip_email_domain( $email ) );
+
+		$contact = Woo_Less_Contact_Sync::get_contact_data( $user_id );
+
+		$this->assertArrayNotHasKey( 'name', $contact, 'A legacy generated display name must not be synced as the contact name.' );
+	}
+
+	public function test_real_display_name_is_synced_without_woocommerce() {
+		$user_id = $this->create_reader( 'reader@example.com', 'Sample Reader' );
+
+		$contact = Woo_Less_Contact_Sync::get_contact_data( $user_id );
+
+		$this->assertSame( 'Sample Reader', $contact['name'], 'A reader-provided display name must be synced as the contact name.' );
+	}
+
+	public function test_intentionally_saved_generic_display_name_is_synced() {
+		$email        = 'lindy@example.com';
+		$display_name = Reader_Activation::generate_user_nicename( $email );
+		$user_id      = $this->create_reader( $email, $display_name );
+		// The reader deliberately saved a display name we would consider generic.
+		update_user_meta( $user_id, Reader_Activation::READER_SAVED_GENERIC_DISPLAY_NAME, true );
+
+		$contact = Woo_Less_Contact_Sync::get_contact_data( $user_id );
+
+		$this->assertSame( $display_name, $contact['name'], 'A deliberately saved display name must sync even when it matches the generated construction.' );
+	}
+
+	public function test_billing_name_is_used_when_woocommerce_is_available() {
+		$original_version  = Metadata::$version;
+		Metadata::$version = 'legacy';
+
+		$email   = 'buyer@example.com';
+		$user_id = $this->create_reader( $email, Reader_Activation::generate_user_nicename( $email ) );
+		// The WC_Customer mock reads billing names from first/last name user meta.
+		update_user_meta( $user_id, 'first_name', 'Sample' );
+		update_user_meta( $user_id, 'last_name', 'Buyer' );
+
+		try {
+			$contact = Contact_Sync::get_contact_data( $user_id );
+		} finally {
+			Metadata::$version = $original_version;
+		}
+
+		$this->assertSame( 'Sample Buyer', $contact['name'], 'With WooCommerce available the billing name is the contact name.' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync/class-woo-less-contact-sync.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation-sync/class-woo-less-contact-sync.php
@@ -1,0 +1,25 @@
+<?php
+/**
+ * Contact_Sync test double simulating a site without WooCommerce.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Reader_Activation\Contact_Sync;
+
+/**
+ * Simulates a site without WooCommerce. The suite's WC mocks are loaded
+ * process-wide, so the real is_woocommerce_available() check can never be
+ * false when tests run — this override makes the WooCommerce-less early
+ * return of get_contact_data() reachable.
+ */
+class Woo_Less_Contact_Sync extends Contact_Sync {
+	/**
+	 * Report WooCommerce as unavailable.
+	 *
+	 * @return bool
+	 */
+	protected static function is_woocommerce_available() {
+		return false;
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On sites without WooCommerce, contact sync sends the reader's display name to the ESP as the contact name. Readers who register without providing a name get a display name generated from the email address (`jdoe` for `jdoe@example.com`), so the ESP stores that slug as the reader's name and newsletter greetings render it ("Hi jdoe"). With WooCommerce active the contact name comes from the billing name instead, which is why activating WooCommerce made the problem disappear on affected sites.

Contact sync now omits the name when the display name was auto-generated, using the same `reader_has_generic_display_name()` check that already governs display names in My Account and comments. The name key is omitted rather than sent empty, so ESP providers leave any existing contact name untouched. Readers who deliberately saved a generic-looking name, and sites with `NEWSPACK_ALLOW_GENERIC_READER_DISPLAY_NAMES`, keep syncing their display names.

Closes NPPM-3018.

### How to test the changes in this Pull Request:

1. On a site with reader activation and ESP sync enabled and WooCommerce inactive, register a reader with only an email address. The ESP contact is created without a first or last name (previously: the email slug as First Name).
2. Give that reader a real display name (`wp user update <id> --display_name='Sample Reader'`) and run `wp newspack esp sync --user-ids=<id>`. The ESP contact now has the display name as its name.
3. Run `n test-php --filter Test_Contact_Sync_Name` in `plugins/newspack-plugin`. All 5 tests pass.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?