### PR TITLE
ci(release): include packages in the post-release workspace:* restore

### DIFF
--- a/.github/scripts/post-release.sh
+++ b/.github/scripts/post-release.sh
@@ -52,7 +52,11 @@ restore_workspace_deps_and_commit() {
   node -e '
     const fs = require("fs"), path = require("path");
     const WS_PACKAGES = ["newspack-scripts", "newspack-components", "newspack-colors", "newspack-icons"];
-    const roots = ["plugins", "themes"];
+    // "packages" belongs here too: msr pins the shared packages the same way
+    // it pins plugins and themes, and pnpm-lock.yaml is keyed to workspace:*
+    // for all three roots. Leaving packages out is what made every release
+    // since need a hand-written restore PR.
+    const roots = ["packages", "plugins", "themes"];
     const changed = [];
     for (const r of roots) {
       if (!fs.existsSync(r)) continue;

--- a/packages/colors/package.json
+++ b/packages/colors/package.json
@@ -32,7 +32,7 @@
 		"access": "public"
 	},
 	"devDependencies": {
-		"newspack-scripts": "5.10.0"
+		"newspack-scripts": "workspace:*"
 	},
 	"scripts": {
 		"typescript:check": "newspack-scripts typescript-check"

--- a/packages/components/package.json
+++ b/packages/components/package.json
@@ -30,7 +30,7 @@
 		"classnames": "^2.3.1",
 		"lodash": "^4.17.21",
 		"moment-range": "^3.1.1",
-		"newspack-icons": "1.1.0",
+		"newspack-icons": "workspace:*",
 		"qs": "^6.15.2",
 		"react-router-dom": "^5.3.4",
 		"@babel/runtime": "^7.29.7",
@@ -58,7 +58,7 @@
 		"@babel/preset-env": "^7.29.7",
 		"@babel/preset-react": "^7.29.7",
 		"@babel/preset-typescript": "^7.29.7",
-		"newspack-scripts": "5.10.0",
+		"newspack-scripts": "workspace:*",
 		"recursive-copy": "^2.0.0"
 	},
 	"babel": {

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -34,7 +34,7 @@
 	},
 	"devDependencies": {
 		"@types/react": "^18.0.0",
-		"newspack-scripts": "5.10.0"
+		"newspack-scripts": "workspace:*"
 	},
 	"scripts": {
 		"build-types": "node build-types.js",


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

CI is red on `release`. `pnpm install --frozen-lockfile` fails before anything else runs, so `Install deps` and `Release` both fail and `JS` / `Build ZIP` never start:

```
ERR_PNPM_OUTDATED_LOCKFILE  Cannot install with "frozen-lockfile" because
pnpm-lock.yaml is not up to date with <ROOT>/packages/colors/package.json
  - newspack-scripts (lockfile: workspace:*, manifest: 5.10.0)
```

This has two parts: the breakage, and the reason it keeps coming back.

**The breakage.** A release run rewrites internal workspace deps to concrete versions so the packages publish correctly, and `post-release.sh` is meant to put `workspace:*` back afterwards. Three manifests are still pinned while `pnpm-lock.yaml` continues to record `workspace:*`:

| File | Dependency | On `release` | Lockfile |
| --- | --- | --- | --- |
| `packages/colors` | `newspack-scripts` | `5.10.0` | `workspace:*` |
| `packages/components` | `newspack-scripts` | `5.10.0` | `workspace:*` |
| `packages/components` | `newspack-icons` | `1.1.0` | `workspace:*` |
| `packages/icons` | `newspack-scripts` | `5.10.0` | `workspace:*` |

**Why it keeps coming back.** `post-release.sh` only ever looked at two of the three workspace roots:

```js
const roots = [ 'plugins', 'themes' ];
```

`packages` was missing, so the shared packages — the only ones that ever break this — were never restored. The automated sync commit on `release` (a69472642) shows it: 14 files, all under `plugins/` and `themes/`, none under `packages/`. That is why this has needed a hand-written PR after each release (#713 for `alpha`, #788 for `main`), and it would have needed another one next time.

This PR restores the four entries and adds `packages` to `roots` so the next release does it automatically.

`pnpm-lock.yaml` was already correct and is untouched.

### How to test the changes in this Pull Request:

1. On `release` as it stands, run `pnpm install --frozen-lockfile` — it fails with the error above.
2. On this branch, run `pnpm install --frozen-lockfile` — it completes.
3. Confirm CI goes green here and on other PRs targeting `release` once this lands.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — n/a, dependency manifests and a release script.
* [x] Have you successfully run tests with your changes locally?

Verified against a copy of the workspace manifests plus the lockfile, so nothing else in the tree could affect the outcome:

```
before  ERR_PNPM_OUTDATED_LOCKFILE ... newspack-scripts (lockfile: workspace:*, manifest: 5.10.0)
after   Packages: +2506 · Done in 14s using pnpm v10.33.0
```

The script change was checked by replaying both versions of the restore against the current `release` tree: the old roots select **no** files, which is exactly the no-op we saw; the new roots select the three `packages/*` manifests, and the JSON they produce is byte-identical to the manifest changes committed here.

Found while opening #789, which is blocked by this.
