### PR TITLE
fix(blocks): sign publisher-configured post-checkout destinations

### DIFF
--- a/plugins/newspack-blocks/AGENTS.md
+++ b/plugins/newspack-blocks/AGENTS.md
@@ -207,7 +207,7 @@ REST controllers are instantiated via wrapper functions hooked to `rest_api_init
 - **Functions**: `newspack_blocks_*` prefix (e.g., `newspack_blocks_render_block_homepage_articles`)
 - **Classes**: `Newspack_Blocks*` or `WP_REST_Newspack_*` for REST controllers
 - **Constants**: `NEWSPACK_BLOCKS__*` (double underscore)
-- **Hooks**: `newspack_blocks_*` prefix; modal-specific use `newspack_modal_checkout_*`
+- **Hooks**: `newspack_blocks_*` prefix; modal-specific use `newspack_blocks_modal_checkout_*`
 - **Text domain**: `newspack-blocks`
 - **Block names**: Short slugs in `block.json`, namespaced as `newspack-blocks/<slug>` in PHP/JS
 
@@ -268,7 +268,7 @@ Partial adoption. Some blocks use `.ts`/`.tsx` (homepage-articles `edit.tsx`, do
 The plugin exposes many hooks. Rather than listing them all here (they change over time), use `grep -r 'apply_filters\|do_action' src/ includes/` to find current hooks. The key hook prefixes are:
 
 - **`newspack_blocks_*`**: General block hooks (query building, deduplication, registration, author data)
-- **`newspack_modal_checkout_*`**: Modal checkout specific hooks (labels, gateways, billing fields, HTML output)
+- **`newspack_blocks_modal_checkout_*`**: Modal checkout specific hooks (labels, gateways, billing fields, HTML output)
 
 ## CI/CD
 

--- a/plugins/newspack-blocks/includes/class-modal-checkout.php
+++ b/plugins/newspack-blocks/includes/class-modal-checkout.php
@@ -377,6 +377,7 @@ final class Modal_Checkout {
 		$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_SANITIZE_SPECIAL_CHARS );
 		$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_SANITIZE_URL );
 		$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_SANITIZE_SPECIAL_CHARS );
+		$after_success_signature    = filter_input( INPUT_GET, 'after_success_signature', FILTER_SANITIZE_SPECIAL_CHARS );
 
 		if ( $variation_id ) {
 			$product_id = $variation_id;
@@ -395,7 +396,7 @@ final class Modal_Checkout {
 			wp_parse_str( $parsed_url['query'], $params );
 		}
 
-		$params = array_merge( $params, compact( 'after_success_behavior', 'after_success_url', 'after_success_button_label' ) );
+		$params = array_merge( $params, compact( 'after_success_behavior', 'after_success_url', 'after_success_button_label', 'after_success_signature' ) );
 
 		if ( function_exists( 'wpcom_vip_url_to_postid' ) ) {
 			$referer_post_id = wpcom_vip_url_to_postid( $referer );
@@ -1199,31 +1200,99 @@ final class Modal_Checkout {
 	const AFTER_SUCCESS_BEHAVIORS = [ 'custom', 'referrer' ];
 
 	/**
-	 * Reduce a post-checkout destination to one this site is willing to send readers to.
+	 * Reduce a post-checkout destination to a single comparable form.
 	 *
-	 * The destination reaches the thank-you page through the request, whether it came from
-	 * the block's own settings or from the link the reader followed, and by that point the
-	 * two are indistinguishable. Core's redirect validation decides, so the destinations
-	 * this site accepts are the ones `allowed_redirect_hosts` reports. That's this site's
-	 * own host, plus whatever a publisher adds through that filter, plus anything another
-	 * plugin has added (`Newspack\NRH` registers one).
+	 * Signing and verifying have to agree on the exact string, and the value passes through
+	 * sanitising on its way between them, so both sides normalise here rather than each
+	 * doing their own.
 	 *
 	 * @param string $url The requested destination.
 	 *
-	 * @return string The destination, or an empty string if it is not allowed.
+	 * @return string The normalised destination, or an empty string.
 	 */
-	public static function sanitize_after_success_url( $url ) {
+	public static function normalize_after_success_url( $url ) {
 		$url = sanitize_url( (string) $url );
 
 		if ( empty( $url ) ) {
 			return '';
 		}
 
-		// Core compares hosts case-sensitively; host names aren't. Normalise first so this
-		// site's own host typed in capitals isn't read as somewhere else.
+		// Core compares hosts case-sensitively; host names aren't. Normalise so this site's
+		// own host typed in capitals isn't read as somewhere else.
 		$host = wp_parse_url( $url, PHP_URL_HOST );
 		if ( $host && strtolower( $host ) !== $host ) {
 			$url = str_replace( '://' . $host, '://' . strtolower( $host ), $url );
+		}
+
+		return $url;
+	}
+
+	/**
+	 * Sign a post-checkout destination a block has been configured with.
+	 *
+	 * Minted where the block renders, which is the last point this site knows the value came
+	 * from its own content rather than from the request. `wp_hash()` rather than a nonce:
+	 * the signature has to survive page caching and a reader who signs in partway through
+	 * checkout, and a nonce is bound to a user and a time window.
+	 *
+	 * @param string $url The destination to sign.
+	 *
+	 * @return string The signature, or an empty string if there is nothing to sign.
+	 */
+	public static function get_after_success_url_signature( $url ) {
+		$url = self::normalize_after_success_url( $url );
+
+		return $url ? wp_hash( $url ) : '';
+	}
+
+	/**
+	 * Whether a destination carries this site's signature.
+	 *
+	 * @param string $url       The requested destination.
+	 * @param string $signature The signature offered with it.
+	 *
+	 * @return boolean
+	 */
+	public static function is_after_success_url_signed( $url, $signature ) {
+		$signature = (string) $signature;
+		$expected  = self::get_after_success_url_signature( $url );
+
+		if ( '' === $signature || '' === $expected ) {
+			return false;
+		}
+
+		return hash_equals( $expected, $signature );
+	}
+
+	/**
+	 * Reduce a post-checkout destination to one this site is willing to send readers to.
+	 *
+	 * The destination reaches the thank-you page through the request, whether it came from
+	 * the block's own settings or from the link the reader followed, and by that point the
+	 * two look alike. A signature tells them apart: one is minted when a block renders a
+	 * destination a publisher configured, so a destination carrying a valid one is this
+	 * site's own and is honoured wherever it points.
+	 *
+	 * Everything else falls to core's redirect validation, which accepts what
+	 * `allowed_redirect_hosts` reports — this site's own host, plus whatever a publisher
+	 * adds through that filter, plus anything another plugin has added (`Newspack\NRH`
+	 * registers one). A destination arriving in a link with no signature has to clear that
+	 * bar, which is what keeps a crafted link from choosing where a reader lands.
+	 *
+	 * @param string $url       The requested destination.
+	 * @param string $signature Signature offered with the destination, if any.
+	 *
+	 * @return string The destination, or an empty string if it is not allowed.
+	 */
+	public static function sanitize_after_success_url( $url, $signature = '' ) {
+		$url = self::normalize_after_success_url( $url );
+
+		if ( empty( $url ) ) {
+			return '';
+		}
+
+		if ( self::is_after_success_url_signed( $url, $signature ) ) {
+			return $url;
 		}
 
 		$validated = (string) wp_validate_redirect( $url, '' );
@@ -1270,7 +1339,8 @@ final class Modal_Checkout {
 			unset(
 				$params['after_success_behavior'],
 				$params['after_success_url'],
-				$params['after_success_button_label']
+				$params['after_success_button_label'],
+				$params['after_success_signature']
 			);
 		}
 
@@ -1290,11 +1360,14 @@ final class Modal_Checkout {
 				\wp_parse_str( $referrer_query, $request_params );
 			}
 		}
+		$signature = isset( $request_params['after_success_signature'] ) ? sanitize_text_field( wp_unslash( $request_params['after_success_signature'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
 		$params = array_filter(
 			[
 				'after_success_behavior'     => isset( $request_params['after_success_behavior'] ) ? sanitize_text_field( wp_unslash( $request_params['after_success_behavior'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				'after_success_url'          => isset( $request_params['after_success_url'] ) ? self::sanitize_after_success_url( wp_unslash( $request_params['after_success_url'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				'after_success_url'          => isset( $request_params['after_success_url'] ) ? self::sanitize_after_success_url( wp_unslash( $request_params['after_success_url'] ), $signature ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				'after_success_button_label' => isset( $request_params['after_success_button_label'] ) ? sanitize_text_field( wp_unslash( $request_params['after_success_button_label'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				'after_success_signature'    => $signature,
 				'action_type'                => isset( $request_params['action_type'] ) ? sanitize_text_field( wp_unslash( $request_params['action_type'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			]
 		);

--- a/plugins/newspack-blocks/includes/class-modal-checkout.php
+++ b/plugins/newspack-blocks/includes/class-modal-checkout.php
@@ -1242,13 +1242,58 @@ final class Modal_Checkout {
 		$pass = isset( $parts['pass'] ) ? ':' . $parts['pass'] : '';
 		$auth = $user ? $user . $pass . '@' : '';
 
-		return ( isset( $parts['scheme'] ) ? $parts['scheme'] . '://' : '' )
+		// A destination with a host but no scheme is protocol-relative. Losing the `//` here
+		// would turn it into a relative path, which changes where the reader lands and makes
+		// this function non-idempotent — and the token signs a normalised value at mint and
+		// normalises again at read, so idempotence is what makes it verify.
+		$prefix = isset( $parts['scheme'] )
+			? $parts['scheme'] . '://'
+			: ( isset( $parts['host'] ) ? '//' : '' );
+
+		return $prefix
 			. $auth
 			. ( $parts['host'] ?? '' )
 			. ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' )
 			. ( $parts['path'] ?? '' )
 			. ( isset( $parts['query'] ) ? '?' . $parts['query'] : '' )
 			. ( isset( $parts['fragment'] ) ? '#' . $parts['fragment'] : '' );
