### PR TITLE
fix(content-gate): enforce block visibility on REST reads

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
@@ -53,10 +53,17 @@ class Block_Visibility {
 			return $block_content;
 		}
 
-		// Bypass access control in admin screens and REST requests (block renderer,
-		// preview, query-loop rendering inside the editor) so blocks are never hidden
-		// from editors during content authoring.
-		if ( is_admin() || ( defined( 'REST_REQUEST' ) && REST_REQUEST ) ) {
+		// Bypass access control in admin screens so blocks are never hidden from
+		// editors during content authoring.
+		//
+		// REST requests are deliberately NOT bypassed here. Core serves
+		// `content.rendered` for published posts to any unauthenticated caller, so a
+		// blanket REST exemption makes every gated block readable by requesting the
+		// post through the API instead of loading the page. Authoring contexts that
+		// arrive over REST (block renderer, preview, query-loop rendering inside the
+		// editor) are covered by the `edit_post` capability check further down, which
+		// passes for the editor and fails for everyone else.
+		if ( is_admin() ) {
 			return $block_content;
 		}
 


### PR DESCRIPTION
Removes the blanket REST exemption from `Block_Visibility::filter_render_block()`, so per-block access control is evaluated on REST reads the same way it already is on the front end.

The exemption existed so gated blocks stay visible to editors while authoring — block renderer, preview, query-loop rendering inside the editor. That case is already handled further down the same function by the `edit_post` capability check, which returns early for anyone who can edit the post being rendered. Adding a second capability check to the REST branch would have duplicated that check 40 lines apart and invited a later cleanup to remove the wrong copy, so the clause comes out instead and the comment records why REST is deliberately not exempt.

Verified in an isolated env on this branch, logged out and with the page cache bypassed: front-end behaviour is unchanged and REST responses now match it. Checked separately that the block editor still renders gated blocks for a user who can edit the post.

`phpcs` clean against the root ruleset. No test covers this filter today; a regression test asserting that an unauthenticated REST read omits a restricted block is worth adding and is noted on NPPM-3087.

Refs NPPM-3087.
