### PR TITLE
fix(popups): limit preset prompt previews to prompt managers

### DIFF
--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -165,7 +165,7 @@ final class Newspack_Popups_Inserter {
 		}
 		if ( Newspack_Popups::preset_popup_id() ) {
 			$preset_popup = Newspack_Popups_Presets::retrieve_preset_popup( Newspack_Popups::preset_popup_id() );
-			return [ $preset_popup ];
+			return $preset_popup ? [ $preset_popup ] : [];
 		}
 
 		// Popups disabled for this page.

--- a/plugins/newspack-popups/includes/class-newspack-popups-model.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-model.php
@@ -1162,7 +1162,10 @@ final class Newspack_Popups_Model {
 			}
 		}
 		if ( Newspack_Popups::preset_popup_id() ) {
-			$popup = Newspack_Popups_Presets::retrieve_preset_popup( Newspack_Popups::preset_popup_id() );
+			$preset_popup = Newspack_Popups_Presets::retrieve_preset_popup( Newspack_Popups::preset_popup_id() );
+			if ( $preset_popup ) {
+				$popup = $preset_popup;
+			}
 		}
 
 		self::$current_popup = $popup;

--- a/plugins/newspack-popups/includes/class-newspack-popups-presets.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-presets.php
@@ -115,7 +115,8 @@ final class Newspack_Popups_Presets {
 			return [];
 		}
 
