### PR TITLE
fix(subscriptions): support subscription-plan products in tiers

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -795,10 +795,16 @@ class Subscriptions_Tiers {
 	/**
 	 * Render frequency form control.
 	 *
-	 * Up until 3 frequencies, we render buttons.
-	 * After that, we render a select control.
+	 * Up until 3 frequencies, we render buttons (or plan-posting radios, see
+	 * below). After that, we render a select control - unreachable for
+	 * plan-based products, since the plan-radio branch below runs first
+	 * regardless of $frequencies count when $plan_keys/$parent_id are set.
 	 *
-	 * @param array  $frequencies       Frequencies.
+	 * @param array  $frequencies       Frequencies. Expected to be exactly the
+	 *                                  keys present in $plan_keys when the
+	 *                                  latter is non-empty, so the caller's
+	 *                                  panel loop and this tab loop stay
+	 *                                  positionally in sync.
 	 * @param string $current_frequency Current frequency.
 	 * @param bool   $is_form_control   Whether to treat it as a form input.
 	 * @param array  $plan_keys         Optional frequency key => scheme key map. When
@@ -875,18 +881,40 @@ class Subscriptions_Tiers {
 			return;
 		}
 
+		// The plan-radio control (and its hidden-input fallback below) only
+		// make sense when $product is the actual parent WooCommerce will add
+		// to the cart: a variable or simple subscription product. For a
+		// grouped product each tier can come from a different child product
+		// with its own parent ID, and for the "all products" view ($product
+		// is null) there is no common parent at all - a single
+		// convert_to_sub_<id> input can't carry the right key for every
+		// tier in either case, so the plan path is skipped rather than
+		// emitting a key nothing reads (or, for the null case, a
+		// convert_to_sub_0 that reads as a real but wrong parent ID).
+		$parent_id = ( $product && ! $product->is_type( 'grouped' ) ) ? $product->get_id() : 0;
+
+		$plan_keys = [];
+		if ( $parent_id ) {
+			foreach ( $tiers as $frequency => $tier_products ) {
+				$plan_key = empty( $tier_products ) ? '' : WooCommerce_Subscriptions::get_active_plan_key( $tier_products[0] );
+				if ( $plan_key ) {
+					$plan_keys[ $frequency ] = $plan_key;
+				}
+			}
+			// Keep the tab headers and the panels positionally in sync: a
+			// frequency without a resolvable plan key would otherwise still
+			// get a panel below but no tab here, shifting every subsequent
+			// tab onto the wrong panel (setupTabController() pairs
+			// tab_headers[i] with tab_contents[i] by index).
+			if ( ! empty( $plan_keys ) ) {
+				$tiers = array_intersect_key( $tiers, $plan_keys );
+			}
+		}
+
 		$is_single_tier = self::is_single_tier( $tiers );
 		$is_nyp         = $is_single_tier && self::is_nyp( $tiers ); // Only treat as NYP form if there's only 1 tier.
 
 		$frequencies = array_keys( $tiers );
-
-		$plan_keys = [];
-		foreach ( $tiers as $frequency => $tier_products ) {
-			$plan_key = empty( $tier_products ) ? '' : WooCommerce_Subscriptions::get_active_plan_key( $tier_products[0] );
-			if ( $plan_key ) {
-				$plan_keys[ $frequency ] = $plan_key;
-			}
-		}
 
 		$current_frequency = null;
 		$current_product   = null;
@@ -896,6 +924,12 @@ class Subscriptions_Tiers {
 		}
 
 		if ( ! $switch_data ) {
+			$current_frequency = $frequencies[0];
+		} elseif ( ! $current_frequency ) {
+			// A subscriber on a retired plan, or one filtered out by the
+			// ownership check, has no matching tier. Fall back to the first
+			// frequency so a radio is checked and the plan gets posted,
+			// rather than leaving nothing selected (and posting no plan).
 			$current_frequency = $frequencies[0];
 		}
 
@@ -934,13 +968,22 @@ class Subscriptions_Tiers {
 		}
 
 		$should_render_tabs = ! $is_single_tier || $is_nyp;
+
+		// Whether render_frequency_control() below will actually post the
+		// plan. When it won't - a single frequency, or the flat (no-tabs)
+		// product-card layout - the hidden input further down carries the
+		// plan for $current_frequency instead. Without this, a product with
+		// exactly one plan (the ordinary case: one monthly plan plus
+		// price-tier variations) posts no plan at all and the reader is
+		// charged once instead of subscribing.
+		$frequency_control_rendered = $should_render_tabs && count( $frequencies ) > 1;
 		?>
 		<form class="newspack__subscription-tiers__form <?php echo esc_attr( $is_nyp ? 'nyp' : '' ); ?>" target="newspack_modal_checkout_iframe" data-title="<?php echo esc_attr( $title ); ?>" data-product-id="<?php echo esc_attr( $product ? $product->get_id() : '' ); ?>">
 			<?php if ( $should_render_tabs ) : ?>
 				<div class="newspack-ui__segmented-control">
 					<?php
-					if ( count( $frequencies ) > 1 ) {
-						self::render_frequency_control( $frequencies, $current_frequency, $is_nyp, $plan_keys, $product ? $product->get_id() : 0 );
+					if ( $frequency_control_rendered ) {
+						self::render_frequency_control( $frequencies, $current_frequency, $is_nyp, $plan_keys, $parent_id );
 					}
 					?>
 					<div class="newspack-ui__segmented-control__content">
@@ -971,6 +1014,9 @@ class Subscriptions_Tiers {
 			?>
 			<input type="hidden" name="newspack_checkout" value="1">
 			<input type="hidden" name="modal_checkout" value="1">
+			<?php if ( ! $frequency_control_rendered && ! empty( $plan_keys[ $current_frequency ] ) ) : ?>
+				<input type="hidden" name="convert_to_sub_<?php echo absint( $parent_id ); ?>" value="<?php echo esc_attr( $plan_keys[ $current_frequency ] ); ?>">
+			<?php endif; ?>
 			<?php if ( ! empty( $switch_data ) ) : ?>
 				<input type="hidden" name="switch-subscription" value="<?php echo esc_attr( $switch_data['subscription']->get_id() ); ?>">
 				<input type="hidden" name="item" value="<?php echo absint( $switch_data['item_id'] ); ?>">

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -749,8 +749,14 @@ class Subscriptions_Tiers {
 		$frequency = $parts['period'];
 		$interval  = $parts['interval'];
 
-		if ( $switch_subscription ) {
-			$base_product   = wc_get_product( $switch_subscription['item']['product_id'] );
+		$base_product = $switch_subscription ? wc_get_product( $switch_subscription['item']['product_id'] ) : null;
+
+		// A deleted product leaves behind an ID that no longer resolves, and
+		// wc_get_product() returns false for it. There's no billing period to
+		// convert from in that case, so keep the target product's own price
+		// rather than feeding `false` into the plan accessors - the same way
+		// the tier composition skips a grouped child that no longer resolves.
+		if ( $base_product instanceof \WC_Product ) {
 			$base_parts     = self::get_frequency_parts( $base_product );
 			$base_frequency = $base_parts['period'];
 			$base_interval  = $base_parts['interval'];

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -313,9 +313,10 @@ class Subscriptions_Tiers {
 			}
 		}
 
+		$interval = (int) $product->get_meta( '_subscription_period_interval' );
 		return [
 			'period'   => (string) $product->get_meta( '_subscription_period' ),
-			'interval' => (int) $product->get_meta( '_subscription_period_interval' ),
+			'interval' => $interval > 0 ? $interval : 1,
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -260,6 +260,21 @@ class Subscriptions_Tiers {
 	 * @return string Frequency.
 	 */
 	public static function get_frequency( $product ) {
+		// Under the subscription-plan model the recurrence lives on the plan, not
+		// in post meta - APFS only ever applies it as in-memory runtime meta, so
+		// the legacy keys are either absent or a hardcoded default unrelated to
+		// the configured plan.
+		$plan_key = WooCommerce_Subscriptions::get_active_plan_key( $product );
+		if ( $plan_key ) {
+			$plans = WooCommerce_Subscriptions::get_subscription_plans( $product );
+			if ( isset( $plans[ $plan_key ] ) ) {
+				$frequency = WooCommerce_Subscriptions::get_plan_frequency( $plans[ $plan_key ] );
+				if ( $frequency ) {
+					return $frequency;
+				}
+			}
+		}
+
 		$period = $product->get_meta( '_subscription_period', true );
 		if ( empty( $period ) ) {
 			$period = 'once';

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -362,7 +362,7 @@ class Subscriptions_Tiers {
 			foreach ( $plans as $plan_key => $plan ) {
 				foreach ( $tier_products as $tier_product ) {
 					$instance = clone $tier_product;
-					\WCS_ATT_Product_Schemes::set_subscription_scheme( $instance, $plan_key );
+					WooCommerce_Subscriptions::set_active_plan_key( $instance, $plan_key );
 					$selected_products[] = $instance;
 				}
 			}
@@ -442,23 +442,99 @@ class Subscriptions_Tiers {
 		$user_subscriptions = wcs_get_users_subscriptions( $user_id );
 		foreach ( $tiers as $frequency => $products ) {
 			foreach ( $products as $product ) {
+				// Under the plan model the same product/variation ID is stamped
+				// into every plan's bucket (NPPM-3053's expansion in
+				// get_tiers_by_frequency()), so an ID match alone can no longer
+				// tell a monthly subscriber from an annual one apart. A
+				// plan-carrying product only counts as "current" if the
+				// subscription is actually on that plan.
+				$plan_key = WooCommerce_Subscriptions::get_active_plan_key( $product );
+
 				foreach ( $user_subscriptions as $subscription ) {
 					if (
-						$subscription->has_product( $product->get_id() )
-						&& $subscription->has_status( WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES )
+						! $subscription->has_product( $product->get_id() )
+						|| ! $subscription->has_status( WooCommerce_Connection::ACTIVE_SUBSCRIPTION_STATUSES )
 						// `wcs_get_users_subscriptions` is filtered (e.g. group
 						// subscriptions inject subs the user is only a member of, owned
 						// by someone else); only a subscription the user owns is their
 						// "current" tier — matching the ownership test the switch
 						// backstop applies.
-						&& (int) $subscription->get_user_id() === (int) $user_id
+						|| (int) $subscription->get_user_id() !== (int) $user_id
 					) {
-						return [ $frequency, $product, $subscription ];
+						continue;
 					}
+
+					if ( $plan_key && ! self::subscription_is_on_plan( $subscription, $product, $plan_key, $frequency ) ) {
+						continue;
+					}
+
+					return [ $frequency, $product, $subscription ];
 				}
 			}
 		}
 		return $none;
+	}
+
+	/**
+	 * Whether a subscription is on the same plan as a plan-stamped tier
+	 * product instance.
+	 *
+	 * Tries the subscription's own scheme key first — the `_wcsatt_scheme`
+	 * order item meta APFS records on the line item at checkout. When that
+	 * can't be resolved (older order, meta absent, or the constant isn't the
+	 * one this WCS version uses), falls back to comparing the subscription's
+	 * billing period/interval against the bucket's frequency. The fallback is
+	 * a weaker signal — it can't tell apart two plans that share a period and
+	 * interval (NPPM-3053's own "colliding plans" case) — but degrades
+	 * gracefully rather than hiding a legitimate match outright.
+	 *
+	 * @param \WC_Subscription $subscription Subscription instance.
+	 * @param \WC_Product      $product      Plan-stamped tier product instance.
+	 * @param string           $plan_key     The product's stamped plan key.
+	 * @param string           $frequency    The bucket's frequency key.
+	 *
+	 * @return bool Whether the subscription is on the product's stamped plan.
+	 */
+	private static function subscription_is_on_plan( $subscription, $product, $plan_key, $frequency ) {
+		$subscription_plan_key = self::get_subscription_plan_key( $subscription, $product );
+		if ( $subscription_plan_key ) {
+			return $subscription_plan_key === $plan_key;
+		}
+
+		if ( ! method_exists( $subscription, 'get_billing_period' ) || ! method_exists( $subscription, 'get_billing_interval' ) ) {
+			return false;
+		}
+		$subscription_frequency = $subscription->get_billing_period() . '_' . $subscription->get_billing_interval();
+		return $frequency === $subscription_frequency || 0 === strpos( $frequency, $subscription_frequency . '_' );
+	}
+
+	/**
+	 * The subscription plan key stamped on the line item holding a product,
+	 * if the subscription still carries it.
+	 *
+	 * @param \WC_Subscription $subscription Subscription instance.
+	 * @param \WC_Product      $product      Product to locate the line item for.
+	 *
+	 * @return string Scheme key, or an empty string if it can't be determined.
+	 */
+	private static function get_subscription_plan_key( $subscription, $product ) {
+		if ( ! method_exists( $subscription, 'get_items' ) ) {
+			return '';
+		}
+		foreach ( $subscription->get_items() as $item ) {
+			if ( ! method_exists( $item, 'get_product_id' ) || ! method_exists( $item, 'get_meta' ) ) {
+				continue;
+			}
+			$item_product_id = method_exists( $item, 'get_variation_id' ) && $item->get_variation_id()
+				? $item->get_variation_id()
+				: $item->get_product_id();
+			if ( (int) $item_product_id !== (int) $product->get_id() ) {
+				continue;
+			}
+			$scheme_key = $item->get_meta( '_wcsatt_scheme', true );
+			return is_string( $scheme_key ) ? $scheme_key : '';
+		}
+		return '';
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -337,6 +337,8 @@ class Subscriptions_Tiers {
 			return [];
 		}
 
+		$is_grouped_parent = false;
+
 		if ( empty( $product ) ) {
 			$products = wc_get_products(
 				[
@@ -346,8 +348,9 @@ class Subscriptions_Tiers {
 			);
 			$sort_by_price = $sort_by_price ?? true;
 		} elseif ( $product->is_type( 'grouped' ) ) {
-			$products = $product->get_children();
-			$sort_by_price = $sort_by_price ?? false;
+			$products          = $product->get_children();
+			$sort_by_price     = $sort_by_price ?? false;
+			$is_grouped_parent = true;
 		} elseif ( $product->is_type( 'variable' ) || WooCommerce_Subscriptions::is_subscription_product( $product ) ) {
 			$products = [ $product ];
 			$sort_by_price = $sort_by_price ?? true;
@@ -369,6 +372,19 @@ class Subscriptions_Tiers {
 			}
 
 			if ( $product->get_status() === 'private' ) {
+				continue;
+			}
+
+			// A grouped product's children are each their own cart-item parent,
+			// so APFS's convert_to_sub_<parent_id> - a single key at the form
+			// level - can never be keyed correctly for a plan-based child. Skip
+			// it here, in composition, so the tier never exists: rendering it
+			// would produce a purchasable form that silently takes a one-time
+			// payment instead of creating a subscription. Legacy `subscription`/
+			// `variable-subscription` children (no APFS schemes) are unaffected -
+			// they carry their recurrence in their own meta, not a plan, so
+			// there's no parent-ID mismatch for them to trip over.
+			if ( $is_grouped_parent && WooCommerce_Subscriptions::has_subscription_plans( $product ) ) {
 				continue;
 			}
 

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -479,11 +479,11 @@ class Subscriptions_Tiers {
 	 * Whether a subscription is on the same plan as a plan-stamped tier
 	 * product instance.
 	 *
-	 * Tries the subscription's own scheme key first — the `_wcsatt_scheme`
-	 * order item meta APFS records on the line item at checkout. When that
-	 * can't be resolved (older order, meta absent, or the constant isn't the
-	 * one this WCS version uses), falls back to comparing the subscription's
-	 * billing period/interval against the bucket's frequency. The fallback is
+	 * Tries the subscription's own scheme key first — see
+	 * {@see self::get_item_subscription_scheme()} for how that's resolved.
+	 * When it can't be resolved at all (older order, no matching line item),
+	 * falls back to comparing the subscription's billing period/interval
+	 * against the bucket's frequency. The fallback is
 	 * a weaker signal — it can't tell apart two plans that share a period and
 	 * interval (NPPM-3053's own "colliding plans" case) — but degrades
 	 * gracefully rather than hiding a legitimate match outright.
@@ -531,10 +531,35 @@ class Subscriptions_Tiers {
 			if ( (int) $item_product_id !== (int) $product->get_id() ) {
 				continue;
 			}
-			$scheme_key = $item->get_meta( '_wcsatt_scheme', true );
-			return is_string( $scheme_key ) ? $scheme_key : '';
+			return self::get_item_subscription_scheme( $item );
 		}
 		return '';
+	}
+
+	/**
+	 * The scheme key APFS recorded on an order/subscription line item.
+	 *
+	 * Prefers WCS's own `WCS_ATT_Order::get_subscription_scheme()` accessor
+	 * over a direct meta read: it also falls back to the pre-9.0 APFS-v1 meta
+	 * key (`_wcsatt_scheme_id`) and normalises the result through
+	 * `WCS_ATT_Product_Schemes::parse_subscription_scheme_key()`, both of
+	 * which a direct `_wcsatt_scheme` read would miss — most importantly for
+	 * publishers who ran the standalone All Products for Subscriptions plugin
+	 * before WCS 9.0 folded it into core. Falls back to the direct meta read
+	 * when the accessor isn't available, so nothing regresses on a site
+	 * without APFS.
+	 *
+	 * @param \WC_Order_Item $item Order/subscription line item.
+	 *
+	 * @return string Scheme key, or an empty string if none is recorded.
+	 */
+	private static function get_item_subscription_scheme( $item ) {
+		if ( class_exists( 'WCS_ATT_Order' ) && method_exists( 'WCS_ATT_Order', 'get_subscription_scheme' ) ) {
+			$scheme_key = \WCS_ATT_Order::get_subscription_scheme( $item );
+			return is_string( $scheme_key ) ? $scheme_key : '';
+		}
+		$scheme_key = $item->get_meta( '_wcsatt_scheme', true );
+		return is_string( $scheme_key ) ? $scheme_key : '';
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -253,6 +253,62 @@ class Subscriptions_Tiers {
 	}
 
 	/**
+	 * Whether a product carries WooCommerce Subscriptions "subscription plans".
+	 *
+	 * Subscriptions 9.0 folded All Products for Subscriptions into core, so a
+	 * recurring product no longer has to use the dedicated `subscription` /
+	 * `variable-subscription` product types: an ordinary `simple` or `variable`
+	 * product with subscription schemes attached is now the way the product
+	 * editor creates one. Mirrors the detection Subscriptions itself uses in
+	 * `WCSG_Product::product_has_subscription_plans()`, including the opt-out
+	 * meta, so we stay in step with what Subscriptions treats as recurring.
+	 *
+	 * @param \WC_Product $product Product object.
+	 *
+	 * @return bool Whether the product has subscription plans.
+	 */
+	public static function has_subscription_plans( $product ) {
+		if ( ! class_exists( 'WCS_ATT_Product_Schemes' ) || ! method_exists( 'WCS_ATT_Product_Schemes', 'has_subscription_schemes' ) ) {
+			return false;
+		}
+		if ( 'yes' === $product->get_meta( '_wcsatt_disabled' ) ) {
+			return false;
+		}
+		return (bool) \WCS_ATT_Product_Schemes::has_subscription_schemes( $product );
+	}
+
+	/**
+	 * Whether a product is a subscription, under either product model.
+	 *
+	 * @param \WC_Product $product Product object.
+	 *
+	 * @return bool Whether the product is a subscription.
+	 */
+	public static function is_subscription_product( $product ) {
+		if ( in_array( $product->get_type(), [ 'subscription', 'variable-subscription' ], true ) ) {
+			return true;
+		}
+		return self::has_subscription_plans( $product );
+	}
+
+	/**
+	 * Whether a product is a variable subscription, under either product model.
+	 *
+	 * Determines whether tiers come from the product's variations rather than
+	 * from the product itself.
+	 *
+	 * @param \WC_Product $product Product object.
+	 *
+	 * @return bool Whether the product is a variable subscription.
+	 */
+	public static function is_variable_subscription_product( $product ) {
+		if ( $product->is_type( 'variable-subscription' ) ) {
+			return true;
+		}
+		return $product->is_type( 'variable' ) && self::has_subscription_plans( $product );
+	}
+
+	/**
 	 * Get the frequency of a product.
 	 *
 	 * @param \WC_Product $product Product object.
@@ -299,7 +355,7 @@ class Subscriptions_Tiers {
 		} elseif ( $product->is_type( 'grouped' ) ) {
 			$products = $product->get_children();
 			$sort_by_price = $sort_by_price ?? false;
-		} elseif ( $product->is_type( 'variable' ) || $product->is_type( 'variable-subscription' ) || $product->is_type( 'subscription' ) ) {
+		} elseif ( $product->is_type( 'variable' ) || self::is_subscription_product( $product ) ) {
 			$products = [ $product ];
 			$sort_by_price = $sort_by_price ?? true;
 		}
@@ -315,7 +371,7 @@ class Subscriptions_Tiers {
 				$product = wc_get_product( $product );
 			}
 
-			if ( ! in_array( $product->get_type(), [ 'subscription', 'variable-subscription' ], true ) ) {
+			if ( ! self::is_subscription_product( $product ) ) {
 				continue;
 			}
 
@@ -324,7 +380,7 @@ class Subscriptions_Tiers {
 			}
 
 			// Extract the variations if it's a variable subscription product.
-			if ( $product->is_type( 'variable-subscription' ) ) {
+			if ( self::is_variable_subscription_product( $product ) ) {
 				$variations = $product->get_available_variations();
 				foreach ( $variations as $variation ) {
 					$selected_products[] = new \WC_Product_Variation( $variation['variation_id'] );

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -253,62 +253,6 @@ class Subscriptions_Tiers {
 	}
 
 	/**
-	 * Whether a product carries WooCommerce Subscriptions "subscription plans".
-	 *
-	 * Subscriptions 9.0 folded All Products for Subscriptions into core, so a
-	 * recurring product no longer has to use the dedicated `subscription` /
-	 * `variable-subscription` product types: an ordinary `simple` or `variable`
-	 * product with subscription schemes attached is now the way the product
-	 * editor creates one. Mirrors the detection Subscriptions itself uses in
-	 * `WCSG_Product::product_has_subscription_plans()`, including the opt-out
-	 * meta, so we stay in step with what Subscriptions treats as recurring.
-	 *
-	 * @param \WC_Product $product Product object.
-	 *
-	 * @return bool Whether the product has subscription plans.
-	 */
-	public static function has_subscription_plans( $product ) {
-		if ( ! class_exists( 'WCS_ATT_Product_Schemes' ) || ! method_exists( 'WCS_ATT_Product_Schemes', 'has_subscription_schemes' ) ) {
-			return false;
-		}
-		if ( 'yes' === $product->get_meta( '_wcsatt_disabled' ) ) {
-			return false;
-		}
-		return (bool) \WCS_ATT_Product_Schemes::has_subscription_schemes( $product );
-	}
-
-	/**
-	 * Whether a product is a subscription, under either product model.
-	 *
-	 * @param \WC_Product $product Product object.
-	 *
-	 * @return bool Whether the product is a subscription.
-	 */
-	public static function is_subscription_product( $product ) {
-		if ( in_array( $product->get_type(), [ 'subscription', 'variable-subscription' ], true ) ) {
-			return true;
-		}
-		return self::has_subscription_plans( $product );
-	}
-
-	/**
-	 * Whether a product is a variable subscription, under either product model.
-	 *
-	 * Determines whether tiers come from the product's variations rather than
-	 * from the product itself.
-	 *
-	 * @param \WC_Product $product Product object.
-	 *
-	 * @return bool Whether the product is a variable subscription.
-	 */
-	public static function is_variable_subscription_product( $product ) {
-		if ( $product->is_type( 'variable-subscription' ) ) {
-			return true;
-		}
-		return $product->is_type( 'variable' ) && self::has_subscription_plans( $product );
-	}
-
-	/**
 	 * Get the frequency of a product.
 	 *
 	 * @param \WC_Product $product Product object.
@@ -355,7 +299,7 @@ class Subscriptions_Tiers {
 		} elseif ( $product->is_type( 'grouped' ) ) {
 			$products = $product->get_children();
 			$sort_by_price = $sort_by_price ?? false;
-		} elseif ( $product->is_type( 'variable' ) || self::is_subscription_product( $product ) ) {
+		} elseif ( $product->is_type( 'variable' ) || WooCommerce_Subscriptions::is_subscription_product( $product ) ) {
 			$products = [ $product ];
 			$sort_by_price = $sort_by_price ?? true;
 		}
@@ -371,7 +315,7 @@ class Subscriptions_Tiers {
 				$product = wc_get_product( $product );
 			}
 
-			if ( ! self::is_subscription_product( $product ) ) {
+			if ( ! WooCommerce_Subscriptions::is_subscription_product( $product ) ) {
 				continue;
 			}
 
@@ -380,7 +324,7 @@ class Subscriptions_Tiers {
 			}
 
 			// Extract the variations if it's a variable subscription product.
-			if ( self::is_variable_subscription_product( $product ) ) {
+			if ( WooCommerce_Subscriptions::is_variable_subscription_product( $product ) ) {
 				$variations = $product->get_available_variations();
 				foreach ( $variations as $variation ) {
 					$selected_products[] = new \WC_Product_Variation( $variation['variation_id'] );

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -341,20 +341,56 @@ class Subscriptions_Tiers {
 			// Extract the variations if it's a variable subscription product.
 			if ( WooCommerce_Subscriptions::is_variable_subscription_product( $product ) ) {
 				$variations = $product->get_available_variations();
+				$tier_products = [];
 				foreach ( $variations as $variation ) {
-					$selected_products[] = new \WC_Product_Variation( $variation['variation_id'] );
+					$tier_products[] = new \WC_Product_Variation( $variation['variation_id'] );
 				}
 			} else {
-				$selected_products[] = $product;
+				$tier_products = [ $product ];
+			}
+
+			$plans = WooCommerce_Subscriptions::get_subscription_plans( $product );
+			if ( empty( $plans ) ) {
+				$selected_products = array_merge( $selected_products, $tier_products );
+				continue;
+			}
+
+			// Under the plan model the frequency is the plan and the variations are
+			// orthogonal to it, so every tier is purchasable on every plan. Stamp a
+			// separate instance per pair - APFS filters price off the active plan,
+			// so each instance prices itself.
+			foreach ( $plans as $plan_key => $plan ) {
+				foreach ( $tier_products as $tier_product ) {
+					$instance = clone $tier_product;
+					\WCS_ATT_Product_Schemes::set_subscription_scheme( $instance, $plan_key );
+					$selected_products[] = $instance;
+				}
 			}
 		}
 
 		$products_by_frequency = [];
+		$frequency_plans       = [];
 		foreach ( $selected_products as $product ) {
 			$frequency = self::get_frequency( $product );
 			if ( ! $frequency ) {
 				continue;
 			}
+
+			// Two plans can share a period and interval - a monthly plan and a
+			// discounted monthly plan, say. Give the second its own bucket instead
+			// of merging it into the first, which would duplicate the tiers and
+			// hide one of the plans.
+			$plan_key = WooCommerce_Subscriptions::get_active_plan_key( $product );
+			if ( $plan_key ) {
+				$base   = $frequency;
+				$suffix = 1;
+				while ( isset( $frequency_plans[ $frequency ] ) && $frequency_plans[ $frequency ] !== $plan_key ) {
+					++$suffix;
+					$frequency = $base . '_' . $suffix;
+				}
+				$frequency_plans[ $frequency ] = $plan_key;
+			}
+
 			$products_by_frequency[ $frequency ][] = $product;
 		}
 

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -927,6 +927,14 @@ class Subscriptions_Tiers {
 			// get a panel below but no tab here, shifting every subsequent
 			// tab onto the wrong panel (setupTabController() pairs
 			// tab_headers[i] with tab_contents[i] by index).
+			//
+			// Dropping the bucket is deliberate, and must stay that way: a tier
+			// we cannot post a plan for is a tier we cannot bill correctly.
+			// Rendering it anyway - with the legacy button control, say - would
+			// give the reader a purchasable card that posts no plan, and APFS
+			// would take a single one-time payment instead of starting a
+			// subscription. An offer we can't fulfil is worse than an offer
+			// that isn't shown, so an unbillable tier must not be purchasable.
 			if ( ! empty( $plan_keys ) ) {
 				$tiers = array_intersect_key( $tiers, $plan_keys );
 			}

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -988,15 +988,31 @@ class Subscriptions_Tiers {
 			}
 		}
 
-		$should_render_tabs = ! $is_single_tier || $is_nyp;
+		// Under the plan model the reader's choice of plan can only be carried
+		// by the frequency control's convert_to_sub_<parent_id> value: every
+		// bucket holds the same product (or the same variations) stamped with a
+		// different plan, so a card's product_id cannot tell one plan from
+		// another. More than one plan on offer therefore *requires* the
+		// control. Without this the flat card layout would print one card per
+		// plan, each with its own price, while the single hidden input below
+		// pinned every one of them to the first plan - the reader picks
+		// "Yearly $100" and is billed $10 monthly.
+		//
+		// $plan_keys and $frequencies have identical keys at this point (see
+		// the array_intersect_key() above), so this also guarantees
+		// $frequency_control_rendered below is true whenever it is set.
+		$has_multiple_plans = count( $frequencies ) > 1 && ! empty( $plan_keys );
+
+		$should_render_tabs = ! $is_single_tier || $is_nyp || $has_multiple_plans;
 
 		// Whether render_frequency_control() below will actually post the
 		// plan. When it won't - a single frequency, or the flat (no-tabs)
-		// product-card layout - the hidden input further down carries the
-		// plan for $current_frequency instead. Without this, a product with
-		// exactly one plan (the ordinary case: one monthly plan plus
-		// price-tier variations) posts no plan at all and the reader is
-		// charged once instead of subscribing.
+		// product-card layout, which $has_multiple_plans above keeps to at
+		// most one plan - the hidden input further down carries the plan for
+		// $current_frequency instead. Without this, a product with exactly one
+		// plan (the ordinary case: one monthly plan plus price-tier
+		// variations) posts no plan at all and the reader is charged once
+		// instead of subscribing.
 		$frequency_control_rendered = $should_render_tabs && count( $frequencies ) > 1;
 		?>
 		<form class="newspack__subscription-tiers__form <?php echo esc_attr( $is_nyp ? 'nyp' : '' ); ?>" target="newspack_modal_checkout_iframe" data-title="<?php echo esc_attr( $title ); ?>" data-product-id="<?php echo esc_attr( $product ? $product->get_id() : '' ); ?>">
@@ -1025,6 +1041,10 @@ class Subscriptions_Tiers {
 				</div>
 			<?php endif; ?>
 			<?php
+			// The flat layout renders every bucket's cards at once with no
+			// frequency control, so it may only ever run when at most one plan
+			// is in play - see $has_multiple_plans above, which is what
+			// guarantees it.
 			if ( ! $should_render_tabs ) {
 				foreach ( $tiers as $products ) {
 					foreach ( $products as $product ) {

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -800,16 +800,44 @@ class Subscriptions_Tiers {
 	 *
 	 * @param array  $frequencies       Frequencies.
 	 * @param string $current_frequency Current frequency.
-	 * @param bool   $is_form_control     Whether to treat it as a form input.
+	 * @param bool   $is_form_control   Whether to treat it as a form input.
+	 * @param array  $plan_keys         Optional frequency key => scheme key map. When
+	 *                                  non-empty along with $parent_id, tabs render as
+	 *                                  radios posting the chosen plan.
+	 * @param int    $parent_id         Optional parent product ID, used to name the
+	 *                                  radio input group.
 	 */
-	public static function render_frequency_control( $frequencies, $current_frequency, $is_form_control = false ) {
+	public static function render_frequency_control( $frequencies, $current_frequency, $is_form_control = false, $plan_keys = [], $parent_id = 0 ) {
 		if ( $is_form_control ) :
 			?>
 			<div class="newspack-ui__segmented-control__form-control">
 				<label><?php _e( 'Frequency', 'newspack-plugin' ); ?></label>
 				<?php
 		endif;
-		if ( count( $frequencies ) <= 3 ) :
+		if ( ! empty( $plan_keys ) && $parent_id ) :
+			// Under the plan model the frequency IS the subscription plan, so the
+			// control carries the value APFS reads from $_REQUEST to resolve which
+			// plan the reader chose. A hidden input synced by JS would revert to a
+			// one-time purchase whenever the JS did not run.
+			?>
+			<div class="newspack-ui__segmented-control__tabs">
+				<?php foreach ( $frequencies as $frequency ) : ?>
+					<?php if ( empty( $plan_keys[ $frequency ] ) ) : ?>
+						<?php continue; ?>
+					<?php endif; ?>
+					<label class="newspack-ui__button newspack-ui__button--small <?php echo esc_attr( $frequency === $current_frequency ? 'selected' : '' ); ?>">
+						<input
+							type="radio"
+							name="convert_to_sub_<?php echo absint( $parent_id ); ?>"
+							value="<?php echo esc_attr( $plan_keys[ $frequency ] ); ?>"
+							<?php checked( $frequency, $current_frequency ); ?>
+						>
+						<?php echo esc_html( WooCommerce_Subscriptions::get_frequency_label( $frequency ) ); ?>
+					</label>
+				<?php endforeach; ?>
+			</div>
+			<?php
+		elseif ( count( $frequencies ) <= 3 ) :
 			?>
 			<div class="newspack-ui__segmented-control__tabs">
 				<?php foreach ( $frequencies as $frequency ) : ?>
@@ -850,7 +878,16 @@ class Subscriptions_Tiers {
 		$is_single_tier = self::is_single_tier( $tiers );
 		$is_nyp         = $is_single_tier && self::is_nyp( $tiers ); // Only treat as NYP form if there's only 1 tier.
 
-		$frequencies       = array_keys( $tiers );
+		$frequencies = array_keys( $tiers );
+
+		$plan_keys = [];
+		foreach ( $tiers as $frequency => $tier_products ) {
+			$plan_key = empty( $tier_products ) ? '' : WooCommerce_Subscriptions::get_active_plan_key( $tier_products[0] );
+			if ( $plan_key ) {
+				$plan_keys[ $frequency ] = $plan_key;
+			}
+		}
+
 		$current_frequency = null;
 		$current_product   = null;
 		$user_subscription = null;
@@ -903,7 +940,7 @@ class Subscriptions_Tiers {
 				<div class="newspack-ui__segmented-control">
 					<?php
 					if ( count( $frequencies ) > 1 ) {
-						self::render_frequency_control( $frequencies, $current_frequency, $is_nyp );
+						self::render_frequency_control( $frequencies, $current_frequency, $is_nyp, $plan_keys, $product ? $product->get_id() : 0 );
 					}
 					?>
 					<div class="newspack-ui__segmented-control__content">

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -367,6 +367,11 @@ class Subscriptions_Tiers {
 				$product = wc_get_product( $product );
 			}
 
+			// A deleted grouped child leaves an ID that no longer resolves.
+			if ( ! $product instanceof \WC_Product ) {
+				continue;
+			}
+
 			if ( ! WooCommerce_Subscriptions::is_subscription_product( $product ) ) {
 				continue;
 			}

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-subscriptions-tiers.php
@@ -287,6 +287,39 @@ class Subscriptions_Tiers {
 	}
 
 	/**
+	 * Billing period and interval for a product, plan-aware.
+	 *
+	 * Prefers the subscription plan stamped on the product instance, because the
+	 * legacy meta is either absent under the plan model or a hardcoded default
+	 * unrelated to the configured plan.
+	 *
+	 * @param \WC_Product $product Product object.
+	 *
+	 * @return array{period: string, interval: int} Billing period and interval.
+	 */
+	public static function get_frequency_parts( $product ) {
+		$plan_key = WooCommerce_Subscriptions::get_active_plan_key( $product );
+		if ( $plan_key ) {
+			$plans = WooCommerce_Subscriptions::get_subscription_plans( $product );
+			if ( isset( $plans[ $plan_key ] ) && method_exists( $plans[ $plan_key ], 'get_period' ) ) {
+				$period = $plans[ $plan_key ]->get_period();
+				if ( ! empty( $period ) ) {
+					$interval = (int) $plans[ $plan_key ]->get_interval();
+					return [
+						'period'   => $period,
+						'interval' => $interval > 0 ? $interval : 1,
+					];
+				}
+			}
+		}
+
+		return [
+			'period'   => (string) $product->get_meta( '_subscription_period' ),
+			'interval' => (int) $product->get_meta( '_subscription_period_interval' ),
+		];
+	}
+
+	/**
 	 * Get tiered products by frequency given a grouped or
 	 * variable subscription product.
 	 *
@@ -635,11 +668,12 @@ class Subscriptions_Tiers {
 		$price  = '';
 		if ( ! $is_nyp ) {
 			if ( function_exists( 'wcs_price_string' ) ) {
+				$parts = self::get_frequency_parts( $product );
 				$price = wcs_price_string(
 					[
 						'recurring_amount'      => $product->get_price(),
-						'subscription_period'   => $product->get_meta( '_subscription_period' ),
-						'subscription_interval' => $product->get_meta( '_subscription_period_interval' ),
+						'subscription_period'   => $parts['period'],
+						'subscription_interval' => $parts['interval'],
 					]
 				);
 			} else {
@@ -689,13 +723,15 @@ class Subscriptions_Tiers {
 		$symbol    = get_woocommerce_currency_symbol();
 		$currency  = get_woocommerce_currency();
 		$value     = $product->get_price();
-		$frequency = $product->get_meta( '_subscription_period' );
-		$interval  = $product->get_meta( '_subscription_period_interval' );
+		$parts     = self::get_frequency_parts( $product );
+		$frequency = $parts['period'];
+		$interval  = $parts['interval'];
 
 		if ( $switch_subscription ) {
 			$base_product   = wc_get_product( $switch_subscription['item']['product_id'] );
-			$base_frequency = $base_product->get_meta( '_subscription_period' );
-			$base_interval  = $base_product->get_meta( '_subscription_period_interval' );
+			$base_parts     = self::get_frequency_parts( $base_product );
+			$base_frequency = $base_parts['period'];
+			$base_interval  = $base_parts['interval'];
 			$base_amount    = $switch_subscription['item']['line_total'] / $base_interval;
 
 			// Get the direct conversion multiplier from base frequency to target frequency.

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -702,6 +702,72 @@ class WooCommerce_Subscriptions {
 	}
 
 	/**
+	 * Whether a product carries WooCommerce Subscriptions "subscription plans".
+	 *
+	 * Subscriptions 9.0 folded All Products for Subscriptions into core, so a
+	 * recurring product no longer has to use the dedicated `subscription` /
+	 * `variable-subscription` product types: an ordinary `simple` or `variable`
+	 * product with subscription schemes attached is now the way the product
+	 * editor creates one.
+	 *
+	 * Subscriptions makes this same check in
+	 * `WCSG_Product::product_has_subscription_plans()`, but that class lives in
+	 * the gifting module, which `WC_Subscriptions_Plugin::init_gifting()` skips
+	 * entirely when the standalone gifting plugin is active — in which case
+	 * `WCSG_Product` is that plugin's class and may not have the method. So we
+	 * mirror it here, opt-out meta included, rather than depend on it.
+	 *
+	 * @param \WC_Product $product Product object.
+	 *
+	 * @return bool Whether the product has subscription plans.
+	 */
+	public static function has_subscription_plans( $product ) {
+		if ( ! class_exists( 'WCS_ATT_Product_Schemes' ) || ! method_exists( 'WCS_ATT_Product_Schemes', 'has_subscription_schemes' ) ) {
+			return false;
+		}
+		if ( 'yes' === $product->get_meta( '_wcsatt_disabled' ) ) {
+			return false;
+		}
+		return (bool) \WCS_ATT_Product_Schemes::has_subscription_schemes( $product );
+	}
+
+	/**
+	 * Whether a product is a subscription, under either product model.
+	 *
+	 * `WC_Subscriptions_Product::is_subscription()` is not a substitute: it
+	 * recognises a plan-based product only once a scheme is active on the
+	 * product object (a cart/runtime state, via the `woocommerce_is_subscription`
+	 * filter APFS adds), so it returns false for a product read from the catalog.
+	 *
+	 * @param \WC_Product $product Product object.
+	 *
+	 * @return bool Whether the product is a subscription.
+	 */
+	public static function is_subscription_product( $product ) {
+		if ( in_array( $product->get_type(), [ 'subscription', 'variable-subscription' ], true ) ) {
+			return true;
+		}
+		return self::has_subscription_plans( $product );
+	}
+
+	/**
+	 * Whether a product is a variable subscription, under either product model.
+	 *
+	 * Determines whether tiers come from the product's variations rather than
+	 * from the product itself.
+	 *
+	 * @param \WC_Product $product Product object.
+	 *
+	 * @return bool Whether the product is a variable subscription.
+	 */
+	public static function is_variable_subscription_product( $product ) {
+		if ( $product->is_type( 'variable-subscription' ) ) {
+			return true;
+		}
+		return $product->is_type( 'variable' ) && self::has_subscription_plans( $product );
+	}
+
+	/**
 	 * Sanitize and validate a subscription ID or object as a WC_Subscription object.
 	 *
 	 * @param int|WC_Subscription $subscription The subscription ID or object.

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -722,6 +722,17 @@ class WooCommerce_Subscriptions {
 	 * @return bool Whether the product has subscription plans.
 	 */
 	public static function has_subscription_plans( $product ) {
+		// Belt and braces, and deliberately not dead code: the two models are
+		// mutually exclusive, and a legacy product must keep behaving exactly
+		// as it does today. APFS's own `supports_feature()` excludes the legacy
+		// types, so a `variable-subscription` product on a store with storewide
+		// plans configured reports no schemes — but that is an APFS
+		// implementation detail, and if it ever changed, the plan path would
+		// start rewriting the frequency, price and cart key of every legacy
+		// subscription product on the site. Keep this guard.
+		if ( in_array( $product->get_type(), [ 'subscription', 'variable-subscription' ], true ) ) {
+			return false;
+		}
 		if ( ! class_exists( 'WCS_ATT_Product_Schemes' ) || ! method_exists( 'WCS_ATT_Product_Schemes', 'has_subscription_schemes' ) ) {
 			return false;
 		}

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -768,6 +768,65 @@ class WooCommerce_Subscriptions {
 	}
 
 	/**
+	 * Get the subscription plans configured for a product.
+	 *
+	 * Plans may be defined on the product or inherited from the storewide plans,
+	 * so they are always read through the Subscriptions API rather than from
+	 * product meta.
+	 *
+	 * @param \WC_Product $product Product object.
+	 *
+	 * @return array Schemes keyed by scheme key. Empty when the product has no
+	 *               plans or the APFS API is unavailable.
+	 */
+	public static function get_subscription_plans( $product ) {
+		if ( ! self::has_subscription_plans( $product ) ) {
+			return [];
+		}
+		if ( ! method_exists( 'WCS_ATT_Product_Schemes', 'get_subscription_schemes' ) ) {
+			return [];
+		}
+		return (array) \WCS_ATT_Product_Schemes::get_subscription_schemes( $product );
+	}
+
+	/**
+	 * Frequency key for a subscription plan.
+	 *
+	 * Uses the same `<period>_<interval>` shape the legacy product model
+	 * produces, so frequency labels and controls work unchanged.
+	 *
+	 * @param \WCS_ATT_Scheme $plan Subscription plan.
+	 *
+	 * @return string Frequency key, or an empty string if the plan has no period.
+	 */
+	public static function get_plan_frequency( $plan ) {
+		if ( ! is_object( $plan ) || ! method_exists( $plan, 'get_period' ) ) {
+			return '';
+		}
+		$period = $plan->get_period();
+		if ( empty( $period ) ) {
+			return '';
+		}
+		$interval = (int) $plan->get_interval();
+		return $period . '_' . ( $interval > 0 ? $interval : 1 );
+	}
+
+	/**
+	 * The subscription plan currently stamped on a product instance.
+	 *
+	 * @param \WC_Product $product Product object.
+	 *
+	 * @return string Scheme key, or an empty string if none is set.
+	 */
+	public static function get_active_plan_key( $product ) {
+		if ( ! class_exists( 'WCS_ATT_Product_Schemes' ) || ! method_exists( 'WCS_ATT_Product_Schemes', 'get_subscription_scheme' ) ) {
+			return '';
+		}
+		$key = \WCS_ATT_Product_Schemes::get_subscription_scheme( $product );
+		return is_string( $key ) ? $key : '';
+	}
+
+	/**
 	 * Sanitize and validate a subscription ID or object as a WC_Subscription object.
 	 *
 	 * @param int|WC_Subscription $subscription The subscription ID or object.

--- a/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions.php
@@ -827,6 +827,22 @@ class WooCommerce_Subscriptions {
 	}
 
 	/**
+	 * Stamp a subscription plan onto a product instance.
+	 *
+	 * Mirrors {@see self::get_active_plan_key()}: a no-op when the APFS API is
+	 * unavailable, rather than a fatal, so callers can stamp unconditionally.
+	 *
+	 * @param \WC_Product $product Product instance to stamp.
+	 * @param string      $key     Scheme key.
+	 */
+	public static function set_active_plan_key( $product, $key ) {
+		if ( ! class_exists( 'WCS_ATT_Product_Schemes' ) || ! method_exists( 'WCS_ATT_Product_Schemes', 'set_subscription_scheme' ) ) {
+			return;
+		}
+		\WCS_ATT_Product_Schemes::set_subscription_scheme( $product, $key );
+	}
+
+	/**
 	 * Sanitize and validate a subscription ID or object as a WC_Subscription object.
 	 *
 	 * @param int|WC_Subscription $subscription The subscription ID or object.

--- a/plugins/newspack-plugin/src/newspack-ui/scss/elements/_segmented-control.scss
+++ b/plugins/newspack-plugin/src/newspack-ui/scss/elements/_segmented-control.scss
@@ -86,6 +86,35 @@
 					border-color: var(--newspack-ui-color-neutral-30);
 					color: var(--newspack-ui-color-neutral-90);
 				}
+
+				// Plan-based frequency pills wrap a radio input (to post the chosen
+				// plan - see Subscriptions_Tiers::render_frequency_control()), which
+				// otherwise matches the global radio-label layout in _labels.scss
+				// (two-column grid with a visible radio dot). Override it back to a
+				// plain pill and visually hide the input - `clip`/`appearance`
+				// rather than `display: none`, which would drop it from the
+				// accessibility tree and, in some browsers, from form submission.
+				&:has(input[type="radio"]) {
+					display: inline-flex !important;
+					position: relative;
+
+					input[type="radio"] {
+						position: absolute;
+						width: 1px;
+						height: 1px;
+						margin: -1px;
+						padding: 0;
+						overflow: hidden;
+						white-space: nowrap;
+						clip-path: inset(50%);
+						border: 0;
+					}
+
+					&:has(input:focus-visible) {
+						outline: 2px solid var(--newspack-ui-color-button-bg);
+						outline-offset: 1px;
+					}
+				}
 			}
 		}
 

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -1600,3 +1600,17 @@ class WC_Webhook {
 function wc_get_webhook( $id ) {
 	return isset( WC_Webhook::$registry[ (int) $id ] ) ? WC_Webhook::$registry[ (int) $id ] : null;
 }
+
+if ( ! class_exists( 'WCS_ATT_Product_Schemes' ) ) {
+	/**
+	 * Stub of the All Products for Subscriptions scheme reader that WooCommerce
+	 * Subscriptions 9.0+ ships in core. Tests opt products in by ID via
+	 * self::$products_with_schemes.
+	 */
+	class WCS_ATT_Product_Schemes {
+		public static $products_with_schemes = [];
+		public static function has_subscription_schemes( $product ) {
+			return in_array( $product->get_id(), self::$products_with_schemes, true );
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -280,8 +280,8 @@ class WC_Order_Item_Product implements ArrayAccess {
 }
 
 class WC_Product {
-	private $data = [];
-	private $meta = [];
+	protected $data = [];
+	private $meta   = [];
 	public function __construct( $data = [] ) {
 		$this->data = $data;
 		if ( isset( $data['meta'] ) ) {
@@ -306,6 +306,20 @@ class WC_Product {
 	}
 	public function get_children() {
 		return $this->data['children'] ?? [];
+	}
+	public function get_status() {
+		return $this->data['status'] ?? 'publish';
+	}
+	public function get_available_variations() {
+		return array_map(
+			function ( $id ) {
+				return [ 'variation_id' => $id ];
+			},
+			$this->get_children()
+		);
+	}
+	public function get_mock_data() {
+		return $this->data;
 	}
 	public function get_regular_price() {
 		return $this->data['regular_price'] ?? ( $this->meta['_regular_price'] ?? 0 );
@@ -364,6 +378,21 @@ function wc_create_mock_product( $data = [] ) {
 	$product = new WC_Product( $data );
 	$products_database[ $product->get_id() ] = $product;
 	return $product;
+}
+
+if ( ! class_exists( 'WC_Product_Variation' ) ) {
+	/**
+	 * Minimal variation stub. Resolves from the mock product database by ID so
+	 * `new WC_Product_Variation( $id )` behaves like the real constructor, which
+	 * is how Subscriptions_Tiers rebuilds variations.
+	 */
+	class WC_Product_Variation extends WC_Product {
+		public function __construct( $id = 0 ) {
+			global $products_database;
+			$existing = $products_database[ $id ] ?? null;
+			parent::__construct( $existing ? $existing->get_mock_data() : [ 'id' => $id ] );
+		}
+	}
 }
 
 class WC_Order {
@@ -1601,16 +1630,151 @@ function wc_get_webhook( $id ) {
 	return isset( WC_Webhook::$registry[ (int) $id ] ) ? WC_Webhook::$registry[ (int) $id ] : null;
 }
 
+if ( ! class_exists( 'WCS_ATT_Scheme' ) ) {
+	/**
+	 * Stub of an All Products for Subscriptions scheme (a "subscription plan").
+	 */
+	class WCS_ATT_Scheme {
+		/**
+		 * Scheme data.
+		 *
+		 * @var array
+		 */
+		private $data;
+
+		/**
+		 * Constructor.
+		 *
+		 * @param string $key  Scheme key.
+		 * @param array  $data [ 'period' => string, 'interval' => int ].
+		 */
+		public function __construct( $key, $data ) {
+			$this->data = array_merge(
+				[
+					'key'      => $key,
+					'period'   => 'month',
+					'interval' => 1,
+				],
+				$data
+			);
+		}
+
+		/**
+		 * Scheme key.
+		 *
+		 * @return string
+		 */
+		public function get_key() {
+			return $this->data['key'];
+		}
+
+		/**
+		 * Billing period.
+		 *
+		 * @return string
+		 */
+		public function get_period() {
+			return $this->data['period'];
+		}
+
+		/**
+		 * Billing interval.
+		 *
+		 * @return int
+		 */
+		public function get_interval() {
+			return $this->data['interval'];
+		}
+	}
+}
+
 if ( ! class_exists( 'WCS_ATT_Product_Schemes' ) ) {
 	/**
 	 * Stub of the All Products for Subscriptions scheme reader that WooCommerce
 	 * Subscriptions 9.0+ ships in core. Tests opt products in by ID via
-	 * self::$products_with_schemes.
+	 * self::$products_with_schemes, and describe their plans via
+	 * self::$product_schemes.
 	 */
 	class WCS_ATT_Product_Schemes {
+		/**
+		 * Product IDs treated as carrying schemes.
+		 *
+		 * @var int[]
+		 */
 		public static $products_with_schemes = [];
-		public static function has_subscription_schemes( $product ) {
+
+		/**
+		 * Plans per product: [ product_id => [ scheme_key => [ 'period', 'interval' ] ] ].
+		 *
+		 * @var array
+		 */
+		public static $product_schemes = [];
+
+		/**
+		 * Active scheme key per product instance, keyed by spl_object_id.
+		 *
+		 * @var array
+		 */
+		public static $active_schemes = [];
+
+		/**
+		 * Whether the product has schemes.
+		 *
+		 * @param \WC_Product $product Product.
+		 * @param string      $context Unused, matches the real signature.
+		 *
+		 * @return bool
+		 */
+		public static function has_subscription_schemes( $product, $context = 'any' ) {
 			return in_array( $product->get_id(), self::$products_with_schemes, true );
+		}
+
+		/**
+		 * The product's schemes, keyed by scheme key.
+		 *
+		 * @param \WC_Product $product Product.
+		 * @param string      $context Unused, matches the real signature.
+		 *
+		 * @return array
+		 */
+		public static function get_subscription_schemes( $product, $context = 'any' ) {
+			$id = $product->get_id();
+			if ( ! isset( self::$product_schemes[ $id ] ) ) {
+				return [];
+			}
+			$schemes = [];
+			foreach ( self::$product_schemes[ $id ] as $key => $data ) {
+				$schemes[ $key ] = new WCS_ATT_Scheme( $key, $data );
+			}
+			return $schemes;
+		}
+
+		/**
+		 * Stamp an active scheme onto a product instance.
+		 *
+		 * @param \WC_Product $product Product.
+		 * @param string      $key     Scheme key.
+		 */
+		public static function set_subscription_scheme( $product, $key ) {
+			self::$active_schemes[ spl_object_id( $product ) ] = $key;
+		}
+
+		/**
+		 * The active scheme stamped on a product instance.
+		 *
+		 * @param \WC_Product $product    Product.
+		 * @param string      $return     'key' or 'object'.
+		 * @param string      $scheme_key Unused, matches the real signature.
+		 *
+		 * @return mixed
+		 */
+		public static function get_subscription_scheme( $product, $return = 'key', $scheme_key = '' ) {
+			$key = self::$active_schemes[ spl_object_id( $product ) ] ?? false;
+			if ( 'object' !== $return || ! $key ) {
+				return $key;
+			}
+			$schemes = self::get_subscription_schemes( $product );
+			return $schemes[ $key ] ?? null;
 		}
 	}
 }

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -1246,6 +1246,30 @@ function woocommerce_wp_text_input( $field ) {
 	);
 }
 /**
+ * Minimal currency stubs, enough for `render_nyp_product_card()` to render.
+ *
+ * @return string
+ */
+function get_woocommerce_currency_symbol() {
+	return '$';
+}
+/**
+ * Store currency code.
+ *
+ * @return string
+ */
+function get_woocommerce_currency() {
+	return 'USD';
+}
+/**
+ * Number of decimals prices are displayed with.
+ *
+ * @return int
+ */
+function wc_get_price_decimals() {
+	return 2;
+}
+/**
  * Minimal `wc_get_products()` stub: filters the mock product database by
  * `type`, the only query arg `Subscriptions_Tiers` reads.
  *

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -1237,6 +1237,51 @@ function woocommerce_wp_text_input( $field ) {
 	);
 }
 /**
+ * Minimal `wc_get_products()` stub: filters the mock product database by
+ * `type`, the only query arg `Subscriptions_Tiers` reads.
+ *
+ * @param array $args Query args. Only `type` is honored.
+ *
+ * @return \WC_Product[] Matching mock products.
+ */
+function wc_get_products( $args = [] ) {
+	global $products_database;
+	$products = array_values( $products_database );
+	if ( isset( $args['type'] ) ) {
+		$types    = (array) $args['type'];
+		$products = array_values(
+			array_filter(
+				$products,
+				function ( $product ) use ( $types ) {
+					return in_array( $product->get_type(), $types, true );
+				}
+			)
+		);
+	}
+	return $products;
+}
+/**
+ * Minimal `wcs_user_has_subscription()` stub, present so
+ * `function_exists( 'wcs_user_has_subscription' )` guards pass. Tests that
+ * need real subscription-ownership behavior use
+ * `wcs_get_users_subscriptions()` instead.
+ *
+ * @param int   $user_id    User ID.
+ * @param mixed $product_id Product ID, unused by this stub.
+ * @param mixed $status     Status, unused by this stub.
+ *
+ * @return bool Whether the user holds any subscription.
+ */
+function wcs_user_has_subscription( $user_id = 0, $product_id = '', $status = 'any' ) {
+	global $subscriptions_database;
+	foreach ( (array) $subscriptions_database as $subscription ) {
+		if ( $subscription->get_customer_id() === $user_id ) {
+			return true;
+		}
+	}
+	return false;
+}
+/**
  * Recording mock: notices land on the $wc_mock_notices global so tests can
  * assert the reader-facing half of code paths gated on
  * function_exists( 'wc_add_notice' ).

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -294,6 +294,15 @@ class WC_Product {
 	public function get_name() {
 		return $this->data['name'] ?? '';
 	}
+	public function get_title() {
+		return $this->data['title'] ?? $this->get_name();
+	}
+	public function get_description() {
+		return $this->data['description'] ?? '';
+	}
+	public function get_price_html() {
+		return $this->data['price_html'] ?? '';
+	}
 	public function get_type() {
 		return $this->data['type'] ?? 'simple';
 	}

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -1830,3 +1830,33 @@ if ( ! class_exists( 'WCS_ATT_Product_Schemes' ) ) {
 		}
 	}
 }
+
+if ( ! class_exists( 'WCS_ATT_Order' ) ) {
+	/**
+	 * Stub of WCS's order-item scheme accessor
+	 * (`includes/apfs/class-wcs-att-order.php` in real WooCommerce
+	 * Subscriptions 9.x). Reads `_wcsatt_scheme`, falling back to the pre-9.0
+	 * APFS-v1 meta key `_wcsatt_scheme_id` when absent — mirrors the real
+	 * accessor's own fallback closely enough to pin the v1-key regression
+	 * path in tests.
+	 */
+	class WCS_ATT_Order {
+		/**
+		 * The subscription scheme key recorded on an order/subscription line item.
+		 *
+		 * @param \WC_Order_Item $order_item Order item.
+		 *
+		 * @return string|false Scheme key, or false if none is recorded.
+		 */
+		public static function get_subscription_scheme( $order_item ) {
+			if ( ! method_exists( $order_item, 'get_meta' ) ) {
+				return false;
+			}
+			$scheme_key = $order_item->get_meta( '_wcsatt_scheme', true );
+			if ( '' === $scheme_key ) {
+				$scheme_key = $order_item->get_meta( '_wcsatt_scheme_id', true );
+			}
+			return '' === $scheme_key ? false : $scheme_key;
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -1261,23 +1261,30 @@ function wc_get_products( $args = [] ) {
 	return $products;
 }
 /**
- * Minimal `wcs_user_has_subscription()` stub, present so
- * `function_exists( 'wcs_user_has_subscription' )` guards pass. Tests that
- * need real subscription-ownership behavior use
- * `wcs_get_users_subscriptions()` instead.
+ * Minimal `wcs_user_has_subscription()` stub, matching the real signature:
+ * a product ID and/or status narrow the match, not just the user.
  *
- * @param int   $user_id    User ID.
- * @param mixed $product_id Product ID, unused by this stub.
- * @param mixed $status     Status, unused by this stub.
+ * @param int    $user_id    User ID.
+ * @param string $product_id Product ID to require on the subscription. Empty string matches any product.
+ * @param string $status     Status to require, or 'any' to match regardless of status.
  *
- * @return bool Whether the user holds any subscription.
+ * @return bool Whether the user holds a matching subscription.
  */
 function wcs_user_has_subscription( $user_id = 0, $product_id = '', $status = 'any' ) {
 	global $subscriptions_database;
 	foreach ( (array) $subscriptions_database as $subscription ) {
-		if ( $subscription->get_customer_id() === $user_id ) {
-			return true;
+		// Customer IDs arrive as both int and numeric string depending on the
+		// fixture, so compare loosely rather than with a strict ===.
+		if ( (int) $subscription->get_customer_id() !== (int) $user_id ) {
+			continue;
 		}
+		if ( '' !== $product_id && ! $subscription->has_product( $product_id ) ) {
+			continue;
+		}
+		if ( 'any' !== $status && ! $subscription->has_status( $status ) ) {
+			continue;
+		}
+		return true;
 	}
 	return false;
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -1062,23 +1062,19 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 	 */
 	public function test_render_form_skips_plan_posting_with_no_product() {
 		// Registered so get_tiers_by_frequency( null ) picks it up in its
-		// catalog-wide aggregation, giving the form something to render.
+		// catalog-wide aggregation, giving the form something to render. The
+		// aggregation queries the legacy product types only, and a legacy
+		// product never carries plans (see
+		// WooCommerce_Subscriptions::has_subscription_plans()) - which is
+		// precisely why this path can never have a plan key to post.
 		wc_create_mock_product(
 			[
-				'id'   => 450,
-				'type' => 'subscription',
-				'meta' => [
+				'id'    => 450,
+				'type'  => 'subscription',
+				'price' => 5,
+				'meta'  => [
 					'_subscription_period'          => 'month',
 					'_subscription_period_interval' => '1',
-				],
-			]
-		);
-		$this->give_plans(
-			450,
-			[
-				'mkey' => [
-					'period'   => 'month',
-					'interval' => 1,
 				],
 			]
 		);
@@ -1087,6 +1083,7 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 		\Newspack\Subscriptions_Tiers::render_form( null );
 		$markup = ob_get_clean();
 
+		$this->assertStringContainsString( '<form', $markup, 'Precondition: the form actually renders.' );
 		$this->assertStringNotContainsString( 'convert_to_sub', $markup );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -1014,6 +1014,44 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The switch flow prices a name-your-price card off the subscription's
+	 * current product. That product can have been deleted since, in which case
+	 * `wc_get_product()` returns false - which used to flow straight into the
+	 * plan accessors and fatal, taking the whole modal down. Fall back to the
+	 * target product's own price instead.
+	 */
+	public function test_nyp_card_survives_a_deleted_switch_product() {
+		$product = wc_create_mock_product(
+			[
+				'id'    => 480,
+				'type'  => 'simple',
+				'price' => 10,
+				'meta'  => [
+					'_nyp'                          => 'yes',
+					'_subscription_period'          => 'month',
+					'_subscription_period_interval' => '1',
+				],
+			]
+		);
+
+		ob_start();
+		\Newspack\Subscriptions_Tiers::render_nyp_product_card(
+			$product,
+			false,
+			[
+				'item' => [
+					'product_id' => 4809, // Never registered: a deleted product.
+					'line_total' => 20,
+				],
+			]
+		);
+		$markup = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="price"', $markup );
+		$this->assertStringContainsString( 'value="10"', $markup, 'With no base product to convert from, the target price stands.' );
+	}
+
+	/**
 	 * A grouped product's cart item posts its child product's ID, not the
 	 * grouped parent's - so a convert_to_sub keyed on the grouped parent ID
 	 * would never be read by APFS. render_form() must not emit one.

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -840,6 +840,114 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 	}
 
 	/**
+	 * NPPM-3053 mis-selling regression: when every plan's bucket holds exactly
+	 * one tier - a `simple` product with a monthly and an annual plan - the
+	 * form used to take the flat, no-tabs card layout, printing one card per
+	 * plan at that plan's own price while a single hidden input pinned all of
+	 * them to the *first* plan. The reader picked "Yearly" and was billed
+	 * monthly, and since every card carries the same product_id nothing
+	 * downstream could tell them apart either. More than one plan on offer
+	 * must always render the control that posts which plan was chosen.
+	 */
+	public function test_render_form_posts_the_plan_choice_with_one_tier_per_plan() {
+		$plans = [
+			'mkey' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+			'ykey' => [
+				'period'   => 'year',
+				'interval' => 1,
+			],
+		];
+
+		// A simple product is its own single tier, so each plan's bucket holds
+		// exactly one product and is_single_tier() is true.
+		$product = wc_create_mock_product(
+			[
+				'id'    => 460,
+				'type'  => 'simple',
+				'price' => 5,
+			]
+		);
+		$this->give_plans( 460, $plans );
+
+		ob_start();
+		\Newspack\Subscriptions_Tiers::render_form( $product );
+		$markup = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="convert_to_sub_460"', $markup, 'The plan-posting control must render.' );
+
+		// The posted key varies with the reader's selection: one radio per
+		// plan, each carrying its own scheme key, in a single named group.
+		preg_match_all( '/<input[^>]*name="convert_to_sub_460"[^>]*>/s', $markup, $inputs );
+		$this->assertCount( 2, $inputs[0], 'One plan-posting input per plan.' );
+		foreach ( $inputs[0] as $input ) {
+			$this->assertStringContainsString( 'type="radio"', $input, 'The plan must be posted by a control the reader can change.' );
+		}
+		$this->assertStringContainsString( 'value="mkey"', $inputs[0][0] );
+		$this->assertStringContainsString( 'value="ykey"', $inputs[0][1] );
+
+		// No hidden input pinning every card to one plan - that was the bug.
+		$this->assertStringNotContainsString( 'type="hidden" name="convert_to_sub_460"', $markup );
+
+		$checked_inputs = array_filter(
+			$inputs[0],
+			function ( $input ) {
+				return false !== strpos( $input, 'checked' );
+			}
+		);
+		$this->assertCount( 1, $checked_inputs, 'Exactly one plan radio should be checked.' );
+		$this->assertStringContainsString( 'value="mkey"', reset( $checked_inputs ), 'The first (initially-visible) plan should be the checked one.' );
+	}
+
+	/**
+	 * The same mis-selling case reached through a `variable` product with a
+	 * single variation: one variation across two plans is still one tier per
+	 * bucket, so it took the same flat layout with the same pinned plan.
+	 */
+	public function test_render_form_posts_the_plan_choice_for_a_single_variation() {
+		$plans = [
+			'mkey' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+			'ykey' => [
+				'period'   => 'year',
+				'interval' => 1,
+			],
+		];
+
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 470,
+				'type'     => 'variable',
+				'children' => [ 471 ],
+			]
+		);
+		$this->give_plans( 470, $plans );
+		wc_create_mock_product(
+			[
+				'id'        => 471,
+				'type'      => 'variation',
+				'parent_id' => 470,
+				'price'     => 5,
+			]
+		);
+		$this->give_plans( 471, $plans );
+
+		ob_start();
+		\Newspack\Subscriptions_Tiers::render_form( $parent );
+		$markup = ob_get_clean();
+
+		preg_match_all( '/<input[^>]*name="convert_to_sub_470"[^>]*>/s', $markup, $inputs );
+		$this->assertCount( 2, $inputs[0], 'One plan-posting radio per plan.' );
+		$this->assertStringContainsString( 'value="mkey"', $inputs[0][0] );
+		$this->assertStringContainsString( 'value="ykey"', $inputs[0][1] );
+		$this->assertStringNotContainsString( 'type="hidden" name="convert_to_sub_470"', $markup );
+	}
+
+	/**
 	 * Switch-flow fallback: when the subscriber's current subscription
 	 * matches none of the tiers (a retired plan, or filtered out by the
 	 * ownership check), get_current_tier() returns a null frequency. Without

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -583,7 +583,19 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'name="convert_to_sub_350"', $markup );
 		$this->assertStringContainsString( 'value="mkey"', $markup );
 		$this->assertStringContainsString( 'value="ykey"', $markup );
-		$this->assertStringContainsString( 'checked', $markup );
+		// Exactly one radio checked - assertStringContainsString( 'checked' )
+		// alone would pass with zero or with both checked, neither of which
+		// is a valid form state. Count the `checked='checked'` attribute
+		// checked() emits, not the bare word "checked" - it appears twice
+		// within that single attribute (name and value).
+		$this->assertSame( 1, substr_count( $markup, "checked='checked'" ), 'Exactly one radio should be checked.' );
+		// And it must be the one for the initially-visible panel (`month_1`,
+		// the $current_frequency argument), not just any radio.
+		if ( preg_match( '/<input[^>]*value="mkey"[^>]*>/s', $markup, $checked_input ) ) {
+			$this->assertStringContainsString( 'checked', $checked_input[0], 'The month_1/mkey radio should be the checked one.' );
+		} else {
+			$this->fail( 'Could not find the mkey radio in the markup.' );
+		}
 	}
 
 	/**
@@ -595,6 +607,266 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 		$markup = ob_get_clean();
 
 		$this->assertStringContainsString( '<button', $markup );
+		$this->assertStringNotContainsString( 'convert_to_sub', $markup );
+	}
+
+	/**
+	 * NPPM-3053 critical regression: a product with exactly one plan (the
+	 * ordinary publisher setup - one monthly plan plus price-tier
+	 * variations) has only one frequency bucket, so
+	 * render_frequency_control() is never called (it only runs for >1
+	 * frequency). render_form() must fall back to a hidden input carrying
+	 * that single plan's key, or the reader is charged once instead of
+	 * subscribing - exactly the bug this task exists to fix, for the most
+	 * common case.
+	 */
+	public function test_render_form_posts_the_plan_key_for_a_single_plan_product() {
+		$plans = [
+			'mkey' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+		];
+
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 380,
+				'type'     => 'variable',
+				'children' => [ 381, 382 ],
+			]
+		);
+		$this->give_plans( 380, $plans );
+		foreach ( [ 381, 382 ] as $vid ) {
+			wc_create_mock_product(
+				[
+					'id'        => $vid,
+					'type'      => 'variation',
+					'parent_id' => 380,
+					'price'     => 5,
+				]
+			);
+			$this->give_plans( $vid, $plans );
+		}
+
+		ob_start();
+		\Newspack\Subscriptions_Tiers::render_form( $parent );
+		$markup = ob_get_clean();
+
+		// Exactly one convert_to_sub input, and it's the hidden fallback -
+		// not a radio, since there's only one plan to choose from. The form
+		// still has other, unrelated radios: the price-tier `product_id`
+		// selection (see render_product_card()), which is untouched by this
+		// task and deliberately excluded from this assertion.
+		$this->assertSame( 1, substr_count( $markup, 'convert_to_sub_380' ), 'Exactly one convert_to_sub input should be posted.' );
+		$this->assertStringContainsString( '<input type="hidden" name="convert_to_sub_380" value="mkey">', $markup );
+		$this->assertStringNotContainsString( 'type="radio" name="convert_to_sub_380"', $markup, 'A single plan has nothing to choose between, so no plan radio should render.' );
+	}
+
+	/**
+	 * A product with more than one plan renders the plan-radio control
+	 * (render_frequency_control()'s job, covered directly above), and
+	 * render_form() must wire it up with the correct plan-key map and
+	 * parent ID, with exactly one radio checked - the one for the
+	 * initially-visible panel.
+	 */
+	public function test_render_form_wires_up_the_plan_radios_for_a_multi_plan_product() {
+		$plans = [
+			'mkey' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+			'ykey' => [
+				'period'   => 'year',
+				'interval' => 1,
+			],
+		];
+
+		// Two variations per plan (price tiers), matching the ordinary
+		// publisher setup and keeping is_single_tier() false, so render_form()
+		// takes the tabbed-panel path this test targets rather than the flat
+		// "current subscription" card layout used when every frequency has
+		// exactly one product.
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 420,
+				'type'     => 'variable',
+				'children' => [ 421, 422 ],
+			]
+		);
+		$this->give_plans( 420, $plans );
+		foreach ( [ 421, 422 ] as $vid ) {
+			wc_create_mock_product(
+				[
+					'id'        => $vid,
+					'type'      => 'variation',
+					'parent_id' => 420,
+					'price'     => 5,
+				]
+			);
+			$this->give_plans( $vid, $plans );
+		}
+
+		ob_start();
+		\Newspack\Subscriptions_Tiers::render_form( $parent );
+		$markup = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="convert_to_sub_420"', $markup );
+		$this->assertStringContainsString( 'value="mkey"', $markup );
+		$this->assertStringContainsString( 'value="ykey"', $markup );
+		// No hidden fallback when the radio control itself posts the plan.
+		$this->assertStringNotContainsString( 'type="hidden" name="convert_to_sub_420"', $markup );
+
+		preg_match_all( '/<input[^>]*name="convert_to_sub_420"[^>]*>/s', $markup, $inputs );
+		$checked_inputs = array_filter(
+			$inputs[0],
+			function ( $input ) {
+				return false !== strpos( $input, 'checked' );
+			}
+		);
+		$this->assertCount( 1, $checked_inputs, 'Exactly one plan radio should be checked.' );
+		$this->assertStringContainsString( 'value="mkey"', reset( $checked_inputs ), 'The first (initially-visible) frequency should be the checked one.' );
+	}
+
+	/**
+	 * Switch-flow fallback: when the subscriber's current subscription
+	 * matches none of the tiers (a retired plan, or filtered out by the
+	 * ownership check), get_current_tier() returns a null frequency. Without
+	 * a fallback, zero radios get checked and the switch form posts no plan
+	 * - the same one-time-charge bug, in the switch flow.
+	 */
+	public function test_render_form_checks_a_radio_when_switching_with_no_matching_tier() {
+		$user_id = self::factory()->user->create();
+		wp_set_current_user( $user_id );
+
+		$plans = [
+			'mkey' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+			'ykey' => [
+				'period'   => 'year',
+				'interval' => 1,
+			],
+		];
+
+		// Two variations per plan - see the comment in the multi-plan wiring
+		// test above for why this keeps render_form() on the tabbed-panel
+		// path this test targets.
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 430,
+				'type'     => 'variable',
+				'children' => [ 431, 432 ],
+			]
+		);
+		$this->give_plans( 430, $plans );
+		foreach ( [ 431, 432 ] as $vid ) {
+			wc_create_mock_product(
+				[
+					'id'        => $vid,
+					'type'      => 'variation',
+					'parent_id' => 430,
+					'price'     => 5,
+				]
+			);
+			$this->give_plans( $vid, $plans );
+		}
+
+		// Logged in with no subscriptions at all, so get_current_tier() can't
+		// match anything - the fallback path this test targets.
+		$switch_data = [
+			'subscription' => new WC_Subscription( [ 'id' => 999 ] ),
+			'item_id'      => 111,
+		];
+
+		ob_start();
+		\Newspack\Subscriptions_Tiers::render_form( $parent, null, null, $switch_data );
+		$markup = ob_get_clean();
+
+		preg_match_all( '/<input[^>]*name="convert_to_sub_430"[^>]*>/s', $markup, $inputs );
+		$checked_inputs = array_filter(
+			$inputs[0],
+			function ( $input ) {
+				return false !== strpos( $input, 'checked' );
+			}
+		);
+		$this->assertCount( 1, $checked_inputs, 'A radio should still be checked with no matching tier.' );
+	}
+
+	/**
+	 * A grouped product's cart item posts its child product's ID, not the
+	 * grouped parent's - so a convert_to_sub keyed on the grouped parent ID
+	 * would never be read by APFS. render_form() must not emit one.
+	 */
+	public function test_render_form_skips_plan_posting_for_a_grouped_product() {
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 440,
+				'type'     => 'grouped',
+				'children' => [ 441 ],
+			]
+		);
+		wc_create_mock_product(
+			[
+				'id'    => 441,
+				'type'  => 'subscription',
+				'price' => 5,
+				'meta'  => [
+					'_subscription_period'          => 'month',
+					'_subscription_period_interval' => '1',
+				],
+			]
+		);
+		$this->give_plans(
+			441,
+			[
+				'mkey' => [
+					'period'   => 'month',
+					'interval' => 1,
+				],
+			]
+		);
+
+		ob_start();
+		\Newspack\Subscriptions_Tiers::render_form( $parent );
+		$markup = ob_get_clean();
+
+		$this->assertStringNotContainsString( 'convert_to_sub', $markup, 'Grouped products have no single parent ID to post a plan against.' );
+	}
+
+	/**
+	 * With no product, render_form() aggregates every non-donation
+	 * subscription product with no common parent, so it must never fall
+	 * back to "convert_to_sub_0" - a key that looks real but is read by
+	 * nothing.
+	 */
+	public function test_render_form_skips_plan_posting_with_no_product() {
+		// Registered so get_tiers_by_frequency( null ) picks it up in its
+		// catalog-wide aggregation, giving the form something to render.
+		wc_create_mock_product(
+			[
+				'id'   => 450,
+				'type' => 'subscription',
+				'meta' => [
+					'_subscription_period'          => 'month',
+					'_subscription_period_interval' => '1',
+				],
+			]
+		);
+		$this->give_plans(
+			450,
+			[
+				'mkey' => [
+					'period'   => 'month',
+					'interval' => 1,
+				],
+			]
+		);
+
+		ob_start();
+		\Newspack\Subscriptions_Tiers::render_form( null );
+		$markup = ob_get_clean();
+
 		$this->assertStringNotContainsString( 'convert_to_sub', $markup );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -283,6 +283,118 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A grouped product's children are each their own cart-item parent, so
+	 * APFS's convert_to_sub_<parent_id> - a single key at the form level -
+	 * can never be keyed correctly for a plan-based child. On `release`, a
+	 * grouped product with a plan-based (`variable`) child already yields no
+	 * tiers, because the legacy child-type check rejects `variable`. This
+	 * pins that same "no tiers" outcome for the plan model, rather than
+	 * letting the child's plans expand into a purchasable-but-unaddressable
+	 * form that would take a one-time payment instead of subscribing.
+	 */
+	public function test_grouped_product_with_only_a_plan_based_child_yields_no_tiers() {
+		$plans = [
+			'mkey' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+		];
+
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 350,
+				'type'     => 'grouped',
+				'children' => [ 351 ],
+			]
+		);
+		wc_create_mock_product(
+			[
+				'id'       => 351,
+				'type'     => 'variable',
+				'children' => [ 352, 353 ],
+			]
+		);
+		$this->give_plans( 351, $plans );
+		foreach ( [ 352, 353 ] as $vid ) {
+			wc_create_mock_product(
+				[
+					'id'        => $vid,
+					'type'      => 'variation',
+					'parent_id' => 351,
+				]
+			);
+			$this->give_plans( $vid, $plans );
+		}
+
+		$tiers = \Newspack\Subscriptions_Tiers::get_tiers_by_frequency( $parent );
+
+		$this->assertSame( [], $tiers );
+	}
+
+	/**
+	 * A grouped product mixing a legacy child and a plan-based child must
+	 * still yield the legacy child's tiers, unchanged - the plan-based
+	 * child's exclusion (see the test above) is additive, not a blanket
+	 * "grouped products are broken" regression.
+	 */
+	public function test_grouped_product_with_mixed_children_yields_only_the_legacy_tiers() {
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 355,
+				'type'     => 'grouped',
+				'children' => [ 356, 357 ],
+			]
+		);
+		wc_create_mock_product(
+			[
+				'id'   => 356,
+				'type' => 'subscription',
+				'meta' => [
+					'_subscription_period'          => 'month',
+					'_subscription_period_interval' => '1',
+				],
+			]
+		);
+		wc_create_mock_product(
+			[
+				'id'       => 357,
+				'type'     => 'variable',
+				'children' => [ 358, 359 ],
+			]
+		);
+		$plans = [
+			'mkey' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+		];
+		$this->give_plans( 357, $plans );
+		foreach ( [ 358, 359 ] as $vid ) {
+			wc_create_mock_product(
+				[
+					'id'        => $vid,
+					'type'      => 'variation',
+					'parent_id' => 357,
+				]
+			);
+			$this->give_plans( $vid, $plans );
+		}
+
+		$tiers = \Newspack\Subscriptions_Tiers::get_tiers_by_frequency( $parent );
+
+		$this->assertSame( [ 'month_1' ], array_keys( $tiers ) );
+		$this->assertSame(
+			[ 356 ],
+			array_map(
+				function ( $p ) {
+					return $p->get_id();
+				},
+				$tiers['month_1']
+			)
+		);
+	}
+
+	/**
 	 * NPPM-3053 regression for get_current_tier(): under the plan model the
 	 * same variation ID is stamped into every plan's bucket
 	 * (get_tiers_by_frequency()'s expansion), so ID-only matching resolved an

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -139,4 +139,97 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 
 		$this->assertSame( 'week_2', \Newspack\Subscriptions_Tiers::get_frequency( $product ) );
 	}
+
+	/**
+	 * A plan-based variable product yields one bucket per plan, each holding
+	 * every variation. This is the NPPM-3053 regression: an annual plan that
+	 * never reached the modal at all.
+	 */
+	public function test_plan_based_variable_product_yields_one_bucket_per_plan() {
+		$plans = [
+			'mkey' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+			'ykey' => [
+				'period'   => 'year',
+				'interval' => 1,
+			],
+		];
+
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 320,
+				'type'     => 'variable',
+				'children' => [ 321, 322 ],
+			]
+		);
+		$this->give_plans( 320, $plans );
+		foreach ( [ 321, 322 ] as $vid ) {
+			wc_create_mock_product(
+				[
+					'id'        => $vid,
+					'type'      => 'variation',
+					'parent_id' => 320,
+				]
+			);
+			$this->give_plans( $vid, $plans );
+		}
+
+		$tiers = \Newspack\Subscriptions_Tiers::get_tiers_by_frequency( $parent );
+
+		$this->assertSame( [ 'month_1', 'year_1' ], array_keys( $tiers ) );
+		$this->assertCount( 2, $tiers['month_1'] );
+		$this->assertCount( 2, $tiers['year_1'] );
+		$this->assertSame(
+			[ 321, 322 ],
+			array_map(
+				function ( $p ) {
+					return $p->get_id();
+				},
+				$tiers['year_1']
+			)
+		);
+	}
+
+	/**
+	 * Two plans sharing a period and interval get their own buckets rather than
+	 * merging into one and duplicating the tiers.
+	 */
+	public function test_plans_sharing_a_frequency_do_not_merge() {
+		$plans = [
+			'cheap' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+			'dear'  => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+		];
+
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 330,
+				'type'     => 'variable',
+				'children' => [ 331 ],
+			]
+		);
+		$this->give_plans( 330, $plans );
+		wc_create_mock_product(
+			[
+				'id'        => 331,
+				'type'      => 'variation',
+				'parent_id' => 330,
+			]
+		);
+		$this->give_plans( 331, $plans );
+
+		$tiers = \Newspack\Subscriptions_Tiers::get_tiers_by_frequency( $parent );
+
+		$this->assertCount( 2, $tiers, 'Both plans should survive, in separate buckets.' );
+		foreach ( $tiers as $products ) {
+			$this->assertCount( 1, $products );
+		}
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -88,4 +88,55 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 		);
 		$this->assertSame( [], WooCommerce_Subscriptions::get_subscription_plans( $product ) );
 	}
+
+	/**
+	 * A stamped plan wins over legacy meta.
+	 *
+	 * The legacy meta here is the hardcoded `month` that
+	 * WC_Subscriptions_Admin::set_variation_meta_defaults_on_bulk_add() writes
+	 * onto every generated variation. An annual plan must not render as monthly.
+	 */
+	public function test_frequency_comes_from_the_stamped_plan() {
+		$product = wc_create_mock_product(
+			[
+				'id'   => 310,
+				'type' => 'variable',
+				'meta' => [
+					'_subscription_period'          => 'month',
+					'_subscription_period_interval' => '1',
+				],
+			]
+		);
+		$this->give_plans(
+			310,
+			[
+				'ykey' => [
+					'period'   => 'year',
+					'interval' => 1,
+				],
+			]
+		);
+
+		WCS_ATT_Product_Schemes::set_subscription_scheme( $product, 'ykey' );
+
+		$this->assertSame( 'year_1', \Newspack\Subscriptions_Tiers::get_frequency( $product ) );
+	}
+
+	/**
+	 * With no plan stamped, legacy meta still drives the frequency.
+	 */
+	public function test_frequency_falls_back_to_legacy_meta() {
+		$product = wc_create_mock_product(
+			[
+				'id'   => 311,
+				'type' => 'subscription',
+				'meta' => [
+					'_subscription_period'          => 'week',
+					'_subscription_period_interval' => '2',
+				],
+			]
+		);
+
+		$this->assertSame( 'week_2', \Newspack\Subscriptions_Tiers::get_frequency( $product ) );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -560,4 +560,41 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 			\Newspack\Subscriptions_Tiers::get_frequency_parts( $product )
 		);
 	}
+
+	/**
+	 * The frequency control posts the chosen plan, so APFS can resolve it from
+	 * $_REQUEST. Without this the cart falls back to no plan and the reader is
+	 * charged once instead of subscribing.
+	 */
+	public function test_frequency_control_posts_the_plan_key() {
+		ob_start();
+		\Newspack\Subscriptions_Tiers::render_frequency_control(
+			[ 'month_1', 'year_1' ],
+			'month_1',
+			false,
+			[
+				'month_1' => 'mkey',
+				'year_1'  => 'ykey',
+			],
+			350
+		);
+		$markup = ob_get_clean();
+
+		$this->assertStringContainsString( 'name="convert_to_sub_350"', $markup );
+		$this->assertStringContainsString( 'value="mkey"', $markup );
+		$this->assertStringContainsString( 'value="ykey"', $markup );
+		$this->assertStringContainsString( 'checked', $markup );
+	}
+
+	/**
+	 * Legacy products keep the button control - there is no plan to post.
+	 */
+	public function test_frequency_control_stays_buttons_without_plans() {
+		ob_start();
+		\Newspack\Subscriptions_Tiers::render_frequency_control( [ 'month_1', 'year_1' ], 'month_1' );
+		$markup = ob_get_clean();
+
+		$this->assertStringContainsString( '<button', $markup );
+		$this->assertStringNotContainsString( 'convert_to_sub', $markup );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -1017,13 +1017,21 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 	 * A grouped product's cart item posts its child product's ID, not the
 	 * grouped parent's - so a convert_to_sub keyed on the grouped parent ID
 	 * would never be read by APFS. render_form() must not emit one.
+	 *
+	 * The fixture deliberately mixes a legacy child with a plan-based one: the
+	 * plan-based child is dropped in composition, so a grouped product with
+	 * *only* plan-based children yields no tiers at all and render_form()
+	 * returns before emitting a single byte - against which "the markup
+	 * contains no convert_to_sub" is vacuously true and would pass against
+	 * unimplemented code. The legacy child keeps the form rendering, so the
+	 * assertion has something to bite on.
 	 */
 	public function test_render_form_skips_plan_posting_for_a_grouped_product() {
 		$parent = wc_create_mock_product(
 			[
 				'id'       => 440,
 				'type'     => 'grouped',
-				'children' => [ 441 ],
+				'children' => [ 441, 442 ],
 			]
 		);
 		wc_create_mock_product(
@@ -1037,20 +1045,37 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 				],
 			]
 		);
-		$this->give_plans(
-			441,
+		$plans = [
+			'mkey' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+		];
+		wc_create_mock_product(
 			[
-				'mkey' => [
-					'period'   => 'month',
-					'interval' => 1,
-				],
+				'id'       => 442,
+				'type'     => 'variable',
+				'children' => [ 443 ],
 			]
 		);
+		$this->give_plans( 442, $plans );
+		wc_create_mock_product(
+			[
+				'id'        => 443,
+				'type'      => 'variation',
+				'parent_id' => 442,
+				'price'     => 7,
+			]
+		);
+		$this->give_plans( 443, $plans );
 
 		ob_start();
 		\Newspack\Subscriptions_Tiers::render_form( $parent );
 		$markup = ob_get_clean();
 
+		$this->assertStringContainsString( '<form', $markup, 'Precondition: the legacy child keeps the form rendering.' );
+		$this->assertStringContainsString( 'name="product_id" value="441"', $markup, 'The legacy child is still offered.' );
+		$this->assertStringNotContainsString( 'value="443"', $markup, 'The plan-based child is dropped in composition.' );
 		$this->assertStringNotContainsString( 'convert_to_sub', $markup, 'Grouped products have no single parent ID to post a plan against.' );
 	}
 

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -476,4 +476,39 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 
 		$this->assertSame( 'year_1', $frequency );
 	}
+
+	/**
+	 * Card period and interval follow the stamped plan, not the legacy meta the
+	 * editor stamps on generated variations.
+	 */
+	public function test_frequency_parts_follow_the_plan() {
+		$product = wc_create_mock_product(
+			[
+				'id'   => 340,
+				'type' => 'variable',
+				'meta' => [
+					'_subscription_period'          => 'month',
+					'_subscription_period_interval' => '1',
+				],
+			]
+		);
+		$this->give_plans(
+			340,
+			[
+				'ykey' => [
+					'period'   => 'year',
+					'interval' => 2,
+				],
+			]
+		);
+		WCS_ATT_Product_Schemes::set_subscription_scheme( $product, 'ykey' );
+
+		$this->assertSame(
+			[
+				'period'   => 'year',
+				'interval' => 2,
+			],
+			\Newspack\Subscriptions_Tiers::get_frequency_parts( $product )
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -406,4 +406,74 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 
 		$this->assertSame( 'year_1', $frequency );
 	}
+
+	/**
+	 * A subscription created back when the site ran the standalone All
+	 * Products for Subscriptions plugin (pre-WCS-9.0) carries the APFS-v1
+	 * meta key `_wcsatt_scheme_id`, not the current `_wcsatt_scheme`. The
+	 * scheme lookup must still resolve it via `WCS_ATT_Order::get_subscription_scheme()`
+	 * rather than reading `_wcsatt_scheme` directly, or these are exactly the
+	 * publishers most likely to have plan-based products - the ones who were
+	 * early on APFS - and they'd silently drop to the weaker billing-period
+	 * fallback instead.
+	 */
+	public function test_get_current_tier_resolves_the_v1_scheme_key() {
+		$user_id = self::factory()->user->create();
+
+		$plans = [
+			'mkey' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+			'ykey' => [
+				'period'   => 'year',
+				'interval' => 1,
+			],
+		];
+
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 370,
+				'type'     => 'variable',
+				'children' => [ 371 ],
+			]
+		);
+		$this->give_plans( 370, $plans );
+		wc_create_mock_product(
+			[
+				'id'        => 371,
+				'type'      => 'variation',
+				'parent_id' => 370,
+			]
+		);
+		$this->give_plans( 371, $plans );
+
+		$tiers = \Newspack\Subscriptions_Tiers::get_tiers_by_frequency( $parent );
+		$this->assertSame( [ 'month_1', 'year_1' ], array_keys( $tiers ), 'Precondition: both buckets exist.' );
+
+		// The v1 key, no `_wcsatt_scheme` present - and a billing period/interval
+		// that would itself resolve to the *wrong* bucket if the v1 key weren't
+		// read, proving the scheme-key path (not the fallback) is what matched.
+		$item = new WC_Order_Item_Product(
+			[
+				'id'         => 901,
+				'product_id' => 371,
+				'meta'       => [ '_wcsatt_scheme_id' => 'ykey' ],
+			]
+		);
+		wcs_create_subscription(
+			[
+				'customer_id'      => $user_id,
+				'status'           => 'active',
+				'products'         => [ 371 ],
+				'items'            => [ $item ],
+				'billing_period'   => 'month',
+				'billing_interval' => 1,
+			]
+		);
+
+		[ $frequency ] = \Newspack\Subscriptions_Tiers::get_current_tier( $tiers, $user_id );
+
+		$this->assertSame( 'year_1', $frequency );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -511,4 +511,53 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 			\Newspack\Subscriptions_Tiers::get_frequency_parts( $product )
 		);
 	}
+
+	/**
+	 * Without a stamped plan, get_frequency_parts() falls back to legacy meta.
+	 */
+	public function test_frequency_parts_falls_back_to_legacy_meta() {
+		$product = wc_create_mock_product(
+			[
+				'id'   => 411,
+				'type' => 'subscription',
+				'meta' => [
+					'_subscription_period'          => 'week',
+					'_subscription_period_interval' => '2',
+				],
+			]
+		);
+
+		$this->assertSame(
+			[
+				'period'   => 'week',
+				'interval' => 2,
+			],
+			\Newspack\Subscriptions_Tiers::get_frequency_parts( $product )
+		);
+	}
+
+	/**
+	 * When legacy meta is absent, get_frequency_parts() floors the interval at 1,
+	 * preventing division-by-zero errors in render_nyp_product_card().
+	 */
+	public function test_frequency_parts_floors_absent_interval_at_one() {
+		$product = wc_create_mock_product(
+			[
+				'id'   => 412,
+				'type' => 'subscription',
+				'meta' => [
+					'_subscription_period' => 'month',
+					// No _subscription_period_interval meta.
+				],
+			]
+		);
+
+		$this->assertSame(
+			[
+				'period'   => 'month',
+				'interval' => 1,
+			],
+			\Newspack\Subscriptions_Tiers::get_frequency_parts( $product )
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -1,0 +1,91 @@
+<?php
+/**
+ * Tests tier composition under the APFS subscription-plan product model.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_Subscriptions;
+
+require_once __DIR__ . '/../../../mocks/wc-mocks.php';
+
+/**
+ * Test tiers under the subscription-plan product model.
+ *
+ * @group WooCommerce_Subscriptions_Integration
+ */
+class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
+	/**
+	 * Reset mock state before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $products_database;
+		$products_database                              = [];
+		WCS_ATT_Product_Schemes::$products_with_schemes = [];
+		WCS_ATT_Product_Schemes::$product_schemes       = [];
+	}
+
+	/**
+	 * Reset mock state after each test.
+	 */
+	public function tear_down() {
+		WCS_ATT_Product_Schemes::$products_with_schemes = [];
+		WCS_ATT_Product_Schemes::$product_schemes       = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * Register a product with the given plans in the mock scheme registry.
+	 *
+	 * @param int   $id    Product ID.
+	 * @param array $plans [ scheme_key => [ 'period' => string, 'interval' => int ] ].
+	 */
+	protected function give_plans( $id, $plans ) {
+		WCS_ATT_Product_Schemes::$products_with_schemes[] = $id;
+		WCS_ATT_Product_Schemes::$product_schemes[ $id ]  = $plans;
+	}
+
+	/**
+	 * A product's plans come back keyed by scheme key.
+	 */
+	public function test_get_subscription_plans_returns_schemes() {
+		$product = wc_create_mock_product(
+			[
+				'id'   => 300,
+				'type' => 'variable',
+			]
+		);
+		$this->give_plans(
+			300,
+			[
+				'mkey' => [
+					'period'   => 'month',
+					'interval' => 1,
+				],
+				'ykey' => [
+					'period'   => 'year',
+					'interval' => 1,
+				],
+			]
+		);
+
+		$plans = WooCommerce_Subscriptions::get_subscription_plans( $product );
+		$this->assertEquals( [ 'mkey', 'ykey' ], array_keys( $plans ) );
+		$this->assertSame( 'month_1', WooCommerce_Subscriptions::get_plan_frequency( $plans['mkey'] ) );
+		$this->assertSame( 'year_1', WooCommerce_Subscriptions::get_plan_frequency( $plans['ykey'] ) );
+	}
+
+	/**
+	 * A product with no plans returns an empty array, not a warning.
+	 */
+	public function test_get_subscription_plans_without_plans() {
+		$product = wc_create_mock_product(
+			[
+				'id'   => 301,
+				'type' => 'variable',
+			]
+		);
+		$this->assertSame( [], WooCommerce_Subscriptions::get_subscription_plans( $product ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-plans.php
@@ -20,10 +20,15 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 	 */
 	public function set_up() {
 		parent::set_up();
-		global $products_database;
+		global $products_database, $subscriptions_database;
 		$products_database                              = [];
+		$subscriptions_database                          = [];
 		WCS_ATT_Product_Schemes::$products_with_schemes = [];
 		WCS_ATT_Product_Schemes::$product_schemes       = [];
+		// spl_object_id() is recycled once a clone is freed, so a stale plan key
+		// from a previous test's clone can otherwise leak onto an unrelated
+		// object in this one.
+		WCS_ATT_Product_Schemes::$active_schemes = [];
 	}
 
 	/**
@@ -32,6 +37,7 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 	public function tear_down() {
 		WCS_ATT_Product_Schemes::$products_with_schemes = [];
 		WCS_ATT_Product_Schemes::$product_schemes       = [];
+		WCS_ATT_Product_Schemes::$active_schemes         = [];
 		parent::tear_down();
 	}
 
@@ -231,5 +237,173 @@ class Newspack_Test_Subscriptions_Tiers_Plans extends WP_UnitTestCase {
 		foreach ( $tiers as $products ) {
 			$this->assertCount( 1, $products );
 		}
+	}
+
+	/**
+	 * A legacy `variable-subscription` product (no plans) must produce exactly
+	 * the buckets it produced before NPPM-3053: one bucket keyed by the legacy
+	 * period/interval, the same product IDs, in the same order. This pins the
+	 * "expansion is additive, legacy flow unperturbed" constraint in CI —
+	 * previously only exercised manually against a live fixture.
+	 */
+	public function test_legacy_variable_subscription_product_is_unchanged() {
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 340,
+				'type'     => 'variable-subscription',
+				'children' => [ 341, 342 ],
+			]
+		);
+		foreach ( [ 341, 342 ] as $vid ) {
+			wc_create_mock_product(
+				[
+					'id'        => $vid,
+					'type'      => 'variation',
+					'parent_id' => 340,
+					'meta'      => [
+						'_subscription_period'          => 'month',
+						'_subscription_period_interval' => '1',
+					],
+				]
+			);
+		}
+
+		$tiers = \Newspack\Subscriptions_Tiers::get_tiers_by_frequency( $parent );
+
+		$this->assertSame( [ 'month_1' ], array_keys( $tiers ) );
+		$this->assertSame(
+			[ 341, 342 ],
+			array_map(
+				function ( $p ) {
+					return $p->get_id();
+				},
+				$tiers['month_1']
+			)
+		);
+	}
+
+	/**
+	 * NPPM-3053 regression for get_current_tier(): under the plan model the
+	 * same variation ID is stamped into every plan's bucket
+	 * (get_tiers_by_frequency()'s expansion), so ID-only matching resolved an
+	 * annual subscriber to whichever bucket happened to be checked first
+	 * (`month_1`). A reader on the annual plan must resolve to `year_1`.
+	 */
+	public function test_get_current_tier_matches_the_subscribed_plan() {
+		$user_id = self::factory()->user->create();
+
+		$plans = [
+			'mkey' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+			'ykey' => [
+				'period'   => 'year',
+				'interval' => 1,
+			],
+		];
+
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 350,
+				'type'     => 'variable',
+				'children' => [ 351 ],
+			]
+		);
+		$this->give_plans( 350, $plans );
+		wc_create_mock_product(
+			[
+				'id'        => 351,
+				'type'      => 'variation',
+				'parent_id' => 350,
+			]
+		);
+		$this->give_plans( 351, $plans );
+
+		$tiers = \Newspack\Subscriptions_Tiers::get_tiers_by_frequency( $parent );
+		$this->assertSame( [ 'month_1', 'year_1' ], array_keys( $tiers ), 'Precondition: both buckets exist.' );
+
+		// The reader's subscription holds variation 351, checked out on the
+		// annual scheme - `_wcsatt_scheme` is the order item meta APFS records
+		// at checkout.
+		$item = new WC_Order_Item_Product(
+			[
+				'id'         => 900,
+				'product_id' => 351,
+				'meta'       => [ '_wcsatt_scheme' => 'ykey' ],
+			]
+		);
+		wcs_create_subscription(
+			[
+				'customer_id'      => $user_id,
+				'status'           => 'active',
+				'products'         => [ 351 ],
+				'items'            => [ $item ],
+				'billing_period'   => 'year',
+				'billing_interval' => 1,
+			]
+		);
+
+		[ $frequency, $product, $subscription ] = \Newspack\Subscriptions_Tiers::get_current_tier( $tiers, $user_id );
+
+		$this->assertSame( 'year_1', $frequency );
+		$this->assertNotNull( $product );
+		$this->assertNotNull( $subscription );
+	}
+
+	/**
+	 * The get_current_tier() fallback path: when the subscription's line item
+	 * carries no resolvable scheme key, the match falls back to comparing
+	 * billing period/interval against the bucket's frequency - still enough
+	 * to tell the annual bucket from the monthly one.
+	 */
+	public function test_get_current_tier_falls_back_to_billing_period_without_a_scheme_key() {
+		$user_id = self::factory()->user->create();
+
+		$plans = [
+			'mkey' => [
+				'period'   => 'month',
+				'interval' => 1,
+			],
+			'ykey' => [
+				'period'   => 'year',
+				'interval' => 1,
+			],
+		];
+
+		$parent = wc_create_mock_product(
+			[
+				'id'       => 360,
+				'type'     => 'variable',
+				'children' => [ 361 ],
+			]
+		);
+		$this->give_plans( 360, $plans );
+		wc_create_mock_product(
+			[
+				'id'        => 361,
+				'type'      => 'variation',
+				'parent_id' => 360,
+			]
+		);
+		$this->give_plans( 361, $plans );
+
+		$tiers = \Newspack\Subscriptions_Tiers::get_tiers_by_frequency( $parent );
+
+		// No item, so no `_wcsatt_scheme` to resolve - only the billing
+		// period/interval on the subscription itself.
+		wcs_create_subscription(
+			[
+				'customer_id'      => $user_id,
+				'status'           => 'active',
+				'products'         => [ 361 ],
+				'billing_period'   => 'year',
+				'billing_interval' => 1,
+			]
+		);
+
+		[ $frequency ] = \Newspack\Subscriptions_Tiers::get_current_tier( $tiers, $user_id );
+
+		$this->assertSame( 'year_1', $frequency );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-product-models.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-subscriptions-tiers-product-models.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Tests that Subscriptions_Tiers recognises both subscription product models.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Subscriptions_Tiers;
+
+require_once __DIR__ . '/../../../mocks/wc-mocks.php';
+
+/**
+ * Test Subscriptions_Tiers product-model detection.
+ *
+ * Subscriptions 9.0 folded All Products for Subscriptions into core, so a
+ * recurring product is no longer necessarily of the `subscription` /
+ * `variable-subscription` type — an ordinary `variable` product carrying
+ * subscription plans is now what the product editor produces. Tiers have to
+ * recognise both, or the variation modal renders empty (NPPM-3053).
+ *
+ * @group WooCommerce_Subscriptions_Integration
+ */
+class Newspack_Test_Subscriptions_Tiers_Product_Models extends WP_UnitTestCase {
+	/**
+	 * Reset the mock databases and scheme registry before each test.
+	 */
+	public function set_up() {
+		parent::set_up();
+		global $products_database;
+		$products_database = [];
+		WCS_ATT_Product_Schemes::$products_with_schemes = [];
+	}
+
+	/**
+	 * Reset the scheme registry after each test.
+	 */
+	public function tear_down() {
+		WCS_ATT_Product_Schemes::$products_with_schemes = [];
+		parent::tear_down();
+	}
+
+	/**
+	 * Build a mock product.
+	 *
+	 * @param int    $id      Product ID.
+	 * @param string $type    Product type.
+	 * @param array  $meta    Product meta.
+	 *
+	 * @return \WC_Product
+	 */
+	private function make_product( $id, $type, $meta = [] ) {
+		return wc_create_mock_product(
+			[
+				'id'   => $id,
+				'type' => $type,
+				'meta' => $meta,
+			]
+		);
+	}
+
+	/**
+	 * The legacy `subscription` product type is still a subscription.
+	 */
+	public function test_legacy_subscription_type_is_a_subscription() {
+		$product = $this->make_product( 201, 'subscription' );
+		$this->assertTrue( Subscriptions_Tiers::is_subscription_product( $product ) );
+		$this->assertFalse( Subscriptions_Tiers::is_variable_subscription_product( $product ) );
+	}
+
+	/**
+	 * The legacy `variable-subscription` type is a variable subscription.
+	 */
+	public function test_legacy_variable_subscription_type_is_variable() {
+		$product = $this->make_product( 202, 'variable-subscription' );
+		$this->assertTrue( Subscriptions_Tiers::is_subscription_product( $product ) );
+		$this->assertTrue( Subscriptions_Tiers::is_variable_subscription_product( $product ) );
+	}
+
+	/**
+	 * A plain product with no subscription plans is not a subscription.
+	 */
+	public function test_plain_product_is_not_a_subscription() {
+		$simple   = $this->make_product( 203, 'simple' );
+		$variable = $this->make_product( 204, 'variable' );
+		$this->assertFalse( Subscriptions_Tiers::is_subscription_product( $simple ) );
+		$this->assertFalse( Subscriptions_Tiers::is_subscription_product( $variable ) );
+		$this->assertFalse( Subscriptions_Tiers::is_variable_subscription_product( $variable ) );
+	}
+
+	/**
+	 * A `variable` product carrying subscription plans is a variable subscription.
+	 *
+	 * This is the NPPM-3053 regression: without it the variation modal renders
+	 * its header and an empty body.
+	 */
+	public function test_variable_product_with_plans_is_a_variable_subscription() {
+		$product = $this->make_product( 205, 'variable' );
+		WCS_ATT_Product_Schemes::$products_with_schemes = [ 205 ];
+
+		$this->assertTrue( Subscriptions_Tiers::has_subscription_plans( $product ) );
+		$this->assertTrue( Subscriptions_Tiers::is_subscription_product( $product ) );
+		$this->assertTrue( Subscriptions_Tiers::is_variable_subscription_product( $product ) );
+	}
+
+	/**
+	 * A `simple` product carrying subscription plans is a subscription, but is
+	 * not variable — its tier is the product itself, not its variations.
+	 */
+	public function test_simple_product_with_plans_is_a_non_variable_subscription() {
+		$product = $this->make_product( 206, 'simple' );
+		WCS_ATT_Product_Schemes::$products_with_schemes = [ 206 ];
+
+		$this->assertTrue( Subscriptions_Tiers::is_subscription_product( $product ) );
+		$this->assertFalse( Subscriptions_Tiers::is_variable_subscription_product( $product ) );
+	}
+
+	/**
+	 * The `_wcsatt_disabled` opt-out wins over the presence of schemes, matching
+	 * the check Subscriptions itself makes.
+	 */
+	public function test_disabled_meta_opts_out_of_subscription_plans() {
+		$product = $this->make_product( 207, 'variable', [ '_wcsatt_disabled' => 'yes' ] );
+		WCS_ATT_Product_Schemes::$products_with_schemes = [ 207 ];
+
+		$this->assertFalse( Subscriptions_Tiers::has_subscription_plans( $product ) );
+		$this->assertFalse( Subscriptions_Tiers::is_subscription_product( $product ) );
+		$this->assertFalse( Subscriptions_Tiers::is_variable_subscription_product( $product ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-apfs-absent.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-apfs-absent.php
@@ -1,0 +1,43 @@
+<?php
+/**
+ * Tests the product-model predicates on a site without the APFS API.
+ *
+ * Deliberately does NOT require wc-mocks.php: that file defines the
+ * WCS_ATT_Product_Schemes stub unconditionally, which would mask the guard this
+ * covers. Runs in a separate process so no other test file's require leaks in.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\WooCommerce_Subscriptions;
+
+/**
+ * Test the pre-9.0 guard.
+ *
+ * @group WooCommerce_Subscriptions_Integration
+ * @runTestsInSeparateProcesses
+ * @preserveGlobalState disabled
+ */
+class Newspack_Test_WooCommerce_Subscriptions_APFS_Absent extends WP_UnitTestCase {
+	/**
+	 * Without the APFS API, no product carries subscription plans and the legacy
+	 * type check is the only thing that decides.
+	 */
+	public function test_plans_are_absent_without_the_apfs_api() {
+		$this->assertFalse(
+			class_exists( 'WCS_ATT_Product_Schemes' ),
+			'This test is meaningless if the APFS stub has leaked into the process.'
+		);
+
+		$product = $this->getMockBuilder( 'stdClass' )
+			->addMethods( [ 'get_meta', 'get_type', 'is_type' ] )
+			->getMock();
+		$product->method( 'get_meta' )->willReturn( '' );
+		$product->method( 'get_type' )->willReturn( 'simple' );
+		$product->method( 'is_type' )->willReturn( false );
+
+		$this->assertFalse( WooCommerce_Subscriptions::has_subscription_plans( $product ) );
+		$this->assertFalse( WooCommerce_Subscriptions::is_subscription_product( $product ) );
+		$this->assertSame( [], WooCommerce_Subscriptions::get_subscription_plans( $product ) );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-product-models.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-product-models.php
@@ -115,6 +115,27 @@ class Newspack_Test_WooCommerce_Subscriptions_Product_Models extends WP_UnitTest
 	}
 
 	/**
+	 * A legacy-typed product never takes the plan path, whatever the scheme
+	 * registry says about it.
+	 *
+	 * The two product models are mutually exclusive, and APFS's own
+	 * `supports_feature()` excludes the legacy types — so on a real store a
+	 * `variable-subscription` product reports no schemes even with storewide
+	 * plans configured. This pins that as a contract rather than an APFS
+	 * implementation detail: were it ever to change, the plan path would start
+	 * rewriting the frequency, price and cart key of every legacy subscription
+	 * product on the site.
+	 */
+	public function test_legacy_types_never_take_the_plan_path() {
+		foreach ( [ 'subscription', 'variable-subscription' ] as $i => $type ) {
+			$product = $this->make_product( 208 + $i, $type );
+			WCS_ATT_Product_Schemes::$products_with_schemes[] = 208 + $i;
+
+			$this->assertFalse( WooCommerce_Subscriptions::has_subscription_plans( $product ), $type . ' must not report subscription plans.' );
+		}
+	}
+
+	/**
 	 * The `_wcsatt_disabled` opt-out wins over the presence of schemes, matching
 	 * the check Subscriptions itself makes.
 	 */

--- a/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-product-models.php
+++ b/plugins/newspack-plugin/tests/unit-tests/plugins/woocommerce-subscriptions/class-woocommerce-subscriptions-product-models.php
@@ -1,16 +1,16 @@
 <?php
 /**
- * Tests that Subscriptions_Tiers recognises both subscription product models.
+ * Tests that WooCommerce_Subscriptions recognises both subscription product models.
  *
  * @package Newspack\Tests
  */
 
-use Newspack\Subscriptions_Tiers;
+use Newspack\WooCommerce_Subscriptions;
 
 require_once __DIR__ . '/../../../mocks/wc-mocks.php';
 
 /**
- * Test Subscriptions_Tiers product-model detection.
+ * Test WooCommerce_Subscriptions product-model detection.
  *
  * Subscriptions 9.0 folded All Products for Subscriptions into core, so a
  * recurring product is no longer necessarily of the `subscription` /
@@ -20,7 +20,7 @@ require_once __DIR__ . '/../../../mocks/wc-mocks.php';
  *
  * @group WooCommerce_Subscriptions_Integration
  */
-class Newspack_Test_Subscriptions_Tiers_Product_Models extends WP_UnitTestCase {
+class Newspack_Test_WooCommerce_Subscriptions_Product_Models extends WP_UnitTestCase {
 	/**
 	 * Reset the mock databases and scheme registry before each test.
 	 */
@@ -63,8 +63,8 @@ class Newspack_Test_Subscriptions_Tiers_Product_Models extends WP_UnitTestCase {
 	 */
 	public function test_legacy_subscription_type_is_a_subscription() {
 		$product = $this->make_product( 201, 'subscription' );
-		$this->assertTrue( Subscriptions_Tiers::is_subscription_product( $product ) );
-		$this->assertFalse( Subscriptions_Tiers::is_variable_subscription_product( $product ) );
+		$this->assertTrue( WooCommerce_Subscriptions::is_subscription_product( $product ) );
+		$this->assertFalse( WooCommerce_Subscriptions::is_variable_subscription_product( $product ) );
 	}
 
 	/**
@@ -72,8 +72,8 @@ class Newspack_Test_Subscriptions_Tiers_Product_Models extends WP_UnitTestCase {
 	 */
 	public function test_legacy_variable_subscription_type_is_variable() {
 		$product = $this->make_product( 202, 'variable-subscription' );
-		$this->assertTrue( Subscriptions_Tiers::is_subscription_product( $product ) );
-		$this->assertTrue( Subscriptions_Tiers::is_variable_subscription_product( $product ) );
+		$this->assertTrue( WooCommerce_Subscriptions::is_subscription_product( $product ) );
+		$this->assertTrue( WooCommerce_Subscriptions::is_variable_subscription_product( $product ) );
 	}
 
 	/**
@@ -82,9 +82,9 @@ class Newspack_Test_Subscriptions_Tiers_Product_Models extends WP_UnitTestCase {
 	public function test_plain_product_is_not_a_subscription() {
 		$simple   = $this->make_product( 203, 'simple' );
 		$variable = $this->make_product( 204, 'variable' );
-		$this->assertFalse( Subscriptions_Tiers::is_subscription_product( $simple ) );
-		$this->assertFalse( Subscriptions_Tiers::is_subscription_product( $variable ) );
-		$this->assertFalse( Subscriptions_Tiers::is_variable_subscription_product( $variable ) );
+		$this->assertFalse( WooCommerce_Subscriptions::is_subscription_product( $simple ) );
+		$this->assertFalse( WooCommerce_Subscriptions::is_subscription_product( $variable ) );
+		$this->assertFalse( WooCommerce_Subscriptions::is_variable_subscription_product( $variable ) );
 	}
 
 	/**
@@ -97,9 +97,9 @@ class Newspack_Test_Subscriptions_Tiers_Product_Models extends WP_UnitTestCase {
 		$product = $this->make_product( 205, 'variable' );
 		WCS_ATT_Product_Schemes::$products_with_schemes = [ 205 ];
 
-		$this->assertTrue( Subscriptions_Tiers::has_subscription_plans( $product ) );
-		$this->assertTrue( Subscriptions_Tiers::is_subscription_product( $product ) );
-		$this->assertTrue( Subscriptions_Tiers::is_variable_subscription_product( $product ) );
+		$this->assertTrue( WooCommerce_Subscriptions::has_subscription_plans( $product ) );
+		$this->assertTrue( WooCommerce_Subscriptions::is_subscription_product( $product ) );
+		$this->assertTrue( WooCommerce_Subscriptions::is_variable_subscription_product( $product ) );
 	}
 
 	/**
@@ -110,8 +110,8 @@ class Newspack_Test_Subscriptions_Tiers_Product_Models extends WP_UnitTestCase {
 		$product = $this->make_product( 206, 'simple' );
 		WCS_ATT_Product_Schemes::$products_with_schemes = [ 206 ];
 
-		$this->assertTrue( Subscriptions_Tiers::is_subscription_product( $product ) );
-		$this->assertFalse( Subscriptions_Tiers::is_variable_subscription_product( $product ) );
+		$this->assertTrue( WooCommerce_Subscriptions::is_subscription_product( $product ) );
+		$this->assertFalse( WooCommerce_Subscriptions::is_variable_subscription_product( $product ) );
 	}
 
 	/**
@@ -122,8 +122,8 @@ class Newspack_Test_Subscriptions_Tiers_Product_Models extends WP_UnitTestCase {
 		$product = $this->make_product( 207, 'variable', [ '_wcsatt_disabled' => 'yes' ] );
 		WCS_ATT_Product_Schemes::$products_with_schemes = [ 207 ];
 
-		$this->assertFalse( Subscriptions_Tiers::has_subscription_plans( $product ) );
-		$this->assertFalse( Subscriptions_Tiers::is_subscription_product( $product ) );
-		$this->assertFalse( Subscriptions_Tiers::is_variable_subscription_product( $product ) );
+		$this->assertFalse( WooCommerce_Subscriptions::has_subscription_plans( $product ) );
+		$this->assertFalse( WooCommerce_Subscriptions::is_subscription_product( $product ) );
+		$this->assertFalse( WooCommerce_Subscriptions::is_variable_subscription_product( $product ) );
 	}
 }


### PR DESCRIPTION
> [!IMPORTANT]
> **Retargeted to `main`.** This started as a hotfix against `release`, but grew well past patch scope once review found that the code downstream of the original fix was still written for the legacy product model. The narrow, genuinely patch-sized piece was split out into #819. This PR now takes the normal route through `main`.

## Why

WooCommerce Subscriptions 9.0 folded All Products for Subscriptions into core. A recurring product no longer has to use the dedicated `subscription` / `variable-subscription` product types — the product editor now creates an ordinary `simple` or `variable` product with **subscription plans** (APFS schemes) attached.

`Subscriptions_Tiers` only understood the legacy types, so a variable subscription built the new way produced **no tiers at all**: the modal rendered its header above an empty body.

Fixing the recognition turned out to be the easy half. Everything downstream of that gate — frequency, price, what the form posts — was written when one product meant one frequency, and none of it had been taught otherwise. Review (thanks @wil-gerken) found two blockers, and building the fix surfaced three more.

## The model

**Frequency = plan, tier = variation.** The form already renders a frequency segmented control with tier cards beneath it, which is exactly the shape APFS implies: under the legacy model variations *are* the frequency axis, but under plans the frequency is the plan and variations are orthogonal to it. A product with 3 variations and 2 plans is 6 purchase options; the old code emitted 3.

So a plan-based product now renders as a Monthly/Annual toggle over its price tiers — what the legacy model produced, and what publishers expect.

## What changed

**Tier composition.** `get_tiers_by_frequency()` emits one frequency bucket per plan, each holding the variations cloned and stamped with that plan. Because APFS filters `woocommerce_product_variation_get_price` off the active plan, each instance prices itself — there is no pricing code here at all. Two plans sharing a period and interval get separate buckets rather than merging, so a configured plan can never silently vanish.

**Frequency and price come from the plan.** `get_frequency()` and a new `get_frequency_parts()` read the stamped plan instead of `_subscription_period`, which APFS never persists. Where that meta was absent the card rendered the literal string `$10.00 every Array`; where it held the hardcoded `'month'` that `WC_Subscriptions_Admin::set_variation_meta_defaults_on_bulk_add()` writes onto every generated variation, an annual plan rendered as `/ month`.

**The form posts the chosen plan.** The frequency control renders as radios named `convert_to_sub_<parent_id>`, which is where APFS reads the plan from. Without it, `get_default_subscription_scheme()` returns `false` and the reader is **charged once with no subscription created**. Single-plan products, which never render the control, emit a hidden input instead.

**`get_current_tier()` matches on the plan too**, not the product alone — otherwise an annual subscriber resolved to the monthly bucket, giving the wrong "Current" badge, the wrong preselection, and a re-purchase guard pointed at the wrong plan.

**Grouped products with plan-based children yield no tiers**, restoring `release` behaviour. A grouped parent cannot carry the per-child plan key APFS needs, so anything we rendered there would take a one-time payment.

Also: the product-model predicates moved onto `WooCommerce_Subscriptions` rather than living on `Subscriptions_Tiers` (see [the thread with @leogermani](https://github.com/Automattic/newspack-workspace/pull/801#issuecomment-5194227263) for why none of the existing WCS helpers could be reused), the pre-9.0 guard gained the test it never had, and a deleted grouped child no longer fatals.

## Testing

- **2724 tests, 7806 assertions, 0 failures** on the full suite after rebasing onto `main`; 246 in the `WooCommerce_Subscriptions_Integration` group. PHPCS clean on all six changed PHP files.
- **Live, on a Subscriptions 9.0.1 site**, across four fixtures — two plans with legacy meta, two plans without, a single-plan product, and a legacy control:

```
#194  two plans          month_1  subscription=true  billing=month/1  PASS
                         year_1   subscription=true  billing=year/1   PASS
#205  no legacy meta     month_1/year_1                               PASS
#216  single plan        month_1  subscription=true  billing=month/1  PASS
#209  legacy control     month_1  subscription=true  billing=month/1  PASS
```

The legacy control is the canary: it renders identically to `release` and emits no `convert_to_sub` anywhere.

Plan-specific pricing was verified separately, since the first fixture could not show it — both its plans inherited the store price with no discount, so every check passed while blind to whether per-plan pricing worked at all. With a 20% annual discount the same variation prices itself differently per plan, in the card **and** in the cart line item.

## Known limitations

- Two plans sharing a period and interval render two tabs both labelled e.g. "Monthly". Both stay reachable, which is the point; distinguishing them needs a plan name the frequency key does not carry.
- `render_product_card()`'s price call site is not exercised by the suite — `wcs_price_string()` has no stub and the code is `function_exists()`-guarded. Verified live instead. A stub would close it cheaply later.
- `get_frequency_parts()` duplicates the plan-walk in `get_frequency()`; the two could drift.
- **APFS discounts only reduce.** The familiar "$10/month or $100/year" cannot be expressed as plans on a $10 base — the base price is what is charged per plan period, and plans differ by cadence plus an optional discount. A publisher wanting annual at roughly 10× monthly must set the base to the annual figure and discount the monthly plan, or use an override price and lose per-tier pricing. That is WooCommerce's model rather than anything introduced here, but it shapes how useful plan-based products are for selling tiers.

## Follow-up, not this PR

`get_tier_eligible_products()` still defaults to the legacy product types, so plan-based products never appear in the Audience wizard's dropdown. Only the wizard-configured upgrade route is affected — the on-page modal and `?tiers-modal=<id>` already reach these products.

Worth folding two existing helpers into that work rather than leaving three parallel implementations: `Audience_Subscription_Products::group_has_subscription_children()` duplicates the grouped-child logic in `get_tier_eligible_products()`, and `Product_Network_Ids::is_taggable_product()` in newspack-network is the same predicate under a different name. The legacy type check is currently written inline 24 times across 10 files in three plugins.

Refs NPPM-3053.