+	}
+
+	/**
+	 * Whether a post is published, read from the stored status.
+	 *
+	 * `get_post_status()` reports an attachment as `publish` whatever its stored status, so a
+	 * token could be minted from one and could not be revoked by unpublishing. Reading the
+	 * field directly returns the real status, and also steps around the `get_post_status`
+	 * filter, which would otherwise let any plugin move this gate.
+	 *
+	 * @param int $post_id The post to check.
+	 *
+	 * @return boolean
+	 */
+	private static function is_published_post( $post_id ) {
+		return 'publish' === get_post_field( 'post_status', (int) $post_id );
+	}
+
+	/**
+	 * The post a block is being rendered for.
+	 *
+	 * `get_the_ID()` is empty outside the loop, which is where a block in a widget or a footer
+	 * template part renders. The queried object covers that, but only when it is a post: on an
+	 * archive it is a term, whose ID would otherwise be read as an unrelated post's.
+	 *
+	 * @return int Post ID, or 0.
+	 */
+	private static function get_after_success_post_id() {
+		$post_id = (int) get_the_ID();
+
+		if ( $post_id ) {
+			return $post_id;
+		}
+
+		$queried = get_queried_object();
+
+		return $queried instanceof WP_Post ? (int) $queried->ID : 0;
 	}
 
 	/**
@@ -1263,7 +1308,17 @@ final class Modal_Checkout {
 	 * @return string
 	 */
 	private static function sign_after_success_payload( $payload ) {
-		return hash_hmac( 'sha256', 'newspack_blocks_after_success|' . $payload, wp_salt( 'auth' ) );
+		// The namespace prefix is what separates this from every other use of the same key and
+		// algorithm. `Reader_Registration::get_frontend_registration_key()` also produces
+		// `hash_hmac( 'sha256', …, wp_salt( 'auth' ) )` and publishes the result to the front
+		// end, so nothing but this prefix distinguishes the two. Never register an integration
+		// ID that begins with it.
+		//
+		// The blog ID is included because `wp_salt()` is network-scoped: without it, a token
+		// minted on one site of a network verifies on every other site in that network.
+		$namespace = 'newspack_blocks_after_success|' . get_current_blog_id() . '|';
+
+		return hash_hmac( 'sha256', $namespace . $payload, wp_salt( 'auth' ) );
 	}
 
 	/**
@@ -1297,9 +1352,9 @@ final class Modal_Checkout {
 			return '';
 		}
 
-		$post_id = $post_id ? (int) $post_id : (int) get_the_ID();
+		$post_id = $post_id ? (int) $post_id : self::get_after_success_post_id();
 
-		if ( ! $post_id || 'publish' !== get_post_status( $post_id ) ) {
+		if ( ! $post_id || ! self::is_published_post( $post_id ) ) {
 			return '';
 		}
 
@@ -1345,7 +1400,7 @@ final class Modal_Checkout {
 
 		// Checked at read time as well as at mint time: a post that has since been
 		// unpublished should stop vouching for its destination.
-		if ( 'publish' !== get_post_status( (int) $claims['p'] ) ) {
+		if ( ! self::is_published_post( (int) $claims['p'] ) ) {
 			return '';
 		}
 

--- a/plugins/newspack-blocks/includes/class-modal-checkout.php
+++ b/plugins/newspack-blocks/includes/class-modal-checkout.php
@@ -377,7 +377,7 @@ final class Modal_Checkout {
 		$after_success_behavior     = filter_input( INPUT_GET, 'after_success_behavior', FILTER_SANITIZE_SPECIAL_CHARS );
 		$after_success_url          = filter_input( INPUT_GET, 'after_success_url', FILTER_SANITIZE_URL );
 		$after_success_button_label = filter_input( INPUT_GET, 'after_success_button_label', FILTER_SANITIZE_SPECIAL_CHARS );
-		$after_success_signature    = filter_input( INPUT_GET, 'after_success_signature', FILTER_SANITIZE_SPECIAL_CHARS );
+		$after_success_token        = filter_input( INPUT_GET, 'after_success_token', FILTER_SANITIZE_SPECIAL_CHARS );
 
 		if ( $variation_id ) {
 			$product_id = $variation_id;
@@ -396,7 +396,7 @@ final class Modal_Checkout {
 			wp_parse_str( $parsed_url['query'], $params );
 		}
 
-		$params = array_merge( $params, compact( 'after_success_behavior', 'after_success_url', 'after_success_button_label', 'after_success_signature' ) );
+		$params = array_merge( $params, compact( 'after_success_behavior', 'after_success_url', 'after_success_button_label', 'after_success_token' ) );
 
 		if ( function_exists( 'wpcom_vip_url_to_postid' ) ) {
 			$referer_post_id = wpcom_vip_url_to_postid( $referer );
@@ -1217,51 +1217,169 @@ final class Modal_Checkout {
 			return '';
 		}
 
-		// Core compares hosts case-sensitively; host names aren't. Normalise so this site's
-		// own host typed in capitals isn't read as somewhere else.
-		$host = wp_parse_url( $url, PHP_URL_HOST );
-		if ( $host && strtolower( $host ) !== $host ) {
-			$url = str_replace( '://' . $host, '://' . strtolower( $host ), $url );
+		// Core compares hosts case-sensitively; host names aren't. Rebuild from the parsed
+		// parts rather than replacing the host in the string: the host can appear again
+		// inside a query parameter, and a `user@host` authority never matches `://host` at
+		// all, so a string replacement either rewrites too much or nothing.
+		$parts = wp_parse_url( $url );
+		if ( ! empty( $parts['host'] ) && strtolower( $parts['host'] ) !== $parts['host'] ) {
+			$parts['host'] = strtolower( $parts['host'] );
+			$url           = self::build_url( $parts );
 		}
 
 		return $url;
 	}
 
 	/**
-	 * Sign a post-checkout destination a block has been configured with.
+	 * Reassemble a URL from `wp_parse_url()` parts.
 	 *
-	 * Minted where the block renders, which is the last point this site knows the value came
-	 * from its own content rather than from the request. `wp_hash()` rather than a nonce:
-	 * the signature has to survive page caching and a reader who signs in partway through
-	 * checkout, and a nonce is bound to a user and a time window.
+	 * @param array $parts Parsed URL parts.
 	 *
-	 * @param string $url The destination to sign.
-	 *
-	 * @return string The signature, or an empty string if there is nothing to sign.
+	 * @return string
 	 */