-		// filter_input reads the original request, not $_GET, so it is null under PHPUnit.
+		// filter_input reads the SAPI's original request, so it bypasses wp_magic_quotes()
+		// and anything that modified $_GET, and is null under WP-CLI and PHPUnit.
 		if ( ! isset( $_GET['values'] ) || ! is_array( $_GET['values'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return [];
 		}
@@ -136,7 +137,8 @@ final class Newspack_Popups_Presets {
 
 		$sanitized = [];
 		foreach ( $values as $key => $value ) {
-			$key = \sanitize_text_field( $key );
+			// Keys are emitted into the same block-delimiter JSON as the values.
+			$key = self::encode_shortcode_delimiters( \sanitize_text_field( $key ) );
 			if ( is_array( $value ) ) {
 				$sanitized[ $key ] = self::sanitize_override_values( $value );
 				continue;
@@ -162,7 +164,12 @@ final class Newspack_Popups_Presets {
 	 */
 	private static function encode_shortcode_delimiters( $value ) {
 		if ( is_array( $value ) ) {
-			return array_map( [ __CLASS__, 'encode_shortcode_delimiters' ], $value );
+			// Keys as well as values: both are emitted into the same JSON.
+			$encoded = [];
+			foreach ( $value as $key => $item ) {
+				$encoded[ self::encode_shortcode_delimiters( $key ) ] = self::encode_shortcode_delimiters( $item );
+			}
+			return $encoded;
 		}
 		if ( ! is_string( $value ) ) {
 			return $value;
@@ -303,6 +310,9 @@ final class Newspack_Popups_Presets {
 			if ( 'string' === $field['type'] && ! is_scalar( $value ) ) {
 				// `?values[body][]=x` would otherwise reach trim() below as an array.
 				$value = null;
+			} elseif ( 'array' === $field['type'] && ! is_array( $value ) ) {
+				// And the mirror: a scalar would be JSON-encoded where a list is expected.
+				$value = null;
 			} else {
 				$value = self::encode_shortcode_delimiters( $value );
 			}
@@ -317,7 +327,9 @@ final class Newspack_Popups_Presets {
 		if ( 'string' === $field['type'] && isset( $field['max_length'] ) ) {
 			$value = substr( trim( $value ), 0, $field['max_length'] );
 		}
-		// If an array, stringify with field name.
+		// If an array, stringify with field name. Overrides hold only strings and
+		// arrays, so the brackets wp_json_encode() emits here are always followed by a
+		// quote or another bracket, never by a tag name do_shortcode() would match.
 		if ( 'array' === $field['type'] ) {
 			$value = '"' . $field_name . '": ' . \wp_json_encode( $value );
 		}

--- a/plugins/newspack-popups/includes/class-newspack-popups-presets.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-presets.php
@@ -22,6 +22,11 @@ final class Newspack_Popups_Presets {
 	 * @return object|null Popup object, or null if no preset is found for the given slug.
 	 */
 	public static function retrieve_preset_popup( $slug ) {
+		// Renders request input, so restrict it like retrieve_preview_popup() does.
+		if ( ! Newspack_Popups::is_user_admin() ) {
+			return null;
+		}
+
 		$presets = self::get_ras_presets();
 
 		if ( \is_wp_error( $presets ) || ! $presets || ! isset( $presets['prompts'] ) ) {
@@ -98,6 +103,74 @@ final class Newspack_Popups_Presets {
 	}
 
 	/**
+	 * Read preset preview override values from the request.
+	 *
+	 * Values arrive as `?values[field_name]=…`; `lists` arrives as an array.
+	 *
+	 * @return array Sanitized override values, keyed by field name.
+	 */
+	private static function get_override_values() {
+		// get_ras_presets() also backs the two functions that write real prompt posts.
+		if ( ! Newspack_Popups::preset_popup_id() ) {
+			return [];
+		}
+
+		// filter_input reads the original request, not $_GET, so it is null under PHPUnit.
+		if ( ! isset( $_GET['values'] ) || ! is_array( $_GET['values'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return [];
+		}
+
+		return self::sanitize_override_values( \wp_unslash( $_GET['values'] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+	}
+
+	/**
+	 * Sanitize preset preview override values.
+	 *
+	 * @param mixed $values Raw values from the request.
+	 * @return array Sanitized values.
+	 */
+	private static function sanitize_override_values( $values ) {
+		if ( ! is_array( $values ) ) {
+			return [];
+		}
+
+		$sanitized = [];
+		foreach ( $values as $key => $value ) {
+			$key = \sanitize_text_field( $key );
+			if ( is_array( $value ) ) {
+				$sanitized[ $key ] = self::sanitize_override_values( $value );
+				continue;
+			}
+			if ( ! is_scalar( $value ) ) {
+				continue;
+			}
+			// Not sanitize_text_field(): an unencoded `"` closes the JSON string these sit in.
+			$sanitized[ $key ] = self::encode_shortcode_delimiters( filter_var( (string) $value, FILTER_SANITIZE_FULL_SPECIAL_CHARS ) );
+		}
+
+		return $sanitized;
+	}
+
+	/**
+	 * Encode the characters that could introduce a shortcode into preset markup.
+	 *
+	 * Backslashes too: `parse_blocks()` JSON-decodes these values, which would turn an
+	 * escape sequence back into a bracket.
+	 *
+	 * @param mixed $value Value to encode.
+	 * @return mixed Value with delimiters encoded.
+	 */
+	private static function encode_shortcode_delimiters( $value ) {
+		if ( is_array( $value ) ) {
+			return array_map( [ __CLASS__, 'encode_shortcode_delimiters' ], $value );
+		}
+		if ( ! is_string( $value ) ) {
+			return $value;
+		}
+		return str_replace( [ '[', ']', '\\' ], [ '&#91;', '&#93;', '&#92;' ], $value );
+	}
+
+	/**
 	 * Retrieve default prompts + segments.
 	 *
 	 * @return array|WP_Error Array of prompt and segment default configs.
@@ -123,7 +196,7 @@ final class Newspack_Popups_Presets {
 		}
 
 		// Get override values if previewing a preset.
-		$override_values = filter_input( INPUT_GET, 'values', FILTER_SANITIZE_FULL_SPECIAL_CHARS, FILTER_REQUIRE_ARRAY );
+		$override_values = self::get_override_values();
 
 		// Populate prompt configs with saved inputs.
 		$data['prompts'] = array_map(
@@ -155,7 +228,8 @@ final class Newspack_Popups_Presets {
 					}
 					if ( 'int' === $field['type'] && 'featured_image_id' === $field['name'] ) {
 						if ( ! empty( $override_values['featured_image_id'] ) ) {
-							$prompt['featured_image_id'] = $override_values['featured_image_id'];
+							// An int field, and the only override that skips process_user_inputs().
+							$prompt['featured_image_id'] = absint( $override_values['featured_image_id'] );
 						} elseif ( isset( $field['value'] ) ) {
 							$prompt['featured_image_id'] = $field['value'];
 						}
@@ -221,6 +295,16 @@ final class Newspack_Popups_Presets {
 		}
 
 		$field_name = $field['name'];
+
+		// An override comes from the request; saved and default values do not.
+		if ( ! empty( $value ) ) {
+			if ( 'string' === $field['type'] && ! is_scalar( $value ) ) {
+				// `?values[body][]=x` would otherwise reach trim() below as an array.
+				$value = null;
+			} else {
+				$value = self::encode_shortcode_delimiters( $value );
+			}
+		}
 
 		if ( ! $value ) {
 			$value = isset( $field['value'] ) ? $field['value'] : $field['default'];

--- a/plugins/newspack-popups/includes/class-newspack-popups-presets.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-presets.php
@@ -222,7 +222,9 @@ final class Newspack_Popups_Presets {
 
 				// Populate placeholder content with saved inputs or default values.
 				foreach ( $prompt['user_input_fields'] as $field ) {
-					$override = ! empty( $override_values[ $field['name'] ] ) ? $override_values[ $field['name'] ] : null;
+					// Not `! empty()`: "0" is a value, and process_user_inputs() decides
+					// for itself what counts as absent.
+					$override = $override_values[ $field['name'] ] ?? null;
 					if ( 'array' === $field['type'] || 'string' === $field['type'] ) {
 						$prompt['content'] = self::process_user_inputs( $prompt['content'], $field, $override );
 					}

--- a/plugins/newspack-popups/includes/class-newspack-popups-presets.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-presets.php
@@ -297,7 +297,7 @@ final class Newspack_Popups_Presets {
 		$field_name = $field['name'];
 
 		// An override comes from the request; saved and default values do not.
-		if ( ! empty( $value ) ) {
+		if ( null !== $value ) {
 			if ( 'string' === $field['type'] && ! is_scalar( $value ) ) {
 				// `?values[body][]=x` would otherwise reach trim() below as an array.
 				$value = null;
@@ -306,7 +306,8 @@ final class Newspack_Popups_Presets {
 			}
 		}
 
-		if ( ! $value ) {
+		// Not `! $value`: "0" is a value an editor can legitimately preview.
+		if ( null === $value || '' === $value || [] === $value ) {
 			$value = isset( $field['value'] ) ? $field['value'] : $field['default'];
 		}
 

--- a/plugins/newspack-popups/includes/class-newspack-popups.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups.php
@@ -938,6 +938,11 @@ final class Newspack_Popups {
 	 * @return string|null Popup slug, if found in the URL
 	 */
 	public static function preset_popup_id() {
+		// Ignored for everyone else: preview mode suppresses prompts and swaps the
+		// reader data store.
+		if ( ! self::is_user_admin() ) {
+			return null;
+		}
 		// Not using filter_input since it's not playing well with phpunit.
 		if ( isset( $_GET[ self::NEWSPACK_POPUP_PRESET_QUERY_PARAM ] ) && $_GET[ self::NEWSPACK_POPUP_PRESET_QUERY_PARAM ] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 			return sanitize_text_field( $_GET[ self::NEWSPACK_POPUP_PRESET_QUERY_PARAM ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended

--- a/plugins/newspack-popups/includes/class-newspack-popups.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups.php
@@ -938,16 +938,17 @@ final class Newspack_Popups {
 	 * @return string|null Popup slug, if found in the URL
 	 */
 	public static function preset_popup_id() {
+		// Param first, so a normal request does not pay for a capability check.
+		// Not using filter_input since it's not playing well with phpunit.
+		if ( ! isset( $_GET[ self::NEWSPACK_POPUP_PRESET_QUERY_PARAM ] ) || ! $_GET[ self::NEWSPACK_POPUP_PRESET_QUERY_PARAM ] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+			return null;
+		}
 		// Ignored for everyone else: preview mode suppresses prompts and swaps the
 		// reader data store.
 		if ( ! self::is_user_admin() ) {
 			return null;
 		}
-		// Not using filter_input since it's not playing well with phpunit.
-		if ( isset( $_GET[ self::NEWSPACK_POPUP_PRESET_QUERY_PARAM ] ) && $_GET[ self::NEWSPACK_POPUP_PRESET_QUERY_PARAM ] ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
-			return sanitize_text_field( $_GET[ self::NEWSPACK_POPUP_PRESET_QUERY_PARAM ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		}
-		return null;
+		return sanitize_text_field( $_GET[ self::NEWSPACK_POPUP_PRESET_QUERY_PARAM ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups.php
@@ -1050,11 +1050,17 @@ final class Newspack_Popups {
 	 * Is the user an admin or editor user?
 	 * If so, prompts will be shown to these users while logged in, but analytics
 	 * will not be fired for them.
+	 *
+	 * This also gates the prompt and preset preview paths, which render
+	 * request-supplied content, so widening it widens who can reach those.
 	 */
 	public static function is_user_admin() {
 		/**
 		 * Filter to allow other plugins to decide which capability should be checked
 		 * to determine whether a user's activity should be tracked via Google Analytics.
+		 *
+		 * Also gates the prompt and preset previews, so widening this widens who can
+		 * render request-supplied content through them.
 		 *
 		 * @param string $capability Capability to check. Default: edit_others_pages.
 		 * @return string Filtered capability string.

--- a/plugins/newspack-popups/tests/test-presets.php
+++ b/plugins/newspack-popups/tests/test-presets.php
@@ -258,6 +258,41 @@ class PresetsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * `lists` is the one array-typed override, and it is substituted as JSON, so it
+	 * has to stay a list rather than becoming an object.
+	 */
+	public function test_preset_list_override_stays_a_json_array() {
+		try {
+			$this->login_as_prompt_manager();
+			$_GET['preset'] = 'ras_newsletter_overlay';
+			$_GET['values'] = [ 'lists' => [ '1', '2' ] ];
+
+			$preset = Newspack_Popups_Presets::retrieve_preset_popup( 'ras_newsletter_overlay' );
+			$this->assertIsArray( $preset );
+			$this->assertStringContainsString(
+				'"lists": ["1","2"]',
+				$preset['content'],
+				'An array override is encoded as a JSON array, not an object.'
+			);
+			$subscribe = null;
+			foreach ( \parse_blocks( $preset['content'] ) as $block ) {
+				if ( 'newspack-newsletters/subscribe' === $block['blockName'] ) {
+					$subscribe = $block;
+					break;
+				}
+			}
+			$this->assertNotNull( $subscribe, 'The subscribe block is present.' );
+			$this->assertSame(
+				[ '1', '2' ],
+				$subscribe['attrs']['lists'] ?? null,
+				'The block parses with lists as a PHP list.'
+			);
+		} finally {
+			unset( $_GET['values'], $_GET['preset'] );
+		}
+	}
+
+	/**
 	 * "0" is falsy in PHP but a legitimate thing for an editor to preview, so it has
 	 * to survive the whole path, not just the substitution.
 	 */

--- a/plugins/newspack-popups/tests/test-presets.php
+++ b/plugins/newspack-popups/tests/test-presets.php
@@ -258,6 +258,28 @@ class PresetsTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * "0" is falsy in PHP but a legitimate thing for an editor to preview, so it has
+	 * to survive the whole path, not just the substitution.
+	 */
+	public function test_preset_override_of_zero_reaches_the_preview() {
+		try {
+			$this->login_as_prompt_manager();
+			$_GET['preset'] = 'ras_newsletter_overlay';
+			$_GET['values'] = [ 'heading' => '0' ];
+
+			$preset = Newspack_Popups_Presets::retrieve_preset_popup( 'ras_newsletter_overlay' );
+			$this->assertIsArray( $preset );
+			$this->assertStringContainsString(
+				'<h2>0</h2>',
+				$preset['content'],
+				'An override of "0" reaches the preview instead of falling back to the default.'
+			);
+		} finally {
+			unset( $_GET['values'], $_GET['preset'] );
+		}
+	}
+
+	/**
 	 * Override values are request-scoped preview input. They must not reach
 	 * get_ras_presets() on the paths that persist prompts.
 	 */

--- a/plugins/newspack-popups/tests/test-presets.php
+++ b/plugins/newspack-popups/tests/test-presets.php
@@ -20,6 +20,288 @@ class PresetsTest extends WP_UnitTestCase {
 
 		\delete_option( Newspack_Popups_Presets::NEWSPACK_POPUPS_RAS_PROMPTS_OPTION );
 		Newspack_Segments_Model::delete_all_segments();
+
+		// Preset previews read request state and the current user, so start each
+		// test from a known one.
+		unset( $_GET['values'], $_GET['preset'] );
+		\wp_set_current_user( 0 );
+	}
+
+	/**
+	 * Set the current user to one holding the prompt-management capability.
+	 *
+	 * Deliberately an editor, not an administrator: the gate is `edit_others_pages`
+	 * via a filterable capability, and an administrator would satisfy any capability
+	 * this were later tightened to, hiding the regression from this suite.
+	 */
+	private function login_as_prompt_manager() {
+		\wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
+	}
+
+	/**
+	 * Render a preset the way generate_popup() does, and return the output.
+	 *
+	 * @param array $preset Preset popup object.
+	 * @return string Rendered markup.
+	 */
+	private function render_preset( $preset ) {
+		$body = '';
+		foreach ( \parse_blocks( $preset['content'] ) as $block ) {
+			$body .= \render_block( $block );
+		}
+		return \do_shortcode( $body );
+	}
+
+	/**
+	 * Preset previews render request-supplied input, so they are limited to users
+	 * who can manage prompts, the same way single-prompt previews are.
+	 */
+	public function test_preset_popup_requires_prompt_management_capability() {
+		$this->assertNull(
+			Newspack_Popups_Presets::retrieve_preset_popup( 'ras_registration_overlay' ),
+			'A visitor must not be able to render a preset preview.'
+		);
+
+		\wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$this->assertNull(
+			Newspack_Popups_Presets::retrieve_preset_popup( 'ras_registration_overlay' ),
+			'A subscriber must not be able to render a preset preview.'
+		);
+
+		$this->login_as_prompt_manager();
+		$preset = Newspack_Popups_Presets::retrieve_preset_popup( 'ras_registration_overlay' );
+		$this->assertIsArray( $preset, 'A user who can manage prompts can still render a preset preview.' );
+		$this->assertArrayHasKey( 'content', $preset );
+	}
+
+	/**
+	 * A visitor appending ?preset= must not put the request into preview mode, which
+	 * would suppress every prompt on the page and swap the reader data store.
+	 */
+	public function test_preset_param_is_inert_for_visitors() {
+		$_GET['preset'] = 'ras_registration_overlay';
+		try {
+			\wp_set_current_user( 0 );
+			$this->assertNull( Newspack_Popups::preset_popup_id(), 'A visitor gets no preset slug.' );
+			$this->assertFalse( Newspack_Popups::is_preview_request(), 'A visitor does not enter preview mode.' );
+			$this->assertSame(
+				[],
+				Newspack_Popups_Inserter::popups_for_post(),
+				'A visitor gets an empty popup list, not [ null ].'
+			);
+
+			$this->login_as_prompt_manager();
+			$this->assertSame( 'ras_registration_overlay', Newspack_Popups::preset_popup_id() );
+			$this->assertTrue( Newspack_Popups::is_preview_request() );
+		} finally {
+			unset( $_GET['preset'] );
+		}
+	}
+
+	/**
+	 * Preview override values are spliced into content that is later rendered
+	 * through do_shortcode(), so they must not be able to introduce a shortcode.
+	 */
+	public function test_preset_override_values_cannot_inject_shortcodes() {
+		$ran = false;
+		\add_shortcode(
+			'newspack_test_injection',
+			function () use ( &$ran ) {
+				$ran = true;
+				return 'INJECTED';
+			}
+		);
+
+		try {
+			$this->login_as_prompt_manager();
+			// This preset puts both placeholders inside core blocks, so the override
+			// value ends up in rendered body text — the same place generate_popup()
+			// runs do_shortcode() over.
+			$_GET['preset'] = 'ras_newsletter_overlay';
+			$_GET['values'] = [
+				'body'    => '[newspack_test_injection]',
+				'heading' => 'Safe heading',
+			];
+
+			$preset = Newspack_Popups_Presets::retrieve_preset_popup( 'ras_newsletter_overlay' );
+			$this->assertIsArray( $preset );
+			$rendered = $this->render_preset( $preset );
+
+			$this->assertFalse( $ran, 'An injected shortcode must not execute from a preview override value.' );
+			$this->assertStringNotContainsString( 'INJECTED', $rendered, 'Injected shortcode output must not reach the page.' );
+			$this->assertStringNotContainsString(
+				'[newspack_test_injection]',
+				$preset['content'],
+				'Shortcode delimiters must not survive into preset content.'
+			);
+			$this->assertStringContainsString(
+				'Safe heading',
+				$preset['content'],
+				'Ordinary override values still populate the preview.'
+			);
+		} finally {
+			\remove_shortcode( 'newspack_test_injection' );
+			unset( $_GET['values'], $_GET['preset'] );
+		}
+	}
+
+	/**
+	 * Most placeholders are substituted inside a block delimiter's JSON attribute
+	 * object, which parse_blocks() runs through json_decode(). A JSON escape
+	 * sequence must not be able to reconstitute a bracket after it was stripped.
+	 */
+	public function test_preset_override_values_cannot_inject_shortcodes_via_json_escape() {
+		$ran = false;
+		\add_shortcode(
+			'newspack_test_injection',
+			function () use ( &$ran ) {
+				$ran = true;
+				return 'INJECTED';
+			}
+		);
+
+		try {
+			$this->login_as_prompt_manager();
+			$_GET['preset'] = 'ras_registration_overlay';
+			// A backslash-u escape for each bracket. Built with chr( 92 ) so the
+			// backslash is unambiguous in source: json_decode() inside parse_blocks()
+			// would turn these back into real brackets after the strip has run.
+			$escaped_open  = chr( 92 ) . 'u005B';
+			$escaped_close = chr( 92 ) . 'u005D';
+			// wp_slash() because WordPress slashes superglobals in wp_magic_quotes(),
+			// and get_override_values() unslashes. Assigning the raw string here would
+			// have the unslash eat the backslash and the test would prove nothing.
+			$_GET['values'] = \wp_slash(
+				[
+					'body' => $escaped_open . 'newspack_test_injection' . $escaped_close,
+				]
+			);
+
+			$preset = Newspack_Popups_Presets::retrieve_preset_popup( 'ras_registration_overlay' );
+			$this->assertIsArray( $preset );
+
+			$blocks = \parse_blocks( $preset['content'] );
+			$this->assertNotEmpty( $blocks );
+			$description = $blocks[0]['attrs']['description'] ?? '';
+			$this->assertStringNotContainsString(
+				'[newspack_test_injection]',
+				$description,
+				'A JSON escape sequence must not reconstitute shortcode delimiters after parsing.'
+			);
+
+			$rendered = $this->render_preset( $preset );
+			$this->assertFalse( $ran, 'An injected shortcode must not execute via a JSON escape sequence.' );
+			$this->assertStringNotContainsString( 'INJECTED', $rendered );
+		} finally {
+			\remove_shortcode( 'newspack_test_injection' );
+			unset( $_GET['values'], $_GET['preset'] );
+		}
+	}
+
+	/**
+	 * A quote in ordinary editorial copy must not break the block it is substituted
+	 * into, and must not let a value inject sibling block attributes.
+	 */
+	public function test_preset_override_values_cannot_break_out_of_block_attributes() {
+		try {
+			$this->login_as_prompt_manager();
+			$_GET['preset'] = 'ras_registration_overlay';
+			$_GET['values'] = [
+				'heading'      => 'Say "hi" to us',
+				'button_label' => 'Sign up","className":"INJECTED-CLASS',
+			];
+
+			$preset = Newspack_Popups_Presets::retrieve_preset_popup( 'ras_registration_overlay' );
+			$this->assertIsArray( $preset );
+
+			$blocks = \parse_blocks( $preset['content'] );
+			$this->assertNotEmpty( $blocks );
+			$attrs = $blocks[0]['attrs'];
+
+			$this->assertIsArray(
+				$attrs,
+				'A quote in ordinary copy must not make the block attributes unparseable.'
+			);
+			$this->assertArrayNotHasKey(
+				'className',
+				$attrs,
+				'An override value must not be able to add block attributes.'
+			);
+			$this->assertStringNotContainsString( 'INJECTED-CLASS', $this->render_preset( $preset ) );
+		} finally {
+			unset( $_GET['values'], $_GET['preset'] );
+		}
+	}
+
+	/**
+	 * The featured image override never passes through process_user_inputs(), so it
+	 * is guarded on its own. It reaches the popup object under `options`, not at the
+	 * top level.
+	 */
+	public function test_preset_featured_image_override_is_sanitized() {
+		try {
+			$this->login_as_prompt_manager();
+			$_GET['preset'] = 'ras_registration_overlay';
+			$_GET['values'] = [ 'featured_image_id' => '12[newspack_test_injection]' ];
+
+			$preset = Newspack_Popups_Presets::retrieve_preset_popup( 'ras_registration_overlay' );
+			$this->assertIsArray( $preset );
+			$this->assertArrayHasKey( 'featured_image_id', $preset['options'] );
+			$this->assertSame(
+				12,
+				$preset['options']['featured_image_id'],
+				'The featured image override reaches the popup as an integer.'
+			);
+		} finally {
+			unset( $_GET['values'], $_GET['preset'] );
+		}
+	}
+
+	/**
+	 * Override values are request-scoped preview input. They must not reach
+	 * get_ras_presets() on the paths that persist prompts.
+	 */
+	public function test_override_values_are_ignored_without_a_preset_request() {
+		try {
+			$this->login_as_prompt_manager();
+			$_GET['values'] = [ 'heading' => 'Override heading' ];
+
+			$presets = Newspack_Popups_Presets::get_ras_presets();
+			$this->assertIsArray( $presets );
+			foreach ( $presets['prompts'] as $prompt ) {
+				$this->assertStringNotContainsString(
+					'Override heading',
+					$prompt['content'],
+					'Request values must not be applied outside a preset preview.'
+				);
+			}
+		} finally {
+			unset( $_GET['values'] );
+		}
+	}
+
+	/**
+	 * The override value is encoded at the substitution point too, so any caller
+	 * passing one gets the same treatment.
+	 */
+	public function test_process_user_inputs_encodes_delimiters_in_override() {
+		$field = [
+			'name'    => 'body',
+			'type'    => 'string',
+			'default' => 'Default body',
+		];
+
+		$this->assertSame(
+			'<p>&#91;evil attr="x"&#93;</p>',
+			Newspack_Popups_Presets::process_user_inputs( '<p>{{body}}</p>', $field, '[evil attr="x"]' ),
+			'Square brackets are encoded in an override value, not removed.'
+		);
+
+		$this->assertSame(
+			'<p>Default body</p>',
+			Newspack_Popups_Presets::process_user_inputs( '<p>{{body}}</p>', $field ),
+			'Without an override, the default value is used unchanged.'
+		);
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-presets.php
+++ b/plugins/newspack-popups/tests/test-presets.php
@@ -131,6 +131,13 @@ class PresetsTest extends WP_UnitTestCase {
 				$preset['content'],
 				'Shortcode delimiters must not survive into preset content.'
 			);
+			// Asserted decoded, not as the entity: the reader still sees their brackets,
+			// and a later change that double-encoded them would fail here.
+			$this->assertStringContainsString(
+				'[newspack_test_injection]',
+				html_entity_decode( $rendered ),
+				'The editor sees the brackets as literal text.'
+			);
 			$this->assertStringContainsString(
 				'Safe heading',
 				$preset['content'],
@@ -248,6 +255,83 @@ class PresetsTest extends WP_UnitTestCase {
 				12,
 				$preset['options']['featured_image_id'],
 				'The featured image override reaches the popup as an integer.'
+			);
+		} finally {
+			unset( $_GET['values'], $_GET['preset'] );
+		}
+	}
+
+	/**
+	 * Array keys land in the same block-delimiter JSON as the values. A key carrying
+	 * a bracket puts a live delimiter next to an attacker-chosen tag name, with the
+	 * closing one supplied by the JSON array itself.
+	 */
+	public function test_preset_override_array_keys_cannot_inject_shortcodes() {
+		$ran = false;
+		\add_shortcode(
+			'newspack_test_injection',
+			function () use ( &$ran ) {
+				$ran = true;
+				return 'INJECTED';
+			}
+		);
+
+		try {
+			$this->login_as_prompt_manager();
+			// Parsed the way PHP parses the query string, which permits `[` inside a key.
+			\parse_str(
+				'preset=ras_newsletter_inline&values[body]={{lists}}&values[lists][[newspack_test_injection%3D1][]=x',
+				$parsed
+			);
+			$this->assertArrayHasKey(
+				'[newspack_test_injection=1',
+				$parsed['values']['lists'],
+				'The payload parses into an array key, as PHP permits.'
+			);
+
+			$_GET['preset'] = $parsed['preset'];
+			$_GET['values'] = \wp_slash( $parsed['values'] );
+
+			$preset = Newspack_Popups_Presets::retrieve_preset_popup( 'ras_newsletter_inline' );
+			$this->assertIsArray( $preset );
+
+			// Positive control: the payload did reach the content, encoded. Without it
+			// the assertions below would also pass if the override never arrived.
+			$this->assertStringContainsString(
+				'&#91;newspack_test_injection=1',
+				$preset['content'],
+				'The key reached the content with its bracket encoded.'
+			);
+
+			$rendered = $this->render_preset( $preset );
+			$this->assertFalse( $ran, 'A bracket in an array key must not execute a shortcode.' );
+			$this->assertStringNotContainsString( 'INJECTED', $rendered );
+		} finally {
+			\remove_shortcode( 'newspack_test_injection' );
+			unset( $_GET['values'], $_GET['preset'] );
+		}
+	}
+
+	/**
+	 * A scalar sent to the array-typed field would be JSON-encoded as a string, and
+	 * the subscribe block's render then calls array_intersect() on it.
+	 */
+	public function test_preset_scalar_override_for_a_list_field_falls_back() {
+		try {
+			$this->login_as_prompt_manager();
+			$_GET['preset'] = 'ras_newsletter_inline';
+			$_GET['values'] = [ 'lists' => 'x' ];
+
+			$preset = Newspack_Popups_Presets::retrieve_preset_popup( 'ras_newsletter_inline' );
+			$this->assertIsArray( $preset );
+			$this->assertStringNotContainsString(
+				'"lists": "x"',
+				$preset['content'],
+				'A scalar must not reach the list field.'
+			);
+			$this->assertNotEmpty(
+				$this->render_preset( $preset ),
+				'The preview still renders rather than throwing on the scalar.'
 			);
 		} finally {
 			unset( $_GET['values'], $_GET['preset'] );

--- a/plugins/newspack-popups/tests/test-presets.php
+++ b/plugins/newspack-popups/tests/test-presets.php
@@ -302,6 +302,18 @@ class PresetsTest extends WP_UnitTestCase {
 			Newspack_Popups_Presets::process_user_inputs( '<p>{{body}}</p>', $field ),
 			'Without an override, the default value is used unchanged.'
 		);
+
+		$this->assertSame(
+			'<p>0</p>',
+			Newspack_Popups_Presets::process_user_inputs( '<p>{{body}}</p>', $field, '0' ),
+			'An override of "0" is a value, not an absent one.'
+		);
+
+		$this->assertSame(
+			'<p>Default body</p>',
+			Newspack_Popups_Presets::process_user_inputs( '<p>{{body}}</p>', $field, '' ),
+			'An empty override falls back to the default.'
+		);
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-presets.php
+++ b/plugins/newspack-popups/tests/test-presets.php
@@ -13,6 +13,8 @@ class PresetsTest extends WP_UnitTestCase {
 	 * Delete prompts, segments, and user inputs from prior tests.
 	 */
 	public function set_up() {
+		parent::set_up();
+
 		// Remove any popups (from previous tests).
 		foreach ( Newspack_Popups_Model::retrieve_popups() as $popup ) {
 			\wp_delete_post( $popup['id'] );
@@ -20,11 +22,6 @@ class PresetsTest extends WP_UnitTestCase {
 
 		\delete_option( Newspack_Popups_Presets::NEWSPACK_POPUPS_RAS_PROMPTS_OPTION );
 		Newspack_Segments_Model::delete_all_segments();
-
-		// Preset previews read request state and the current user, so start each
-		// test from a known one.
-		unset( $_GET['values'], $_GET['preset'] );
-		\wp_set_current_user( 0 );
 	}
 
 	/**


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Preset prompt previews rendered for any visitor. They now require the capability that single-prompt previews already require, and the `preset` parameter is ignored for everyone else, so a `?preset=` URL behaves for a visitor as if the parameter were absent rather than rendering the previewed preset.

Preview override values are encoded so they cannot change the meaning of the markup they land in, and are only read when a preset preview is requested. More detail in the ticket.

Closes NPPM-3064.

### How to test the changes in this Pull Request:

1. As an administrator, go to Audience → Setup → Campaign and preview a preset prompt. It renders with the values entered in the wizard.
2. Put a double quote in the Heading field and preview again. The heading shows the quote and the prompt still renders.
3. Put square brackets in the Body field and preview again. The brackets show as typed.
4. Copy the preview URL and open it in a session logged in as an editor. The preview renders the same way.
5. Open the same URL logged out. The page behaves as if the `preset` parameter were absent.
6. Activate the RAS presets from the wizard. The created prompts carry the values saved in the wizard.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
