### PR TITLE
fix(newsletters): ad dates shift a day on negative-offset sites

### DIFF
--- a/plugins/newspack-newsletters/includes/ads/class-ads.php
+++ b/plugins/newspack-newsletters/includes/ads/class-ads.php
@@ -375,6 +375,32 @@ final class Ads {
 	}
 
 	/**
+	 * Format a date-only ad meta value for display.
+	 *
+	 * `start_date`/`expiry_date` are whole calendar days: `is_ad_active()`
+	 * compares them as `Y-m-d` strings against the newsletter's own date, so
+	 * they carry neither a time nor a timezone. Anchoring at midnight in the
+	 * site timezone is what keeps the rendered day equal to the stored one —
+	 * `strtotime( 'Y-m-d' )` resolves against PHP's default zone (UTC under
+	 * WordPress) and `wp_date()` then converts into the site zone, which moved
+	 * the date a day earlier on every site at a negative UTC offset.
+	 *
+	 * @param mixed $value Raw meta value.
+	 * @return string Localized date, or '' when the value is empty or invalid.
+	 */
+	public static function format_ad_date( $value ) {
+		$value = self::sanitize_ad_date( $value );
+		if ( '' === $value ) {
+			return '';
+		}
+		$date = date_create_immutable( $value . ' 00:00:00', wp_timezone() );
+		if ( false === $date ) {
+			return '';
+		}
+		return wp_date( __( 'F j, Y' ), $date->getTimestamp() );
+	}
+
+	/**
 	 * Count only ads (self::CPT) tagged with each advertiser term, across
 	 * the same statuses the Ads list shows. Registered as the taxonomy's
 	 * `update_count_callback` so newsletter posts tagged with an advertiser
@@ -740,19 +766,11 @@ final class Ads {
 	 */
 	public static function custom_column( $column_name, $post_id ) {
 		if ( 'start_date' === $column_name ) {
-			$start_date = get_post_meta( $post_id, 'start_date', true );
-			if ( ! empty( $start_date ) ) {
-				echo esc_html( wp_date( __( 'F j, Y' ), strtotime( $start_date ) ) );
-			} else {
-				echo '—';
-			}
+			$start_date = self::format_ad_date( get_post_meta( $post_id, 'start_date', true ) );
+			echo '' === $start_date ? '—' : esc_html( $start_date );
 		} elseif ( 'expiry_date' === $column_name ) {
-			$expiry_date = get_post_meta( $post_id, 'expiry_date', true );
-			if ( ! empty( $expiry_date ) ) {
-				echo esc_html( wp_date( __( 'F j, Y' ), strtotime( $expiry_date ) ) );
-			} else {
-				echo '—';
-			}
+			$expiry_date = self::format_ad_date( get_post_meta( $post_id, 'expiry_date', true ) );
+			echo '' === $expiry_date ? '—' : esc_html( $expiry_date );
 		} elseif ( 'price' === $column_name ) {
 			$price = get_post_meta( $post_id, 'price', true );
 			if ( ! empty( $price ) ) {

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
@@ -8,7 +8,7 @@
 import { Icon, Tooltip } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { drafts, notAllowed, published, scheduled, trash } from '@wordpress/icons';
-import { gmdateI18n } from '@wordpress/date';
+import { dateI18n, getSettings as getDateSettings, gmdateI18n } from '@wordpress/date';
 
 import { getAdminUrl } from '../../admin-globals';
 import { formatPostDate } from '../../utils/format-date';
@@ -24,27 +24,41 @@ const STATUS_KIND_ICONS = {
 };
 
 // Ad windows are whole calendar days: the meta is `Y-m-d`, and `is_ad_active()`
-// compares it as a string against the newsletter's own date. Nothing about
-// these values carries a time or a timezone, so they're formatted in UTC with
-// a date-only pattern. Two things that looks like over-caution but isn't:
-// converting into the site timezone shifts the day (that is the whole family of
-// bugs this file sits next to), and the site's `date_format` may legitimately
-// include a time, which would then render as a clock reading with no meaning —
-// a noon anchor showing up as "8:00 am" on an EDT site, say.
-const adDateFormat = () => __( 'F j, Y', 'newspack-newsletters' );
+// compares it as a string against the newsletter's own date, so none of these
+// values carries a time.
+//
+// Keep the publisher's configured pattern, which is what supplies locale
+// ordering (`j. F Y` on a German site). Fall back only when that pattern also
+// carries a time — `date_format` is allowed to, and then the anchor below
+// would surface as a meaningless clock reading, e.g. "8:00 am" on an EDT site.
+const TIME_FORMAT_TOKENS = /[aABgGhHisuvcrTeIOPZ]/;
+const adDateFormat = () => {
+	const configured = getDateSettings().formats?.date;
+	if ( configured && ! TIME_FORMAT_TOKENS.test( configured.replace( /\\./g, '' ) ) ) {
+		return configured;
+	}
+	/* translators: PHP date format for an ad's start/expiration day. Date tokens only — these values have no time. */
+	return __( 'F j, Y', 'newspack-newsletters' );
+};
 
 // One hint per column: each says the thing relevant to its own date, so the
 // inclusivity falls out of the wording rather than needing its own sentence.
 const startDateHint = () => __( 'Runs from this day, in the site timezone.', 'newspack-newsletters' );
 const expiryDateHint = () => __( 'Runs through the end of this day, in the site timezone.', 'newspack-newsletters' );
 
-const formatTimestampAsDate = timestamp => {
-	if ( ! timestamp ) {
-		return '';
-	}
-	// `starts_at`/`expires_at` are anchored at noon UTC by the REST layer.
-	return gmdateI18n( adDateFormat(), timestamp * 1000 );
-};
+// The REST status payload sends `starts_at`/`expires_at` in two shapes that
+// need opposite handling, so keep them as separate named formatters rather
+// than one function that guesses.
+//
+// A day anchor stands for a calendar day off the `Y-m-d` meta, pinned at noon
+// UTC by the REST layer: format it in UTC, because site time moves it to the
+// next day once the offset reaches +12.
+const formatDayAnchor = timestamp => ( timestamp ? gmdateI18n( adDateFormat(), timestamp * 1000 ) : '' );
+
+// An instant is a real moment — `post_date_gmt`, the auto-publish time of a
+// `future` post: format it in site time, the day the scheduler shows. In UTC an
+// ad publishing at 21:00 in New York would be dated the following day.
+const formatInstant = timestamp => ( timestamp ? dateI18n( adDateFormat(), timestamp * 1000 ) : '' );
 
 const formatDate = value => {
 	if ( ! value ) {
@@ -77,16 +91,20 @@ const renderStatus = ( { item } ) => {
 
 	let label;
 	if ( 'expired' === kind && status.expires_at ) {
+		// `expires_at` is only ever set from the date meta, so always an anchor.
 		label = sprintf(
 			/* translators: %s: formatted expiry date */
 			__( 'Expired %s', 'newspack-newsletters' ),
-			formatTimestampAsDate( status.expires_at )
+			formatDayAnchor( status.expires_at )
 		);
 	} else if ( 'scheduled' === kind && status.starts_at ) {
+		// Scheduled has two sources: a `future` post reports its publish instant,
+		// while a published ad with a future start date reports a day anchor.
+		const formatStart = 'future' === item?.status ? formatInstant : formatDayAnchor;
 		label = sprintf(
 			/* translators: %s: formatted start date */
 			__( 'Starts %s', 'newspack-newsletters' ),
-			formatTimestampAsDate( status.starts_at )
+			formatStart( status.starts_at )
 		);
 	} else {
 		label = statusKindLabel( kind );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
@@ -8,7 +8,7 @@
 import { Icon } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { drafts, notAllowed, published, scheduled, trash } from '@wordpress/icons';
-import { dateI18n, getSettings as getDateSettings } from '@wordpress/date';
+import { gmdateI18n } from '@wordpress/date';
 
 import { getAdminUrl } from '../../admin-globals';
 import { formatPostDate } from '../../utils/format-date';
@@ -23,24 +23,37 @@ const STATUS_KIND_ICONS = {
 	trash,
 };
 
+// Ad windows are whole calendar days: the meta is `Y-m-d`, and `is_ad_active()`
+// compares it as a string against the newsletter's own date. Nothing about
+// these values carries a time or a timezone, so they're formatted in UTC with
+// a date-only pattern. Two things that looks like over-caution but isn't:
+// converting into the site timezone shifts the day (that is the whole family of
+// bugs this file sits next to), and the site's `date_format` may legitimately
+// include a time, which would then render as a clock reading with no meaning —
+// a noon anchor showing up as "8:00 am" on an EDT site, say.
+const adDateFormat = () => __( 'F j, Y', 'newspack-newsletters' );
+
+const adDateHint = () =>
+	__(
+		'Ad scheduling uses whole days in the site timezone, matched against the newsletter’s own date. Both the start and expiration days are included.',
+		'newspack-newsletters'
+	);
+
 const formatTimestampAsDate = timestamp => {
 	if ( ! timestamp ) {
 		return '';
 	}
-	const settings = getDateSettings();
-	const format = settings.formats?.date || 'M j, Y';
-	return dateI18n( format, timestamp * 1000 );
+	// `starts_at`/`expires_at` are anchored at noon UTC by the REST layer.
+	return gmdateI18n( adDateFormat(), timestamp * 1000 );
 };
 
 const formatDate = value => {
 	if ( ! value ) {
 		return '';
 	}
-	const settings = getDateSettings();
-	const format = settings.formats?.date || 'M j, Y';
-	// Tolerate ISO datetime meta; noon UTC keeps the parsed day timezone-safe.
+	// Tolerate a legacy ISO datetime meta value by keeping only the date.
 	const ymd = String( value ).slice( 0, 10 );
-	return dateI18n( format, `${ ymd }T12:00:00Z` );
+	return gmdateI18n( adDateFormat(), `${ ymd }T00:00:00Z` );
 };
 
 const editUrl = item => `${ getAdminUrl() }post.php?post=${ item.id }&action=edit`;
@@ -98,8 +111,16 @@ const renderTerms =
 			.join( ', ' );
 	};
 
-const renderStartDate = ( { item } ) => formatDate( item?.meta?.start_date );
-const renderExpiryDate = ( { item } ) => formatDate( item?.meta?.expiry_date );
+const renderAdDate = value => {
+	const formatted = formatDate( value );
+	if ( ! formatted ) {
+		return '';
+	}
+	return <span title={ adDateHint() }>{ formatted }</span>;
+};
+
+const renderStartDate = ( { item } ) => renderAdDate( item?.meta?.start_date );
+const renderExpiryDate = ( { item } ) => renderAdDate( item?.meta?.expiry_date );
 
 const renderImpressions = ( { item } ) => String( item?.meta?.tracking_impressions ?? 0 );
 const renderClicks = ( { item } ) => String( item?.meta?.tracking_clicks ?? 0 );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.js
@@ -5,7 +5,7 @@
  * `newspack_newsletters_ad_status` so the column matches the filter.
  */
 
-import { Icon } from '@wordpress/components';
+import { Icon, Tooltip } from '@wordpress/components';
 import { __, sprintf } from '@wordpress/i18n';
 import { drafts, notAllowed, published, scheduled, trash } from '@wordpress/icons';
 import { gmdateI18n } from '@wordpress/date';
@@ -33,11 +33,10 @@ const STATUS_KIND_ICONS = {
 // a noon anchor showing up as "8:00 am" on an EDT site, say.
 const adDateFormat = () => __( 'F j, Y', 'newspack-newsletters' );
 
-const adDateHint = () =>
-	__(
-		'Ad scheduling uses whole days in the site timezone, matched against the newsletter’s own date. Both the start and expiration days are included.',
-		'newspack-newsletters'
-	);
+// One hint per column: each says the thing relevant to its own date, so the
+// inclusivity falls out of the wording rather than needing its own sentence.
+const startDateHint = () => __( 'Runs from this day, in the site timezone.', 'newspack-newsletters' );
+const expiryDateHint = () => __( 'Runs through the end of this day, in the site timezone.', 'newspack-newsletters' );
 
 const formatTimestampAsDate = timestamp => {
 	if ( ! timestamp ) {
@@ -111,16 +110,20 @@ const renderTerms =
 			.join( ', ' );
 	};
 
-const renderAdDate = value => {
+const renderAdDate = ( value, hint ) => {
 	const formatted = formatDate( value );
 	if ( ! formatted ) {
 		return '';
 	}
-	return <span title={ adDateHint() }>{ formatted }</span>;
+	return (
+		<Tooltip text={ hint }>
+			<span>{ formatted }</span>
+		</Tooltip>
+	);
 };
 
-const renderStartDate = ( { item } ) => renderAdDate( item?.meta?.start_date );
-const renderExpiryDate = ( { item } ) => renderAdDate( item?.meta?.expiry_date );
+const renderStartDate = ( { item } ) => renderAdDate( item?.meta?.start_date, startDateHint() );
+const renderExpiryDate = ( { item } ) => renderAdDate( item?.meta?.expiry_date, expiryDateHint() );
 
 const renderImpressions = ( { item } ) => String( item?.meta?.tracking_impressions ?? 0 );
 const renderClicks = ( { item } ) => String( item?.meta?.tracking_clicks ?? 0 );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.test.js
@@ -80,6 +80,14 @@ describe( 'Ads list date columns', () => {
 		expect( rendered ).not.toMatch( /\d:\d{2}\s*[ap]m/i );
 	} );
 
+	it( "keeps the site's configured date pattern when it carries no time", () => {
+		// de_DE's default `date_format`. Locale ordering is the publisher's
+		// setting, so only a pattern containing a time should be overridden.
+		configureSite( -4, 'j. F Y' );
+
+		expect( renderText( 'start_date', adWithMeta( { start_date: '2026-08-04' } ) ) ).toBe( '4. August 2026' );
+	} );
+
 	it( 'reduces a legacy stored datetime to its date', () => {
 		configureSite( -4 );
 
@@ -117,22 +125,56 @@ describe( 'Ads list date columns', () => {
 describe( 'Ads list status column dates', () => {
 	afterEach( () => configureSite( 0 ) );
 
-	// `starts_at` / `expires_at` are anchored at noon UTC by the REST layer.
-	const NOON_UTC_AUG_4 = Date.UTC( 2026, 7, 4, 12 ) / 1000;
+	const statusLabel = ( status, postStatus = 'publish' ) =>
+		fieldById( 'status' ).render( {
+			item: { id: 1, meta: {}, status: postStatus, newspack_newsletters_ad_status: status },
+		} ).props.children[ 1 ].props.children;
+
+	it( 'drops the clock time when the site date format carries one', () => {
+		configureSite( -4, 'F j, Y, g:i a' );
+
+		// Noon-UTC anchor derived from `start_date` meta of 2026-08-04.
+		const label = statusLabel( { kind: 'scheduled', starts_at: Date.UTC( 2026, 7, 4, 12 ) / 1000 } );
+
+		expect( label ).toBe( 'Starts August 4, 2026' );
+		expect( label ).not.toMatch( /\d:\d{2}\s*[ap]m/i );
+	} );
+
+	// For a `future` post the REST layer sends `post_date_gmt` — a real publish
+	// instant, not a calendar-day anchor. Formatting that in UTC dates a
+	// late-evening scheduled ad a day forward.
+	it( 'dates a future-scheduled ad by its site-local publish day', () => {
+		configureSite( -4 );
+
+		// 2026-08-10 21:00 America/New_York === 2026-08-11 01:00 UTC.
+		const label = statusLabel( { kind: 'scheduled', starts_at: Date.UTC( 2026, 7, 11, 1 ) / 1000 }, 'future' );
+
+		expect( label ).toBe( 'Starts August 10, 2026' );
+	} );
+
+	// The other half of the pair: a published ad with a future start date sends
+	// a noon-UTC anchor, which site time would move to the next day at UTC+12
+	// and beyond — disagreeing with the Start column in the same row.
+	it.each( [
+		[ 'New York', -4 ],
+		[ 'Auckland', 12 ],
+		[ 'Kiritimati', 14 ],
+	] )( 'dates an anchored start by the stored day in %s', ( _label, offset ) => {
+		configureSite( offset );
+
+		const label = statusLabel( { kind: 'scheduled', starts_at: Date.UTC( 2026, 7, 4, 12 ) / 1000 } );
+
+		expect( label ).toBe( 'Starts August 4, 2026' );
+	} );
 
 	it.each( [
 		[ 'New York', -4 ],
 		[ 'Kiritimati', 14 ],
-	] )( 'dates the scheduled label by the stored day in %s', ( _label, offset ) => {
-		configureSite( offset, 'F j, Y, g:i a' );
+	] )( 'dates an expired ad by its stored expiry day in %s', ( _label, offset ) => {
+		configureSite( offset );
 
-		const item = {
-			id: 1,
-			meta: {},
-			newspack_newsletters_ad_status: { kind: 'scheduled', starts_at: NOON_UTC_AUG_4 },
-		};
-		const label = fieldById( 'status' ).render( { item } ).props.children[ 1 ].props.children;
+		const label = statusLabel( { kind: 'expired', expires_at: Date.UTC( 2026, 7, 4, 12 ) / 1000 } );
 
-		expect( label ).toBe( 'Starts August 4, 2026' );
+		expect( label ).toBe( 'Expired August 4, 2026' );
 	} );
 } );

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.test.js
@@ -10,6 +10,7 @@
  * timezone shifts the day itself once the offset is far enough from UTC.
  */
 
+import { render, screen } from '@testing-library/react';
 import { setSettings } from '@wordpress/date';
 
 import { getFields } from './fields';
@@ -45,10 +46,10 @@ const configureSite = ( offset, dateFormat = 'F j, Y' ) =>
 
 const fieldById = id => getFields().find( field => field.id === id );
 
-/** Render a field and return its text, unwrapping the tooltip element. */
+/** Render a field and return its text, unwrapping `<Tooltip><span>…</span></Tooltip>`. */
 const renderText = ( id, item ) => {
 	const output = fieldById( id ).render( { item } );
-	return typeof output === 'string' ? output : output.props.children;
+	return typeof output === 'string' ? output : output.props.children.props.children;
 };
 
 const adWithMeta = meta => ( { id: 1, meta } );
@@ -92,12 +93,24 @@ describe( 'Ads list date columns', () => {
 		expect( renderText( 'expiry_date', adWithMeta( { expiry_date: '' } ) ) ).toBe( '' );
 	} );
 
-	it( 'explains the window semantics on hover', () => {
+	it( 'gives each column its own hint about what the date means', () => {
 		configureSite( -4 );
 
-		const output = fieldById( 'start_date' ).render( { item: adWithMeta( { start_date: '2026-08-04' } ) } );
-		expect( output.props.title ).toMatch( /whole days/i );
-		expect( output.props.title ).toMatch( /included/i );
+		const start = fieldById( 'start_date' ).render( { item: adWithMeta( { start_date: '2026-08-04' } ) } );
+		const expiry = fieldById( 'expiry_date' ).render( { item: adWithMeta( { expiry_date: '2026-08-04' } ) } );
+
+		expect( start.props.text ).toBe( 'Runs from this day, in the site timezone.' );
+		expect( expiry.props.text ).toBe( 'Runs through the end of this day, in the site timezone.' );
+	} );
+
+	it( 'mounts the tooltip-wrapped cell without error', () => {
+		configureSite( -4 );
+
+		// The props assertions above never mount `Tooltip`; this catches the
+		// runtime shape it requires (a single element child).
+		render( fieldById( 'start_date' ).render( { item: adWithMeta( { start_date: '2026-08-04' } ) } ) );
+
+		expect( screen.getByText( 'August 4, 2026' ) ).toBeInTheDocument();
 	} );
 } );
 

--- a/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.test.js
+++ b/plugins/newspack-newsletters/src/admin-shell/screens/ads-list/fields.test.js
@@ -1,0 +1,125 @@
+/**
+ * Ad windows are whole calendar days: the meta is `Y-m-d`, and the server
+ * compares it as a string against the newsletter's own date. The list columns
+ * therefore have to show the day that was stored, with no clock time attached.
+ *
+ * Two regressions are pinned here. The columns used to format with the site's
+ * `date_format` option, which may legitimately include a time — on a site set
+ * to `F j, Y, g:i a` the noon-UTC anchor surfaced as "8:00 am", implying a
+ * time-of-day boundary that does not exist. And formatting into the site
+ * timezone shifts the day itself once the offset is far enough from UTC.
+ */
+
+import { setSettings } from '@wordpress/date';
+
+import { getFields } from './fields';
+
+const L10N = {
+	locale: 'en_US',
+	months: [ 'January', 'February', 'March', 'April', 'May', 'June', 'July', 'August', 'September', 'October', 'November', 'December' ],
+	monthsShort: [ 'Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec' ],
+	weekdays: [ 'Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday' ],
+	weekdaysShort: [ 'Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat' ],
+	meridiem: { am: 'am', pm: 'pm', AM: 'AM', PM: 'PM' },
+	relative: { future: '%s from now', past: '%s ago' },
+	startOfWeek: 0,
+};
+
+/**
+ * Configure @wordpress/date the way WordPress does for a given site.
+ *
+ * @param {number} offset     Site UTC offset in hours.
+ * @param {string} dateFormat The site's `date_format` option.
+ */
+const configureSite = ( offset, dateFormat = 'F j, Y' ) =>
+	setSettings( {
+		l10n: L10N,
+		formats: {
+			time: 'g:i a',
+			date: dateFormat,
+			datetime: 'F j, Y g:i a',
+			datetimeAbbreviated: 'M j, Y g:i a',
+		},
+		timezone: { offset, offsetFormatted: String( offset ), string: '', abbr: '' },
+	} );
+
+const fieldById = id => getFields().find( field => field.id === id );
+
+/** Render a field and return its text, unwrapping the tooltip element. */
+const renderText = ( id, item ) => {
+	const output = fieldById( id ).render( { item } );
+	return typeof output === 'string' ? output : output.props.children;
+};
+
+const adWithMeta = meta => ( { id: 1, meta } );
+
+describe( 'Ads list date columns', () => {
+	afterEach( () => configureSite( 0 ) );
+
+	it.each( [
+		[ 'UTC', 0 ],
+		[ 'Honolulu', -10 ],
+		[ 'Los Angeles', -7 ],
+		[ 'New York', -4 ],
+		[ 'Paris', 2 ],
+		[ 'Tokyo', 9 ],
+		[ 'Kiritimati', 14 ],
+	] )( 'shows the stored day in %s', ( _label, offset ) => {
+		configureSite( offset );
+
+		expect( renderText( 'start_date', adWithMeta( { start_date: '2026-08-04' } ) ) ).toBe( 'August 4, 2026' );
+		expect( renderText( 'expiry_date', adWithMeta( { expiry_date: '2026-08-04' } ) ) ).toBe( 'August 4, 2026' );
+	} );
+
+	it( 'never renders a clock time, even when the site date format carries one', () => {
+		configureSite( -4, 'F j, Y, g:i a' );
+
+		const rendered = renderText( 'start_date', adWithMeta( { start_date: '2026-08-04' } ) );
+		expect( rendered ).toBe( 'August 4, 2026' );
+		expect( rendered ).not.toMatch( /\d:\d{2}\s*[ap]m/i );
+	} );
+
+	it( 'reduces a legacy stored datetime to its date', () => {
+		configureSite( -4 );
+
+		expect( renderText( 'start_date', adWithMeta( { start_date: '2026-08-04T23:59:59' } ) ) ).toBe( 'August 4, 2026' );
+	} );
+
+	it( 'renders nothing when the date is unset', () => {
+		configureSite( -4 );
+
+		expect( renderText( 'start_date', adWithMeta( {} ) ) ).toBe( '' );
+		expect( renderText( 'expiry_date', adWithMeta( { expiry_date: '' } ) ) ).toBe( '' );
+	} );
+
+	it( 'explains the window semantics on hover', () => {
+		configureSite( -4 );
+
+		const output = fieldById( 'start_date' ).render( { item: adWithMeta( { start_date: '2026-08-04' } ) } );
+		expect( output.props.title ).toMatch( /whole days/i );
+		expect( output.props.title ).toMatch( /included/i );
+	} );
+} );
+
+describe( 'Ads list status column dates', () => {
+	afterEach( () => configureSite( 0 ) );
+
+	// `starts_at` / `expires_at` are anchored at noon UTC by the REST layer.
+	const NOON_UTC_AUG_4 = Date.UTC( 2026, 7, 4, 12 ) / 1000;
+
+	it.each( [
+		[ 'New York', -4 ],
+		[ 'Kiritimati', 14 ],
+	] )( 'dates the scheduled label by the stored day in %s', ( _label, offset ) => {
+		configureSite( offset, 'F j, Y, g:i a' );
+
+		const item = {
+			id: 1,
+			meta: {},
+			newspack_newsletters_ad_status: { kind: 'scheduled', starts_at: NOON_UTC_AUG_4 },
+		};
+		const label = fieldById( 'status' ).render( { item } ).props.children[ 1 ].props.children;
+
+		expect( label ).toBe( 'Starts August 4, 2026' );
+	} );
+} );

--- a/plugins/newspack-newsletters/src/ads/editor/index.js
+++ b/plugins/newspack-newsletters/src/ads/editor/index.js
@@ -27,6 +27,15 @@ apiFetch.use( ( options, next ) => {
 	return next( options );
 } );
 
+// `DatePicker` works out whether a string already carries a UTC offset with
+// `/Z|[+-]\d{2}(:?\d{2})?$/`, and that also matches the `-DD` day component of
+// a bare `Y-m-d`. A date handed over as `2026-08-05` is therefore read as UTC
+// midnight rather than site-local midnight, which renders as the previous day
+// on any site whose UTC offset is negative. Give the picker the timezone-less
+// datetime it documents (`TIMEZONELESS_FORMAT`) so there is nothing in the
+// string to mistake for an offset.
+const toPickerDate = value => ( value ? `${ value }T00:00:00` : value );
+
 function AdEdit() {
 	const { status, isSaving, price, startDate, expiryDate, insertionStrategy, positionInContent, positionBlockCount } = useSelect( select => {
 		const { getEditedPostAttribute, isSavingPost } = select( 'core/editor' );
@@ -308,7 +317,7 @@ function AdEdit() {
 				/>
 				{ startDate ? (
 					<DatePicker
-						currentDate={ startDate }
+						currentDate={ toPickerDate( startDate ) }
 						onChange={ next => editPost( { meta: { start_date: format( 'Y-m-d', next ) } } ) }
 						isInvalidDate={ date => ! isInTheFuture( date ) }
 					/>
@@ -331,7 +340,7 @@ function AdEdit() {
 				/>
 				{ expiryDate ? (
 					<DatePicker
-						currentDate={ expiryDate }
+						currentDate={ toPickerDate( expiryDate ) }
 						onChange={ next => editPost( { meta: { expiry_date: format( 'Y-m-d', next ) } } ) }
 						isInvalidDate={ date => {
 							return startDate ? format( 'Y-m-d', date ) < startDate : ! isInTheFuture( date );

--- a/plugins/newspack-newsletters/src/ads/editor/index.js
+++ b/plugins/newspack-newsletters/src/ads/editor/index.js
@@ -27,14 +27,20 @@ apiFetch.use( ( options, next ) => {
 	return next( options );
 } );
 
-// `DatePicker` works out whether a string already carries a UTC offset with
-// `/Z|[+-]\d{2}(:?\d{2})?$/`, and that also matches the `-DD` day component of
-// a bare `Y-m-d`. A date handed over as `2026-08-05` is therefore read as UTC
-// midnight rather than site-local midnight, which renders as the previous day
-// on any site whose UTC offset is negative. Give the picker the timezone-less
-// datetime it documents (`TIMEZONELESS_FORMAT`) so there is nothing in the
-// string to mistake for an offset.
-const toPickerDate = value => ( value ? `${ value }T00:00:00` : value );
+// A bare `Y-m-d` reaches `DatePicker` as a UTC instant, which renders — and
+// saves back — as the previous day wherever the UTC offset is negative. Both
+// supported WordPress versions get there, by different routes: 6.9 hands the
+// string to `new Date()`, where a date-only ISO string is UTC by spec while a
+// date-time one is local; 7.0 first tests it against `/Z|[+-]\d{2}(:?\d{2})?$/`
+// to decide whether it already carries an offset, and the `-DD` day component
+// matches. Appending a time component is what avoids both, so keep it even if
+// that regex is fixed upstream — 6.9 would still be wrong without it.
+//
+// Noon, not midnight: only Y/m/d is ever read back off this value, and midday
+// survives the zones where local midnight does not exist on DST-transition
+// days. `includes/admin/class-ads-list-rest.php` anchors these same dates the
+// same way.
+const toTimezonelessDateTime = value => ( value ? `${ String( value ).slice( 0, 10 ) }T12:00:00` : value );
 
 function AdEdit() {
 	const { status, isSaving, price, startDate, expiryDate, insertionStrategy, positionInContent, positionBlockCount } = useSelect( select => {
@@ -317,7 +323,7 @@ function AdEdit() {
 				/>
 				{ startDate ? (
 					<DatePicker
-						currentDate={ toPickerDate( startDate ) }
+						currentDate={ toTimezonelessDateTime( startDate ) }
 						onChange={ next => editPost( { meta: { start_date: format( 'Y-m-d', next ) } } ) }
 						isInvalidDate={ date => ! isInTheFuture( date ) }
 					/>
@@ -340,7 +346,7 @@ function AdEdit() {
 				/>
 				{ expiryDate ? (
 					<DatePicker
-						currentDate={ toPickerDate( expiryDate ) }
+						currentDate={ toTimezonelessDateTime( expiryDate ) }
 						onChange={ next => editPost( { meta: { expiry_date: format( 'Y-m-d', next ) } } ) }
 						isInvalidDate={ date => {
 							return startDate ? format( 'Y-m-d', date ) < startDate : ! isInTheFuture( date );

--- a/plugins/newspack-newsletters/src/ads/editor/index.test.js
+++ b/plugins/newspack-newsletters/src/ads/editor/index.test.js
@@ -1,17 +1,17 @@
 /**
- * The ad sidebar stores `start_date` / `expiry_date` as a bare `Y-m-d` and
- * hands that same string to core's `<DatePicker currentDate>`. Core decides
- * whether the string already carries a UTC offset with
- * `/Z|[+-]\d{2}(:?\d{2})?$/`, which also matches the `-DD` **day** component
- * of a bare `Y-m-d` — so `2026-08-05` is read as UTC midnight rather than
- * site-local midnight. Rendered back in the site timezone that lands on the
- * previous day for any negative UTC offset, while the stored value and the
- * ads list stay correct (NPPM-3078).
+ * Handing `DatePicker` a bare `Y-m-d` made it select — and save back — the
+ * previous day wherever the UTC offset is negative (NPPM-3078); see
+ * `toTimezonelessDateTime` in ./index.js for why, on both supported
+ * WordPress versions. These tests pin both directions: that the picker is
+ * handed a datetime rather than a bare date, and that a bare `Y-m-d` is
+ * still what reaches meta.
  *
- * Passing the format the component documents — `TIMEZONELESS_FORMAT`,
- * `Y-m-d\TH:i:s` — leaves nothing for that regex to mistake for an offset.
- * These tests pin both directions: what the picker is handed, and what is
- * written back to meta.
+ * They deliberately assert the value passed to a stubbed picker rather than
+ * rendering the real one: `@wordpress/components` is externalized to
+ * `wp.components` at runtime, so the copy in node_modules is not the code
+ * any site runs — and its date handling differs from both shipped versions.
+ * Rendering it here would pin an implementation nobody has. The end-to-end
+ * behavior is covered by manual QA against a negative-offset site.
  */
 
 jest.mock( '@wordpress/api-fetch', () => ( {
@@ -20,9 +20,7 @@ jest.mock( '@wordpress/api-fetch', () => ( {
 } ) );
 
 // `DatePicker` is what's under test, so its props are captured; the rest of
-// the sidebar's controls are stubbed. Pulling in the real
-// `@wordpress/components` is not an option here — it loads the block editor
-// stores, which the `@wordpress/data` mock below cannot satisfy.
+// the sidebar's controls are stubbed.
 const mockDatePickerProps = [];
 jest.mock( '@wordpress/components', () => {
 	const stub = name => () => <div data-testid={ name } />;
@@ -114,9 +112,10 @@ const renderSidebar = meta => {
 	return render( <AdSidebar /> );
 };
 
-// Core's own offset detection, verbatim from
-// `@wordpress/components` `date-time/utils.js` `inputToDate()`.
-const CORE_HAS_TIMEZONE = /Z|[+-]\d{2}(:?\d{2})?$/;
+// WordPress 7.0's offset detection, from `inputToDate()`. A value that
+// matches this is treated as already carrying a UTC offset — which is what a
+// bare `Y-m-d` wrongly did.
+const WP70_HAS_TIMEZONE = /Z|[+-]\d{2}(:?\d{2})?$/;
 
 describe( 'Newsletter ad sidebar date pickers', () => {
 	beforeEach( () => {
@@ -126,33 +125,33 @@ describe( 'Newsletter ad sidebar date pickers', () => {
 	it( 'hands the start date to the picker as a timezone-less datetime', () => {
 		renderSidebar( { start_date: '2026-08-05' } );
 
-		expect( mockDatePickerProps[ 0 ].currentDate ).toBe( '2026-08-05T00:00:00' );
-		expect( CORE_HAS_TIMEZONE.test( mockDatePickerProps[ 0 ].currentDate ) ).toBe( false );
+		expect( mockDatePickerProps[ 0 ].currentDate ).toBe( '2026-08-05T12:00:00' );
+		expect( WP70_HAS_TIMEZONE.test( mockDatePickerProps[ 0 ].currentDate ) ).toBe( false );
 	} );
 
 	it( 'hands the expiry date to the picker as a timezone-less datetime', () => {
 		renderSidebar( { expiry_date: '2026-08-05' } );
 
-		expect( mockDatePickerProps[ 0 ].currentDate ).toBe( '2026-08-05T00:00:00' );
-		expect( CORE_HAS_TIMEZONE.test( mockDatePickerProps[ 0 ].currentDate ) ).toBe( false );
+		expect( mockDatePickerProps[ 0 ].currentDate ).toBe( '2026-08-05T12:00:00' );
+		expect( WP70_HAS_TIMEZONE.test( mockDatePickerProps[ 0 ].currentDate ) ).toBe( false );
 	} );
 
 	it( 'normalizes a legacy stored datetime before handing it to the picker', () => {
 		renderSidebar( { start_date: '2026-08-05T23:59:59' } );
 
-		expect( mockDatePickerProps[ 0 ].currentDate ).toBe( '2026-08-05T00:00:00' );
+		expect( mockDatePickerProps[ 0 ].currentDate ).toBe( '2026-08-05T12:00:00' );
 	} );
 
 	it( 'still writes a bare Y-m-d back to start_date meta', () => {
 		renderSidebar( { start_date: '2026-08-05' } );
-		mockDatePickerProps[ 0 ].onChange( '2026-08-10T00:00:00' );
+		mockDatePickerProps[ 0 ].onChange( '2026-08-10T12:00:00' );
 
 		expect( mockEditPost ).toHaveBeenCalledWith( { meta: { start_date: '2026-08-10' } } );
 	} );
 
 	it( 'still writes a bare Y-m-d back to expiry_date meta', () => {
 		renderSidebar( { expiry_date: '2026-08-05' } );
-		mockDatePickerProps[ 0 ].onChange( '2026-08-10T00:00:00' );
+		mockDatePickerProps[ 0 ].onChange( '2026-08-10T12:00:00' );
 
 		expect( mockEditPost ).toHaveBeenCalledWith( { meta: { expiry_date: '2026-08-10' } } );
 	} );

--- a/plugins/newspack-newsletters/src/ads/editor/index.test.js
+++ b/plugins/newspack-newsletters/src/ads/editor/index.test.js
@@ -1,0 +1,159 @@
+/**
+ * The ad sidebar stores `start_date` / `expiry_date` as a bare `Y-m-d` and
+ * hands that same string to core's `<DatePicker currentDate>`. Core decides
+ * whether the string already carries a UTC offset with
+ * `/Z|[+-]\d{2}(:?\d{2})?$/`, which also matches the `-DD` **day** component
+ * of a bare `Y-m-d` — so `2026-08-05` is read as UTC midnight rather than
+ * site-local midnight. Rendered back in the site timezone that lands on the
+ * previous day for any negative UTC offset, while the stored value and the
+ * ads list stay correct (NPPM-3078).
+ *
+ * Passing the format the component documents — `TIMEZONELESS_FORMAT`,
+ * `Y-m-d\TH:i:s` — leaves nothing for that regex to mistake for an offset.
+ * These tests pin both directions: what the picker is handed, and what is
+ * written back to meta.
+ */
+
+jest.mock( '@wordpress/api-fetch', () => ( {
+	__esModule: true,
+	default: { use: jest.fn() },
+} ) );
+
+// `DatePicker` is what's under test, so its props are captured; the rest of
+// the sidebar's controls are stubbed. Pulling in the real
+// `@wordpress/components` is not an option here — it loads the block editor
+// stores, which the `@wordpress/data` mock below cannot satisfy.
+const mockDatePickerProps = [];
+jest.mock( '@wordpress/components', () => {
+	const stub = name => () => <div data-testid={ name } />;
+	return {
+		DatePicker: props => {
+			mockDatePickerProps.push( props );
+			return <div data-testid="date-picker" />;
+		},
+		ToggleControl: stub( 'toggle' ),
+		TextControl: stub( 'text' ),
+		RadioControl: stub( 'radio' ),
+		RangeControl: stub( 'range' ),
+		Notice: stub( 'notice' ),
+		Button: stub( 'button' ),
+		Modal: stub( 'modal' ),
+	};
+} );
+
+jest.mock( '@wordpress/edit-post', () => ( {
+	PluginDocumentSettingPanel: ( { children } ) => <div>{ children }</div>,
+	PluginPrePublishPanel: ( { children } ) => <div>{ children }</div>,
+	store: 'core/edit-post',
+} ) );
+
+jest.mock( 'newspack-components', () => ( {
+	SelectControl: () => <div />,
+} ) );
+
+jest.mock( '../../components/ad-placements', () => ( {
+	__esModule: true,
+	default: () => <div />,
+} ) );
+
+const mockEditPost = jest.fn();
+
+jest.mock( '@wordpress/data', () => {
+	const select = store => {
+		if ( store === 'core/editor' ) {
+			return {
+				isSavingPost: () => false,
+				getEditedPostAttribute: attribute => {
+					if ( 'meta' === attribute ) {
+						return global.__adMeta;
+					}
+					if ( 'status' === attribute ) {
+						return 'publish';
+					}
+					return '';
+				},
+			};
+		}
+		return { getEntityRecords: () => [] };
+	};
+	return {
+		useSelect: callback => callback( select ),
+		useDispatch: () => ( {
+			editPost: ( ...args ) => mockEditPost( ...args ),
+			saveEntityRecord: jest.fn(),
+			removeEditorPanel: jest.fn(),
+		} ),
+	};
+} );
+
+// `registerPlugin` runs on import; capturing its `render` is how we get at
+// the sidebar component without exporting it just for the test. The capture
+// lands on `global` because imports are hoisted above any `let` here.
+jest.mock( '@wordpress/plugins', () => ( {
+	registerPlugin: ( name, options ) => {
+		global.__adSidebar = options.render;
+	},
+} ) );
+
+import { render } from '@testing-library/react';
+import './index';
+
+const BASE_META = {
+	price: '0',
+	insertion_strategy: 'percentage',
+	position_in_content: 50,
+	position_block_count: 5,
+	start_date: null,
+	expiry_date: null,
+};
+
+const renderSidebar = meta => {
+	mockDatePickerProps.length = 0;
+	global.__adMeta = { ...BASE_META, ...meta };
+	const AdSidebar = global.__adSidebar;
+	return render( <AdSidebar /> );
+};
+
+// Core's own offset detection, verbatim from
+// `@wordpress/components` `date-time/utils.js` `inputToDate()`.
+const CORE_HAS_TIMEZONE = /Z|[+-]\d{2}(:?\d{2})?$/;
+
+describe( 'Newsletter ad sidebar date pickers', () => {
+	beforeEach( () => {
+		mockEditPost.mockReset();
+	} );
+
+	it( 'hands the start date to the picker as a timezone-less datetime', () => {
+		renderSidebar( { start_date: '2026-08-05' } );
+
+		expect( mockDatePickerProps[ 0 ].currentDate ).toBe( '2026-08-05T00:00:00' );
+		expect( CORE_HAS_TIMEZONE.test( mockDatePickerProps[ 0 ].currentDate ) ).toBe( false );
+	} );
+
+	it( 'hands the expiry date to the picker as a timezone-less datetime', () => {
+		renderSidebar( { expiry_date: '2026-08-05' } );
+
+		expect( mockDatePickerProps[ 0 ].currentDate ).toBe( '2026-08-05T00:00:00' );
+		expect( CORE_HAS_TIMEZONE.test( mockDatePickerProps[ 0 ].currentDate ) ).toBe( false );
+	} );
+
+	it( 'normalizes a legacy stored datetime before handing it to the picker', () => {
+		renderSidebar( { start_date: '2026-08-05T23:59:59' } );
+
+		expect( mockDatePickerProps[ 0 ].currentDate ).toBe( '2026-08-05T00:00:00' );
+	} );
+
+	it( 'still writes a bare Y-m-d back to start_date meta', () => {
+		renderSidebar( { start_date: '2026-08-05' } );
+		mockDatePickerProps[ 0 ].onChange( '2026-08-10T00:00:00' );
+
+		expect( mockEditPost ).toHaveBeenCalledWith( { meta: { start_date: '2026-08-10' } } );
+	} );
+
+	it( 'still writes a bare Y-m-d back to expiry_date meta', () => {
+		renderSidebar( { expiry_date: '2026-08-05' } );
+		mockDatePickerProps[ 0 ].onChange( '2026-08-10T00:00:00' );
+
+		expect( mockEditPost ).toHaveBeenCalledWith( { meta: { expiry_date: '2026-08-10' } } );
+	} );
+} );

--- a/plugins/newspack-newsletters/tests/test-ads-date-display.php
+++ b/plugins/newspack-newsletters/tests/test-ads-date-display.php
@@ -1,0 +1,108 @@
+<?php
+/**
+ * Class Test Ads Date Display
+ *
+ * @package Newspack_Newsletters
+ */
+
+use Newspack_Newsletters\Ads;
+
+/**
+ * `start_date` / `expiry_date` are whole calendar days with no time and no
+ * timezone — `is_ad_active()` compares them as `Y-m-d` strings against the
+ * newsletter's own date. Rendering them therefore has to yield the day that
+ * was stored, on every site.
+ *
+ * The regression this guards: `strtotime( 'Y-m-d' )` resolves against PHP's
+ * default zone (UTC under WordPress), and `wp_date()` then converts into the
+ * site zone, so an ad stored as `2026-08-04` displayed as August 3 on every
+ * site at a negative UTC offset.
+ */
+class Ads_Date_Display_Test extends WP_UnitTestCase {
+
+	/**
+	 * Restore the default timezone between tests.
+	 */
+	public function tear_down() {
+		update_option( 'timezone_string', 'UTC' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Site timezones spanning the usable UTC offset range.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function timezone_provider() {
+		return [
+			'UTC'                 => [ 'UTC' ],
+			'UTC-10 (Honolulu)'   => [ 'Pacific/Honolulu' ],
+			'UTC-7 (Los Angeles)' => [ 'America/Los_Angeles' ],
+			'UTC-4 (New York)'    => [ 'America/New_York' ],
+			'UTC+2 (Paris)'       => [ 'Europe/Paris' ],
+			'UTC+9 (Tokyo)'       => [ 'Asia/Tokyo' ],
+			'UTC+14 (Kiritimati)' => [ 'Pacific/Kiritimati' ],
+		];
+	}
+
+	/**
+	 * The rendered date is the stored date, whatever the site timezone.
+	 *
+	 * @dataProvider timezone_provider
+	 * @param string $timezone Site timezone string.
+	 */
+	public function test_stored_day_survives_every_site_timezone( $timezone ) {
+		update_option( 'timezone_string', $timezone );
+
+		$this->assertSame(
+			'August 4, 2026',
+			Ads::format_ad_date( '2026-08-04' ),
+			"Stored date shifted in {$timezone}."
+		);
+	}
+
+	/**
+	 * Month and year boundaries are where an off-by-one is most damaging.
+	 *
+	 * @dataProvider timezone_provider
+	 * @param string $timezone Site timezone string.
+	 */
+	public function test_month_and_year_boundaries_hold( $timezone ) {
+		update_option( 'timezone_string', $timezone );
+
+		$this->assertSame( 'January 1, 2026', Ads::format_ad_date( '2026-01-01' ) );
+		$this->assertSame( 'March 1, 2026', Ads::format_ad_date( '2026-03-01' ) );
+	}
+
+	/**
+	 * A DST transition day still renders as itself.
+	 */
+	public function test_dst_transition_day_holds() {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		// US DST starts 2026-03-08; local midnight exists, but the offset changes.
+		$this->assertSame( 'March 8, 2026', Ads::format_ad_date( '2026-03-08' ) );
+		// Chile shifts at local midnight, so midnight itself does not exist.
+		update_option( 'timezone_string', 'America/Santiago' );
+		$this->assertSame( 'September 6, 2026', Ads::format_ad_date( '2026-09-06' ) );
+	}
+
+	/**
+	 * A legacy ISO datetime value is reduced to its date.
+	 */
+	public function test_legacy_datetime_value_is_reduced_to_its_date() {
+		update_option( 'timezone_string', 'America/New_York' );
+
+		$this->assertSame( 'August 4, 2026', Ads::format_ad_date( '2026-08-04T23:59:59' ) );
+	}
+
+	/**
+	 * Empty and malformed values render as nothing, so callers can show a dash.
+	 */
+	public function test_empty_and_invalid_values_return_empty_string() {
+		$this->assertSame( '', Ads::format_ad_date( '' ) );
+		$this->assertSame( '', Ads::format_ad_date( null ) );
+		$this->assertSame( '', Ads::format_ad_date( 'not-a-date' ) );
+		$this->assertSame( '', Ads::format_ad_date( '2026-13-45' ) );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Newsletter ad start and expiration dates are whole calendar days. The meta is a bare `Y-m-d`, and `is_ad_active()` compares it as a string against the newsletter's own date — nothing in that path carries a time or a timezone. Every surface that showed one of these dates was nonetheless converting it into a timezone, and each got it wrong in its own way. This fixes all three.

**1. The editor sidebar selected — and saved — the previous day.**

`DatePicker` received a bare `Y-m-d`, which reaches it as a UTC instant rather than a site-local one. Both supported WordPress versions arrive there by different routes:

- **6.9** hands the string to `new Date()`, where a date-only ISO string is UTC by specification while a date-time string without an offset is local.
- **7.0** first tests it against `/Z|[+-]\d{2}(:?\d{2})?$/` to decide whether it already carries an offset — and the `-DD` day component of `2026-08-05` matches, so the value is treated as already-UTC.

Rendered back in the site timezone, that lands on the previous day wherever the offset is negative. This was not only cosmetic: clicking the day the picker had highlighted saved that wrong day back to the ad, so opening an ad and confirming its dates could move them a day earlier with nothing on screen to say so.

The fix appends a time component before handing the value over, so nothing is left to mistake for an offset. Noon rather than midnight: only the year/month/day is ever read back, and midday also survives the timezones where local midnight doesn't exist on a DST-transition day.

Because this works around two different parsing models, please keep the time component even if that regex is corrected upstream — 6.9 would still be wrong without it.

**2. The classic list table showed the wrong day.**

`wp_date( __( 'F j, Y' ), strtotime( $start_date ) )` resolves the bare date against PHP's default zone (UTC under WordPress), then converts into the site zone — so `2026-08-04` displayed as **August 3, 2026** on every site at a negative offset. A new `Ads::format_ad_date()` anchors at midnight in the site timezone instead, and both columns use it.

**3. The Ads list showed a meaningless clock time.**

The DataView columns formatted with the site's `date_format` option, which may legitimately include a time. On a site set to `F j, Y, g:i a`, the noon-UTC anchor surfaced as **"August 4, 2026, 8:00 am"** — implying a time-of-day boundary that does not exist, and shifting with the site's offset (8:00 am in EDT, 6:00 am in MDT, 1:00 pm in CEST) for identical data. The same leaked into the Status column's "Starts …" / "Expired …" labels.

These now format in UTC with a date-only pattern, so the day rendered is always the day stored, and no clock time appears. A hover title explains the window semantics that aren't otherwise discoverable: whole days in the site timezone, matched against the newsletter's own date, with both endpoints included.

Stored meta is unchanged throughout: a bare `Y-m-d` still goes back to the database.

Part of NPPM-3078.

### How to test the changes in this Pull Request:

1. Set the site timezone to one with a negative UTC offset (Settings → General → e.g. `New York`), and set Date Format to the custom value `F j, Y, g:i a`.
2. Create a Newsletter Ad, toggle on **Custom Start Date**, pick a date a few days out, and save.
3. Reload the ad. **Before:** the picker highlights the day before the one you chose. **After:** it highlights the date you saved.
4. Click the highlighted day and save again. **Before:** the stored date silently moves back a day. **After:** it stays put.
5. Repeat for **Expiration Date**.
6. Open the Ads list. **Before:** the Start/Expiration columns read `August 4, 2026, 8:00 am`. **After:** `August 4, 2026`, with a tooltip explaining the window.
7. Open the classic list at `edit.php?post_type=newspack_nl_ads_cpt`. **Before:** the columns read `August 3, 2026`. **After:** `August 4, 2026`.
8. Set the site timezone to UTC and to a positive offset (e.g. `Tokyo`, `Kiritimati`) and confirm every surface still shows the stored day.
9. `cd plugins/newspack-newsletters && npm test` and `n test-php newsletters`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

<details>
<summary>Verification detail</summary>

**Reproduction.** The picker's behaviour was reproduced outside the browser by running WordPress 7.0's own `inputToDate` / `startOfDayInConfiguredTimezone` / `setInConfiguredTimezone` (transcribed from `wp-includes/js/dist/components.js`) against the real `@wordpress/date`, and separately by booting the actual core bundles in jsdom for both 6.9.4 and 7.0.

Stored `2026-08-05`, across site timezones:

| Site offset | Bare `Y-m-d` | With time component |
| --- | --- | --- |
| UTC+0, +2, +9, +12, +14 | selects 5 | selects 5 |
| −4, −6, −7, −10 | selects **4** | selects 5 |

Round trip on a negative-offset site, clicking the highlighted day:

- before — highlights 4 → `onChange` `2026-08-04T20:00:00` → saves `2026-08-04`
- after — highlights 5 → `onChange` `2026-08-05T12:00:00` → saves `2026-08-05`

**Classic list column**, stored `2026-08-04`:

| Site timezone | Before | After |
| --- | --- | --- |
| UTC, Tokyo, Kiritimati | August 4, 2026 | August 4, 2026 |
| New York, Los Angeles, Honolulu | **August 3, 2026** | August 4, 2026 |

**Tests.** Both new suites were confirmed to fail against the previous code rather than passing vacuously — 4 failures in the JS suite and 8 in the PHP suite when the old formatters are restored.

Full runs: JS 268 passed / 31 suites; PHP 716 passed / 2960 assertions (3 pre-existing skips); PHPCS clean.

The day objects the picker hands to `isInvalidDate` are byte-identical before and after this change on both 6.9.4 and 7.0, so the disabled-day ranges are unaffected. (They do differ under the copy of `@wordpress/components` in `node_modules`, but that build ships with no supported WordPress version — the plugin externalizes to `wp.components` — so it isn't the code any site runs. The editor tests stub the picker for that reason rather than rendering the npm build.)

</details>