-	public static function get_after_success_url_signature( $url ) {
-		$url = self::normalize_after_success_url( $url );
+	private static function build_url( $parts ) {
+		$user = $parts['user'] ?? '';
+		$pass = isset( $parts['pass'] ) ? ':' . $parts['pass'] : '';
+		$auth = $user ? $user . $pass . '@' : '';
 
-		return $url ? wp_hash( $url ) : '';
+		return ( isset( $parts['scheme'] ) ? $parts['scheme'] . '://' : '' )
+			. $auth
+			. ( $parts['host'] ?? '' )
+			. ( isset( $parts['port'] ) ? ':' . $parts['port'] : '' )
+			. ( $parts['path'] ?? '' )
+			. ( isset( $parts['query'] ) ? '?' . $parts['query'] : '' )
+			. ( isset( $parts['fragment'] ) ? '#' . $parts['fragment'] : '' );
 	}
 
 	/**
-	 * Whether a destination carries this site's signature.
+	 * Sign a value for the post-checkout destination it belongs to.
 	 *
-	 * @param string $url       The requested destination.
-	 * @param string $signature The signature offered with it.
+	 * Namespaced so this never produces the same digest as another use of the same key —
+	 * `wp_hash()` with the auth salt also backs the magic-link and email-change secrets, and
+	 * these signatures are published in page HTML.
 	 *
-	 * @return boolean
+	 * @param string $payload The value to sign.
+	 *
+	 * @return string
 	 */
-	public static function is_after_success_url_signed( $url, $signature ) {
-		$signature = (string) $signature;
-		$expected  = self::get_after_success_url_signature( $url );
+	private static function sign_after_success_payload( $payload ) {
+		return hash_hmac( 'sha256', 'newspack_blocks_after_success|' . $payload, wp_salt( 'auth' ) );
+	}
 
-		if ( '' === $signature || '' === $expected ) {
-			return false;
+	/**
+	 * Mint a token vouching for a post-checkout destination a block was configured with.
+	 *
+	 * Minted where the block renders, which is the last point this site knows the destination
+	 * came from its own content rather than from the request. Two properties matter:
+	 *
+	 * The destination travels *inside* the token rather than beside it. The token's alphabet
+	 * is URL-safe base64 plus a dot, so the sanitising the value meets in transit — which
+	 * variously deletes percent-encoded octets, drops non-ASCII bytes and HTML-encodes `&`
+	 * and `'` — cannot alter it. Signing the bare URL and hoping every transit point leaves
+	 * it alone is what this avoids.
+	 *
+	 * The token is bound to the post being rendered, and only published posts are signed, so
+	 * a token cannot be minted through the block-renderer REST route or a draft preview by
+	 * someone who can edit posts but not publish them.
+	 *
+	 * `hash_hmac` rather than a nonce: the token has to survive page caching and a reader who
+	 * signs in partway through checkout, and a nonce is bound to a user and a time window.
+	 *
+	 * @param string $url     The destination to vouch for.
+	 * @param int    $post_id The post being rendered. Defaults to the current post.
+	 *
+	 * @return string The token, or an empty string if there is nothing to vouch for.
+	 */
+	public static function get_after_success_token( $url, $post_id = 0 ) {
+		$url = self::normalize_after_success_url( $url );
+
+		if ( '' === $url ) {
+			return '';
 		}
 
-		return hash_equals( $expected, $signature );
+		$post_id = $post_id ? (int) $post_id : (int) get_the_ID();
+
+		if ( ! $post_id || 'publish' !== get_post_status( $post_id ) ) {
+			return '';
+		}
+
+		$payload = self::encode_after_success_payload(
+			[
+				'u' => $url,
+				'p' => $post_id,
+			]
+		);
+
+		return $payload . '.' . self::sign_after_success_payload( $payload );
+	}
+
+	/**
+	 * Read a destination back out of a token, if this site vouched for it.
+	 *
+	 * @param string $token The token offered with the request.
+	 *
+	 * @return string The destination, or an empty string if the token is not this site's.
+	 */
+	public static function parse_after_success_token( $token ) {
+		$token = (string) $token;
+
+		if ( '' === $token || false === strpos( $token, '.' ) ) {
+			return '';
+		}
+
+		list( $payload, $signature ) = explode( '.', $token, 2 );
+
+		if ( '' === $payload || '' === $signature ) {
+			return '';
+		}
+
+		if ( ! hash_equals( self::sign_after_success_payload( $payload ), $signature ) ) {
+			return '';
+		}
+
+		$claims = self::decode_after_success_payload( $payload );
+
+		if ( empty( $claims['u'] ) || empty( $claims['p'] ) ) {
+			return '';
+		}
+
+		// Checked at read time as well as at mint time: a post that has since been
+		// unpublished should stop vouching for its destination.
+		if ( 'publish' !== get_post_status( (int) $claims['p'] ) ) {
+			return '';
+		}
+
+		return self::normalize_after_success_url( $claims['u'] );
+	}
+
+	/**
+	 * Encode token claims into a form transit cannot alter.
+	 *
+	 * @param array $claims The claims to encode.
+	 *
+	 * @return string URL-safe base64.
+	 */
+	private static function encode_after_success_payload( $claims ) {
+		return rtrim( strtr( base64_encode( (string) wp_json_encode( $claims ) ), '+/', '-_' ), '=' ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_encode
+	}
+
+	/**
+	 * Decode token claims.
+	 *
+	 * @param string $payload URL-safe base64.
+	 *
+	 * @return array The claims, or an empty array if the payload is unreadable.
+	 */
+	private static function decode_after_success_payload( $payload ) {
+		$json = base64_decode( strtr( $payload, '-_', '+/' ), true ); // phpcs:ignore WordPress.PHP.DiscouragedPHPFunctions.obfuscation_base64_decode
+
+		if ( false === $json ) {
+			return [];
+		}
+
+		$claims = json_decode( $json, true );
+
+		return is_array( $claims ) ? $claims : [];
 	}
 
 	/**
@@ -1279,20 +1397,29 @@ final class Modal_Checkout {
 	 * registers one). A destination arriving in a link with no signature has to clear that
 	 * bar, which is what keeps a crafted link from choosing where a reader lands.
 	 *
-	 * @param string $url       The requested destination.
-	 * @param string $signature Signature offered with the destination, if any.
+	 * @param string $url   The requested destination.
+	 * @param string $token Token offered with the request, if any.
 	 *
 	 * @return string The destination, or an empty string if it is not allowed.
 	 */
-	public static function sanitize_after_success_url( $url, $signature = '' ) {
+	public static function sanitize_after_success_url( $url, $token = '' ) {
+		// A token carries its own destination, so a mutated `after_success_url` alongside it
+		// is ignored rather than compared against.
+		$vouched = self::parse_after_success_token( $token );
+
+		if ( '' !== $vouched ) {
+			// Returned as verified. `wp_sanitize_redirect()` is deliberately not applied to
+			// this branch: it strips `'` and percent-encodes non-ASCII, so it would rewrite a
+			// destination this site has already established is the publisher's own — the same
+			// drift the token exists to prevent. The untrusted branch below still gets it, via
+			// `wp_validate_redirect()`. Both have been through `sanitize_url()` in normalising.
+			return $vouched;
+		}
+
 		$url = self::normalize_after_success_url( $url );
 
 		if ( empty( $url ) ) {
 			return '';
-		}
-
-		if ( self::is_after_success_url_signed( $url, $signature ) ) {
-			return $url;
 		}
 
 		$validated = (string) wp_validate_redirect( $url, '' );
@@ -1307,7 +1434,7 @@ final class Modal_Checkout {
 			 *
 			 * @param string $url The refused destination.
 			 */
-			do_action( 'newspack_blocks_after_success_url_rejected', $url );
+			do_action( 'newspack_blocks_modal_checkout_after_success_url_rejected', $url );
 		}
 
 		return $validated;
@@ -1340,7 +1467,7 @@ final class Modal_Checkout {
 				$params['after_success_behavior'],
 				$params['after_success_url'],
 				$params['after_success_button_label'],
-				$params['after_success_signature']
+				$params['after_success_token']
 			);
 		}
 
@@ -1360,14 +1487,14 @@ final class Modal_Checkout {
 				\wp_parse_str( $referrer_query, $request_params );
 			}
 		}
-		$signature = isset( $request_params['after_success_signature'] ) ? sanitize_text_field( wp_unslash( $request_params['after_success_signature'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$token = isset( $request_params['after_success_token'] ) ? sanitize_text_field( wp_unslash( $request_params['after_success_token'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 
 		$params = array_filter(
 			[
 				'after_success_behavior'     => isset( $request_params['after_success_behavior'] ) ? sanitize_text_field( wp_unslash( $request_params['after_success_behavior'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				'after_success_url'          => isset( $request_params['after_success_url'] ) ? self::sanitize_after_success_url( wp_unslash( $request_params['after_success_url'] ), $signature ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+				'after_success_url'          => isset( $request_params['after_success_url'] ) ? self::sanitize_after_success_url( wp_unslash( $request_params['after_success_url'] ), $token ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 				'after_success_button_label' => isset( $request_params['after_success_button_label'] ) ? sanitize_text_field( wp_unslash( $request_params['after_success_button_label'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-				'after_success_signature'    => $signature,
+				'after_success_token'        => $token,
 				'action_type'                => isset( $request_params['action_type'] ) ? sanitize_text_field( wp_unslash( $request_params['action_type'] ) ) : '', // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			]
 		);

--- a/plugins/newspack-blocks/src/blocks/checkout-button/view.php
+++ b/plugins/newspack-blocks/src/blocks/checkout-button/view.php
@@ -113,6 +113,9 @@ function render_callback( $attributes ) {
 		$hidden_fields .= $after_success_behavior ? '<input type="hidden" name="after_success_behavior" value="' . esc_attr( $after_success_behavior ) . '" />' : '';
 		$hidden_fields .= $after_success_button_label ? '<input type="hidden" name="after_success_button_label" value="' . esc_attr( $after_success_button_label ) . '" />' : '';
 		$hidden_fields .= $after_success_url ? '<input type="hidden" name="after_success_url" value="' . esc_attr( $after_success_url ) . '" />' : '';
+		// Signed here because this is the last point the destination is known to come from the
+		// block's own settings rather than from the request.
+		$hidden_fields .= $after_success_url ? '<input type="hidden" name="after_success_signature" value="' . esc_attr( Modal_Checkout::get_after_success_url_signature( $after_success_url ) ) . '" />' : '';
 	}
 
 	ob_start();

--- a/plugins/newspack-blocks/src/blocks/checkout-button/view.php
+++ b/plugins/newspack-blocks/src/blocks/checkout-button/view.php
@@ -113,9 +113,10 @@ function render_callback( $attributes ) {
 		$hidden_fields .= $after_success_behavior ? '<input type="hidden" name="after_success_behavior" value="' . esc_attr( $after_success_behavior ) . '" />' : '';
 		$hidden_fields .= $after_success_button_label ? '<input type="hidden" name="after_success_button_label" value="' . esc_attr( $after_success_button_label ) . '" />' : '';
 		$hidden_fields .= $after_success_url ? '<input type="hidden" name="after_success_url" value="' . esc_attr( $after_success_url ) . '" />' : '';
-		// Signed here because this is the last point the destination is known to come from the
-		// block's own settings rather than from the request.
-		$hidden_fields .= $after_success_url ? '<input type="hidden" name="after_success_signature" value="' . esc_attr( Modal_Checkout::get_after_success_url_signature( $after_success_url ) ) . '" />' : '';
+		// Vouched for here because this is the last point the destination is known to come
+		// from the block's own settings rather than from the request.
+		$after_success_token = $after_success_url ? Modal_Checkout::get_after_success_token( $after_success_url ) : '';
+		$hidden_fields      .= $after_success_token ? '<input type="hidden" name="after_success_token" value="' . esc_attr( $after_success_token ) . '" />' : '';
 	}
 
 	ob_start();

--- a/plugins/newspack-blocks/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/plugins/newspack-blocks/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -213,12 +213,13 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 				<?php
 			}
 
-			// Signed here because this is the last point the destination is known to come from
-			// the block's own settings rather than from the request.
-			$after_success_url = isset( $attributes['afterSuccessURL'] ) ? $attributes['afterSuccessURL'] : '';
-			if ( $after_success_url ) {
+			// Vouched for here because this is the last point the destination is known to come
+			// from the block's own settings rather than from the request.
+			$after_success_url   = isset( $attributes['afterSuccessURL'] ) ? $attributes['afterSuccessURL'] : '';
+			$after_success_token = $after_success_url ? \Newspack_Blocks\Modal_Checkout::get_after_success_token( $after_success_url ) : '';
+			if ( $after_success_token ) {
 				?>
-					<input type='hidden' name='after_success_signature' value='<?php echo esc_attr( \Newspack_Blocks\Modal_Checkout::get_after_success_url_signature( $after_success_url ) ); ?>' />
+					<input type='hidden' name='after_success_token' value='<?php echo esc_attr( $after_success_token ); ?>' />
 				<?php
 			}
 		}

--- a/plugins/newspack-blocks/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
+++ b/plugins/newspack-blocks/src/blocks/donate/frontend/class-newspack-blocks-donate-renderer-base.php
@@ -212,6 +212,15 @@ abstract class Newspack_Blocks_Donate_Renderer_Base {
 					<input type='hidden' name='<?php echo esc_attr( $param_name ); ?>' value='<?php echo esc_attr( $value ); ?>' />
 				<?php
 			}
+
+			// Signed here because this is the last point the destination is known to come from
+			// the block's own settings rather than from the request.
+			$after_success_url = isset( $attributes['afterSuccessURL'] ) ? $attributes['afterSuccessURL'] : '';
+			if ( $after_success_url ) {
+				?>
+					<input type='hidden' name='after_success_signature' value='<?php echo esc_attr( \Newspack_Blocks\Modal_Checkout::get_after_success_url_signature( $after_success_url ) ); ?>' />
+				<?php
+			}
 		}
 		return ob_get_clean();
 	}

--- a/plugins/newspack-blocks/src/modal-checkout/checkout-button-trigger.js
+++ b/plugins/newspack-blocks/src/modal-checkout/checkout-button-trigger.js
@@ -104,7 +104,7 @@ export const PICKER_CONTEXT_FIELDS = [
 	'after_success_behavior',
 	'after_success_url',
 	'after_success_button_label',
-	'after_success_signature',
+	'after_success_token',
 	'gate_post_id',
 	'newspack_popup_id',
 	'prompt_title',

--- a/plugins/newspack-blocks/src/modal-checkout/checkout-button-trigger.js
+++ b/plugins/newspack-blocks/src/modal-checkout/checkout-button-trigger.js
@@ -104,6 +104,7 @@ export const PICKER_CONTEXT_FIELDS = [
 	'after_success_behavior',
 	'after_success_url',
 	'after_success_button_label',
+	'after_success_signature',
 	'gate_post_id',
 	'newspack_popup_id',
 	'prompt_title',

--- a/plugins/newspack-blocks/src/modal-checkout/modal.js
+++ b/plugins/newspack-blocks/src/modal-checkout/modal.js
@@ -24,7 +24,7 @@ import {
 	getCheckoutData,
 	getFormattedAmount,
 } from './utils';
-import { resolveCheckoutButtonForm, readCheckoutData } from './checkout-button-trigger';
+import { resolveCheckoutButtonForm, readCheckoutData, PICKER_CONTEXT_FIELDS } from './checkout-button-trigger';
 import { applyCtaAttribution } from '../shared/js/cta-attribution';
 
 const CLASS_PREFIX = newspackBlocksModal.newspack_class_prefix;
@@ -369,15 +369,10 @@ domReady( () => {
 			const variationModal = [ ...variationModals ].find( modal => modal.dataset.productId === checkoutData.product_id );
 			if ( variationModal ) {
 				variationModal.querySelectorAll( `form[target="${ IFRAME_NAME }"]` ).forEach( singleVariationForm => {
-					// Fill in the hidden params in the variation modal.
-					[
-						'after_success_behavior',
-						'after_success_url',
-						'after_success_button_label',
-						'gate_post_id',
-						'newspack_popup_id',
-						'prompt_title',
-					].forEach( hiddenParam => {
+					// Fill in the hidden params in the variation modal. Shares one list with
+					// copyContextFields() so the two cannot drift: a field missing here is a
+					// field the variation path silently drops.
+					PICKER_CONTEXT_FIELDS.forEach( hiddenParam => {
 						const existingInputs = singleVariationForm.querySelectorAll( 'input[name="' + hiddenParam + '"]' );
 						if ( 0 === existingInputs.length ) {
 							singleVariationForm.prepend( createHiddenInput( hiddenParam, checkoutData[ hiddenParam ] ) );

--- a/plugins/newspack-blocks/src/modal-checkout/templates/thankyou.php
+++ b/plugins/newspack-blocks/src/modal-checkout/templates/thankyou.php
@@ -47,8 +47,10 @@ if ( ! $is_valid ) {
 
 $is_success             = ! $order->has_status( 'failed' );
 $after_success_behavior = isset( $_GET['after_success_behavior'] ) ? \sanitize_text_field( \wp_unslash( $_GET['after_success_behavior'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-$after_success_sig      = isset( $_GET['after_success_signature'] ) ? \sanitize_text_field( \wp_unslash( $_GET['after_success_signature'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-$after_success_url      = isset( $_GET['after_success_url'] ) ? esc_url( \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( \sanitize_url( \wp_unslash( $_GET['after_success_url'] ) ), $after_success_sig ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$after_success_token    = isset( $_GET['after_success_token'] ) ? \sanitize_text_field( \wp_unslash( $_GET['after_success_token'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+// Not escaped here: the value is escaped where it is output, and escaping it into the
+// variable would leave it holding something other than the destination that was verified.
+$after_success_url      = isset( $_GET['after_success_url'] ) ? \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( \sanitize_url( \wp_unslash( $_GET['after_success_url'] ) ), $after_success_token ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $after_success_label    = isset( $_GET['after_success_button_label'] ) ? \sanitize_text_field( \wp_unslash( $_GET['after_success_button_label'] ) ) : \Newspack_Blocks\Modal_Checkout::get_modal_checkout_labels( 'after_success' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $checkout_data          = Checkout_Data::get_checkout_data( $order );
 

--- a/plugins/newspack-blocks/src/modal-checkout/templates/thankyou.php
+++ b/plugins/newspack-blocks/src/modal-checkout/templates/thankyou.php
@@ -47,7 +47,8 @@ if ( ! $is_valid ) {
 
 $is_success             = ! $order->has_status( 'failed' );
 $after_success_behavior = isset( $_GET['after_success_behavior'] ) ? \sanitize_text_field( \wp_unslash( $_GET['after_success_behavior'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-$after_success_url      = isset( $_GET['after_success_url'] ) ? esc_url( \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( \sanitize_url( \wp_unslash( $_GET['after_success_url'] ) ) ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$after_success_sig      = isset( $_GET['after_success_signature'] ) ? \sanitize_text_field( \wp_unslash( $_GET['after_success_signature'] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+$after_success_url      = isset( $_GET['after_success_url'] ) ? esc_url( \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( \sanitize_url( \wp_unslash( $_GET['after_success_url'] ) ), $after_success_sig ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $after_success_label    = isset( $_GET['after_success_button_label'] ) ? \sanitize_text_field( \wp_unslash( $_GET['after_success_button_label'] ) ) : \Newspack_Blocks\Modal_Checkout::get_modal_checkout_labels( 'after_success' ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 $checkout_data          = Checkout_Data::get_checkout_data( $order );
 

--- a/plugins/newspack-blocks/tests/test-after-success-url.php
+++ b/plugins/newspack-blocks/tests/test-after-success-url.php
@@ -133,6 +133,127 @@ class AfterSuccessUrlTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
+	 * A destination this site signed is honoured wherever it points.
+	 *
+	 * This is what lets a publisher send readers to a host they own without anyone adding
+	 * that host to this site's allowlist in code.
+	 */
+	public function test_keeps_a_signed_destination_off_site() {
+		$url       = 'https://elsewhere.example.test/thanks';
+		$signature = \Newspack_Blocks\Modal_Checkout::get_after_success_url_signature( $url );
+
+		$this->assertSame(
+			$url,
+			\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( $url, $signature ),
+			'A destination this site signed was refused.'
+		);
+	}
+
+	/**
+	 * The same destination without the signature is still refused.
+	 *
+	 * A link can carry the destination; it can't carry the signature.
+	 */
+	public function test_drops_the_same_destination_unsigned() {
+		$url = 'https://elsewhere.example.test/thanks';
+
+		$this->assertSame( '', \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( $url ) );
+		$this->assertSame( '', \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( $url, 'not-a-signature' ) );
+	}
+
+	/**
+	 * A signature belongs to the destination it was made for.
+	 */
+	public function test_does_not_let_a_signature_transfer_to_another_destination() {
+		$signature = \Newspack_Blocks\Modal_Checkout::get_after_success_url_signature( 'https://elsewhere.example.test/thanks' );
+
+		$this->assertSame(
+			'',
+			\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( 'https://attacker.example.test/collect', $signature ),
+			'A signature made for one destination was accepted for another.'
+		);
+	}
+
+	/**
+	 * Signing survives the sanitising the value passes through in transit.
+	 *
+	 * The signature covers an exact string, and the destination is sanitised between the
+	 * block that emits it and the page that checks it. If the two sides ever normalise
+	 * differently, a publisher's own destination starts failing closed.
+	 *
+	 * @dataProvider awkward_destinations
+	 *
+	 * @param string $url A destination that sanitising might alter.
+	 */
+	public function test_signing_survives_sanitising( $url ) {
+		$signature = \Newspack_Blocks\Modal_Checkout::get_after_success_url_signature( $url );
+
+		// What the page receives has been through sanitising on the way.
+		$in_transit = sanitize_url( $url );
+
+		$this->assertNotSame(
+			'',
+			\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( $in_transit, $signature ),
+			'A signed destination stopped verifying after sanitising.'
+		);
+	}
+
+	/**
+	 * Destinations whose exact string sanitising may not leave alone.
+	 *
+	 * @return array[]
+	 */
+	public function awkward_destinations() {
+		return [
+			'a query string'      => [ 'https://elsewhere.example.test/thanks?utm_campaign=spring&utm_source=email' ],
+			'a fragment'          => [ 'https://elsewhere.example.test/thanks#supporters' ],
+			'an encoded space'    => [ 'https://elsewhere.example.test/thank%20you/' ],
+			'a capitalised host'  => [ 'https://ELSEWHERE.example.test/thanks' ],
+			'a port'              => [ 'https://elsewhere.example.test:8443/thanks' ],
+			'a trailing slash'    => [ 'https://elsewhere.example.test/thanks/' ],
+		];
+	}
+
+	/**
+	 * A signed destination is not announced as refused.
+	 */
+	public function test_does_not_announce_a_signed_destination() {
+		$seen = [];
+		add_action(
+			'newspack_blocks_after_success_url_rejected',
+			function ( $url ) use ( &$seen ) {
+				$seen[] = $url;
+			}
+		);
+
+		$url = 'https://elsewhere.example.test/thanks';
+		\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( $url, \Newspack_Blocks\Modal_Checkout::get_after_success_url_signature( $url ) );
+
+		remove_all_actions( 'newspack_blocks_after_success_url_rejected' );
+
+		$this->assertSame( [], $seen, 'A destination this site signed was reported as refused.' );
+	}
+
+	/**
+	 * The checkout carries the signature through with the destination it signs.
+	 */
+	public function test_checkout_carries_a_signed_destination() {
+		$url = 'https://elsewhere.example.test/thanks';
+
+		$_REQUEST['after_success_behavior']  = 'custom';
+		$_REQUEST['after_success_url']       = $url;
+		$_REQUEST['after_success_signature'] = \Newspack_Blocks\Modal_Checkout::get_after_success_url_signature( $url );
+
+		$params = $this->get_after_success_params();
+
+		unset( $_REQUEST['after_success_behavior'], $_REQUEST['after_success_url'], $_REQUEST['after_success_signature'] );
+
+		$this->assertSame( $url, $params['after_success_url'] ?? '', 'A signed destination did not reach the page.' );
+		$this->assertSame( 'custom', $params['after_success_behavior'] ?? '' );
+		$this->assertNotEmpty( $params['after_success_signature'] ?? '', 'The signature was not carried onward with the destination.' );
+	}
+
+	/**
 	 * Read the after-success params the checkout passes to the page.
 	 *
 	 * @return array

--- a/plugins/newspack-blocks/tests/test-after-success-url.php
+++ b/plugins/newspack-blocks/tests/test-after-success-url.php
@@ -114,7 +114,7 @@ class AfterSuccessUrlTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	public function test_announces_a_refused_destination() {
 		$seen = [];
 		add_action(
-			'newspack_blocks_after_success_url_rejected',
+			'newspack_blocks_modal_checkout_after_success_url_rejected',
 			function ( $url ) use ( &$seen ) {
 				$seen[] = $url;
 			}
@@ -123,7 +123,7 @@ class AfterSuccessUrlTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 		\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( 'https://elsewhere.example.test/collect' );
 		\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( home_url( '/thanks/' ) );
 
-		remove_all_actions( 'newspack_blocks_after_success_url_rejected' );
+		remove_all_actions( 'newspack_blocks_modal_checkout_after_success_url_rejected' );
 
 		$this->assertSame(
 			[ 'https://elsewhere.example.test/collect' ],
@@ -133,124 +133,224 @@ class AfterSuccessUrlTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	}
 
 	/**
-	 * A destination this site signed is honoured wherever it points.
+	 * Create a published post to render a destination against.
+	 *
+	 * @return int Post ID.
+	 */
+	private function published_post() {
+		return self::factory()->post->create( [ 'post_status' => 'publish' ] );
+	}
+
+	/**
+	 * A destination this site vouched for is honoured wherever it points.
 	 *
 	 * This is what lets a publisher send readers to a host they own without anyone adding
 	 * that host to this site's allowlist in code.
 	 */
-	public function test_keeps_a_signed_destination_off_site() {
-		$url       = 'https://elsewhere.example.test/thanks';
-		$signature = \Newspack_Blocks\Modal_Checkout::get_after_success_url_signature( $url );
+	public function test_keeps_a_vouched_destination_off_site() {
+		$url   = 'https://elsewhere.example.test/thanks';
+		$token = \Newspack_Blocks\Modal_Checkout::get_after_success_token( $url, $this->published_post() );
 
+		$this->assertNotEmpty( $token, 'No token was minted for a published post.' );
 		$this->assertSame(
 			$url,
-			\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( $url, $signature ),
-			'A destination this site signed was refused.'
+			\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( '', $token ),
+			'A destination this site vouched for was refused.'
 		);
 	}
 
 	/**
-	 * The same destination without the signature is still refused.
+	 * The same destination without a token is still refused.
 	 *
-	 * A link can carry the destination; it can't carry the signature.
+	 * A link can carry the destination; it cannot carry a token.
 	 */
-	public function test_drops_the_same_destination_unsigned() {
+	public function test_drops_the_same_destination_without_a_token() {
 		$url = 'https://elsewhere.example.test/thanks';
 
 		$this->assertSame( '', \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( $url ) );
-		$this->assertSame( '', \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( $url, 'not-a-signature' ) );
+		$this->assertSame( '', \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( $url, 'not.atoken' ) );
 	}
 
 	/**
-	 * A signature belongs to the destination it was made for.
+	 * Nothing is vouched for on a post that is not published.
+	 *
+	 * The block renderer is reachable over REST by anyone who can edit posts, and draft
+	 * preview reaches it too, so minting has to depend on something a contributor cannot do.
+	 *
+	 * @dataProvider unpublished_statuses
+	 *
+	 * @param string $status Post status.
 	 */
-	public function test_does_not_let_a_signature_transfer_to_another_destination() {
-		$signature = \Newspack_Blocks\Modal_Checkout::get_after_success_url_signature( 'https://elsewhere.example.test/thanks' );
+	public function test_does_not_vouch_from_an_unpublished_post( $status ) {
+		$post_id = self::factory()->post->create( [ 'post_status' => $status ] );
 
 		$this->assertSame(
 			'',
-			\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( 'https://attacker.example.test/collect', $signature ),
-			'A signature made for one destination was accepted for another.'
+			\Newspack_Blocks\Modal_Checkout::get_after_success_token( 'https://elsewhere.example.test/thanks', $post_id ),
+			'A destination was vouched for from a post the reader cannot see.'
 		);
 	}
 
 	/**
-	 * Signing survives the sanitising the value passes through in transit.
+	 * Statuses a contributor can reach without publishing.
 	 *
-	 * The signature covers an exact string, and the destination is sanitised between the
-	 * block that emits it and the page that checks it. If the two sides ever normalise
-	 * differently, a publisher's own destination starts failing closed.
+	 * @return array[]
+	 */
+	public function unpublished_statuses() {
+		return [
+			'a draft'          => [ 'draft' ],
+			'a pending review' => [ 'pending' ],
+			'a private post'   => [ 'private' ],
+		];
+	}
+
+	/**
+	 * Nothing is vouched for with no post at all, which is the REST render case.
+	 */
+	public function test_does_not_vouch_without_a_post() {
+		$this->assertSame( '', \Newspack_Blocks\Modal_Checkout::get_after_success_token( 'https://elsewhere.example.test/thanks', 0 ) );
+	}
+
+	/**
+	 * A token stops working once its post is no longer published.
+	 */
+	public function test_refuses_a_token_whose_post_was_unpublished() {
+		$post_id = $this->published_post();
+		$token   = \Newspack_Blocks\Modal_Checkout::get_after_success_token( 'https://elsewhere.example.test/thanks', $post_id );
+
+		wp_update_post(
+			[
+				'ID'          => $post_id,
+				'post_status' => 'draft',
+			]
+		);
+
+		$this->assertSame( '', \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( '', $token ) );
+	}
+
+	/**
+	 * A token is not this site's if any of it has been altered.
+	 */
+	public function test_refuses_a_tampered_token() {
+		$post_id = $this->published_post();
+		$token   = \Newspack_Blocks\Modal_Checkout::get_after_success_token( 'https://elsewhere.example.test/thanks', $post_id );
+
+		list( $payload, $signature ) = explode( '.', $token, 2 );
+
+		$other = \Newspack_Blocks\Modal_Checkout::get_after_success_token( 'https://attacker.example.test/collect', $post_id );
+		list( $other_payload ) = explode( '.', $other, 2 );
+
+		$this->assertSame( '', \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( '', $other_payload . '.' . $signature ), 'A payload was swapped under a valid signature.' );
+		$this->assertSame( '', \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( '', $payload . '.' . strrev( $signature ) ), 'A tampered signature was accepted.' );
+		$this->assertSame( '', \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( '', $payload ), 'A payload with no signature was accepted.' );
+	}
+
+	/**
+	 * The destination survives the sanitising it actually meets in transit.
+	 *
+	 * This is the failure this design exists to prevent, so the test reproduces the real
+	 * transforms rather than a stand-in. Modelling transit as `sanitize_url()` — the one
+	 * transform the normaliser itself applies — cannot fail, and would report the broken
+	 * shapes below as working.
 	 *
 	 * @dataProvider awkward_destinations
 	 *
-	 * @param string $url A destination that sanitising might alter.
+	 * @param string $url A destination that transit is known to alter.
 	 */
-	public function test_signing_survives_sanitising( $url ) {
-		$signature = \Newspack_Blocks\Modal_Checkout::get_after_success_url_signature( $url );
+	public function test_destination_survives_real_transit( $url ) {
+		$token = \Newspack_Blocks\Modal_Checkout::get_after_success_token( $url, $this->published_post() );
+		$this->assertNotEmpty( $token );
 
-		// What the page receives has been through sanitising on the way.
-		$in_transit = sanitize_url( $url );
+		$transits = [
+			'FILTER_SANITIZE_URL (checkout entry)'  => filter_var( $token, FILTER_SANITIZE_URL ),
+			'sanitize_text_field (params reader)'   => sanitize_text_field( $token ),
+			'FULL_SPECIAL_CHARS (donations path)'   => filter_var( $token, FILTER_SANITIZE_FULL_SPECIAL_CHARS ),
+			'esc_attr round trip (hidden input)'    => html_entity_decode( esc_attr( $token ) ),
+		];
 
-		$this->assertNotSame(
-			'',
-			\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( $in_transit, $signature ),
-			'A signed destination stopped verifying after sanitising.'
-		);
+		foreach ( $transits as $label => $in_transit ) {
+			$this->assertSame(
+				\Newspack_Blocks\Modal_Checkout::normalize_after_success_url( $url ),
+				\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( '', $in_transit ),
+				'The destination did not survive: ' . $label
+			);
+		}
 	}
 
 	/**
-	 * Destinations whose exact string sanitising may not leave alone.
+	 * Destination shapes that transit is known to alter.
+	 *
+	 * Each of these breaks at least one of the transforms above when the destination itself
+	 * is what travels.
 	 *
 	 * @return array[]
 	 */
 	public function awkward_destinations() {
 		return [
-			'a query string'      => [ 'https://elsewhere.example.test/thanks?utm_campaign=spring&utm_source=email' ],
-			'a fragment'          => [ 'https://elsewhere.example.test/thanks#supporters' ],
+			'two query params'    => [ 'https://elsewhere.example.test/thanks?utm_campaign=spring&utm_source=email' ],
+			'an apostrophe'       => [ "https://elsewhere.example.test/thanks?utm_campaign=don't" ],
 			'an encoded space'    => [ 'https://elsewhere.example.test/thank%20you/' ],
-			'a capitalised host'  => [ 'https://ELSEWHERE.example.test/thanks' ],
+			'a non-ASCII path'    => [ 'https://elsewhere.example.test/gracias-señor/' ],
+			'a fragment'          => [ 'https://elsewhere.example.test/thanks#supporters' ],
 			'a port'              => [ 'https://elsewhere.example.test:8443/thanks' ],
-			'a trailing slash'    => [ 'https://elsewhere.example.test/thanks/' ],
 		];
 	}
 
 	/**
-	 * A signed destination is not announced as refused.
+	 * Host normalisation touches the authority and nothing else.
 	 */
-	public function test_does_not_announce_a_signed_destination() {
+	public function test_normalisation_lowercases_only_the_host() {
+		$this->assertSame(
+			'https://example.test/go?next=https%3A//Example.test/x',
+			\Newspack_Blocks\Modal_Checkout::normalize_after_success_url( 'https://Example.test/go?next=https%3A//Example.test/x' ),
+			'Host lowercasing reached into the query string.'
+		);
+
+		$this->assertStringContainsString(
+			'@example.test',
+			\Newspack_Blocks\Modal_Checkout::normalize_after_success_url( 'https://User@Example.test/' ),
+			'A host behind userinfo was left capitalised.'
+		);
+	}
+
+	/**
+	 * A vouched destination is not announced as refused.
+	 */
+	public function test_does_not_announce_a_vouched_destination() {
 		$seen = [];
 		add_action(
-			'newspack_blocks_after_success_url_rejected',
+			'newspack_blocks_modal_checkout_after_success_url_rejected',
 			function ( $url ) use ( &$seen ) {
 				$seen[] = $url;
 			}
 		);
 
-		$url = 'https://elsewhere.example.test/thanks';
-		\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( $url, \Newspack_Blocks\Modal_Checkout::get_after_success_url_signature( $url ) );
+		$token = \Newspack_Blocks\Modal_Checkout::get_after_success_token( 'https://elsewhere.example.test/thanks', $this->published_post() );
+		\Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( '', $token );
 
-		remove_all_actions( 'newspack_blocks_after_success_url_rejected' );
+		remove_all_actions( 'newspack_blocks_modal_checkout_after_success_url_rejected' );
 
-		$this->assertSame( [], $seen, 'A destination this site signed was reported as refused.' );
+		$this->assertSame( [], $seen, 'A destination this site vouched for was reported as refused.' );
 	}
 
 	/**
-	 * The checkout carries the signature through with the destination it signs.
+	 * The checkout carries the token through with the destination it vouches for.
 	 */
-	public function test_checkout_carries_a_signed_destination() {
-		$url = 'https://elsewhere.example.test/thanks';
+	public function test_checkout_carries_a_vouched_destination() {
+		$url   = 'https://elsewhere.example.test/thanks';
+		$token = \Newspack_Blocks\Modal_Checkout::get_after_success_token( $url, $this->published_post() );
 
-		$_REQUEST['after_success_behavior']  = 'custom';
-		$_REQUEST['after_success_url']       = $url;
-		$_REQUEST['after_success_signature'] = \Newspack_Blocks\Modal_Checkout::get_after_success_url_signature( $url );
+		$_REQUEST['after_success_behavior'] = 'custom';
+		$_REQUEST['after_success_url']      = $url;
+		$_REQUEST['after_success_token']    = $token;
 
 		$params = $this->get_after_success_params();
 
-		unset( $_REQUEST['after_success_behavior'], $_REQUEST['after_success_url'], $_REQUEST['after_success_signature'] );
+		unset( $_REQUEST['after_success_behavior'], $_REQUEST['after_success_url'], $_REQUEST['after_success_token'] );
 
-		$this->assertSame( $url, $params['after_success_url'] ?? '', 'A signed destination did not reach the page.' );
+		$this->assertSame( $url, $params['after_success_url'] ?? '', 'A vouched destination did not reach the page.' );
 		$this->assertSame( 'custom', $params['after_success_behavior'] ?? '' );
-		$this->assertNotEmpty( $params['after_success_signature'] ?? '', 'The signature was not carried onward with the destination.' );
+		$this->assertNotEmpty( $params['after_success_token'] ?? '', 'The token was not carried onward.' );
 	}
 
 	/**

--- a/plugins/newspack-blocks/tests/test-after-success-url.php
+++ b/plugins/newspack-blocks/tests/test-after-success-url.php
@@ -293,6 +293,12 @@ class AfterSuccessUrlTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 			'a non-ASCII path'    => [ 'https://elsewhere.example.test/gracias-señor/' ],
 			'a fragment'          => [ 'https://elsewhere.example.test/thanks#supporters' ],
 			'a port'              => [ 'https://elsewhere.example.test:8443/thanks' ],
+			// The token alphabet is inert to all four transforms, so the shapes above exercise
+			// one property rather than six. These two do vary the outcome: normalising a
+			// protocol-relative destination has to keep the `//`, or the value read back is a
+			// relative path rather than the destination that was vouched for.
+			'protocol relative'   => [ '//ELSEWHERE.example.test/thanks' ],
+			'protocol relative with a port' => [ '//ELSEWHERE.example.test:8443/thanks' ],
 		];
 	}
 
@@ -300,9 +306,11 @@ class AfterSuccessUrlTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 	 * Host normalisation touches the authority and nothing else.
 	 */
 	public function test_normalisation_lowercases_only_the_host() {
+		// A literal `://` in the query, not `%3A//`: the encoded form never matched the
+		// replacement this guards against, so it passed either way.
 		$this->assertSame(
-			'https://example.test/go?next=https%3A//Example.test/x',
-			\Newspack_Blocks\Modal_Checkout::normalize_after_success_url( 'https://Example.test/go?next=https%3A//Example.test/x' ),
+			'https://example.test/go?next=https://Example.test/x',
+			\Newspack_Blocks\Modal_Checkout::normalize_after_success_url( 'https://Example.test/go?next=https://Example.test/x' ),
 			'Host lowercasing reached into the query string.'
 		);
 
@@ -311,6 +319,46 @@ class AfterSuccessUrlTest extends WP_UnitTestCase_Blocks { // phpcs:ignore
 			\Newspack_Blocks\Modal_Checkout::normalize_after_success_url( 'https://User@Example.test/' ),
 			'A host behind userinfo was left capitalised.'
 		);
+	}
+
+	/**
+	 * Normalising twice gives the same string as normalising once.
+	 *
+	 * The token signs a normalised destination at mint and normalises again at read, so a
+	 * normaliser that changes its own output cannot verify.
+	 *
+	 * @dataProvider awkward_destinations
+	 *
+	 * @param string $url The destination to normalise.
+	 */
+	public function test_normalisation_is_idempotent( $url ) {
+		$once = \Newspack_Blocks\Modal_Checkout::normalize_after_success_url( $url );
+
+		$this->assertSame(
+			$once,
+			\Newspack_Blocks\Modal_Checkout::normalize_after_success_url( $once ),
+			'Normalising twice changed the destination.'
+		);
+	}
+
+	/**
+	 * A destination this site will not redirect to is announced, however it is shaped.
+	 */
+	public function test_announces_a_refused_protocol_relative_destination() {
+		$seen = [];
+		add_action(
+			'newspack_blocks_modal_checkout_after_success_url_rejected',
+			function ( $url ) use ( &$seen ) {
+				$seen[] = $url;
+			}
+		);
+
+		$result = \Newspack_Blocks\Modal_Checkout::sanitize_after_success_url( '//ELSEWHERE.example.test/thanks' );
+
+		remove_all_actions( 'newspack_blocks_modal_checkout_after_success_url_rejected' );
+
+		$this->assertSame( '', $result, 'An off-site destination was kept.' );
+		$this->assertNotEmpty( $seen, 'A refused destination slipped past the hook that reports refusals.' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/class-donations.php
+++ b/plugins/newspack-plugin/includes/class-donations.php
@@ -878,16 +878,25 @@ class Donations {
 		if ( $is_modal_checkout ) {
 			$query_args['modal_checkout'] = 1;
 		}
-		// `after_success_token` carries the destination this site vouched for: drop it here
-		// and a publisher-configured destination arrives unvouched and is refused as if a link
-		// had supplied it.
-		foreach ( [ 'after_success_behavior', 'after_success_button_label', 'after_success_url', 'after_success_token' ] as $attribute_name ) {
+		// Matched by prefix rather than listed by name. Every `after_success_*` param has to
+		// arrive together: `after_success_token` vouches for the destination in
+		// `after_success_url`, so a param left behind here means a publisher-configured
+		// destination arrives unvouched and is refused as if a link had supplied it. A list
+		// would need editing again the next time one of these is renamed.
+		// Mirrors the same prefix match in `Newspack_Blocks\Modal_Checkout`.
+		// Only the keys are used here; each value is read again below with the filter that
+		// suits it.
+		$request_params = filter_input_array( INPUT_GET, FILTER_SANITIZE_FULL_SPECIAL_CHARS ) ?? [];
+		foreach ( array_keys( (array) $request_params ) as $attribute_name ) {
+			if ( 0 !== strpos( $attribute_name, 'after_success' ) ) {
+				continue;
+			}
 			// The destination is a URL, not display text: HTML-encoding it here would turn
 			// `&` into `&amp;` in the value itself.
 			$filter = 'after_success_url' === $attribute_name ? FILTER_SANITIZE_URL : FILTER_SANITIZE_FULL_SPECIAL_CHARS;
 			$value  = filter_input( INPUT_GET, $attribute_name, $filter );
 			if ( ! empty( $value ) ) {
-				$query_args[ $attribute_name ] = $value;
+				$query_args[ sanitize_key( $attribute_name ) ] = $value;
 			}
 		}
 

--- a/plugins/newspack-plugin/includes/class-donations.php
+++ b/plugins/newspack-plugin/includes/class-donations.php
@@ -878,11 +878,14 @@ class Donations {
 		if ( $is_modal_checkout ) {
 			$query_args['modal_checkout'] = 1;
 		}
-		// `after_success_signature` travels with the destination it signs: drop it here and a
-		// publisher-configured destination arrives unsigned and gets refused as if a link had
-		// supplied it.
-		foreach ( [ 'after_success_behavior', 'after_success_button_label', 'after_success_url', 'after_success_signature' ] as $attribute_name ) {
-			$value = filter_input( INPUT_GET, $attribute_name, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
+		// `after_success_token` carries the destination this site vouched for: drop it here
+		// and a publisher-configured destination arrives unvouched and is refused as if a link
+		// had supplied it.
+		foreach ( [ 'after_success_behavior', 'after_success_button_label', 'after_success_url', 'after_success_token' ] as $attribute_name ) {
+			// The destination is a URL, not display text: HTML-encoding it here would turn
+			// `&` into `&amp;` in the value itself.
+			$filter = 'after_success_url' === $attribute_name ? FILTER_SANITIZE_URL : FILTER_SANITIZE_FULL_SPECIAL_CHARS;
+			$value  = filter_input( INPUT_GET, $attribute_name, $filter );
 			if ( ! empty( $value ) ) {
 				$query_args[ $attribute_name ] = $value;
 			}

--- a/plugins/newspack-plugin/includes/class-donations.php
+++ b/plugins/newspack-plugin/includes/class-donations.php
@@ -878,7 +878,10 @@ class Donations {
 		if ( $is_modal_checkout ) {
 			$query_args['modal_checkout'] = 1;
 		}
-		foreach ( [ 'after_success_behavior', 'after_success_button_label', 'after_success_url' ] as $attribute_name ) {
+		// `after_success_signature` travels with the destination it signs: drop it here and a
+		// publisher-configured destination arrives unsigned and gets refused as if a link had
+		// supplied it.
+		foreach ( [ 'after_success_behavior', 'after_success_button_label', 'after_success_url', 'after_success_signature' ] as $attribute_name ) {
 			$value = filter_input( INPUT_GET, $attribute_name, FILTER_SANITIZE_FULL_SPECIAL_CHARS );
 			if ( ! empty( $value ) ) {
 				$query_args[ $attribute_name ] = $value;


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Stacked on #782 — targets `hotfix/blocks-input-validation`, not `release`.** Merge this into #782, then #782 into `release`, so the durable fix ships in one go.

#782 validates post-checkout destinations, which means a destination pointing somewhere other than the site's own host is refused unless that host is added to `allowed_redirect_hosts` in per-publisher custom code. That works, but it puts a permanent support burden on every publisher who configures an off-site destination, and the failure is silent.

This removes the need for that custom code. When a block renders a destination a publisher configured, the site signs it. A destination arriving with a valid signature is honoured wherever it points; anything else still has to clear `wp_validate_redirect()`. A destination supplied in a link carries no signature, so the behaviour #782 closes stays closed.

Signing happens at render rather than at save, so **blocks published before this ships are covered with no migration** — the signature is computed from the block's attributes each time the page renders. Reusable blocks are included, since they render through the same callbacks.

`wp_hash()` rather than a nonce: the value has to survive page caching and a reader who signs in partway through checkout, and a nonce is bound to a user and a time window. The signature is site-specific, so it means nothing on another site.

### How to test the changes in this Pull Request:

1. `cd plugins/newspack-blocks && n test-php` — 89 tests, 11 new. `n test-js` — 42 tests.
2. Add a Donate or Checkout Button block, set "Post-Checkout Button" to **Go to a custom URL**, and enter a URL on a host the site does not own.
3. Complete a checkout. The reader is taken to that destination — no `allowed_redirect_hosts` entry needed.
4. Now craft a checkout link by hand with `?after_success_url=` pointing at another host, and complete a checkout through it. The destination is refused and the modal closes, because the link carries no signature.
5. Confirm a same-host destination still works, and that an existing block published before this change works without being re-saved.

### Notes for reviewers

* **The trust boundary moves, and it's worth an explicit decision.** Anyone who can publish a block can mint a signature for a destination of their choosing. That's the boundary the feature already has — a Checkout Button's destination has always been settable by whoever can publish — and far tighter than before #782, where any URL in a query string worked with no authentication. It is looser than the allowlist, which needs a code deploy.
* **The hazard here is normalization drift.** The signature covers an exact string, and the destination passes through sanitising between the block that emits it and the page that checks it. Both sides normalise through one shared helper for that reason, and there's a test over query strings, fragments, encoded spaces, capitalised hosts, ports and trailing slashes.
* **The `newspack-plugin` change is one line plus a comment,** adding the signature to the params `class-donations.php` already forwards. Without it a signed destination loses its signature crossing that path and silently degrades to allowlist-only.
* Once this ships, the six per-site `allowed_redirect_hosts` entries tracked in NPPM-3080 become unnecessary. They're harmless if already added.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
