### PR TITLE
feat(campaigns): pin prompt children, add layout and Additional CSS

### DIFF
--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.js
@@ -54,6 +54,7 @@ const ContextualPrompts = props => {
 	const [ status, setStatus ] = useState( null );
 	const [ values, setValues ] = useState( {} );
 	const [ blockStyles, setBlockStyles ] = useState( {} );
+	const [ customCss, setCustomCss ] = useState( '' );
 	const [ inFlight, setInFlight ] = useState( false );
 	const [ error, setError ] = useState( null );
 	const [ loaded, setLoaded ] = useState( false );
@@ -67,9 +68,21 @@ const ContextualPrompts = props => {
 	const savedValuesRef = useRef( {} );
 	// Same, for the block style overrides: the save only sends them when they differ.
 	const savedStylesRef = useRef( {} );
+	// Same again, for the custom CSS, which is its own option.
+	const savedCustomCssRef = useRef( '' );
 	// Monotonic id so a slow status response can't clobber state written by a
 	// newer request or mutation.
 	const statusRequestRef = useRef( 0 );
+
+	// Re-seed the drawer's state and the snapshots its dirty check measures against.
+	const applyStyleState = next => {
+		const nextStyles = normalizeStyles( next.styles );
+		setBlockStyles( nextStyles );
+		savedStylesRef.current = nextStyles;
+		const nextCustomCss = next.custom_css || '';
+		setCustomCss( nextCustomCss );
+		savedCustomCssRef.current = nextCustomCss;
+	};
 
 	const loadStatus = () => {
 		setError( null );
@@ -84,9 +97,7 @@ const ContextualPrompts = props => {
 				const nextValues = fieldsToValues( next.fields );
 				setValues( nextValues );
 				savedValuesRef.current = nextValues;
-				const nextStyles = normalizeStyles( next.styles );
-				setBlockStyles( nextStyles );
-				savedStylesRef.current = nextStyles;
+				applyStyleState( next );
 			} )
 			.catch( err => {
 				if ( requestId === statusRequestRef.current ) {
@@ -112,9 +123,7 @@ const ContextualPrompts = props => {
 				const nextValues = fieldsToValues( next.fields );
 				setValues( nextValues );
 				savedValuesRef.current = nextValues;
-				const nextStyles = normalizeStyles( next.styles );
-				setBlockStyles( nextStyles );
-				savedStylesRef.current = nextStyles;
+				applyStyleState( next );
 				return next;
 			} )
 			.catch( err => {
@@ -138,9 +147,7 @@ const ContextualPrompts = props => {
 				const nextValues = fieldsToValues( next.fields );
 				setValues( nextValues );
 				savedValuesRef.current = nextValues;
-				const nextStyles = normalizeStyles( next.styles );
-				setBlockStyles( nextStyles );
-				savedStylesRef.current = nextStyles;
+				applyStyleState( next );
 				return next;
 			} )
 			.catch( err => {
@@ -150,12 +157,18 @@ const ContextualPrompts = props => {
 			.finally( () => setInFlight( false ) );
 	};
 	// The endpoint replaces the whole styles option when the key is present and
-	// leaves it alone when it is absent, so only an actual edit sends it.
+	// leaves it alone when it is absent, so only an actual edit sends it. The
+	// custom CSS is its own option, on the same terms.
 	const stylesDirty = ! isEqual( blockStyles, savedStylesRef.current );
+	const customCssDirty = customCss !== savedCustomCssRef.current;
+	const styleDrawerDirty = stylesDirty || customCssDirty;
 	const saveProfile = () => {
 		const data = { fields: values };
 		if ( stylesDirty ) {
 			data.styles = blockStyles;
+		}
+		if ( customCssDirty ) {
+			data.custom_css = customCss;
 		}
 		return request( PROFILE_PATH, data ).then( () => setSnackbar( __( 'Settings saved.', 'newspack-plugin' ) ) );
 	};
@@ -165,13 +178,21 @@ const ContextualPrompts = props => {
 	const saveStyles = () => {
 		setInFlight( true );
 		setError( null );
-		return apiFetch( { path: PROFILE_PATH, method: 'POST', data: { fields: {}, styles: blockStyles } } )
+		const data = { fields: {} };
+		// Each key travels only when it was edited: an unedited styles snapshot
+		// would clobber a newer save, and an unedited custom_css would fail
+		// outright for a user without `edit_css`.
+		if ( stylesDirty ) {
+			data.styles = blockStyles;
+		}
+		if ( customCssDirty ) {
+			data.custom_css = customCss;
+		}
+		return apiFetch( { path: PROFILE_PATH, method: 'POST', data } )
 			.then( next => {
 				statusRequestRef.current++;
 				setStatus( next );
-				const nextStyles = normalizeStyles( next.styles );
-				setBlockStyles( nextStyles );
-				savedStylesRef.current = nextStyles;
+				applyStyleState( next );
 				setSnackbar( __( 'Styles saved.', 'newspack-plugin' ) );
 				return next;
 			} )
@@ -184,7 +205,7 @@ const ContextualPrompts = props => {
 	const onSave = () => saveProfile().catch( () => {} );
 	const setValue = ( key, value ) => setValues( previous => ( { ...previous, [ key ]: value } ) );
 
-	const isDirty = ! valuesEqual( values, savedValuesRef.current ) || stylesDirty;
+	const isDirty = ! valuesEqual( values, savedValuesRef.current ) || styleDrawerDirty;
 	// Guard stays active during an in-flight save: the edits are only safe once
 	// a successful response has refreshed the saved snapshot.
 	const { confirmDialog, requestConfirm } = useUnsavedChangesDialog( { when: isDirty } );
@@ -195,6 +216,7 @@ const ContextualPrompts = props => {
 	// block would catch and answer with a prompt of its own.
 	const discardStyles = () => {
 		setBlockStyles( savedStylesRef.current );
+		setCustomCss( savedCustomCssRef.current );
 		setError( null );
 		setEditingStyles( false );
 	};
@@ -202,7 +224,7 @@ const ContextualPrompts = props => {
 		if ( inFlight ) {
 			return;
 		}
-		if ( stylesDirty ) {
+		if ( styleDrawerDirty ) {
 			requestConfirm( discardStyles );
 		} else {
 			setError( null );
@@ -320,10 +342,12 @@ const ContextualPrompts = props => {
 				<StyleDrawer
 					status={ status }
 					styles={ blockStyles }
+					customCss={ customCss }
 					error={ error }
 					inFlight={ inFlight }
-					isDirty={ stylesDirty }
+					isDirty={ styleDrawerDirty }
 					onChangeStyles={ setBlockStyles }
+					onChangeCustomCss={ setCustomCss }
 					onRequestClose={ onStyleDrawerClose }
 					onSave={ onStyleDrawerSave }
 				/>

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/index.test.js
@@ -44,9 +44,11 @@ const SAVED_STYLES = { color: { background: '#123456' }, border: { radius: '4px'
 const styledStatus = () => ( {
 	enabled: true,
 	can_manage: true,
+	can_edit_css: true,
 	fields: [ PROFILE_FIELD ],
 	is_block_theme: false,
 	styles: SAVED_STYLES,
+	custom_css: '',
 	style_defaults: { color: { background: '#f7f7f7' }, border: { radius: '10px' } },
 	style_palette: [ { name: 'Accent', slug: 'accent', color: '#178f15' } ],
 	style_font_sizes: [ { name: 'Small', slug: 'small', size: '14px' } ],
@@ -280,7 +282,46 @@ describe( 'ContextualPrompts tab', () => {
 		const { data } = apiFetch.mock.calls[ 1 ][ 0 ];
 		expect( data.styles ).toEqual( { color: { background: '#123456' }, border: { radius: '4px' } } );
 		expect( data.fields ).toEqual( {} );
+		// The endpoint rejects the key outright from a user who cannot write it.
+		expect( data ).not.toHaveProperty( 'custom_css' );
 		await waitFor( () => expect( drawerElement() ).toBeNull() );
+	} );
+
+	it( 'enables the drawer save on a custom CSS edit and sends it', async () => {
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		renderTab();
+		await openDrawer();
+
+		expect( drawer().getByRole( 'button', { name: 'Save' } ) ).toBeDisabled();
+
+		fireEvent.change( drawer().getByLabelText( 'Additional CSS' ), { target: { value: 'color: red;' } } );
+		expect( drawer().getByRole( 'button', { name: 'Save' } ) ).toBeEnabled();
+
+		apiFetch.mockResolvedValueOnce( { ...styledStatus(), custom_css: 'color: red;' } );
+		fireEvent.click( drawer().getByRole( 'button', { name: 'Save' } ) );
+
+		await waitFor( () => expect( apiFetch ).toHaveBeenCalledTimes( 2 ) );
+		const { data } = apiFetch.mock.calls[ 1 ][ 0 ];
+		expect( data.custom_css ).toBe( 'color: red;' );
+		// Sending the loaded snapshot back would clobber a styles save made elsewhere.
+		expect( data ).not.toHaveProperty( 'styles' );
+		await waitFor( () => expect( drawerElement() ).toBeNull() );
+	} );
+
+	it( 'confirms before Cancel discards a custom CSS edit', async () => {
+		apiFetch.mockResolvedValueOnce( styledStatus() );
+		renderTab();
+		await openDrawer();
+
+		fireEvent.change( drawer().getByLabelText( 'Additional CSS' ), { target: { value: 'color: red;' } } );
+
+		fireEvent.click( drawer().getByRole( 'button', { name: 'Cancel' } ) );
+		fireEvent.click( await screen.findByRole( 'button', { name: 'Discard Changes' } ) );
+		await waitFor( () => expect( drawerElement() ).toBeNull() );
+
+		expect( apiFetch ).toHaveBeenCalledTimes( 1 );
+		fireEvent.click( screen.getByRole( 'button', { name: 'Edit Styles' } ) );
+		expect( drawer().getByLabelText( 'Additional CSS' ) ).toHaveValue( '' );
 	} );
 
 	it( 'leaves dirty profile fields unsaved and intact when the drawer saves', async () => {

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-drawer.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-drawer.js
@@ -20,7 +20,7 @@ import { Icon, close, styles as stylesIcon } from '@wordpress/icons';
 import { Button } from '../../../../../../packages/components/src';
 import StyleSection from './style-section';
 
-const StyleDrawer = ( { status, styles, error, inFlight, isDirty, onChangeStyles, onRequestClose, onSave } ) => {
+const StyleDrawer = ( { status, styles, customCss, error, inFlight, isDirty, onChangeStyles, onChangeCustomCss, onRequestClose, onSave } ) => {
 	// Veto first: a close the parent answers with a confirm must reach it without
 	// the exit animation replaying, so only closes that really unmount go through
 	// the Modal's own Escape handler, which is what animates them. The overlay
@@ -66,7 +66,14 @@ const StyleDrawer = ( { status, styles, error, inFlight, isDirty, onChangeStyles
 					<Button icon={ close } size="small" label={ __( 'Close', 'newspack-plugin' ) } onClick={ requestClose } disabled={ inFlight } />
 				</HStack>
 				<div className="newspack-prompt-style-drawer__content">
-					<StyleSection status={ status } styles={ styles } inFlight={ inFlight } onChangeStyles={ onChangeStyles } />
+					<StyleSection
+						status={ status }
+						styles={ styles }
+						customCss={ customCss }
+						inFlight={ inFlight }
+						onChangeStyles={ onChangeStyles }
+						onChangeCustomCss={ onChangeCustomCss }
+					/>
 				</div>
 				{ error && (
 					<Notice status="error" isDismissible={ false } className="newspack-prompt-style-drawer__notice">

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.js
@@ -25,6 +25,7 @@ import {
 	FontSizePicker,
 	Notice,
 	RangeControl,
+	TextareaControl,
 	__experimentalBorderBoxControl as BorderBoxControl, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalHStack as HStack, // eslint-disable-line @wordpress/no-unsafe-wp-apis
 	__experimentalParseQuantityAndUnitFromRawValue as parseQuantityAndUnitFromRawValue, // eslint-disable-line @wordpress/no-unsafe-wp-apis
@@ -75,6 +76,8 @@ const RADIUS_SLIDER_MAX = 100;
 // The units a custom padding value may be given in while the site declares none,
 // which is the fallback core's own spacing controls carry for the same setting.
 const DEFAULT_SPACING_UNITS = [ 'px', 'em', 'rem', 'vh', 'vw', '%' ];
+
+const noop = () => {};
 
 const getPath = ( source, path ) => path.reduce( ( node, key ) => node?.[ key ], source );
 
@@ -290,8 +293,9 @@ const PaddingControl = ( { steps, units, allowCustom, values, onChange, disabled
 	);
 };
 
-const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
+const StyleSection = ( { status, styles = {}, customCss = '', inFlight, onChangeStyles, onChangeCustomCss } ) => {
 	const {
+		can_edit_css: canEditCss,
 		style_defaults: styleDefaults,
 		style_palette: stylePalette,
 		style_font_sizes: styleFontSizes,
@@ -363,6 +367,10 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 	// The slider only moves the number, so it writes back with the unit already in
 	// play, as core's BorderControl does for the border width.
 	const setRadiusQuantity = value => setRadius( undefined === value ? undefined : `${ value }${ radiusUnit || 'px' }` );
+
+	// A site can lose `edit_css` after custom CSS was written, and the stored CSS
+	// keeps rendering, so it stays visible read-only rather than disappearing.
+	const showCustomCss = canEditCss || '' !== customCss;
 
 	// ColorPalette, FontSizePicker, BoxControl and BorderBoxControl take no
 	// `disabled` prop, so the whole stack goes inert while a save is in flight.
@@ -507,6 +515,52 @@ const StyleSection = ( { status, styles = {}, inFlight, onChangeStyles } ) => {
 						</VStack>
 					</ToolsPanelItem>
 				</StylePanel>
+				{ showCustomCss &&
+					( canEditCss ? (
+						<StylePanel label={ __( 'Additional CSS', 'newspack-plugin' ) } resetAll={ () => onChangeCustomCss( '' ) }>
+							<ToolsPanelItem
+								label={ __( 'Additional CSS', 'newspack-plugin' ) }
+								hasValue={ () => '' !== customCss }
+								onDeselect={ () => onChangeCustomCss( '' ) }
+								isShownByDefault
+							>
+								<TextareaControl
+									label={ __( 'Additional CSS', 'newspack-plugin' ) }
+									hideLabelFromVision
+									className="newspack-prompt-style-custom-css"
+									value={ customCss }
+									onChange={ onChangeCustomCss }
+									rows={ 8 }
+									help={ __(
+										'These styles apply to the prompt. Declarations need no selector, and in a nested rule & refers to the prompt.',
+										'newspack-plugin'
+									) }
+									disabled={ inFlight }
+									__nextHasNoMarginBottom
+								/>
+							</ToolsPanelItem>
+						</StylePanel>
+					) : (
+						// Registering no panel item leaves the header without its options
+						// menu, so nothing offers a reset the capability no longer allows.
+						<StylePanel label={ __( 'Additional CSS', 'newspack-plugin' ) }>
+							<TextareaControl
+								label={ __( 'Additional CSS', 'newspack-plugin' ) }
+								hideLabelFromVision
+								className="newspack-prompt-style-custom-css"
+								value={ customCss }
+								onChange={ noop }
+								rows={ 8 }
+								help={ __(
+									'Additional CSS can no longer be edited on this site. These styles keep applying and are shown read-only.',
+									'newspack-plugin'
+								) }
+								disabled={ inFlight }
+								readOnly
+								__nextHasNoMarginBottom
+							/>
+						</StylePanel>
+					) ) }
 			</VStack>
 		</Disabled>
 	);

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.scss
@@ -118,6 +118,16 @@
 			flex: 1 1 60%;
 		}
 	}
+
+	// Read-only, the field is a direct child of the panel grid rather than a panel
+	// item, so it spans the columns the item would have spanned for it.
+	.newspack-prompt-style-custom-css {
+		grid-column: 1 / -1;
+
+		textarea {
+			font-family: wp-vars.$font-family-mono;
+		}
+	}
 }
 
 // Popover content is `width: min-content`, which would collapse the palette to

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/contextual-prompts/style-section.test.js
@@ -40,6 +40,7 @@ const paddingRow = index => within( document.querySelectorAll( '.newspack-prompt
 
 const CLASSIC_STATUS = {
 	is_block_theme: false,
+	can_edit_css: true,
 	style_defaults: {
 		color: { background: '#f7f7f7' },
 		border: { radius: '10px' },
@@ -72,7 +73,7 @@ describe( 'StyleSection on a classic theme', () => {
 
 		// Each group offers its resets from an options menu, not a Reset button, and
 		// the radius belongs to the Border group rather than one of its own.
-		[ 'Color', 'Typography', 'Padding', 'Border' ].forEach( label =>
+		[ 'Color', 'Typography', 'Padding', 'Border', 'Additional CSS' ].forEach( label =>
 			expect( screen.getByRole( 'button', { name: `${ label } options` } ) ).toBeInTheDocument()
 		);
 		expect( screen.queryByRole( 'button', { name: 'Border Radius options' } ) ).toBeNull();
@@ -499,5 +500,99 @@ describe( 'StyleSection on a classic theme', () => {
 		};
 		render( <StyleSection status={ status } styles={ { color: { background: '#7a5c3e' } } } inFlight={ false } onChangeStyles={ () => {} } /> );
 		expect( screen.getByText( CONTRAST_WARNING_BRIGHTER_BACKGROUND, { selector: NOTICE_CONTENT } ) ).toBeInTheDocument();
+	} );
+
+	it( 'shows the stored custom CSS and reports every edit', () => {
+		const onChangeCustomCss = jest.fn();
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ {} }
+				customCss="color: red;"
+				inFlight={ false }
+				onChangeStyles={ () => {} }
+				onChangeCustomCss={ onChangeCustomCss }
+			/>
+		);
+
+		const field = screen.getByLabelText( 'Additional CSS' );
+		expect( field ).toHaveValue( 'color: red;' );
+
+		fireEvent.change( field, { target: { value: '& a { color: blue; }' } } );
+
+		expect( onChangeCustomCss ).toHaveBeenCalledWith( '& a { color: blue; }' );
+	} );
+
+	it( 'clears the custom CSS from the panel menu', () => {
+		const onChangeCustomCss = jest.fn();
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ {} }
+				customCss="color: red;"
+				inFlight={ false }
+				onChangeStyles={ () => {} }
+				onChangeCustomCss={ onChangeCustomCss }
+			/>
+		);
+
+		openPanelMenu( 'Additional CSS' );
+		clickMenuItem( 'Reset Additional CSS' );
+
+		expect( onChangeCustomCss ).toHaveBeenCalledWith( '' );
+	} );
+
+	it( 'shows stored custom CSS read-only once the capability is revoked, rather than hiding it', () => {
+		render(
+			<StyleSection
+				status={ { ...CLASSIC_STATUS, can_edit_css: false } }
+				styles={ {} }
+				customCss="color: red;"
+				inFlight={ false }
+				onChangeStyles={ () => {} }
+				onChangeCustomCss={ () => {} }
+			/>
+		);
+
+		const field = screen.getByLabelText( 'Additional CSS' );
+		expect( field ).toHaveValue( 'color: red;' );
+		// Read-only, not disabled, so the value stays selectable and focusable.
+		expect( field ).toHaveAttribute( 'readonly' );
+		expect( field ).not.toBeDisabled();
+		expect( screen.getByText( /Additional CSS can no longer be edited on this site/ ) ).toBeInTheDocument();
+		// No options menu, so no reset is offered that the capability would refuse.
+		expect( screen.queryByRole( 'button', { name: 'Additional CSS options' } ) ).toBeNull();
+	} );
+
+	it( 'omits the Additional CSS panel when nothing is stored and the capability is gone', () => {
+		render(
+			<StyleSection
+				status={ { ...CLASSIC_STATUS, can_edit_css: false } }
+				styles={ {} }
+				customCss=""
+				inFlight={ false }
+				onChangeStyles={ () => {} }
+				onChangeCustomCss={ () => {} }
+			/>
+		);
+
+		expect( screen.queryByLabelText( 'Additional CSS' ) ).toBeNull();
+		expect( screen.queryByRole( 'button', { name: 'Additional CSS options' } ) ).toBeNull();
+		expect( screen.getByRole( 'button', { name: 'Border options' } ) ).toBeInTheDocument();
+	} );
+
+	it( 'disables the custom CSS field while a save is in flight', () => {
+		render(
+			<StyleSection
+				status={ CLASSIC_STATUS }
+				styles={ {} }
+				customCss="color: red;"
+				inFlight={ true }
+				onChangeStyles={ () => {} }
+				onChangeCustomCss={ () => {} }
+			/>
+		);
+
+		expect( screen.getByLabelText( 'Additional CSS' ) ).toBeDisabled();
 	} );
 } );

--- a/plugins/newspack-popups/includes/class-newspack-popups-api.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-api.php
@@ -178,13 +178,19 @@ final class Newspack_Popups_API {
 					'callback'            => [ __CLASS__, 'api_save_contextual_prompt_profile' ],
 					'permission_callback' => [ $this, 'permission_callback' ],
 					'args'                => [
-						'fields' => [
+						'fields'     => [
 							'required' => true,
 							'type'     => 'object',
 						],
-						'styles' => [
+						'styles'     => [
 							'required' => false,
 							'type'     => 'object',
+						],
+						// Deliberately unsanitized: custom CSS is validated, not
+						// filtered, and the `edit_css` capability is the control.
+						'custom_css' => [
+							'required' => false,
+							'type'     => 'string',
 						],
 					],
 				]
@@ -204,10 +210,10 @@ final class Newspack_Popups_API {
 
 	/**
 	 * The Contextual Prompts status payload: opt-in state, whether the user can
-	 * manage it, the publisher-profile fields, and the block's style data. The
-	 * route is open to `edit_posts`, but the profile and style data is wizard
-	 * configuration only an administrator may see: anyone else gets the opt-in
-	 * state alone.
+	 * manage it, the publisher-profile fields, and the block's style data, custom
+	 * CSS and the capability to edit it included. The route is open to
+	 * `edit_posts`, but the profile and style data is wizard configuration only an
+	 * administrator may see: anyone else gets the opt-in state alone.
 	 *
 	 * @return array
 	 */
@@ -231,10 +237,12 @@ final class Newspack_Popups_API {
 		return [
 			'enabled'                => Newspack_Popups_Settings::is_ai_copy_assistant_enabled(),
 			'can_manage'             => $can_manage,
+			'can_edit_css'           => Newspack_Popups_Contextual_Prompt_Styles::can_edit_css(),
 			'fields'                 => Newspack_Popups_Settings::get_ai_copy_assistant_fields(),
 			'override_active'        => Newspack_Popups_Settings::is_override_active(),
 			'is_block_theme'         => wp_is_block_theme(),
 			'styles'                 => empty( $styles ) ? (object) [] : $styles,
+			'custom_css'             => Newspack_Popups_Contextual_Prompt_Styles::get_custom_css(),
 			'style_defaults'         => Newspack_Popups_Contextual_Prompt_Styles::get_defaults(),
 			'style_palette'          => self::get_palette_presets(),
 			'style_font_sizes'       => self::normalize_preset_sizes( $font_sizes ),
@@ -694,10 +702,30 @@ final class Newspack_Popups_API {
 				return $styles;
 			}
 		}
+		$custom_css = null;
+		if ( isset( $request['custom_css'] ) ) {
+			// Rejected rather than dropped, so a save that cannot take effect does
+			// not report success.
+			if ( ! Newspack_Popups_Contextual_Prompt_Styles::can_edit_css() ) {
+				return new \WP_Error(
+					'newspack_contextual_prompts_cannot_edit_css',
+					__( 'You are not allowed to edit custom CSS.', 'newspack-popups' ),
+					[ 'status' => rest_authorization_required_code() ]
+				);
+			}
+			$custom_css = (string) $request['custom_css'];
+			$valid_css  = Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( $custom_css );
+			if ( is_wp_error( $valid_css ) ) {
+				return $valid_css;
+			}
+		}
 
 		Newspack_Popups_Settings::save_ai_copy_assistant_fields( (array) $request['fields'] );
 		if ( null !== $styles ) {
 			Newspack_Popups_Contextual_Prompt_Styles::save_styles( $styles );
+		}
+		if ( null !== $custom_css ) {
+			Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( $custom_css );
 		}
 		return rest_ensure_response( self::contextual_prompt_status() );
 	}

--- a/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-block.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-block.php
@@ -23,7 +23,9 @@ final class Newspack_Popups_Contextual_Prompt_Block {
 	 * Register hooks.
 	 */
 	public static function init() {
-		add_action( 'init', [ __CLASS__, 'register_block' ] );
+		// Priority 20: the supports depend on whether newspack-blocks/donate is
+		// registered, which happens on default-priority init.
+		add_action( 'init', [ __CLASS__, 'register_block' ], 20 );
 		add_filter( 'wp_theme_json_data_default', [ __CLASS__, 'default_design' ] );
 		add_filter( 'render_block_data', [ __CLASS__, 'prepare_block_data' ] );
 		add_filter( 'render_block_' . self::BLOCK_NAME, [ __CLASS__, 'suppress_empty_prompt' ], 9, 2 );
@@ -241,6 +243,66 @@ final class Newspack_Popups_Contextual_Prompt_Block {
 	}
 
 	/**
+	 * The block's layout supports: a flex column for a plain-button CTA, so core
+	 * offers its own orientation toggle, flow layout for the full-width donate
+	 * form. Must stay identical to LAYOUT_SUPPORT in
+	 * src/blocks/contextual-prompt/index.js, which client registration applies.
+	 *
+	 * @return array
+	 */
+	private static function layout_support() {
+		if ( self::use_donate_block() ) {
+			return [
+				'default'            => [ 'type' => 'default' ],
+				'allowSwitching'     => false,
+				'allowJustification' => false,
+				'allowOrientation'   => false,
+				// Without this core still renders an empty "Layout" section.
+				'allowEditing'       => false,
+			];
+		}
+
+		return [
+			// justifyContent: stretch, since core's flex layout zeroes child
+			// margins and the copy and button would otherwise shrink-wrap.
+			'default'                => [
+				'type'           => 'flex',
+				'orientation'    => 'vertical',
+				'justifyContent' => 'stretch',
+			],
+			'allowSwitching'         => false,
+			// Paired with orientation: the toggle rewrites the whole layout
+			// attribute, remapping stretch to flex-start, and only a justification
+			// control can put it back.
+			'allowJustification'     => true,
+			'allowOrientation'       => true,
+			'allowVerticalAlignment' => true,
+		];
+	}
+
+	/**
+	 * The label on a plain-button CTA: the site-wide setting, or "Donate" when
+	 * the publisher has left it empty.
+	 *
+	 * @return string
+	 */
+	public static function get_button_text() {
+		$text = trim( (string) get_option( 'newspack_contextual_prompts_button_text', '' ) );
+		return '' !== $text ? $text : __( 'Donate', 'newspack-popups' );
+	}
+
+	/**
+	 * Where a plain-button CTA points: the site-wide setting, or the donor
+	 * landing page configured in Campaigns settings when it is empty.
+	 *
+	 * @return string
+	 */
+	public static function get_button_url() {
+		$url = trim( (string) get_option( 'newspack_contextual_prompts_button_url', '' ) );
+		return '' !== $url ? $url : Newspack_Popups::get_donor_landing_url();
+	}
+
+	/**
 	 * Make the donate CTA inside a Contextual Prompt use the theme's accent
 	 * color instead of the donate block's default. Always resolved at render so
 	 * it tracks theme changes — any stored buttonColor (stamped by the editor
@@ -282,10 +344,7 @@ final class Newspack_Popups_Contextual_Prompt_Block {
 				'description' => __( 'A story-specific donation ask. Copy is generated from the story and editable; the call to action follows your donation settings.', 'newspack-popups' ),
 				'category'    => 'newspack',
 				'attributes'  => [
-					'layout' => [
-						'type'    => 'object',
-						'default' => [ 'type' => 'default' ],
-					],
+					'layout' => [ 'type' => 'object' ],
 				],
 				'supports'    => [
 					'align'                => [ 'wide', 'full' ],
@@ -293,11 +352,7 @@ final class Newspack_Popups_Contextual_Prompt_Block {
 					'lock'                 => false,
 					'multiple'             => false,
 					'reusable'             => false,
-					'layout'               => [
-						'default'            => [ 'type' => 'default' ],
-						'allowJustification' => false,
-						'allowSwitching'     => false,
-					],
+					'layout'               => self::layout_support(),
 					'shadow'               => true,
 					'color'                => [
 						'background' => true,
@@ -443,8 +498,9 @@ final class Newspack_Popups_Contextual_Prompt_Block {
 	 * A block's CTA type is fixed when it is inserted, so after a change of
 	 * donation platform the stored CTA can disagree with the site. Normalize at
 	 * render: the native platform renders the donate form, off-site renders a
-	 * button to the donor landing page — or copy only when none is configured.
-	 * Matching CTAs pass through untouched, preserving per-story customization.
+	 * button carrying the site-wide label and destination, or copy only when no
+	 * destination is configured anywhere. Matching CTAs pass through untouched,
+	 * preserving per-story customization.
 	 *
 	 * @param array $parsed_block Parsed prompt block.
 	 * @return array
@@ -459,6 +515,9 @@ final class Newspack_Popups_Contextual_Prompt_Block {
 			if ( 'core/buttons' === $cta['name'] ) {
 				$parsed_block['innerBlocks'][ $cta['index'] ] = self::build_donate_child();
 			}
+			// A button-era layout attribute has nothing to apply to the full-width
+			// form, and template sync can swap the CTA child while leaving it behind.
+			unset( $parsed_block['attrs']['layout'] );
 			return $parsed_block;
 		}
 
@@ -469,13 +528,13 @@ final class Newspack_Popups_Contextual_Prompt_Block {
 			|| ! self::buttons_have_destination( $parsed_block['innerBlocks'][ $cta['index'] ] );
 
 		if ( $needs_destination ) {
-			$url = Newspack_Popups::get_donor_landing_url();
+			$url = self::get_button_url();
 			if ( '' === $url ) {
 				// No destination to point a button at: render the copy alone
 				// rather than a dead button or a form on a disabled platform.
 				return self::remove_child( $parsed_block, $cta['index'] );
 			}
-			$parsed_block['innerBlocks'][ $cta['index'] ] = self::build_buttons_child( $url, __( 'Donate', 'newspack-popups' ) );
+			$parsed_block['innerBlocks'][ $cta['index'] ] = self::build_buttons_child( $url, self::get_button_text() );
 		}
 
 		return $parsed_block;

--- a/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-styles.php
@@ -7,7 +7,8 @@
  * directly). Stored as a block-supports-shaped object, rendered to CSS by the
  * style engine, and delivered at :root :where() specificity AFTER the block's
  * theme.json default design so it overrides the default while any per-block
- * style still wins.
+ * style still wins. Publisher-written custom CSS rides along in an option of its
+ * own, scoped to the block by core's custom-css processing.
  *
  * @package Newspack
  */
@@ -19,6 +20,18 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Newspack_Popups_Contextual_Prompt_Styles {
 	const OPTION_NAME = 'newspack_popups_contextual_prompt_styles';
+
+	/**
+	 * Free-form CSS has its own option: it cannot travel through the style
+	 * engine's block-supports shape, and mixing the two would weaken a
+	 * deliberately strict allowlist.
+	 */
+	const CUSTOM_CSS_OPTION_NAME = 'newspack_popups_contextual_prompt_custom_css';
+
+	/**
+	 * The block class both the style engine output and the custom CSS are scoped to.
+	 */
+	const SELECTOR = '.wp-block-newspack-popups-contextual-prompt';
 
 	/**
 	 * Leaf values: CSS-safe fragments only. Permits hex/named colors, units,
@@ -228,20 +241,233 @@ final class Newspack_Popups_Contextual_Prompt_Styles {
 	}
 
 	/**
-	 * The overrides as a single CSS rule, or an empty string.
+	 * Whether the current user may write custom CSS. `edit_css` is core's own gate
+	 * for the same feature, mapped alongside `unfiltered_html`.
+	 *
+	 * @return bool
+	 */
+	public static function can_edit_css() {
+		return current_user_can( 'edit_css' );
+	}
+
+	/**
+	 * The saved custom CSS.
+	 *
+	 * @return string
+	 */
+	public static function get_custom_css() {
+		$css = get_option( self::CUSTOM_CSS_OPTION_NAME, '' );
+		return is_string( $css ) ? $css : '';
+	}
+
+	/**
+	 * Validate custom CSS: it must not close the STYLE element it renders in, and
+	 * its braces, comments and strings must all balance. An unclosed one would
+	 * break every style appended to the shared global-styles handle after it.
+	 *
+	 * @param string $css CSS to validate.
+	 * @return true|WP_Error True when the CSS is safe to store, WP_Error otherwise.
+	 */
+	public static function validate_custom_css( $css ) {
+		$length = strlen( $css );
+		for (
+			$at = strcspn( $css, '<' );
+			$at < $length;
+			$at += strcspn( $css, '<', ++$at )
+		) {
+			$remaining_strlen = $length - $at;
+			// Styles are concatenated, so a trailing prefix of a closing tag is
+			// rejected too: the next one could complete it.
+			$possible_style_close_tag = 0 === substr_compare( $css, '</style', $at, min( 7, $remaining_strlen ), true );
+			if ( ! $possible_style_close_tag ) {
+				continue;
+			}
+			if ( 8 > $remaining_strlen ) {
+				return new WP_Error(
+					'newspack_popups_invalid_custom_css',
+					sprintf(
+						/* translators: %s: the end of the submitted CSS. */
+						__( 'The CSS must not end in "%s".', 'newspack-popups' ),
+						substr( $css, $at )
+					),
+					[ 'status' => 400 ]
+				);
+			}
+			if ( 1 === strspn( $css, " \t\f\r\n/>", $at + 7, 1 ) ) {
+				return new WP_Error(
+					'newspack_popups_invalid_custom_css',
+					sprintf(
+						/* translators: %s: the offending part of the submitted CSS. */
+						__( 'The CSS must not contain "%s".', 'newspack-popups' ),
+						substr( $css, $at, 8 )
+					),
+					[ 'status' => 400 ]
+				);
+			}
+		}
+
+		return self::scan_css_structure( $css );
+	}
+
+	/**
+	 * Scan the CSS once, left to right, balancing braces, parentheses, comments
+	 * and quoted strings together. Strings and comments are tracked so their
+	 * contents do not count as structure: `content: "{"` leaves the brace count
+	 * alone. A bare newline (or carriage return or form feed) inside a string ends
+	 * it in the browser, so it fails here as an unterminated string.
+	 *
+	 * Known limitation: there is no url() state, so `/*` inside an unquoted
+	 * `url()` reads as a comment opener and is rejected. Quoting the URL avoids it.
+	 *
+	 * @param string $css CSS to scan.
+	 * @return true|WP_Error True when comments, strings, braces and parentheses
+	 *                       all close, WP_Error otherwise.
+	 */
+	private static function scan_css_structure( $css ) {
+		$length      = strlen( $css );
+		$depth       = 0;
+		$paren_depth = 0;
+		$quote       = '';
+		$in_comment  = false;
+
+		for ( $at = 0; $at < $length; $at++ ) {
+			$char = $css[ $at ];
+
+			if ( $in_comment ) {
+				if ( '*' === $char && $at + 1 < $length && '/' === $css[ $at + 1 ] ) {
+					$in_comment = false;
+					++$at;
+				}
+				continue;
+			}
+
+			if ( '' !== $quote ) {
+				if ( '\\' === $char ) {
+					// A CRLF line continuation is one escaped unit, so both its bytes
+					// are consumed here rather than the LF reading as a bare newline.
+					if ( $at + 2 < $length && "\r" === $css[ $at + 1 ] && "\n" === $css[ $at + 2 ] ) {
+						$at += 2;
+					} else {
+						++$at;
+					}
+				} elseif ( $quote === $char ) {
+					$quote = '';
+				} elseif ( "\n" === $char || "\r" === $char || "\f" === $char ) {
+					return self::unterminated_string_error();
+				}
+				continue;
+			}
+
+			if ( '/' === $char && $at + 1 < $length && '*' === $css[ $at + 1 ] ) {
+				$in_comment = true;
+				++$at;
+				continue;
+			}
+
+			if ( '"' === $char || "'" === $char ) {
+				$quote = $char;
+				continue;
+			}
+
+			if ( '{' === $char ) {
+				++$depth;
+			} elseif ( '}' === $char ) {
+				--$depth;
+				if ( 0 > $depth ) {
+					return new WP_Error(
+						'newspack_popups_invalid_custom_css',
+						__( 'The CSS contains an unbalanced brace.', 'newspack-popups' ),
+						[ 'status' => 400 ]
+					);
+				}
+			} elseif ( '(' === $char ) {
+				++$paren_depth;
+			} elseif ( ')' === $char && 0 < $paren_depth ) {
+				// Clamped at zero so a stray closer cannot cancel out a later unclosed
+				// opener and hide it from the check below.
+				--$paren_depth;
+			}
+		}
+
+		if ( $in_comment ) {
+			return new WP_Error(
+				'newspack_popups_invalid_custom_css',
+				__( 'The CSS contains an unclosed comment.', 'newspack-popups' ),
+				[ 'status' => 400 ]
+			);
+		}
+		if ( '' !== $quote ) {
+			return self::unterminated_string_error();
+		}
+		if ( 0 !== $depth ) {
+			return new WP_Error(
+				'newspack_popups_invalid_custom_css',
+				__( 'The CSS contains an unbalanced brace.', 'newspack-popups' ),
+				[ 'status' => 400 ]
+			);
+		}
+		if ( 0 !== $paren_depth ) {
+			return new WP_Error(
+				'newspack_popups_invalid_custom_css',
+				__( 'The CSS contains an unbalanced parenthesis.', 'newspack-popups' ),
+				[ 'status' => 400 ]
+			);
+		}
+
+		return true;
+	}
+
+	/**
+	 * The "unterminated string" error.
+	 *
+	 * @return WP_Error
+	 */
+	private static function unterminated_string_error() {
+		return new WP_Error(
+			'newspack_popups_invalid_custom_css',
+			__( 'The CSS contains an unterminated string.', 'newspack-popups' ),
+			[ 'status' => 400 ]
+		);
+	}
+
+	/**
+	 * Validate and persist custom CSS. An empty value removes the option.
+	 *
+	 * @param string $css Additional CSS.
+	 * @return true|WP_Error True on save, WP_Error for CSS that fails validation.
+	 */
+	public static function save_custom_css( $css ) {
+		$css   = is_string( $css ) ? $css : '';
+		$valid = self::validate_custom_css( $css );
+		if ( is_wp_error( $valid ) ) {
+			return $valid;
+		}
+		if ( '' === trim( $css ) ) {
+			delete_option( self::CUSTOM_CSS_OPTION_NAME );
+			return true;
+		}
+		update_option( self::CUSTOM_CSS_OPTION_NAME, $css );
+		return true;
+	}
+
+	/**
+	 * The overrides as a single CSS rule followed by the scoped custom CSS, or an
+	 * empty string.
 	 *
 	 * @return string
 	 */
 	public static function get_css() {
+		$css    = '';
 		$styles = self::get_styles();
-		if ( empty( $styles ) ) {
-			return '';
+		if ( ! empty( $styles ) ) {
+			$result = wp_style_engine_get_styles(
+				$styles,
+				[ 'selector' => ':root :where(' . self::SELECTOR . ')' ]
+			);
+			$css    = isset( $result['css'] ) ? $result['css'] : '';
 		}
-		$result = wp_style_engine_get_styles(
-			$styles,
-			[ 'selector' => ':root :where(.wp-block-newspack-popups-contextual-prompt)' ]
-		);
-		return isset( $result['css'] ) ? $result['css'] : '';
+		// Wraps bare declarations in :root :where( selector ) and substitutes `&`.
+		return $css . WP_Theme_JSON::process_blocks_custom_css( self::get_custom_css(), self::SELECTOR );
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-settings.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-settings.php
@@ -258,6 +258,20 @@ class Newspack_Popups_Settings {
 				'help'  => __( 'Optional house do/don\'ts appended to the AI guidance. Never overrides the non-advocacy guardrail.', 'newspack-popups' ),
 				'type'  => 'textarea',
 			],
+			// Filtered out below on a native site, which renders the donate form
+			// rather than a button.
+			[
+				'key'   => 'newspack_contextual_prompts_button_text',
+				'label' => __( 'Donation button label', 'newspack-popups' ),
+				'help'  => __( 'The label on a newly inserted prompt\'s donation button, and on any prompt with no destination of its own. Defaults to "Donate" when empty. Editable per story.', 'newspack-popups' ),
+				'type'  => 'text',
+			],
+			[
+				'key'   => 'newspack_contextual_prompts_button_url',
+				'label' => __( 'Donation button URL', 'newspack-popups' ),
+				'help'  => __( 'Where a newly inserted prompt\'s donation button links, and any prompt with no destination of its own. Defaults to your donor landing page when empty. Editable per story.', 'newspack-popups' ),
+				'type'  => 'text',
+			],
 			// Site-wide override ("fund-drive mode"): while enabled, this single
 			// CTA temporarily replaces the copy of every Contextual Prompt.
 			[
@@ -308,17 +322,19 @@ class Newspack_Popups_Settings {
 		];
 
 		// The form/button choice only exists where a native donate form exists;
-		// off-site sites are always button mode.
-		if ( ! Newspack_Popups_Contextual_Prompt_Block::use_donate_block() ) {
-			$fields = array_values(
-				array_filter(
-					$fields,
-					function ( $field ) {
-						return self::OVERRIDE_CTA_OPTION !== $field['key'];
-					}
-				)
-			);
-		}
+		// off-site sites are always button mode. The button label and URL are the
+		// mirror image, shaping a CTA a native site never renders.
+		$excluded = Newspack_Popups_Contextual_Prompt_Block::use_donate_block()
+			? [ 'newspack_contextual_prompts_button_text', 'newspack_contextual_prompts_button_url' ]
+			: [ self::OVERRIDE_CTA_OPTION ];
+		$fields   = array_values(
+			array_filter(
+				$fields,
+				function ( $field ) use ( $excluded ) {
+					return ! in_array( $field['key'], $excluded, true );
+				}
+			)
+		);
 
 		foreach ( $fields as &$field ) {
 			$field['section'] = $field['section'] ?? 'profile';
@@ -355,7 +371,7 @@ class Newspack_Popups_Settings {
 			if ( ! is_scalar( $value ) ) {
 				continue;
 			}
-			if ( 'newspack_contextual_prompts_override_url' === $key ) {
+			if ( in_array( $key, [ 'newspack_contextual_prompts_override_url', 'newspack_contextual_prompts_button_url' ], true ) ) {
 				$sanitized = esc_url_raw( (string) $value );
 			} elseif ( self::OVERRIDE_CTA_OPTION === $key ) {
 				// Whitelist: anything but 'button' collapses to the default 'form'.

--- a/plugins/newspack-popups/includes/class-newspack-popups.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups.php
@@ -865,33 +865,34 @@ final class Newspack_Popups {
 			'newspack-popups-blocks',
 			'newspack_popups_blocks_data',
 			[
-				'custom_placements'             => Newspack_Popups_Custom_Placements::get_custom_placements(),
-				'endpoint'                      => '/newspack-popups/v1/prompts',
-				'post_type'                     => self::NEWSPACK_POPUPS_CPT,
-				'is_prompt'                     => self::NEWSPACK_POPUPS_CPT == get_post_type(),
+				'custom_placements'              => Newspack_Popups_Custom_Placements::get_custom_placements(),
+				'endpoint'                       => '/newspack-popups/v1/prompts',
+				'post_type'                      => self::NEWSPACK_POPUPS_CPT,
+				'is_prompt'                      => self::NEWSPACK_POPUPS_CPT == get_post_type(),
 				// Gates client-side registration of the Contextual Prompt block:
 				// the rollout flag plus the admin opt-in, so nothing registers
 				// before the AI disclosure is accepted.
-				'contextual_prompts_enabled'    => self::is_contextual_prompts_enabled() && Newspack_Popups_Settings::is_ai_copy_assistant_enabled(),
+				'contextual_prompts_enabled'     => self::is_contextual_prompts_enabled() && Newspack_Popups_Settings::is_ai_copy_assistant_enabled(),
 				// Whether this screen can author one. Registration is wider than
 				// insertion so the Site Editor can style the block, but only a
 				// supported post editor offers it in the inserter.
-				'contextual_prompts_insertable' => $is_supported_post_editor,
+				'contextual_prompts_insertable'  => $is_supported_post_editor,
 				// So the editor previews the Contextual Prompt CTA in the same
 				// accent the front end resolves at render.
-				'accent_color'                  => Newspack_Popups_Contextual_Prompt_Block::get_accent_color(),
+				'accent_color'                   => Newspack_Popups_Contextual_Prompt_Block::get_accent_color(),
 				// The edited content's own noun ("post", "page", "listing"…), so
 				// prompt UI strings speak the publisher's language.
-				'post_type_label'               => self::get_current_post_type_label(),
+				'post_type_label'                => self::get_current_post_type_label(),
 				// The label as the post type declares it, for headings; recasing
 				// the lowercased noun client-side would mis-case some locales.
-				'post_type_heading'             => self::get_current_post_type_heading(),
+				'post_type_heading'              => self::get_current_post_type_heading(),
 				// Whether the Contextual Prompt CTA is the native donate block
 				// or a plain button.
-				'donations_native'              => Newspack_Popups_Contextual_Prompt_Block::use_donate_block(),
-				// Default target for the plain-button CTA: the donor landing
-				// page, when one is configured in Campaigns settings.
-				'donor_landing_url'             => self::get_donor_landing_url(),
+				'donations_native'               => Newspack_Popups_Contextual_Prompt_Block::use_donate_block(),
+				// What the plain-button CTA an insert starts from carries, already
+				// resolved to its fallbacks.
+				'contextual_prompts_button_text' => Newspack_Popups_Contextual_Prompt_Block::get_button_text(),
+				'contextual_prompts_button_url'  => Newspack_Popups_Contextual_Prompt_Block::get_button_url(),
 			]
 		);
 

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/block.json
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/block.json
@@ -7,10 +7,7 @@
 	"description": "A story-specific donation ask. Copy is generated from the story and editable; the call to action follows your donation settings.",
 	"attributes": {
 		"layout": {
-			"type": "object",
-			"default": {
-				"type": "default"
-			}
+			"type": "object"
 		}
 	},
 	"supports": {
@@ -21,13 +18,6 @@
 		"html": false,
 		"multiple": false,
 		"reusable": false,
-		"layout": {
-			"default": {
-				"type": "default"
-			},
-			"allowJustification": false,
-			"allowSwitching": false
-		},
 		"color": {
 			"background": true,
 			"text": true

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/edit.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/edit.js
@@ -3,9 +3,8 @@
  *
  * The block is the styled container: design (background, text color, padding,
  * border, gap) comes from its own supports, with site-wide defaults supplied
- * as theme.json data. Its two children are fixed — the copy paragraph (text
- * editable) and the CTA, which is disabled outright: it renders from site
- * settings and is not editable per-story.
+ * as theme.json data. Its two children are fixed and edited content-only: their
+ * text and settings stay editable per story, nothing else.
  *
  * Inserting the block generates its copy automatically; the block toolbar and
  * sidebar offer regeneration with per-candidate Apply.
@@ -16,7 +15,7 @@
  */
 import { __, sprintf } from '@wordpress/i18n';
 import { useEffect, useRef, useState } from '@wordpress/element';
-import { useSelect, useDispatch, select as coreSelect, dispatch as coreDispatch } from '@wordpress/data';
+import { useSelect, useDispatch, select as coreSelect } from '@wordpress/data';
 import { InspectorControls, useBlockProps, useInnerBlocksProps, store as blockEditorStore } from '@wordpress/block-editor';
 import { createBlock, createBlocksFromInnerBlocksTemplate } from '@wordpress/blocks';
 import {
@@ -40,17 +39,18 @@ import {
 } from './candidates';
 
 // The CTA follows the site's reader-revenue setup: the donate block when
-// Newspack donations are native, a plain button otherwise. The button defaults
-// to the donor landing page configured in Campaigns settings, so conversions
-// through it count the reader as a donor; publishers can retarget it per-story.
-const DONATIONS_NATIVE = window.newspack_popups_blocks_data?.donations_native ?? true;
-const DONOR_LANDING_URL = window.newspack_popups_blocks_data?.donor_landing_url || undefined;
+// Newspack donations are native, a plain button otherwise. The button's label
+// and destination are resolved server-side from Campaigns settings; publishers
+// can retarget it per-story.
+export const DONATIONS_NATIVE = window.newspack_popups_blocks_data?.donations_native ?? true;
+const BUTTON_TEXT = window.newspack_popups_blocks_data?.contextual_prompts_button_text || __( 'Donate', 'newspack-popups' );
+const BUTTON_URL = window.newspack_popups_blocks_data?.contextual_prompts_button_url || undefined;
 
 export const getTemplate = () => [
 	[ 'core/paragraph', {} ],
 	DONATIONS_NATIVE
 		? [ 'newspack-blocks/donate', { className: 'is-style-modern' } ]
-		: [ 'core/buttons', {}, [ [ 'core/button', { text: __( 'Donate', 'newspack-popups' ), url: DONOR_LANDING_URL } ] ] ],
+		: [ 'core/buttons', {}, [ [ 'core/button', { text: BUTTON_TEXT, url: BUTTON_URL } ] ] ],
 ];
 
 /**
@@ -66,7 +66,7 @@ export const createPromptBlock = copy => {
 	return createBlock( 'newspack-popups/contextual-prompt', {}, createBlocksFromInnerBlocksTemplate( template ) );
 };
 
-export const ContextualPromptEditor = ( { clientId } ) => {
+export const ContextualPromptEditor = ( { clientId, attributes } ) => {
 	const blockProps = useBlockProps();
 	const innerBlocksProps = useInnerBlocksProps( blockProps, {
 		template: getTemplate(),
@@ -97,10 +97,33 @@ export const ContextualPromptEditor = ( { clientId } ) => {
 	// Generation needs a real post: in the Site Editor getCurrentPostId() is a
 	// template id string, which the endpoint cannot use.
 	const canGenerate = Number.isInteger( postId );
-	const { updateBlockAttributes } = useDispatch( blockEditorStore );
+	const {
+		updateBlockAttributes,
+		setBlockEditingMode,
+		unsetBlockEditingMode,
+		__unstableMarkNextChangeAsNotPersistent: markNextChangeAsNotPersistent,
+	} = useDispatch( blockEditorStore );
 
-	// Both children stay selectable so publishers can tweak them per-story; the
-	// template lock prevents moving or removing them.
+	// The template lock alone is defeatable: core offers every locked block an
+	// Unlock button whose `lock` attribute overrides the template. Content-only
+	// editing mode withholds it. Set per block rather than through
+	// `templateLock: 'contentOnly'`, which would swap this block's inspector for
+	// a pattern-style content list. Non-persistent because editing mode is UI
+	// state, and persisting it would dirty a freshly opened post.
+	const descendantClientIds = useSelect( select => select( blockEditorStore ).getClientIdsOfDescendants( clientId ).join( ',' ), [ clientId ] );
+	useEffect( () => {
+		const ids = descendantClientIds ? descendantClientIds.split( ',' ) : [];
+		ids.forEach( id => {
+			markNextChangeAsNotPersistent();
+			setBlockEditingMode( id, 'contentOnly' );
+		} );
+		return () =>
+			ids.forEach( id => {
+				markNextChangeAsNotPersistent();
+				unsetBlockEditingMode( id );
+			} );
+	}, [ descendantClientIds ] );
+
 	const ctaClientId = useSelect(
 		select => {
 			const blockEditor = select( blockEditorStore );
@@ -119,10 +142,19 @@ export const ContextualPromptEditor = ( { clientId } ) => {
 	);
 	useEffect( () => {
 		if ( ctaClientId && accentColor && ctaButtonColor !== accentColor ) {
-			coreDispatch( blockEditorStore ).__unstableMarkNextChangeAsNotPersistent();
+			markNextChangeAsNotPersistent();
 			updateBlockAttributes( ctaClientId, { buttonColor: accentColor } );
 		}
 	}, [ ctaClientId, accentColor, ctaButtonColor ] );
+
+	// Mirrors normalize_cta()'s render-time repair, so the canvas does not preview
+	// a layout the front end drops. Non-persistent, so opening a post stays clean.
+	useEffect( () => {
+		if ( DONATIONS_NATIVE && attributes.layout !== undefined ) {
+			markNextChangeAsNotPersistent();
+			updateBlockAttributes( clientId, { layout: undefined } );
+		}
+	}, [ clientId, attributes.layout ] );
 
 	const [ generating, setGenerating ] = useState( false );
 	const [ candidates, setCandidates ] = useState( [] );

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/edit.test.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/edit.test.js
@@ -1,0 +1,31 @@
+// @wordpress/block-editor pulls in an untransformed ES module (parsel-js).
+jest.mock( '@wordpress/block-editor', () => ( {} ) );
+
+// The editor payload is read at import time, so each case reloads the module.
+const templateWith = data => {
+	jest.resetModules();
+	window.newspack_popups_blocks_data = data;
+	return require( './edit' ).getTemplate();
+};
+
+describe( 'getTemplate', () => {
+	it( 'inserts the donate block on a donations-native site', () => {
+		expect( templateWith( { donations_native: true } )[ 1 ][ 0 ] ).toBe( 'newspack-blocks/donate' );
+	} );
+
+	it( 'seeds the button CTA from the site-wide label and destination', () => {
+		const template = templateWith( {
+			donations_native: false,
+			contextual_prompts_button_text: 'Support us',
+			contextual_prompts_button_url: 'https://example.com/give/',
+		} );
+
+		expect( template[ 1 ][ 2 ][ 0 ][ 1 ] ).toEqual( { text: 'Support us', url: 'https://example.com/give/' } );
+	} );
+
+	it( 'falls back to Donate and no destination when neither is set', () => {
+		const template = templateWith( { donations_native: false } );
+
+		expect( template[ 1 ][ 2 ][ 0 ][ 1 ] ).toEqual( { text: 'Donate', url: undefined } );
+	} );
+} );

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/index.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/index.js
@@ -16,7 +16,33 @@ import { Icon, megaphone } from '@wordpress/icons';
  */
 import './editor.scss';
 import metadata from './block.json';
-import { ContextualPromptEditor } from './edit';
+import { ContextualPromptEditor, DONATIONS_NATIVE } from './edit';
+
+// A flex column for a plain-button CTA, so core offers its own orientation
+// toggle, flow layout for the full-width donate form. Must stay identical to
+// layout_support() in class-newspack-popups-contextual-prompt-block.php;
+// block.json carries no layout supports, since both of these override it.
+const LAYOUT_SUPPORT = DONATIONS_NATIVE
+	? {
+			default: { type: 'default' },
+			allowSwitching: false,
+			allowJustification: false,
+			allowOrientation: false,
+			// Without this core still renders an empty "Layout" section.
+			allowEditing: false,
+	  }
+	: {
+			// justifyContent: stretch, since core's flex layout zeroes child margins
+			// and the copy and button would otherwise shrink-wrap.
+			default: { type: 'flex', orientation: 'vertical', justifyContent: 'stretch' },
+			allowSwitching: false,
+			// Paired with orientation: the toggle rewrites the whole layout
+			// attribute, remapping stretch to flex-start, and only a justification
+			// control can put it back.
+			allowJustification: true,
+			allowOrientation: true,
+			allowVerticalAlignment: true,
+	  };
 
 const Save = () => {
 	const blockProps = useBlockProps.save();
@@ -38,7 +64,7 @@ export const registerContextualPromptBlock = () => {
 
 	registerBlockType( metadata.name, {
 		...metadata,
-		supports: { ...metadata.supports, inserter: isInsertable },
+		supports: { ...metadata.supports, inserter: isInsertable, layout: LAYOUT_SUPPORT },
 		// Registered here rather than in block.json, whose i18n schema does not
 		// translate example content. Feeds the inserter preview and the one the
 		// Site Editor shows above Styles > Blocks. The template swaps this CTA for

--- a/plugins/newspack-popups/src/blocks/contextual-prompt/index.test.js
+++ b/plugins/newspack-popups/src/blocks/contextual-prompt/index.test.js
@@ -1,0 +1,47 @@
+// @wordpress/block-editor pulls in an untransformed ES module (parsel-js).
+jest.mock( '@wordpress/block-editor', () => ( {} ) );
+
+// newspack-colors resolves to a Sass module, which jest cannot parse.
+jest.mock( 'newspack-colors', () => ( {} ) );
+
+jest.mock( '@wordpress/blocks' );
+
+// The editor payload is read at import time, so each case reloads the module.
+const registerWith = data => {
+	jest.resetModules();
+	window.newspack_popups_blocks_data = data;
+	const { registerBlockType } = require( '@wordpress/blocks' );
+	require( './index' ).registerContextualPromptBlock();
+	return registerBlockType.mock.calls;
+};
+
+const supportsWith = data => registerWith( { contextual_prompts_insertable: true, ...data } )[ 0 ][ 1 ].supports;
+
+describe( 'registerContextualPromptBlock', () => {
+	it( 'defaults a button CTA to the flex column core hangs its orientation toggle off', () => {
+		const { layout } = supportsWith( { donations_native: false } );
+
+		expect( layout.default ).toEqual( { type: 'flex', orientation: 'vertical', justifyContent: 'stretch' } );
+		expect( layout.allowOrientation ).toBe( true );
+		expect( layout.allowVerticalAlignment ).toBe( true );
+		expect( layout.allowSwitching ).toBe( false );
+		expect( layout.allowJustification ).toBe( true );
+	} );
+
+	it( 'keeps flow layout for the donate form, which has nothing to flow alongside', () => {
+		const { layout } = supportsWith( { donations_native: true } );
+
+		expect( layout.default ).toEqual( { type: 'default' } );
+		expect( layout.allowOrientation ).toBe( false );
+		expect( layout.allowSwitching ).toBe( false );
+		expect( layout.allowJustification ).toBe( false );
+	} );
+
+	it( 'treats a missing flag as donations-native', () => {
+		expect( supportsWith( {} ).layout.default ).toEqual( { type: 'default' } );
+	} );
+
+	it( 'registers nothing inside a prompt', () => {
+		expect( registerWith( { is_prompt: true } ) ).toHaveLength( 0 );
+	} );
+} );

--- a/plugins/newspack-popups/tests/test-ai-copy-assistant-settings.php
+++ b/plugins/newspack-popups/tests/test-ai-copy-assistant-settings.php
@@ -36,6 +36,10 @@ class AiCopyAssistantSettingsTest extends WP_UnitTestCase {
 		delete_option( 'newspack_contextual_prompts_override_body' );
 		delete_option( 'newspack_contextual_prompts_override_label' );
 		delete_option( 'newspack_contextual_prompts_override_url' );
+		// The field list is gated, so a native site would not report these keys
+		// to the loop below.
+		delete_option( 'newspack_contextual_prompts_button_text' );
+		delete_option( 'newspack_contextual_prompts_button_url' );
 		foreach ( wp_list_pluck( Newspack_Popups_Settings::get_ai_copy_assistant_fields(), 'key' ) as $key ) {
 			delete_option( $key );
 		}
@@ -105,6 +109,54 @@ class AiCopyAssistantSettingsTest extends WP_UnitTestCase {
 		$this->assertNotContains( Newspack_Popups_Settings::OVERRIDE_CTA_OPTION, $button_keys );
 		$this->assertContains( 'newspack_contextual_prompts_override_label', $button_keys );
 		$this->assertContains( 'newspack_contextual_prompts_override_url', $button_keys );
+	}
+
+	/**
+	 * The button label and URL exist only where the CTA is a plain button.
+	 */
+	public function test_button_fields_only_on_non_native_sites() {
+		add_filter( 'newspack_contextual_prompts_use_donate_block', '__return_false' );
+		$button_keys = wp_list_pluck( Newspack_Popups_Settings::get_ai_copy_assistant_fields(), 'key' );
+		$this->assertContains( 'newspack_contextual_prompts_button_text', $button_keys );
+		$this->assertContains( 'newspack_contextual_prompts_button_url', $button_keys );
+		remove_filter( 'newspack_contextual_prompts_use_donate_block', '__return_false' );
+
+		add_filter( 'newspack_contextual_prompts_use_donate_block', '__return_true' );
+		$native_keys = wp_list_pluck( Newspack_Popups_Settings::get_ai_copy_assistant_fields(), 'key' );
+		$this->assertNotContains( 'newspack_contextual_prompts_button_text', $native_keys );
+		$this->assertNotContains( 'newspack_contextual_prompts_button_url', $native_keys );
+
+		// Saving follows the same list, so a native site writes neither.
+		Newspack_Popups_Settings::save_ai_copy_assistant_fields(
+			[
+				'newspack_contextual_prompts_button_text' => 'Support us',
+				'newspack_contextual_prompts_button_url'  => 'https://example.com/give/',
+			]
+		);
+		$this->assertSame( '', get_option( 'newspack_contextual_prompts_button_text', '' ) );
+		$this->assertSame( '', get_option( 'newspack_contextual_prompts_button_url', '' ) );
+	}
+
+	/**
+	 * The button URL is esc_url_raw'd like the override URL; the label takes the
+	 * default text sanitisation.
+	 */
+	public function test_button_fields_are_sanitized() {
+		add_filter( 'newspack_contextual_prompts_use_donate_block', '__return_false' );
+
+		Newspack_Popups_Settings::save_ai_copy_assistant_fields(
+			[
+				'newspack_contextual_prompts_button_text' => '<script>alert(1)</script>Support us',
+				'newspack_contextual_prompts_button_url'  => 'javascript:alert(1)',
+			]
+		);
+		$this->assertSame( 'Support us', get_option( 'newspack_contextual_prompts_button_text' ) );
+		$this->assertSame( '', get_option( 'newspack_contextual_prompts_button_url' ), 'A javascript: destination is dropped.' );
+
+		Newspack_Popups_Settings::save_ai_copy_assistant_fields(
+			[ 'newspack_contextual_prompts_button_url' => 'https://example.com/give/' ]
+		);
+		$this->assertSame( 'https://example.com/give/', get_option( 'newspack_contextual_prompts_button_url' ) );
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-contextual-prompt-block.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-block.php
@@ -22,6 +22,25 @@ class ContextualPromptBlockTest extends WP_UnitTestCase {
 		update_option( Newspack_Popups_Settings::AI_COPY_ASSISTANT_ENABLED_OPTION, true );
 	}
 
+	/**
+	 * Put the block registration back. WP_UnitTestCase rolls back $wp_filter but
+	 * not WP_Block_Type_Registry, so a test that fails mid-body would otherwise
+	 * leave the block registered with native layout supports for the rest of the
+	 * run.
+	 */
+	public function tear_down() {
+		remove_filter( 'newspack_contextual_prompts_use_donate_block', '__return_true' );
+		remove_filter( 'newspack_contextual_prompts_use_donate_block', '__return_false' );
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( 'newspack-blocks/donate' ) ) {
+			unregister_block_type( 'newspack-blocks/donate' );
+		}
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ) ) {
+			unregister_block_type( Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME );
+		}
+		Newspack_Popups_Contextual_Prompt_Block::register_block();
+		parent::tear_down();
+	}
+
 
 	/**
 	 * A single top-level contextual-prompt block carrying a plain-button CTA,
@@ -192,6 +211,53 @@ class ContextualPromptBlockTest extends WP_UnitTestCase {
 			Newspack_Popups::maybe_strip_contextual_prompt_block( '<p>Unrelated.</p>', [ 'blockName' => 'core/paragraph' ] ),
 			'Other blocks always pass through.'
 		);
+	}
+
+	/**
+	 * The registered layout supports follow the CTA the site renders, and must
+	 * match what index.js registers on the client.
+	 */
+	public function test_registered_layout_supports_follow_the_cta() {
+		$name          = Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME;
+		$register_with = function ( $callback ) use ( $name ) {
+			add_filter( 'newspack_contextual_prompts_use_donate_block', $callback );
+			unregister_block_type( $name );
+			Newspack_Popups_Contextual_Prompt_Block::register_block();
+			remove_filter( 'newspack_contextual_prompts_use_donate_block', $callback );
+			return WP_Block_Type_Registry::get_instance()->get_registered( $name )->supports['layout'];
+		};
+
+		$button = $register_with( '__return_false' );
+		$this->assertSame(
+			[
+				'type'           => 'flex',
+				'orientation'    => 'vertical',
+				'justifyContent' => 'stretch',
+			],
+			$button['default']
+		);
+		$this->assertTrue( $button['allowOrientation'] );
+		$this->assertTrue( $button['allowJustification'] );
+
+		// use_donate_block() also requires the donate block itself, which this
+		// test env does not load.
+		register_block_type( 'newspack-blocks/donate' );
+		$form = $register_with( '__return_true' );
+		unregister_block_type( 'newspack-blocks/donate' );
+
+		$this->assertSame( [ 'type' => 'default' ], $form['default'] );
+		$this->assertFalse( $form['allowOrientation'] );
+		$this->assertFalse( $form['allowJustification'] );
+		$this->assertFalse( $form['allowEditing'] );
+	}
+
+	/**
+	 * The layout attribute carries no default, so an untouched prompt follows
+	 * whichever layout the supports declare.
+	 */
+	public function test_layout_attribute_has_no_default() {
+		$attributes = WP_Block_Type_Registry::get_instance()->get_registered( Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME )->attributes;
+		$this->assertArrayNotHasKey( 'default', $attributes['layout'] );
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-contextual-prompt-override.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-override.php
@@ -61,6 +61,18 @@ class ContextualPromptOverrideTest extends WP_UnitTestCase {
 <!-- /wp:buttons --></div>
 <!-- /wp:newspack-popups/contextual-prompt -->';
 
+	const PLAIN_BUTTON_PROMPT_WITH_LAYOUT = '<!-- wp:newspack-popups/contextual-prompt {"layout":{"type":"flex","orientation":"horizontal"}} -->
+<div class="wp-block-newspack-popups-contextual-prompt"><!-- wp:paragraph -->
+<p>Original story copy.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:buttons -->
+<div class="wp-block-buttons"><!-- wp:button {"url":"https://example.com/donate/"} -->
+<div class="wp-block-button"><a class="wp-block-button__link wp-element-button" href="https://example.com/donate/">Donate</a></div>
+<!-- /wp:button --></div>
+<!-- /wp:buttons --></div>
+<!-- /wp:newspack-popups/contextual-prompt -->';
+
 	const EMPTY_COPY_PROMPT = '<!-- wp:newspack-popups/contextual-prompt -->
 <div class="wp-block-newspack-popups-contextual-prompt"><!-- wp:paragraph -->
 <p>&nbsp;</p>
@@ -73,8 +85,19 @@ class ContextualPromptOverrideTest extends WP_UnitTestCase {
 <!-- /wp:buttons --></div>
 <!-- /wp:newspack-popups/contextual-prompt -->';
 
+	const DONATE_FORM_PROMPT_WITH_LAYOUT = '<!-- wp:newspack-popups/contextual-prompt {"layout":{"type":"flex","orientation":"horizontal"}} -->
+<div class="wp-block-newspack-popups-contextual-prompt"><!-- wp:paragraph -->
+<p>Original story copy.</p>
+<!-- /wp:paragraph -->
+
+<!-- wp:newspack-blocks/donate {"className":"is-style-modern"} /--></div>
+<!-- /wp:newspack-popups/contextual-prompt -->';
+
 	/**
-	 * Reset override options, donor landing page and platform filters.
+	 * Reset override options, donor landing page and platform filters, and put
+	 * the block registration back. WP_UnitTestCase rolls back $wp_filter but not
+	 * WP_Block_Type_Registry, so a test that fails mid-body would otherwise leave
+	 * the block registered with native layout supports for the rest of the run.
 	 */
 	public function tear_down() {
 		delete_option( Newspack_Popups_Settings::OVERRIDE_ENABLED_OPTION );
@@ -83,11 +106,17 @@ class ContextualPromptOverrideTest extends WP_UnitTestCase {
 		delete_option( 'newspack_contextual_prompts_override_label' );
 		delete_option( 'newspack_contextual_prompts_override_url' );
 		delete_option( 'newspack_popups_donor_landing_page' );
+		delete_option( 'newspack_contextual_prompts_button_text' );
+		delete_option( 'newspack_contextual_prompts_button_url' );
 		remove_filter( 'newspack_contextual_prompts_use_donate_block', '__return_true' );
 		remove_filter( 'newspack_contextual_prompts_use_donate_block', '__return_false' );
 		if ( WP_Block_Type_Registry::get_instance()->is_registered( 'newspack-blocks/donate' ) ) {
 			unregister_block_type( 'newspack-blocks/donate' );
 		}
+		if ( WP_Block_Type_Registry::get_instance()->is_registered( Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME ) ) {
+			unregister_block_type( Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME );
+		}
+		Newspack_Popups_Contextual_Prompt_Block::register_block();
 		parent::tear_down();
 	}
 
@@ -127,6 +156,39 @@ class ContextualPromptOverrideTest extends WP_UnitTestCase {
 
 		$this->assertSame( 'newspack-blocks/donate', $result['innerBlocks'][1]['blockName'] );
 		$this->assertSame( 'is-style-modern', $result['innerBlocks'][1]['attrs']['className'] );
+	}
+
+	/**
+	 * Native platform: a button-era layout attribute is dropped when the CTA is
+	 * rebuilt into the donate form.
+	 */
+	public function test_native_platform_swap_clears_stale_layout_attribute() {
+		$name = Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME;
+		add_filter( 'newspack_contextual_prompts_use_donate_block', '__return_true' );
+		unregister_block_type( $name );
+		Newspack_Popups_Contextual_Prompt_Block::register_block();
+
+		$html = do_blocks( self::PLAIN_BUTTON_PROMPT_WITH_LAYOUT );
+
+		$this->assertStringNotContainsString( 'flex-direction', $html, 'The stale horizontal orientation no longer applies to the form.' );
+		$this->assertStringContainsString( 'is-layout-flow', $html, 'The registered flow default governs instead.' );
+	}
+
+	/**
+	 * Native platform: the layout attribute is cleared even when the stored CTA is
+	 * already the donate form, which template sync can leave behind.
+	 */
+	public function test_native_platform_donate_cta_clears_stale_layout_attribute() {
+		$name = Newspack_Popups_Contextual_Prompt_Block::BLOCK_NAME;
+		add_filter( 'newspack_contextual_prompts_use_donate_block', '__return_true' );
+		unregister_block_type( $name );
+		Newspack_Popups_Contextual_Prompt_Block::register_block();
+
+		$html = do_blocks( self::DONATE_FORM_PROMPT_WITH_LAYOUT );
+
+		$this->assertStringNotContainsString( 'flex-direction', $html, 'The stale horizontal orientation no longer applies to the form.' );
+		$this->assertStringNotContainsString( 'is-horizontal', $html, 'The stale horizontal orientation class is gone.' );
+		$this->assertStringContainsString( 'is-layout-flow', $html, 'The registered flow default governs instead.' );
 	}
 
 	/**
@@ -228,6 +290,71 @@ class ContextualPromptOverrideTest extends WP_UnitTestCase {
 
 		$this->assertCount( 1, $result['innerBlocks'], 'Only the copy paragraph remains.' );
 		$this->assertStringNotContainsString( 'wp-block-button', do_blocks( self::URLLESS_BUTTON_PROMPT ) );
+	}
+
+	/**
+	 * Off-site platform: a rebuilt CTA carries the site-wide button label and
+	 * destination.
+	 */
+	public function test_normalize_builds_button_from_the_globals() {
+		add_filter( 'newspack_contextual_prompts_use_donate_block', '__return_false' );
+		$permalink = $this->set_donor_landing_page();
+		update_option( 'newspack_contextual_prompts_button_text', 'Support us' );
+		update_option( 'newspack_contextual_prompts_button_url', 'https://example.com/give/' );
+
+		$result = Newspack_Popups_Contextual_Prompt_Block::prepare_block_data( $this->parse_prompt( self::DONATE_FORM_PROMPT ) );
+		$button = $result['innerBlocks'][1]['innerBlocks'][0];
+
+		$this->assertSame( 'https://example.com/give/', $button['attrs']['url'] );
+		$this->assertStringContainsString( 'href="https://example.com/give/"', $button['innerHTML'] );
+		$this->assertStringContainsString( '>Support us</a>', $button['innerHTML'] );
+		$this->assertStringNotContainsString( esc_url( $permalink ), $button['innerHTML'], 'The global URL wins over the donor landing page.' );
+	}
+
+	/**
+	 * Empty globals inherit: "Donate" and the donor landing page.
+	 */
+	public function test_empty_globals_inherit_donate_and_the_landing_page() {
+		add_filter( 'newspack_contextual_prompts_use_donate_block', '__return_false' );
+		$permalink = $this->set_donor_landing_page();
+
+		$this->assertSame( 'Donate', Newspack_Popups_Contextual_Prompt_Block::get_button_text() );
+		$this->assertSame( $permalink, Newspack_Popups_Contextual_Prompt_Block::get_button_url() );
+
+		$result = Newspack_Popups_Contextual_Prompt_Block::prepare_block_data( $this->parse_prompt( self::DONATE_FORM_PROMPT ) );
+		$button = $result['innerBlocks'][1]['innerBlocks'][0];
+
+		$this->assertStringContainsString( 'href="' . esc_url( $permalink ) . '"', $button['innerHTML'] );
+		$this->assertStringContainsString( '>Donate</a>', $button['innerHTML'] );
+	}
+
+	/**
+	 * The globals seed prompts inserted afterwards; a stored prompt keeps its own
+	 * label and destination.
+	 */
+	public function test_globals_do_not_rewrite_stored_prompts() {
+		add_filter( 'newspack_contextual_prompts_use_donate_block', '__return_false' );
+		update_option( 'newspack_contextual_prompts_button_text', 'Support us' );
+		update_option( 'newspack_contextual_prompts_button_url', 'https://example.com/give/' );
+
+		$html = do_blocks( self::PLAIN_BUTTON_PROMPT );
+
+		$this->assertStringContainsString( 'href="https://example.com/donate/"', $html );
+		$this->assertStringContainsString( '>Donate</a>', $html );
+		$this->assertStringNotContainsString( 'https://example.com/give/', $html );
+	}
+
+	/**
+	 * With no landing page and no global URL the CTA is dropped, not rendered as a
+	 * dead button carrying the global label.
+	 */
+	public function test_global_label_alone_does_not_resurrect_a_dead_cta() {
+		add_filter( 'newspack_contextual_prompts_use_donate_block', '__return_false' );
+		update_option( 'newspack_contextual_prompts_button_text', 'Support us' );
+
+		$result = Newspack_Popups_Contextual_Prompt_Block::prepare_block_data( $this->parse_prompt( self::DONATE_FORM_PROMPT ) );
+
+		$this->assertCount( 1, $result['innerBlocks'], 'Only the copy paragraph remains.' );
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles-api.php
@@ -3,7 +3,8 @@
  * Class Contextual Prompt Styles API Test
  *
  * The wizard's Style section rides the existing status/profile endpoints:
- * status carries the style payload, profile save carries optional overrides.
+ * status carries the style payload, profile save carries optional overrides and,
+ * behind `edit_css`, the block's custom CSS.
  *
  * @package Newspack_Popups
  */
@@ -19,6 +20,7 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 		parent::set_up();
 		update_option( Newspack_Popups_Settings::AI_COPY_ASSISTANT_ENABLED_OPTION, true );
 		delete_option( Newspack_Popups_Contextual_Prompt_Styles::OPTION_NAME );
+		delete_option( Newspack_Popups_Contextual_Prompt_Styles::CUSTOM_CSS_OPTION_NAME );
 		wp_set_current_user( $this->factory->user->create( [ 'role' => 'administrator' ] ) );
 		global $wp_rest_server;
 		$wp_rest_server = new WP_REST_Server(); // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
@@ -30,6 +32,7 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 	 * in the theme_json cache group too — so drop all of it.
 	 */
 	public function tear_down() {
+		remove_filter( 'map_meta_cap', [ __CLASS__, 'deny_edit_css' ] );
 		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'add_numeric_font_size_preset' ] );
 		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'disable_default_palette' ] );
 		remove_filter( 'wp_theme_json_data_theme', [ __CLASS__, 'disable_default_spacing_sizes' ] );
@@ -780,5 +783,115 @@ class ContextualPromptStylesApiTest extends WP_UnitTestCase {
 		);
 		rest_do_request( $request );
 		$this->assertSame( [], Newspack_Popups_Contextual_Prompt_Styles::get_styles() );
+	}
+
+	/**
+	 * Status carries the stored custom CSS and whether this user may write it.
+	 */
+	public function test_status_carries_the_custom_css_and_its_capability() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( 'color: red;' );
+
+		$data = rest_do_request( new WP_REST_Request( 'GET', '/newspack-popups/v1/contextual-prompt/status' ) )->get_data();
+
+		$this->assertTrue( $data['can_edit_css'] );
+		$this->assertSame( 'color: red;', $data['custom_css'] );
+
+		add_filter( 'map_meta_cap', [ __CLASS__, 'deny_edit_css' ], 10, 2 );
+		$data = rest_do_request( new WP_REST_Request( 'GET', '/newspack-popups/v1/contextual-prompt/status' ) )->get_data();
+
+		$this->assertFalse( $data['can_edit_css'] );
+	}
+
+	/**
+	 * Profile save with custom CSS persists it, unfiltered, and echoes it back.
+	 */
+	public function test_save_profile_with_custom_css() {
+		$request = new WP_REST_Request( 'POST', '/newspack-popups/v1/contextual-prompt/profile' );
+		$request->set_body_params(
+			[
+				'fields'     => [],
+				'custom_css' => '& a { color: red; }',
+			]
+		);
+		$data = rest_do_request( $request )->get_data();
+
+		$this->assertSame( '& a { color: red; }', $data['custom_css'] );
+		$this->assertSame( '& a { color: red; }', Newspack_Popups_Contextual_Prompt_Styles::get_custom_css() );
+	}
+
+	/**
+	 * Custom CSS is not sanitized, so `edit_css` is the control: a payload
+	 * carrying it from a user without the capability fails the whole request.
+	 */
+	public function test_save_profile_rejects_custom_css_without_the_capability() {
+		add_filter( 'map_meta_cap', [ __CLASS__, 'deny_edit_css' ], 10, 2 );
+
+		$request = new WP_REST_Request( 'POST', '/newspack-popups/v1/contextual-prompt/profile' );
+		$request->set_body_params(
+			[
+				'fields'     => [ 'newspack_contextual_prompts_override_label' => 'Give now' ],
+				'custom_css' => 'color: red;',
+			]
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 403, $response->get_status() );
+		$this->assertSame( '', Newspack_Popups_Contextual_Prompt_Styles::get_custom_css() );
+		$this->assertSame( '', get_option( 'newspack_contextual_prompts_override_label', '' ) );
+	}
+
+	/**
+	 * CSS that could close the STYLE element early fails the request before any
+	 * option write.
+	 */
+	public function test_save_profile_rejects_invalid_custom_css() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( 'color: red;' );
+
+		$request = new WP_REST_Request( 'POST', '/newspack-popups/v1/contextual-prompt/profile' );
+		$request->set_body_params(
+			[
+				'fields'     => [ 'newspack_contextual_prompts_override_label' => 'Give now' ],
+				'custom_css' => 'color: red; </style>',
+			]
+		);
+		$response = rest_do_request( $request );
+
+		$this->assertSame( 400, $response->get_status() );
+		$this->assertSame( 'color: red;', Newspack_Popups_Contextual_Prompt_Styles::get_custom_css() );
+		$this->assertSame( '', get_option( 'newspack_contextual_prompts_override_label', '' ) );
+	}
+
+	/**
+	 * Omitting the key leaves the stored CSS untouched; an explicit empty string
+	 * clears it.
+	 */
+	public function test_save_profile_custom_css_semantics() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( 'color: red;' );
+
+		$request = new WP_REST_Request( 'POST', '/newspack-popups/v1/contextual-prompt/profile' );
+		$request->set_body_params( [ 'fields' => [] ] );
+		rest_do_request( $request );
+		$this->assertSame( 'color: red;', Newspack_Popups_Contextual_Prompt_Styles::get_custom_css() );
+
+		$request = new WP_REST_Request( 'POST', '/newspack-popups/v1/contextual-prompt/profile' );
+		$request->set_body_params(
+			[
+				'fields'     => [],
+				'custom_css' => '',
+			]
+		);
+		rest_do_request( $request );
+		$this->assertSame( '', Newspack_Popups_Contextual_Prompt_Styles::get_custom_css() );
+	}
+
+	/**
+	 * Withhold `edit_css` from a user who otherwise manages options.
+	 *
+	 * @param string[] $caps Primitive capabilities required of the user.
+	 * @param string   $cap  Capability being checked.
+	 * @return string[]
+	 */
+	public static function deny_edit_css( $caps, $cap ) {
+		return 'edit_css' === $cap ? [ 'do_not_allow' ] : $caps;
 	}
 }

--- a/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-styles.php
@@ -6,6 +6,8 @@
  * allowlist sanitization, style-engine CSS output, and the editor delivery
  * path. The CSS must sit at :root :where() specificity so the block's
  * theme.json default design loses by order and per-block styles still win.
+ * Publisher-written custom CSS rides along in its own option, validated and
+ * scoped to the block.
  *
  * @package Newspack_Popups
  */
@@ -28,6 +30,7 @@ class ContextualPromptStylesTest extends WP_UnitTestCase {
 		parent::set_up();
 		update_option( Newspack_Popups_Settings::AI_COPY_ASSISTANT_ENABLED_OPTION, true );
 		delete_option( Newspack_Popups_Contextual_Prompt_Styles::OPTION_NAME );
+		delete_option( Newspack_Popups_Contextual_Prompt_Styles::CUSTOM_CSS_OPTION_NAME );
 	}
 
 	/**
@@ -406,5 +409,332 @@ class ContextualPromptStylesTest extends WP_UnitTestCase {
 
 		$this->assertSame( '#f7f7f7', $defaults['color']['background'] );
 		$this->assertArrayNotHasKey( 'text', $defaults['color'] );
+	}
+
+	/**
+	 * Custom CSS renders inside a STYLE element, so it must not close it, nor end
+	 * in a prefix of a closing tag the next stylesheet could complete.
+	 */
+	public function test_validate_custom_css_rejects_a_premature_style_close() {
+		$rejected = [
+			'p { color: red; } </style>',
+			'p { color: red; } </STYLE >',
+			'p { color: red; } </style/',
+			'p { color: red; } </style',
+			'p { color: red; } </sty',
+			'p { color: red; } <',
+		];
+
+		foreach ( $rejected as $css ) {
+			$result = Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( $css );
+
+			$this->assertWPError( $result, $css );
+			$this->assertSame( 400, $result->get_error_data()['status'] );
+		}
+	}
+
+	/**
+	 * An unclosed comment would comment out every style appended to the shared
+	 * global-styles handle after it.
+	 */
+	public function test_validate_custom_css_rejects_an_unclosed_comment() {
+		$rejected = [
+			"p { color: red; }\n/* unclosed comment",
+			'/* unclosed',
+		];
+
+		foreach ( $rejected as $css ) {
+			$result = Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( $css );
+
+			$this->assertWPError( $result, $css );
+			$this->assertSame( 400, $result->get_error_data()['status'] );
+		}
+	}
+
+	/**
+	 * An unbalanced opening brace, for the same reason.
+	 */
+	public function test_validate_custom_css_rejects_an_unbalanced_opening_brace() {
+		$result = Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( 'p { color: red;' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * An unbalanced closing brace, for the same reason.
+	 */
+	public function test_validate_custom_css_rejects_an_unbalanced_closing_brace() {
+		$rejected = [
+			'p { color: red; } }',
+			'p { } }',
+		];
+
+		foreach ( $rejected as $css ) {
+			$result = Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( $css );
+
+			$this->assertWPError( $result, $css );
+			$this->assertSame( 400, $result->get_error_data()['status'] );
+		}
+	}
+
+	/**
+	 * An unclosed parenthesis, for the same reason: an unterminated function
+	 * consumes input until its closer, so it swallows whatever follows.
+	 */
+	public function test_validate_custom_css_rejects_an_unbalanced_opening_parenthesis() {
+		$rejected = [
+			'& { background: url( }',
+			'& { color: rgb(0,0,0 }',
+		];
+
+		foreach ( $rejected as $css ) {
+			$result = Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( $css );
+
+			$this->assertWPError( $result, $css );
+			$this->assertSame( 400, $result->get_error_data()['status'] );
+		}
+	}
+
+	/**
+	 * Balanced parentheses pass, and a stray closer is harmless in CSS so it
+	 * passes too. Parentheses inside strings and comments are text, not structure.
+	 */
+	public function test_validate_custom_css_accepts_balanced_and_stray_parentheses() {
+		$accepted = [
+			"& { background: url( 'a.png' ); width: calc( 100% - 10px ); }",
+			'& { width: calc( 100% ) ); }',
+			'& { content: "("; }',
+			'& { /* ( */ color: red; }',
+		];
+
+		foreach ( $accepted as $css ) {
+			$this->assertTrue( Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( $css ), $css );
+		}
+	}
+
+	/**
+	 * Everything else passes.
+	 */
+	public function test_validate_custom_css_accepts_ordinary_css() {
+		$accepted = [
+			'',
+			'color: red;',
+			'& a { text-decoration: underline; }',
+			'p { /* a complete comment */ color: red; }',
+			'p::after { content: "</styles"; }',
+		];
+
+		foreach ( $accepted as $css ) {
+			$this->assertTrue( Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( $css ), $css );
+		}
+	}
+
+	/**
+	 * A comment opener immediately followed by a slash opens a comment that never
+	 * closes.
+	 */
+	public function test_validate_custom_css_rejects_a_comment_that_never_closes() {
+		$result = Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( '/*/' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * An unterminated quoted string, for the same reason.
+	 */
+	public function test_validate_custom_css_rejects_an_unterminated_string() {
+		$result = Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( '& { content: "unterminated' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 400, $result->get_error_data()['status'] );
+	}
+
+	/**
+	 * A brace, comment marker or escaped quote inside a quoted string is text,
+	 * not structure.
+	 */
+	public function test_validate_custom_css_accepts_structural_characters_inside_strings() {
+		$accepted = [
+			'&::before { content: "{"; }',
+			'&::after { content: "}"; }',
+			'&::before { content: "/*"; }',
+			'&::before { content: "*/"; }',
+			'& { background: url("data:image/svg+xml;utf8,<svg><text>{</text></svg>"); }',
+			'p { content: "a\\"b"; }',
+			"p { content: 'a\\'b'; }",
+		];
+
+		foreach ( $accepted as $css ) {
+			$this->assertTrue( Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( $css ), $css );
+		}
+	}
+
+	/**
+	 * A bare newline ends a string in the browser, so a comment opened after it
+	 * is real and the CSS must be rejected. All three line endings count.
+	 */
+	public function test_validate_custom_css_rejects_a_string_broken_by_a_bare_newline() {
+		$rejected = [
+			".a { content: \"x\n/*\n\" }",
+			".a { content: \"x\r\n/*\r\n\" }",
+			".a { content: \"x\f/*\f\" }",
+		];
+
+		foreach ( $rejected as $css ) {
+			$result = Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( $css );
+
+			$this->assertWPError( $result, $css );
+			$this->assertSame( 400, $result->get_error_data()['status'] );
+		}
+	}
+
+	/**
+	 * A backslash line continuation keeps the string open across the line break,
+	 * so only a bare newline fails. Both line-ending forms must keep passing.
+	 */
+	public function test_validate_custom_css_accepts_a_backslash_line_continuation_in_a_string() {
+		$accepted = [
+			"p { content: \"a\\\nb\"; }",
+			"p { content: \"a\\\r\nb\"; }",
+		];
+
+		foreach ( $accepted as $css ) {
+			$this->assertTrue( Newspack_Popups_Contextual_Prompt_Styles::validate_custom_css( $css ), $css );
+		}
+	}
+
+	/**
+	 * Saving rejects the same CSS the validator does, leaving the stored value
+	 * standing.
+	 */
+	public function test_save_custom_css_rejects_invalid_css() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( 'color: red;' );
+
+		$result = Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( 'color: red; </style>' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'color: red;', Newspack_Popups_Contextual_Prompt_Styles::get_custom_css() );
+	}
+
+	/**
+	 * Saving rejects structurally invalid CSS the same way, leaving the stored
+	 * value standing.
+	 */
+	public function test_save_custom_css_rejects_structurally_invalid_css() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( 'color: red;' );
+
+		$result = Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( 'p { color: red;' );
+
+		$this->assertWPError( $result );
+		$this->assertSame( 'color: red;', Newspack_Popups_Contextual_Prompt_Styles::get_custom_css() );
+	}
+
+	/**
+	 * An empty value removes the option entirely.
+	 */
+	public function test_save_empty_custom_css_deletes_option() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( 'color: red;' );
+		$this->assertNotEmpty( get_option( Newspack_Popups_Contextual_Prompt_Styles::CUSTOM_CSS_OPTION_NAME ) );
+
+		$this->assertTrue( Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( '' ) );
+		$this->assertFalse( get_option( Newspack_Popups_Contextual_Prompt_Styles::CUSTOM_CSS_OPTION_NAME ) );
+		$this->assertSame( '', Newspack_Popups_Contextual_Prompt_Styles::get_custom_css() );
+	}
+
+	/**
+	 * Bare declarations are wrapped in the block's :root :where() band, and `&`
+	 * stands for the block in a nested rule.
+	 */
+	public function test_custom_css_is_scoped_to_the_block() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( "color: red;\n& a { text-decoration: underline; }" );
+
+		$css = Newspack_Popups_Contextual_Prompt_Styles::get_css();
+
+		$this->assertStringContainsString( ':root :where(.wp-block-newspack-popups-contextual-prompt){color: red;}', $css );
+		$this->assertStringContainsString( ':root :where(.wp-block-newspack-popups-contextual-prompt a){text-decoration: underline;}', $css );
+	}
+
+	/**
+	 * The custom CSS follows the style-engine output, so at the equal specificity
+	 * the two share, the publisher's own rule wins.
+	 */
+	public function test_custom_css_follows_the_style_engine_output() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_styles( [ 'color' => [ 'background' => '#123456' ] ] );
+		Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( 'background-color: #abcdef;' );
+
+		$css = Newspack_Popups_Contextual_Prompt_Styles::get_css();
+
+		$this->assertLessThan( strpos( $css, '#abcdef' ), strpos( $css, '#123456' ) );
+	}
+
+	/**
+	 * Custom CSS with no style overrides beside it still reaches both delivery
+	 * paths.
+	 */
+	public function test_custom_css_ships_without_any_style_overrides() {
+		Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( 'color: red;' );
+		$this->assertSame( [], Newspack_Popups_Contextual_Prompt_Styles::get_styles() );
+
+		$css = Newspack_Popups_Contextual_Prompt_Styles::get_css();
+		$this->assertStringContainsString( 'color: red;', $css );
+
+		$settings = Newspack_Popups_Contextual_Prompt_Styles::filter_block_editor_settings( [ 'styles' => [] ] );
+		$this->assertCount( 1, $settings['styles'] );
+		$this->assertSame( $css, $settings['styles'][0]['css'] );
+	}
+
+	/**
+	 * Custom CSS inherits init()'s opt-in gate.
+	 */
+	public function test_custom_css_is_not_delivered_before_the_opt_in() {
+		if ( wp_is_block_theme() ) {
+			$this->markTestSkipped( 'Block themes keep the class inert regardless of the opt-in.' );
+		}
+		Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( 'color: red;' );
+		$callback = [ 'Newspack_Popups_Contextual_Prompt_Styles', 'enqueue_front_end_styles' ];
+		remove_action( 'wp_footer', $callback, 1 );
+
+		delete_option( Newspack_Popups_Settings::AI_COPY_ASSISTANT_ENABLED_OPTION );
+		Newspack_Popups_Contextual_Prompt_Styles::init();
+
+		$this->assertFalse( has_action( 'wp_footer', $callback ) );
+	}
+
+	/**
+	 * And its block-theme gate, where the Site Editor's own Additional CSS owns
+	 * the block.
+	 */
+	public function test_custom_css_is_not_delivered_on_a_block_theme() {
+		$stylesheet = $this->get_any_block_theme_stylesheet();
+		if ( ! $stylesheet ) {
+			$this->markTestSkipped( 'No block theme installed.' );
+		}
+		Newspack_Popups_Contextual_Prompt_Styles::save_custom_css( 'color: red;' );
+		$callback = [ 'Newspack_Popups_Contextual_Prompt_Styles', 'enqueue_front_end_styles' ];
+		remove_action( 'wp_footer', $callback, 1 );
+
+		$original = get_stylesheet();
+		switch_theme( $stylesheet );
+		Newspack_Popups_Contextual_Prompt_Styles::init();
+		$hooked = has_action( 'wp_footer', $callback );
+		switch_theme( $original );
+
+		$this->assertFalse( $hooked );
+	}
+
+	/**
+	 * Find any installed block theme stylesheet slug.
+	 *
+	 * @return string|null Theme stylesheet, or null if unavailable.
+	 */
+	private function get_any_block_theme_stylesheet() {
+		foreach ( wp_get_themes() as $stylesheet => $theme ) {
+			if ( method_exists( $theme, 'is_block_theme' ) && $theme->is_block_theme() ) {
+				return $stylesheet;
+			}
+		}
+		return null;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Giovanni's feedback on Contextual Prompts, plus a follow-up on the button CTA. Targets
`feat/contextual-prompts` so #686 stays clean while its GA4 sign-off is outstanding.

**The prompt's two children can no longer be rearranged.** `templateLock: 'all'` locked
them, but core offers every locked block an Unlock button in its toolbar, and the `lock`
attribute that button writes takes precedence over the template. One click and a confirm
brought back the drag handle, the movers and the block-type switcher, permanently and in
the saved markup. The lock now pairs with content-only editing mode on every descendant,
which withholds the Unlock button. The mode is set from the block rather than through
`templateLock: 'contentOnly'`, because that variant turns the prompt into a pattern-style
section and replaces its own inspector with a content list.

**Row and Stack on the container, when the CTA is a button.** Core renders the
orientation toggle by itself once the default layout is flex and switching is off, so
there is no bespoke control. Registration branches on whether donations are native, in
the JS and in the PHP block registration both: `wp_render_layout_support_flag()` reads the
server-side `supports.layout.default`, so a JS-only branch would render `is-layout-flow`
under an editor previewing a flex column. The vertical default carries
`justifyContent: 'stretch'` so children still fill the container, as they did under flow.

**Additional CSS in Edit Styles.** Block themes already get this in the Site Editor under
Styles > Blocks > Contextual Prompt > Advanced; classic themes had no equivalent. It
stores in its own option so the existing style allowlist stays strict, scopes through the
public `WP_Theme_JSON::process_blocks_custom_css()`, and needs `edit_css` on top of the
`manage_options` the route already required, which is core's own contract for the same
feature. Stored CSS keeps rendering if that capability is later revoked, and the field
goes read-only rather than disappearing, so it can still be found.

Validation is core's `</style>` check plus a structural scan, which core's server side
does not do. Core's UI for this is a CodeMirror editor that lints client-side; this field
is a plain textarea, and the output is concatenated into the shared `global-styles` inline
stylesheet, so an unclosed comment would swallow every style appended after ours. The scan
tracks quoted strings and comments so that `content: "{"` is not mistaken for an unbalanced
brace, and ends a string at an unescaped newline, carriage return or form feed, as the CSS
tokenizer does. A `/*` inside an unquoted `url()` is rejected; that is a deliberate,
documented conservative call, and quoting the URL avoids it.

**A site-wide label and destination for the button CTA.** The URL already had a global
source in the donor landing page; the label was the literal "Donate" in both the
insert-time template and the render-time repair path. Both now resolve from two new
profile fields, offered only when donations are not native. Empty means inherit. Both stay
editable per post, which survives the lock because core marks `text` and `url` on
`core/button` as content.

Closes DSGNEWS-205.

![Contextual Prompt layout toggle and Additional CSS drawer](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/03/d4950vw6-dsgnews-205-proof.png)

Left: the container keeps its own inspector, now with the orientation toggle, while the copy
and CTA are locked. Right: the Additional CSS panel in Edit Styles, and the new button label
field behind it.

### How to test the changes in this Pull Request:

1. On a site with `NEWSPACK_CONTEXTUAL_PROMPTS` defined and Contextual Prompts opted in,
   open a post holding a prompt. Select the copy paragraph, then the CTA. Neither should
   offer a drag handle, movers, a block-type switcher or an **Unlock** button, and neither
   should be removable. The paragraph should still take text and inline formatting.
2. Select the prompt container. Its own inspector should be unchanged: Layout, the Copy
   panel with **Regenerate Suggestions**, Advanced, and a Styles tab with Color,
   Typography, Dimensions and Border & Shadow.
3. Point the site at off-site donations, so the CTA is a plain button. The container's
   Layout panel should now offer **Horizontal** and **Vertical**. Set Horizontal and
   confirm the front end renders the copy and button side by side. On a native-donations
   site the toggle should be absent.
4. In Audience > Campaigns > Contextual Prompts, with off-site donations, set **Donation
   button label** and **Donation button URL**. Insert a new prompt and confirm the button
   picks both up. Change the settings and confirm an existing prompt keeps its own.
5. On a classic theme, open **Edit Styles**. Below Border there should be an **Additional CSS**
   panel. Enter `border-top: 4px solid magenta;` and `& p { letter-spacing: 0.03em; }`,
   save, and confirm both rules reach the front end scoped to the prompt, after the
   wizard's other style overrides.
6. Confirm `</style>` in that field is rejected with an error and does not overwrite the
   stored value.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

The seven failing PHPCS jobs are the `WordPressVIPMinimum.Performance.NoPaging` sniff that
already fails on `main` and on #686. No line this branch adds is flagged; the flagged lines
in files it touches predate it by years.
