### PR TITLE
fix(reader-activation): reserve internal user meta keys on registration

### DIFF
--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-registration.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-registration.php
@@ -106,7 +106,8 @@ final class Reader_Registration {
 	/**
 	 * Sanitize the metadata parameter.
 	 *
-	 * Ensures all keys and values are sanitized strings.
+	 * Ensures all keys and values are sanitized strings. If this ever accepts
+	 * arrays, revisit {@see is_reserved_meta_key()}.
 	 *
 	 * @param array $metadata Raw metadata from the request.
 	 * @return array Sanitized metadata.
@@ -123,6 +124,61 @@ final class Reader_Registration {
 			}
 		}
 		return $sanitized;
+	}
+
+	/**
+	 * Whether a user meta key is reserved and therefore not caller-writable.
+	 *
+	 * Covers Newspack reader state and reader data, the identity key Jetpack reads,
+	 * and WordPress account state. Other code trusts these values, so registration
+	 * metadata must not set them. Add to the list when adding a key that gates
+	 * anything.
+	 *
+	 * @param string $meta_key Meta key to check.
+	 * @return bool True if the key is reserved.
+	 */
+	public static function is_reserved_meta_key( $meta_key ): bool {
+		global $wpdb;
+
+		$key = strtolower( trim( (string) $meta_key ) );
+		if ( '' === $key ) {
+			return true;
+		}
+
+		$reserved_prefixes = [ 'np_', '_np_', 'newspack_', '_newspack_' ];
+		foreach ( $reserved_prefixes as $prefix ) {
+			if ( 0 === strpos( $key, $prefix ) ) {
+				return true;
+			}
+		}
+
+		$reserved_keys = [
+			'wpcom_user_id', // Jetpack resolves subscriptions against this ID, not the local user ID.
+			'session_tokens',
+			'_application_passwords',
+			'wp_capabilities',
+			'wp_user_level',
+			'wp_user-settings',
+			'wp_user-settings-time',
+			'default_password_nag',
+		];
+		if ( in_array( $key, $reserved_keys, true ) ) {
+			return true;
+		}
+
+		// Table-prefixed, with a per-blog segment on multisite (wp_2_capabilities).
+		// Match the site's prefix and the default, so this holds on any configuration.
+		$prefixes = [ 'wp_' ];
+		if ( isset( $wpdb->base_prefix ) ) {
+			$prefixes[] = strtolower( $wpdb->base_prefix );
+		}
+		foreach ( array_unique( $prefixes ) as $prefix ) {
+			if ( preg_match( '/^' . preg_quote( $prefix, '/' ) . '(\d+_)?(capabilities|user_level)$/', $key ) ) {
+				return true;
+			}
+		}
+
+		return false;
 	}
 
 	/**
@@ -455,12 +511,32 @@ final class Reader_Registration {
 			);
 		}
 
-		// Save arbitrary user metadata.
+		// Save arbitrary user metadata, skipping keys other code trusts.
 		$user_metadata = $request->get_param( 'metadata' );
+		$skipped_keys  = [];
 		if ( ! empty( $user_metadata ) ) {
 			foreach ( $user_metadata as $meta_key => $meta_value ) {
+				if ( self::is_reserved_meta_key( $meta_key ) ) {
+					$skipped_keys[] = $meta_key;
+					continue;
+				}
 				\update_user_meta( $result, $meta_key, $meta_value );
 			}
+		}
+
+		if ( ! empty( $skipped_keys ) ) {
+			// Once per request, not per key: the caller controls how many it sends.
+			// newspack_log() fires regardless of NEWSPACK_LOG_LEVEL.
+			Logger::newspack_log(
+				'newspack_frontend_registration_reserved_metadata',
+				'Frontend registration skipped reserved metadata keys.',
+				[
+					'integration_id' => $integration_id,
+					'count'          => count( $skipped_keys ),
+					'keys'           => array_slice( $skipped_keys, 0, 20 ),
+				],
+				'warning'
+			);
 		}
 
 		$response_data = [
@@ -468,6 +544,11 @@ final class Reader_Registration {
 			'status'  => 'created',
 			'email'   => $email,
 		];
+
+		// So an integration author can tell a saved key from a discarded one.
+		if ( ! empty( $skipped_keys ) ) {
+			$response_data['skipped_metadata_keys'] = $skipped_keys;
+		}
 
 		// Surface verification state so integration callers (via window.newspackReaderActivation.register())
 		// can opt into the post-registration verification modal when their UX warrants it. Callers that

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-registration.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-registration.php
@@ -129,51 +129,77 @@ final class Reader_Registration {
 	/**
 	 * Whether a user meta key is reserved and therefore not caller-writable.
 	 *
-	 * Covers Newspack reader state and reader data, the identity key Jetpack reads,
-	 * and WordPress account state. Other code trusts these values, so registration
-	 * metadata must not set them. Add to the list when adding a key that gates
-	 * anything.
+	 * Covers Newspack reader state and reader data, the identifiers other systems
+	 * resolve records against, and WordPress account state. Other code trusts these
+	 * values, so registration metadata must not set them. Add to the list when adding
+	 * a key that gates anything.
 	 *
-	 * @param string $meta_key Meta key to check.
+	 * Normalizes the key itself, so it is safe to call with a raw request key.
+	 *
+	 * @param int|string $meta_key Meta key to check. Numeric array keys arrive as int.
 	 * @return bool True if the key is reserved.
 	 */
 	public static function is_reserved_meta_key( $meta_key ): bool {
-		global $wpdb;
-
-		$key = strtolower( trim( (string) $meta_key ) );
+		$key = \sanitize_key( \wp_unslash( (string) $meta_key ) );
 		if ( '' === $key ) {
 			return true;
 		}
 
 		$reserved_prefixes = [ 'np_', '_np_', 'newspack_', '_newspack_' ];
 		foreach ( $reserved_prefixes as $prefix ) {
-			if ( 0 === strpos( $key, $prefix ) ) {
+			if ( str_starts_with( $key, $prefix ) ) {
 				return true;
 			}
 		}
 
 		$reserved_keys = [
-			'wpcom_user_id', // Jetpack resolves subscriptions against this ID, not the local user ID.
+			// Other systems' identifiers, read via get_user_option(), which falls back
+			// to the unprefixed key. WooPayments needs all three.
+			'wpcom_user_id',
+			'_stripe_customer_id',
+			'_wcpay_customer_id',
+			'_wcpay_customer_id_live',
+			'_wcpay_customer_id_test',
+
 			'session_tokens',
 			'_application_passwords',
-			'wp_capabilities',
-			'wp_user_level',
-			'wp_user-settings',
-			'wp_user-settings-time',
 			'default_password_nag',
 		];
+
+		/**
+		 * Filters additional user meta keys that registration metadata may not write.
+		 *
+		 * Additive only: the keys above are always reserved and cannot be removed.
+		 *
+		 * @param string[] $keys Additional reserved meta keys.
+		 */
+		$reserved_keys = array_merge( $reserved_keys, (array) \apply_filters( 'newspack_reserved_registration_meta_keys', [] ) );
+
 		if ( in_array( $key, $reserved_keys, true ) ) {
 			return true;
 		}
 
-		// Table-prefixed, with a per-blog segment on multisite (wp_2_capabilities).
-		// Match the site's prefix and the default, so this holds on any configuration.
+		return self::is_prefixed_account_key( $key );
+	}
+
+	/**
+	 * Whether a key is one of the table-prefixed WordPress account keys.
+	 *
+	 * Prefixed, with a per-blog segment on multisite (wp_2_capabilities). Matches the
+	 * site's prefix and the default, so this holds on any configuration.
+	 *
+	 * @param string $key Sanitized meta key.
+	 * @return bool True if the key is a prefixed account key.
+	 */
+	private static function is_prefixed_account_key( string $key ): bool {
+		global $wpdb;
+
 		$prefixes = [ 'wp_' ];
 		if ( isset( $wpdb->base_prefix ) ) {
-			$prefixes[] = strtolower( $wpdb->base_prefix );
+			$prefixes[] = \sanitize_key( $wpdb->base_prefix );
 		}
 		foreach ( array_unique( $prefixes ) as $prefix ) {
-			if ( preg_match( '/^' . preg_quote( $prefix, '/' ) . '(\d+_)?(capabilities|user_level)$/', $key ) ) {
+			if ( preg_match( '/^' . preg_quote( $prefix, '/' ) . '(\d+_)?(capabilities|user_level|user-settings|user-settings-time)$/', $key ) ) {
 				return true;
 			}
 		}
@@ -545,10 +571,17 @@ final class Reader_Registration {
 			'email'   => $email,
 		];
 
-		// So an integration author can tell a saved key from a discarded one.
-		if ( ! empty( $skipped_keys ) ) {
-			$response_data['skipped_metadata_keys'] = $skipped_keys;
-		}
+		// Always present, so callers need no isset() guard. Prefixed account keys are
+		// logged but not echoed: only the matching one comes back, which would
+		// disclose the table prefix.
+		$response_data['skipped_metadata_keys'] = array_values(
+			array_filter(
+				$skipped_keys,
+				function ( $key ) {
+					return ! self::is_prefixed_account_key( \sanitize_key( \wp_unslash( (string) $key ) ) );
+				}
+			)
+		);
 
 		// Surface verification state so integration callers (via window.newspackReaderActivation.register())
 		// can opt into the post-registration verification modal when their UX warrants it. Callers that

--- a/plugins/newspack-plugin/tests/unit-tests/reader-registration-endpoint.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-registration-endpoint.php
@@ -888,4 +888,151 @@ class Newspack_Test_Frontend_Registration_Endpoint extends WP_UnitTestCase {
 		delete_transient( 'newspack_check_email_ip_' . md5( '127.0.0.1' ) );
 		wp_cache_delete( 'newspack_check_email_ip_' . md5( '127.0.0.1' ), 'newspack_rate_limit' );
 	}
+
+	/**
+	 * Metadata sent to the endpoint must not be able to set state the site trusts.
+	 * The endpoint is unauthenticated, so reader state (email verification), reader
+	 * data (which content gates read) and WordPress account state are all off limits.
+	 */
+	public function test_register_metadata_cannot_write_reserved_keys() {
+		global $wpdb;
+
+		$response = $this->do_register_request(
+			[
+				'npe'             => self::$reader_email,
+				'integration_id'  => self::$integration_id,
+				'integration_key' => self::generate_key( self::$integration_id ),
+				'metadata'        => [
+					'np_reader_email_verified'           => '1',
+					'_np_reader_email_verified'          => '1',
+					'newspack_reader_data_item_is_donor' => 'injected-reader-data',
+					'newspack_reader_data_keys'          => 'injected-key-list',
+					'_newspack_group_subscription'       => 'injected-subscription',
+					'wp_capabilities'                    => 'administrator',
+					$wpdb->base_prefix . 'capabilities'  => 'administrator',
+					'wpcom_user_id'                      => '12345',
+					'session_tokens'                     => 'injected-session',
+					'_application_passwords'             => 'injected-password',
+					'partner_member_id'                  => 'abc-123',
+				],
+			]
+		);
+
+		$this->assertEquals( 201, $response->get_status() );
+		$user = get_user_by( 'email', self::$reader_email );
+		$this->assertInstanceOf( 'WP_User', $user );
+
+		$this->assertFalse(
+			Reader_Activation::is_reader_verified( $user ),
+			'Request metadata must not be able to mark the reader email-verified.'
+		);
+		$this->assertSame(
+			'',
+			get_user_meta( $user->ID, 'newspack_reader_data_item_is_donor', true ),
+			'Request metadata must not be able to write reader data that access rules read.'
+		);
+		$this->assertSame(
+			'',
+			get_user_meta( $user->ID, '_newspack_group_subscription', true ),
+			'Request metadata must not be able to write underscore-prefixed Newspack keys.'
+		);
+		$this->assertSame(
+			'',
+			get_user_meta( $user->ID, 'wpcom_user_id', true ),
+			'Request metadata must not be able to claim another WordPress.com identity, which Jetpack resolves paid subscriptions against.'
+		);
+
+		// Registration authenticates the new reader, so these two may legitimately hold
+		// a real value. What must never happen is a caller-supplied scalar landing in
+		// them, which is what their consumers would choke on.
+		foreach ( [ 'newspack_reader_data_keys', 'session_tokens', '_application_passwords' ] as $array_key ) {
+			$stored = get_user_meta( $user->ID, $array_key, true );
+			$this->assertTrue(
+				'' === $stored || is_array( $stored ),
+				sprintf( 'Request metadata must not be able to write a scalar into "%s".', $array_key )
+			);
+		}
+
+		// The harm at the capabilities key is not escalation — sanitize_text_field()
+		// makes the value a scalar, which core ignores — it is that writing a scalar
+		// replaces the role array, stripping the account of every role.
+		$caps = get_user_meta( $user->ID, $wpdb->get_blog_prefix() . 'capabilities', true );
+		$this->assertIsArray(
+			$caps,
+			'Request metadata must not be able to overwrite the capabilities meta.'
+		);
+		$this->assertArrayNotHasKey( 'administrator', $caps );
+		$this->assertFalse( user_can( $user->ID, 'manage_options' ) );
+
+		// The drop is reported back, so an integration author can tell "saved" from
+		// "silently discarded".
+		$data = $response->get_data();
+		$this->assertArrayHasKey( 'skipped_metadata_keys', $data );
+		$this->assertContains( 'np_reader_email_verified', $data['skipped_metadata_keys'] );
+		$this->assertNotContains( 'partner_member_id', $data['skipped_metadata_keys'] );
+
+		// Keys outside the reserved set still write: the metadata contract that
+		// integrations rely on is unchanged.
+		$this->assertSame(
+			'abc-123',
+			get_user_meta( $user->ID, 'partner_member_id', true ),
+			'Non-reserved metadata keys must still be saved.'
+		);
+	}
+
+	/**
+	 * Reserved-key classification, including the case and whitespace variants a
+	 * caller could use to try to slip past the guard.
+	 */
+	public function test_is_reserved_meta_key() {
+		global $wpdb;
+
+		$reserved = [
+			'np_reader',
+			'np_reader_email_verified',
+			'_np_reader',
+			'newspack_reader_data_keys',
+			'newspack_reader_data_item_is_donor',
+			'_newspack_anything',
+			'wp_capabilities',
+			'wp_user_level',
+			'wp_2_capabilities',
+			'wp_2_user_level',
+			$wpdb->base_prefix . 'capabilities',
+			$wpdb->base_prefix . '3_capabilities',
+			$wpdb->base_prefix . 'user_level',
+			'wpcom_user_id',
+			'session_tokens',
+			'_application_passwords',
+			'wp_user-settings',
+			'wp_user-settings-time',
+			'default_password_nag',
+			'NP_Reader_Email_Verified',
+			'  np_reader  ',
+			'',
+		];
+		foreach ( $reserved as $key ) {
+			$this->assertTrue(
+				Reader_Registration::is_reserved_meta_key( $key ),
+				sprintf( 'Key "%s" must be treated as reserved.', $key )
+			);
+		}
+
+		$allowed = [
+			'partner_member_id',
+			'billing_city',
+			'nps_score',
+			'newspaper_subscriber_id',
+			'crm_contact_id',
+			'capabilities',
+			'user_level',
+			'reader_source',
+		];
+		foreach ( $allowed as $key ) {
+			$this->assertFalse(
+				Reader_Registration::is_reserved_meta_key( $key ),
+				sprintf( 'Key "%s" must remain writable.', $key )
+			);
+		}
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/reader-registration-endpoint.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-registration-endpoint.php
@@ -897,6 +897,8 @@ class Newspack_Test_Frontend_Registration_Endpoint extends WP_UnitTestCase {
 	public function test_register_metadata_cannot_write_reserved_keys() {
 		global $wpdb;
 
+		$caps_key = $wpdb->get_blog_prefix() . 'capabilities';
+
 		$response = $this->do_register_request(
 			[
 				'npe'             => self::$reader_email,
@@ -908,8 +910,7 @@ class Newspack_Test_Frontend_Registration_Endpoint extends WP_UnitTestCase {
 					'newspack_reader_data_item_is_donor' => 'injected-reader-data',
 					'newspack_reader_data_keys'          => 'injected-key-list',
 					'_newspack_group_subscription'       => 'injected-subscription',
-					'wp_capabilities'                    => 'administrator',
-					$wpdb->base_prefix . 'capabilities'  => 'administrator',
+					$caps_key                            => 'administrator',
 					'wpcom_user_id'                      => '12345',
 					'session_tokens'                     => 'injected-session',
 					'_application_passwords'             => 'injected-password',
@@ -956,7 +957,7 @@ class Newspack_Test_Frontend_Registration_Endpoint extends WP_UnitTestCase {
 		// The harm at the capabilities key is not escalation — sanitize_text_field()
 		// makes the value a scalar, which core ignores — it is that writing a scalar
 		// replaces the role array, stripping the account of every role.
-		$caps = get_user_meta( $user->ID, $wpdb->get_blog_prefix() . 'capabilities', true );
+		$caps = get_user_meta( $user->ID, $caps_key, true );
 		$this->assertIsArray(
 			$caps,
 			'Request metadata must not be able to overwrite the capabilities meta.'

--- a/plugins/newspack-plugin/tests/unit-tests/reader-registration-endpoint.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-registration-endpoint.php
@@ -912,6 +912,10 @@ class Newspack_Test_Frontend_Registration_Endpoint extends WP_UnitTestCase {
 					'_newspack_group_subscription'       => 'injected-subscription',
 					$caps_key                            => 'administrator',
 					'wpcom_user_id'                      => '12345',
+					'_stripe_customer_id'                => 'cus_attacker',
+					'_wcpay_customer_id'                 => 'cus_attacker',
+					'_wcpay_customer_id_live'            => 'cus_attacker',
+					'_wcpay_customer_id_test'            => 'cus_attacker',
 					'session_tokens'                     => 'injected-session',
 					'_application_passwords'             => 'injected-password',
 					'partner_member_id'                  => 'abc-123',
@@ -937,11 +941,19 @@ class Newspack_Test_Frontend_Registration_Endpoint extends WP_UnitTestCase {
 			get_user_meta( $user->ID, '_newspack_group_subscription', true ),
 			'Request metadata must not be able to write underscore-prefixed Newspack keys.'
 		);
-		$this->assertSame(
-			'',
-			get_user_meta( $user->ID, 'wpcom_user_id', true ),
-			'Request metadata must not be able to claim another WordPress.com identity, which Jetpack resolves paid subscriptions against.'
-		);
+		// Identifiers other systems resolve their own records against. get_user_option()
+		// falls back to the unprefixed key, so an unprefixed write is what gets read.
+		foreach ( [ 'wpcom_user_id', '_stripe_customer_id', '_wcpay_customer_id', '_wcpay_customer_id_live', '_wcpay_customer_id_test' ] as $identity_key ) {
+			$this->assertSame(
+				'',
+				get_user_meta( $user->ID, $identity_key, true ),
+				sprintf( 'Request metadata must not be able to claim another account via "%s".', $identity_key )
+			);
+			$this->assertFalse(
+				get_user_option( $identity_key, $user->ID ),
+				sprintf( 'get_user_option() must not resolve a caller-supplied "%s".', $identity_key )
+			);
+		}
 
 		// Registration authenticates the new reader, so these two may legitimately hold
 		// a real value. What must never happen is a caller-supplied scalar landing in
@@ -963,7 +975,7 @@ class Newspack_Test_Frontend_Registration_Endpoint extends WP_UnitTestCase {
 			'Request metadata must not be able to overwrite the capabilities meta.'
 		);
 		$this->assertArrayNotHasKey( 'administrator', $caps );
-		$this->assertFalse( user_can( $user->ID, 'manage_options' ) );
+		$this->assertNotEmpty( $caps, 'The account keeps the role register_reader() gave it.' );
 
 		// The drop is reported back, so an integration author can tell "saved" from
 		// "silently discarded".
@@ -971,6 +983,14 @@ class Newspack_Test_Frontend_Registration_Endpoint extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'skipped_metadata_keys', $data );
 		$this->assertContains( 'np_reader_email_verified', $data['skipped_metadata_keys'] );
 		$this->assertNotContains( 'partner_member_id', $data['skipped_metadata_keys'] );
+
+		// The prefixed account keys are blocked but not echoed. Echoing only the one
+		// matching this install would tell an unauthenticated caller the table prefix.
+		$this->assertNotContains(
+			$caps_key,
+			$data['skipped_metadata_keys'],
+			'The response must not disclose which table prefix matched.'
+		);
 
 		// Keys outside the reserved set still write: the metadata contract that
 		// integrations rely on is unchanged.
@@ -1003,13 +1023,20 @@ class Newspack_Test_Frontend_Registration_Endpoint extends WP_UnitTestCase {
 			$wpdb->base_prefix . '3_capabilities',
 			$wpdb->base_prefix . 'user_level',
 			'wpcom_user_id',
+			'_stripe_customer_id',
+			'_wcpay_customer_id',
+			'_wcpay_customer_id_live',
+			'_wcpay_customer_id_test',
 			'session_tokens',
 			'_application_passwords',
 			'wp_user-settings',
 			'wp_user-settings-time',
+			$wpdb->base_prefix . 'user-settings',
+			$wpdb->base_prefix . 'user-settings-time',
 			'default_password_nag',
 			'NP_Reader_Email_Verified',
 			'  np_reader  ',
+			'np\\_reader',
 			'',
 		];
 		foreach ( $reserved as $key ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The frontend registration endpoint saved every key of the request's `metadata` object as user meta. It now skips the keys Newspack and WordPress rely on for reader state and account state, and saves the rest as before.

Keys outside the reserved set are unaffected. An integration that was writing a `np_`- or `newspack_`-prefixed key will have it dropped from now on, reported in a new `skipped_metadata_keys` response field and logged once per request. No caller in this repo or in `repos/` writes one, but publisher custom-code repos are outside this workspace. More detail in the ticket.

Closes NPPM-3060.

### How to test the changes in this Pull Request:

1. Register a test integration through the `newspack_frontend_registration_integrations` filter. Its key is published in the page's `newspack_ras_config`.
2. Register a reader through that integration, passing a metadata key of your own. The key is saved as user meta.
3. Repeat with a key starting `np_` or `newspack_`. The response lists it under `skipped_metadata_keys`, no meta row is written for it, and the account still requires the normal email verification before My Account access.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
