### PR TITLE
fix(indesign-export): normalize line endings so exports place cleanly

### DIFF
--- a/plugins/newspack-plugin/includes/optional-modules/class-indesign-exporter.php
+++ b/plugins/newspack-plugin/includes/optional-modules/class-indesign-exporter.php
@@ -24,39 +24,6 @@ class InDesign_Exporter {
 	public const MODULE_NAME = 'indesign-export';
 
 	/**
-	 * Option name storing the platform header preference.
-	 *
-	 * Accepts 'auto', 'mac', or 'win'. 'auto' resolves the header at export
-	 * time from the requesting browser's User-Agent.
-	 *
-	 * @var string
-	 */
-	public const PLATFORM_OPTION = 'newspack_indesign_export_platform';
-
-	/**
-	 * Default value for the platform option.
-	 *
-	 * 'win' rather than 'auto': the Tagged Text start tag declares the format of
-	 * the exported file itself — <ASCII-WIN> for CRLF-delimited, <ASCII-MAC> for
-	 * bare-CR — not the operating system running InDesign. The converter joins
-	 * every line with CRLF unconditionally, so <ASCII-WIN> is the only header
-	 * that describes what is actually written. Resolving from the requesting
-	 * browser meant Mac users received files declaring <ASCII-MAC> over CRLF
-	 * bytes, which InDesign imports as literal markup instead of formatting
-	 * (NPPM-3098).
-	 *
-	 * @var string
-	 */
-	public const PLATFORM_DEFAULT = 'win';
-
-	/**
-	 * Allowed values for the platform option.
-	 *
-	 * @var string[]
-	 */
-	public const ALLOWED_PLATFORMS = [ 'auto', 'mac', 'win' ];
-
-	/**
 	 * Option name storing the list of post types whose admin screens get the export action.
 	 *
 	 * @var string
@@ -450,7 +417,6 @@ class InDesign_Exporter {
 	 */
 	private static function export_posts( $post_ids ) {
 		$converter        = new InDesign_Converter();
-		$platform         = self::resolve_platform();
 		$include_captions = ! self::get_exclude_captions_setting();
 		$exported_files   = [];
 
@@ -462,10 +428,7 @@ class InDesign_Exporter {
 
 			$content          = $converter->convert_post(
 				$post,
-				[
-					'platform'         => $platform,
-					'include_captions' => $include_captions,
-				]
+				[ 'include_captions' => $include_captions ]
 			);
 			$filename         = self::generate_filename( $post );
 			$exported_files[] = [
@@ -485,16 +448,6 @@ class InDesign_Exporter {
 	}
 
 	/**
-	 * Get the configured platform setting.
-	 *
-	 * @return string One of 'auto', 'mac', 'win'.
-	 */
-	public static function get_platform_setting() {
-		$value = get_option( self::PLATFORM_OPTION, self::PLATFORM_DEFAULT );
-		return in_array( $value, self::ALLOWED_PLATFORMS, true ) ? $value : self::PLATFORM_DEFAULT;
-	}
-
-	/**
 	 * Whether photo captions should be excluded from exports.
 	 *
 	 * Photo credits are a separate attribution field and are always exported.
@@ -503,62 +456,6 @@ class InDesign_Exporter {
 	 */
 	public static function get_exclude_captions_setting() {
 		return (bool) get_option( self::EXCLUDE_CAPTIONS_OPTION, self::EXCLUDE_CAPTIONS_DEFAULT );
-	}
-
-	/**
-	 * Map a User-Agent string to a platform.
-	 *
-	 * Pure helper extracted so the auto-detect branch of resolve_platform()
-	 * is testable without spoofing $_SERVER globals.
-	 *
-	 * @param string $user_agent User-Agent string to inspect.
-	 * @return string Either 'mac' or 'win'. Empty/non-Mac strings yield 'win'.
-	 */
-	public static function sniff_user_agent_platform( $user_agent ) {
-		return ( false !== stripos( $user_agent, 'Mac' ) || false !== stripos( $user_agent, 'iPad' ) || false !== stripos( $user_agent, 'iPhone' ) ) ? 'mac' : 'win';
-	}
-
-	/**
-	 * Resolve the InDesign Tagged Text header platform for the current export.
-	 *
-	 * Honors the site setting first. When the setting is 'auto', the platform
-	 * is sniffed from the requesting browser's User-Agent — InDesign requires
-	 * the header to match the host OS or markup is rendered literally. A
-	 * non-browser client (WP-CLI, a direct REST call) under 'auto' has no
-	 * User-Agent and therefore resolves to 'win'.
-	 *
-	 * The return value is normalized to exactly 'mac' or 'win' after the filter
-	 * runs, so a callback returning 'auto', null, or any other value degrades to
-	 * 'win' (the converter's default header) rather than an invalid platform.
-	 *
-	 * @return string Either 'mac' or 'win'.
-	 */
-	public static function resolve_platform() {
-		$setting    = self::get_platform_setting();
-		$user_agent = '';
-
-		if ( 'mac' === $setting || 'win' === $setting ) {
-			$platform = $setting;
-		} else {
-			// The export runs from an authenticated admin request (admin-post.php
-			// for a single export, or an edit.php bulk action) that is never cached.
-			// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-			$user_agent = isset( $_SERVER['HTTP_USER_AGENT'] ) ? sanitize_text_field( wp_unslash( $_SERVER['HTTP_USER_AGENT'] ) ) : '';
-			$platform   = self::sniff_user_agent_platform( $user_agent );
-		}
-
-		/**
-		 * Filters the resolved platform for an InDesign export.
-		 *
-		 * @param string $platform   'mac' or 'win'.
-		 * @param string $setting    The stored platform setting ('auto', 'mac', or 'win').
-		 * @param string $user_agent The User-Agent header from the request after
-		 *                           sanitize_text_field() + wp_unslash(), or '' when
-		 *                           not consulted (i.e. setting is not 'auto').
-		 */
-		$platform = apply_filters( 'newspack_indesign_export_platform', $platform, $setting, $user_agent );
-
-		return 'mac' === $platform ? 'mac' : 'win';
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/optional-modules/class-indesign-exporter.php
+++ b/plugins/newspack-plugin/includes/optional-modules/class-indesign-exporter.php
@@ -36,9 +36,18 @@ class InDesign_Exporter {
 	/**
 	 * Default value for the platform option.
 	 *
+	 * 'win' rather than 'auto': the Tagged Text start tag declares the format of
+	 * the exported file itself — <ASCII-WIN> for CRLF-delimited, <ASCII-MAC> for
+	 * bare-CR — not the operating system running InDesign. The converter joins
+	 * every line with CRLF unconditionally, so <ASCII-WIN> is the only header
+	 * that describes what is actually written. Resolving from the requesting
+	 * browser meant Mac users received files declaring <ASCII-MAC> over CRLF
+	 * bytes, which InDesign imports as literal markup instead of formatting
+	 * (NPPM-3098).
+	 *
 	 * @var string
 	 */
-	public const PLATFORM_DEFAULT = 'auto';
+	public const PLATFORM_DEFAULT = 'win';
 
 	/**
 	 * Allowed values for the platform option.

--- a/plugins/newspack-plugin/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/plugins/newspack-plugin/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -137,7 +137,15 @@ class InDesign_Converter {
 		$content_parts[] = $this->process_post_content( $post->post_content, $options );
 		$content_parts[] = $this->process_post_images( $post, $options );
 
-		return implode( self::EOL, array_filter( $content_parts ) );
+		$content = implode( self::EOL, array_filter( $content_parts ) );
+
+		// Final guarantee that the file matches what self::START_TAG declares.
+		// Post content reaches the converter with line endings of every flavor
+		// (pasted copy, imported HTML, serialized blocks), and the conversion
+		// steps above introduce their own. A single stray CR or LF makes part of
+		// the file Mac- or Unix-terminated while the header promises CRLF, and
+		// InDesign then places that stretch as literal markup.
+		return preg_replace( '/\r\n|\r|\n/', self::EOL, $content );
 	}
 
 	/**
@@ -513,7 +521,11 @@ class InDesign_Converter {
 	 * @return string Cleaned content.
 	 */
 	private function clean_whitespace( $content ) {
-		$content = preg_replace( '/\n{2,}/', self::EOL, $content );
+		// Collapse runs of blank lines into a single terminator. The alternation
+		// consumes CRLF as one unit: matching on \n alone would count the LF of a
+		// CRLF pair as a separate break and rewrite it, stranding the CR in front
+		// as a bare Mac-style terminator (NPPM-2813).
+		$content = preg_replace( '/(?:\r\n|\r|\n){2,}/', self::EOL, $content );
 		$content = trim( $content );
 
 		return $content;

--- a/plugins/newspack-plugin/includes/optional-modules/indesign-export/class-indesign-converter.php
+++ b/plugins/newspack-plugin/includes/optional-modules/indesign-export/class-indesign-converter.php
@@ -15,6 +15,33 @@ defined( 'ABSPATH' ) || exit;
 class InDesign_Converter {
 
 	/**
+	 * Tagged Text start tag, written as the first line of every export.
+	 *
+	 * This declares the format of the file itself — not the operating system
+	 * running InDesign, which reads this format on both macOS and Windows.
+	 * ASCII because get_transformed_text() escapes every code point above 127
+	 * to a <0xXXXX> tag, leaving the payload 7-bit; WIN because every line ends
+	 * with self::EOL.
+	 *
+	 * @var string
+	 */
+	private const START_TAG = '<ASCII-WIN>';
+
+	/**
+	 * Line terminator used throughout the exported file.
+	 *
+	 * Must stay consistent with self::START_TAG: <ASCII-WIN> promises InDesign
+	 * that lines end with CRLF, and <ASCII-MAC> would promise a bare CR. When
+	 * the header and the terminators disagree, the leftover byte pushes each
+	 * <pstyle:...> tag off the start of its paragraph and InDesign renders the
+	 * markup as literal text (NPPM-3098). Change one and you must change the
+	 * other.
+	 *
+	 * @var string
+	 */
+	private const EOL = "\r\n";
+
+	/**
 	 * Block types with no print equivalent, excluded from InDesign export by default.
 	 * Filterable via the newspack_indesign_export_excluded_blocks filter.
 	 *
@@ -72,10 +99,6 @@ class InDesign_Converter {
 	 *     @type bool   $include_captions Whether to append photo captions. Photo credits are
 	 *                                    a separate attribution field and are always exported.
 	 *                                    Default true.
-	 *     @type string $platform         Target platform for the tagged-text header.
-	 *                                    'win' emits <ASCII-WIN>, 'mac' emits <ASCII-MAC>.
-	 *                                    InDesign requires the header to match the host OS,
-	 *                                    otherwise markup is rendered literally. Default 'win'.
 	 * }
 	 * @return string|false InDesign Tagged Text content, or false on failure.
 	 */
@@ -89,13 +112,12 @@ class InDesign_Converter {
 			'include_subtitle' => true,
 			'include_byline'   => true,
 			'include_captions' => true,
-			'platform'         => 'win',
 		];
 		$options = wp_parse_args( $options, $default_options );
 
 		$content_parts = [];
 
-		$content_parts[] = 'mac' === $options['platform'] ? '<ASCII-MAC>' : '<ASCII-WIN>';
+		$content_parts[] = self::START_TAG;
 		$content_parts[] = $this->styles['headline'] . $this->get_transformed_text( $post->post_title );
 
 		if ( $options['include_subtitle'] ) {
@@ -115,7 +137,7 @@ class InDesign_Converter {
 		$content_parts[] = $this->process_post_content( $post->post_content, $options );
 		$content_parts[] = $this->process_post_images( $post, $options );
 
-		return implode( "\r\n", array_filter( $content_parts ) );
+		return implode( self::EOL, array_filter( $content_parts ) );
 	}
 
 	/**
@@ -366,7 +388,7 @@ class InDesign_Converter {
 			if ( ! empty( $cite_matches ) ) {
 				$cite = $cite_matches[1];
 				if ( ! empty( $cite ) ) {
-					$quote_content .= "\r\n" . $this->styles['pullquote_name'] . wp_strip_all_tags( $cite );
+					$quote_content .= self::EOL . $this->styles['pullquote_name'] . wp_strip_all_tags( $cite );
 				}
 			}
 
@@ -415,7 +437,7 @@ class InDesign_Converter {
 			'/<(?:div|ol|ul|a|img|figure)[^>]*>/'  => '',
 
 			// Replace paragraphs and remaining lists end tags with line breaks.
-			'/<\/(?:p|ul|ol)[^>]*>/'               => "\r\n",
+			'/<\/(?:p|ul|ol)[^>]*>/'               => self::EOL,
 
 			// Remove all remaining closing tags.
 			'/<\/[^>]*>/'                          => '',
@@ -491,7 +513,7 @@ class InDesign_Converter {
 	 * @return string Cleaned content.
 	 */
 	private function clean_whitespace( $content ) {
-		$content = preg_replace( '/\n{2,}/', "\r\n", $content );
+		$content = preg_replace( '/\n{2,}/', self::EOL, $content );
 		$content = trim( $content );
 
 		return $content;
@@ -584,12 +606,12 @@ class InDesign_Converter {
 				continue;
 			}
 
-			$tag_content .= "\r\n";
+			$tag_content .= self::EOL;
 			if ( $caption ) {
-				$tag_content .= '<pstyle:PhotoCaption>' . $this->get_transformed_text( $caption ) . "\r\n";
+				$tag_content .= '<pstyle:PhotoCaption>' . $this->get_transformed_text( $caption ) . self::EOL;
 			}
 			if ( $credit ) {
-				$tag_content .= '<pstyle:PhotoCredit>' . $this->get_transformed_text( $credit ) . "\r\n";
+				$tag_content .= '<pstyle:PhotoCredit>' . $this->get_transformed_text( $credit ) . self::EOL;
 			}
 		}
 
@@ -600,7 +622,7 @@ class InDesign_Converter {
 			return '';
 		}
 
-		return "\r\n" . $tag_content;
+		return self::EOL . $tag_content;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/newspack/class-print-section.php
+++ b/plugins/newspack-plugin/includes/wizards/newspack/class-print-section.php
@@ -69,7 +69,6 @@ class Print_Section extends Wizard_Section {
 	public function api_get_print_settings() {
 		return [
 			'module_enabled_print'      => Optional_Modules::is_optional_module_active( InDesign_Exporter::MODULE_NAME ),
-			'indesign_platform'         => InDesign_Exporter::get_platform_setting(),
 			'indesign_post_types'       => InDesign_Exporter::get_post_types_setting(),
 			'available_post_types'      => InDesign_Exporter::get_available_post_types(),
 			'indesign_exclude_captions' => InDesign_Exporter::get_exclude_captions_setting(),
@@ -86,12 +85,6 @@ class Print_Section extends Wizard_Section {
 		$module_enabled_print = $request->get_param( 'module_enabled_print' );
 		if ( ! is_bool( $module_enabled_print ) ) {
 			return new \WP_Error( 'invalid_param', __( 'Invalid parameter for module_enabled_print.', 'newspack-plugin' ), [ 'status' => 400 ] );
-		}
-
-		$has_platform_param = $request->has_param( 'indesign_platform' );
-		$platform           = $has_platform_param ? $request->get_param( 'indesign_platform' ) : null;
-		if ( $has_platform_param && ! in_array( $platform, InDesign_Exporter::ALLOWED_PLATFORMS, true ) ) {
-			return new \WP_Error( 'invalid_param', __( 'Invalid parameter for indesign_platform.', 'newspack-plugin' ), [ 'status' => 400 ] );
 		}
 
 		$has_post_types_param = $request->has_param( 'indesign_post_types' );
@@ -130,10 +123,6 @@ class Print_Section extends Wizard_Section {
 			Optional_Modules::deactivate_optional_module( InDesign_Exporter::MODULE_NAME );
 		}
 
-		if ( $has_platform_param ) {
-			update_option( InDesign_Exporter::PLATFORM_OPTION, $platform );
-		}
-
 		if ( $has_post_types_param ) {
 			update_option( InDesign_Exporter::POST_TYPES_OPTION, $post_types );
 		}
@@ -144,7 +133,6 @@ class Print_Section extends Wizard_Section {
 
 		return [
 			'module_enabled_print'      => $module_enabled_print,
-			'indesign_platform'         => InDesign_Exporter::get_platform_setting(),
 			'indesign_post_types'       => InDesign_Exporter::get_post_types_setting(),
 			'available_post_types'      => InDesign_Exporter::get_available_post_types(),
 			'indesign_exclude_captions' => InDesign_Exporter::get_exclude_captions_setting(),

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/print/index.tsx
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/print/index.tsx
@@ -6,7 +6,7 @@
  * WordPress dependencies
  */
 import { __ } from '@wordpress/i18n';
-import { CheckboxControl, Notice, SelectControl } from '@wordpress/components';
+import { CheckboxControl, Notice } from '@wordpress/components';
 import { useEffect, useRef, useState } from '@wordpress/element';
 
 /**
@@ -17,12 +17,6 @@ import WizardSection from '../../../../wizards-section';
 import WizardsActionCard from '../../../../wizards-action-card';
 import useWizardApiFetchToggle from '../../../../hooks/use-wizard-api-fetch-toggle';
 
-const PLATFORM_OPTIONS: { label: string; value: IndesignPlatform }[] = [
-	{ label: __( 'Auto-detect (per export)', 'newspack-plugin' ), value: 'auto' },
-	{ label: __( 'Mac', 'newspack-plugin' ), value: 'mac' },
-	{ label: __( 'Windows', 'newspack-plugin' ), value: 'win' },
-];
-
 // Coalesce a rapid series of post-type checkbox clicks into a single save.
 const POST_TYPES_SAVE_DEBOUNCE_MS = 500;
 
@@ -32,7 +26,6 @@ function Print() {
 		apiNamespace: 'newspack-settings/print',
 		data: {
 			module_enabled_print: false,
-			indesign_platform: 'auto',
 			indesign_post_types: [ 'post' ],
 			available_post_types: [],
 			indesign_exclude_captions: false,
@@ -120,21 +113,6 @@ function Print() {
 			</WizardSection>
 			{ apiData.module_enabled_print && (
 				<>
-					<WizardSection
-						title={ __( 'Header platform', 'newspack-plugin' ) }
-						description={ __(
-							'InDesign requires the export file to declare its host platform on the first line. Choose "Auto-detect" to match the operating system of whoever clicks Export, or pick a specific platform if your team always lays out on the same OS.',
-							'newspack-plugin'
-						) }
-					>
-						<SelectControl
-							label={ __( 'Platform', 'newspack-plugin' ) }
-							value={ apiData.indesign_platform }
-							disabled={ isFetching }
-							options={ PLATFORM_OPTIONS }
-							onChange={ ( value: IndesignPlatform ) => save( { indesign_platform: value } ) }
-						/>
-					</WizardSection>
 					<WizardSection
 						title={ __( 'Available post types', 'newspack-plugin' ) }
 						description={ __(

--- a/plugins/newspack-plugin/src/wizards/newspack/views/settings/types.d.ts
+++ b/plugins/newspack-plugin/src/wizards/newspack/views/settings/types.d.ts
@@ -101,8 +101,6 @@ type JetpackSSOSettings = Partial< {
 } >;
 
 /** Print */
-type IndesignPlatform = 'auto' | 'mac' | 'win';
-
 type IndesignPostTypeOption = {
 	value: string;
 	label: string;
@@ -113,7 +111,6 @@ type IndesignPostTypeOption = {
  */
 type PrintData = {
 	module_enabled_print: boolean;
-	indesign_platform: IndesignPlatform;
 	indesign_post_types: string[];
 	available_post_types: IndesignPostTypeOption[];
 	indesign_exclude_captions: boolean;

--- a/plugins/newspack-plugin/tests/unit-tests/indesign-exporter/class-test-print-section.php
+++ b/plugins/newspack-plugin/tests/unit-tests/indesign-exporter/class-test-print-section.php
@@ -32,7 +32,6 @@ class Test_Print_Section extends WP_UnitTestCase {
 	public function set_up() {
 		parent::set_up();
 		delete_option( Optional_Modules::OPTION_NAME );
-		delete_option( InDesign_Exporter::PLATFORM_OPTION );
 		delete_option( InDesign_Exporter::POST_TYPES_OPTION );
 		delete_option( InDesign_Exporter::EXCLUDE_CAPTIONS_OPTION );
 		$this->section = new Print_Section();
@@ -46,12 +45,10 @@ class Test_Print_Section extends WP_UnitTestCase {
 
 		$this->assertIsArray( $result );
 		$this->assertArrayHasKey( 'module_enabled_print', $result );
-		$this->assertArrayHasKey( 'indesign_platform', $result );
 		$this->assertArrayHasKey( 'indesign_post_types', $result );
 		$this->assertArrayHasKey( 'available_post_types', $result );
 
 		$this->assertFalse( $result['module_enabled_print'] );
-		$this->assertSame( 'win', $result['indesign_platform'] );
 		$this->assertSame( [ 'post' ], $result['indesign_post_types'] );
 		$this->assertIsArray( $result['available_post_types'] );
 	}
@@ -99,36 +96,7 @@ class Test_Print_Section extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that a valid platform value is persisted.
-	 */
-	public function test_api_update_print_settings_persists_platform() {
-		$request = new WP_REST_Request();
-		$request->set_param( 'module_enabled_print', true );
-		$request->set_param( 'indesign_platform', 'mac' );
-
-		$result = $this->section->api_update_print_settings( $request );
-
-		$this->assertSame( 'mac', $result['indesign_platform'] );
-		$this->assertSame( 'mac', get_option( InDesign_Exporter::PLATFORM_OPTION ) );
-	}
-
-	/**
-	 * Test that an invalid platform value is rejected.
-	 */
-	public function test_api_update_print_settings_rejects_invalid_platform() {
-		$request = new WP_REST_Request();
-		$request->set_param( 'module_enabled_print', true );
-		$request->set_param( 'indesign_platform', 'linux' );
-
-		$result = $this->section->api_update_print_settings( $request );
-
-		$this->assertInstanceOf( WP_Error::class, $result );
-		$this->assertSame( 'invalid_param', $result->get_error_code() );
-		$this->assertSame( 400, $result->get_error_data()['status'] );
-	}
-
-	/**
-	 * Test that an invalid platform value does NOT trigger a module toggle.
+	 * Test that an invalid parameter does NOT trigger a module toggle.
 	 *
 	 * Regression test for an earlier bug where the module was activated
 	 * before parameter validation finished.
@@ -138,7 +106,7 @@ class Test_Print_Section extends WP_UnitTestCase {
 
 		$request = new WP_REST_Request();
 		$request->set_param( 'module_enabled_print', true );
-		$request->set_param( 'indesign_platform', 'linux' );
+		$request->set_param( 'indesign_post_types', 'not-an-array' );
 
 		$result = $this->section->api_update_print_settings( $request );
 

--- a/plugins/newspack-plugin/tests/unit-tests/indesign-exporter/class-test-print-section.php
+++ b/plugins/newspack-plugin/tests/unit-tests/indesign-exporter/class-test-print-section.php
@@ -51,7 +51,7 @@ class Test_Print_Section extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'available_post_types', $result );
 
 		$this->assertFalse( $result['module_enabled_print'] );
-		$this->assertSame( 'auto', $result['indesign_platform'] );
+		$this->assertSame( 'win', $result['indesign_platform'] );
 		$this->assertSame( [ 'post' ], $result['indesign_post_types'] );
 		$this->assertIsArray( $result['available_post_types'] );
 	}

--- a/plugins/newspack-plugin/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/plugins/newspack-plugin/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -66,22 +66,47 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the default export declares a header matching the line endings
-	 * it actually writes.
+	 * Content shapes whose conversion has historically produced a line ending
+	 * that disagreed with the declared header.
+	 *
+	 * @return array<string, array{0: string}>
+	 */
+	public function line_ending_content_provider() {
+		return [
+			// Block content: the shape that broke under <ASCII-MAC> (NPPM-3098).
+			'block paragraphs'   => [ "<!-- wp:paragraph -->\n<p>First para.</p>\n<!-- /wp:paragraph -->\n\n<!-- wp:paragraph -->\n<p>Second para.</p>\n<!-- /wp:paragraph -->" ],
+			// Classic content: the shape that broke under <ASCII-WIN> (NPPM-2813).
+			// Newline-separated <p> tags left a bare CR ahead of each CRLF.
+			'classic paragraphs' => [ "<p>Classic one.</p>\n<p>Classic two.</p>\n<p>Classic three.</p>" ],
+			'mixed line endings' => [ "<p>CRLF source.</p>\r\n<p>LF source.</p>\n<p>CR source.</p>\r<p>Last.</p>" ],
+			'blank line runs'    => [ "<p>Before.</p>\n\n\n<p>After.</p>" ],
+			'heading and list'   => [ "<h2>A subhead</h2>\n<ul><li>One</li>\n<li>Two</li></ul>\n<p>Body.</p>" ],
+			'group block'        => [ "<!-- wp:group -->\n<div class=\"wp-block-group\"><!-- wp:paragraph -->\n<p>Inside.</p>\n<!-- /wp:paragraph --></div>\n<!-- /wp:group -->" ],
+			'blockquote'         => [ "<!-- wp:quote -->\n<blockquote class=\"wp-block-quote\"><p>Quoted.</p><cite>Someone</cite></blockquote>\n<!-- /wp:quote -->" ],
+		];
+	}
+
+	/**
+	 * Test that every export is terminated uniformly with CRLF, matching the
+	 * <ASCII-WIN> header it declares.
 	 *
 	 * The tagged-text start tag describes the file, not the machine running
-	 * InDesign: <ASCII-WIN> means CRLF-delimited, <ASCII-MAC> means bare-CR.
-	 * The converter joins every part with CRLF unconditionally, so <ASCII-WIN>
-	 * is the only header that describes the bytes. Declaring <ASCII-MAC> over
-	 * CRLF leaves an orphan LF at the head of each paragraph, which pushes the
-	 * <pstyle:...> tag off the paragraph start and makes InDesign render the
-	 * markup literally (NPPM-3098).
+	 * InDesign: <ASCII-WIN> promises CRLF, <ASCII-MAC> promises bare CR. When
+	 * any stretch of the file disagrees with the header, InDesign stops treating
+	 * the following <pstyle:...> as paragraph-initial and places it as literal
+	 * text. Both reported forms of this bug came from the same cause — a file
+	 * whose line endings varied with the shape of the post content, so classic
+	 * copy needed one header (NPPM-2813) and block copy the other (NPPM-3098).
+	 *
+	 * @dataProvider line_ending_content_provider
+	 *
+	 * @param string $post_content Post content to convert.
 	 */
-	public function test_convert_post_default_header_matches_line_endings() {
+	public function test_convert_post_line_endings_are_uniformly_crlf( $post_content ) {
 		$post_id = $this->factory->post->create(
 			[
 				'post_title'   => 'Test Post',
-				'post_content' => '<p>First paragraph.</p><p>Second paragraph.</p>',
+				'post_content' => $post_content,
 			]
 		);
 
@@ -89,9 +114,11 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 		$content   = $converter->convert_post( $post_id );
 
 		$this->assertStringContainsString( '<ASCII-WIN>', $content );
-		$this->assertStringContainsString( "\r\n", $content );
-		// Every CR belongs to a CRLF pair — no bare-CR (Mac-format) terminators.
-		$this->assertSame( substr_count( $content, "\r\n" ), substr_count( $content, "\r" ) );
+
+		$crlf = substr_count( $content, "\r\n" );
+		$this->assertGreaterThan( 0, $crlf, 'Expected at least one line terminator.' );
+		$this->assertSame( $crlf, substr_count( $content, "\r" ), 'Found a bare CR: part of the file is Mac-terminated.' );
+		$this->assertSame( $crlf, substr_count( $content, "\n" ), 'Found a bare LF: part of the file is Unix-terminated.' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/plugins/newspack-plugin/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -21,38 +21,11 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	private const TEST_POST_TYPES = [ 'product', 'hidden_cpt', 'partner_rss_feed', 'newspack_nl_list', 'newspack_collection', 'event', 'flyer', 'reviewcpt' ];
 
 	/**
-	 * The ambient User-Agent, captured so platform-resolution tests can restore it.
-	 *
-	 * @var string|null
-	 */
-	private $original_user_agent;
-
-	/**
-	 * Capture request state that individual tests may mutate.
-	 */
-	public function set_up() {
-		parent::set_up();
-		// phpcs:ignore WordPress.Security.ValidatedSanitizedInput.InputNotSanitized, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-		$this->original_user_agent = $_SERVER['HTTP_USER_AGENT'] ?? null;
-	}
-
-	/**
-	 * Set the request User-Agent for the current test. Wraps the write so the VIP
-	 * cache-constraint sniff — not meaningful for a unit test — is silenced once.
-	 *
-	 * @param string $user_agent User-Agent string to set.
-	 */
-	private function set_request_user_agent( $user_agent ) {
-		$_SERVER['HTTP_USER_AGENT'] = $user_agent; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-	}
-
-	/**
-	 * Reset options, post-type registrations, and request state after every test,
-	 * regardless of whether the test's own assertions passed. Keeping cleanup here
-	 * (rather than inline at the end of each test) makes failures self-contained.
+	 * Reset options and post-type registrations after every test, regardless of
+	 * whether the test's own assertions passed. Keeping cleanup here (rather than
+	 * inline at the end of each test) makes failures self-contained.
 	 */
 	public function tear_down() {
-		delete_option( InDesign_Exporter::PLATFORM_OPTION );
 		delete_option( InDesign_Exporter::POST_TYPES_OPTION );
 		delete_option( InDesign_Exporter::EXCLUDE_CAPTIONS_OPTION );
 
@@ -70,12 +43,6 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 		remove_filter( 'handle_bulk_actions-edit-reviewcpt', [ InDesign_Exporter::class, 'handle_bulk_action' ], 100 );
 		remove_filter( 'post_row_actions', [ InDesign_Exporter::class, 'add_row_action' ], 10 );
 		remove_filter( 'page_row_actions', [ InDesign_Exporter::class, 'add_row_action' ], 10 );
-
-		if ( null === $this->original_user_agent ) {
-			unset( $_SERVER['HTTP_USER_AGENT'] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-		} else {
-			$_SERVER['HTTP_USER_AGENT'] = $this->original_user_agent; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__
-		}
 
 		parent::tear_down();
 	}
@@ -125,80 +92,6 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 		$this->assertStringContainsString( "\r\n", $content );
 		// Every CR belongs to a CRLF pair — no bare-CR (Mac-format) terminators.
 		$this->assertSame( substr_count( $content, "\r\n" ), substr_count( $content, "\r" ) );
-	}
-
-	/**
-	 * Test that the Mac platform option emits the <ASCII-MAC> header.
-	 *
-	 * Note this only swaps the declared header — the converter still writes CRLF
-	 * line endings, so a 'mac' export misdescribes its own format. See
-	 * test_convert_post_default_header_matches_line_endings().
-	 */
-	public function test_convert_post_mac_platform() {
-		$post_id = $this->factory->post->create(
-			[
-				'post_title'   => 'Test Post',
-				'post_content' => '<p>This is a test post.</p>',
-			]
-		);
-
-		$converter = new InDesign_Converter();
-		$content   = $converter->convert_post( $post_id, [ 'platform' => 'mac' ] );
-		$this->assertStringContainsString( '<ASCII-MAC>', $content );
-		$this->assertStringNotContainsString( '<ASCII-WIN>', $content );
-	}
-
-	/**
-	 * Test that the Win platform option emits the <ASCII-WIN> header.
-	 */
-	public function test_convert_post_win_platform() {
-		$post_id = $this->factory->post->create(
-			[
-				'post_title'   => 'Test Post',
-				'post_content' => '<p>This is a test post.</p>',
-			]
-		);
-
-		$converter = new InDesign_Converter();
-		$content   = $converter->convert_post( $post_id, [ 'platform' => 'win' ] );
-		$this->assertStringContainsString( '<ASCII-WIN>', $content );
-		$this->assertStringNotContainsString( '<ASCII-MAC>', $content );
-	}
-
-	/**
-	 * Test that the platform setting defaults to 'win' when unset.
-	 *
-	 * The exporter always writes CRLF-delimited files, so 'win' is the only
-	 * default that describes them accurately (NPPM-3098).
-	 */
-	public function test_platform_setting_default() {
-		delete_option( InDesign_Exporter::PLATFORM_OPTION );
-		$this->assertSame( 'win', InDesign_Exporter::get_platform_setting() );
-	}
-
-	/**
-	 * Test that the platform setting returns the stored value when valid.
-	 */
-	public function test_platform_setting_valid_values() {
-		update_option( InDesign_Exporter::PLATFORM_OPTION, 'mac' );
-		$this->assertSame( 'mac', InDesign_Exporter::get_platform_setting() );
-
-		update_option( InDesign_Exporter::PLATFORM_OPTION, 'win' );
-		$this->assertSame( 'win', InDesign_Exporter::get_platform_setting() );
-
-		update_option( InDesign_Exporter::PLATFORM_OPTION, 'auto' );
-		$this->assertSame( 'auto', InDesign_Exporter::get_platform_setting() );
-	}
-
-	/**
-	 * Test that the platform setting sanitizes invalid stored values.
-	 */
-	public function test_platform_setting_rejects_invalid_value() {
-		update_option( InDesign_Exporter::PLATFORM_OPTION, 'linux' );
-		$this->assertSame( 'win', InDesign_Exporter::get_platform_setting() );
-
-		update_option( InDesign_Exporter::PLATFORM_OPTION, '' );
-		$this->assertSame( 'win', InDesign_Exporter::get_platform_setting() );
 	}
 
 	/**
@@ -346,39 +239,6 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 		$this->assertNotContains( 'flyer', $slugs );
 
 		remove_filter( 'newspack_indesign_export_excluded_post_types', $callback );
-	}
-
-	/**
-	 * Test User-Agent → platform mapping for representative strings.
-	 */
-	public function test_sniff_user_agent_platform() {
-		// macOS Safari / Chrome.
-		$this->assertSame(
-			'mac',
-			InDesign_Exporter::sniff_user_agent_platform( 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.5 Safari/605.1.15' )
-		);
-		// iPad.
-		$this->assertSame(
-			'mac',
-			InDesign_Exporter::sniff_user_agent_platform( 'Mozilla/5.0 (iPad; CPU OS 17_5 like Mac OS X) AppleWebKit/605.1.15' )
-		);
-		// iPhone.
-		$this->assertSame(
-			'mac',
-			InDesign_Exporter::sniff_user_agent_platform( 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_5 like Mac OS X) AppleWebKit/605.1.15' )
-		);
-		// Windows Chrome.
-		$this->assertSame(
-			'win',
-			InDesign_Exporter::sniff_user_agent_platform( 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/120.0.0.0 Safari/537.36' )
-		);
-		// Linux (treated as Windows-compatible by InDesign Tagged Text — there is no Linux variant).
-		$this->assertSame(
-			'win',
-			InDesign_Exporter::sniff_user_agent_platform( 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36' )
-		);
-		// Empty.
-		$this->assertSame( 'win', InDesign_Exporter::sniff_user_agent_platform( '' ) );
 	}
 
 	/**
@@ -1121,96 +981,6 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 		);
 		// The filters registered here are removed in tear_down(), so a failed
 		// assertion above can't leak them into later tests.
-	}
-
-	/**
-	 * Test that an explicit platform setting wins over the request User-Agent.
-	 */
-	public function test_resolve_platform_setting_overrides_user_agent() {
-		update_option( InDesign_Exporter::PLATFORM_OPTION, 'mac' );
-		$this->set_request_user_agent( 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' );
-		$this->assertSame( 'mac', InDesign_Exporter::resolve_platform() );
-
-		update_option( InDesign_Exporter::PLATFORM_OPTION, 'win' );
-		$this->set_request_user_agent( 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)' );
-		$this->assertSame( 'win', InDesign_Exporter::resolve_platform() );
-	}
-
-	/**
-	 * Test that an unconfigured site resolves to 'win' for a Mac client.
-	 *
-	 * Regression guard for NPPM-3098: the header describes the file's own
-	 * format, not the OS the reader runs on, so the requesting browser must not
-	 * influence it on a site that never picked a platform. Exports reaching Mac
-	 * users had been declaring <ASCII-MAC> over CRLF bytes, which InDesign
-	 * imports as literal markup.
-	 */
-	public function test_resolve_platform_default_ignores_mac_user_agent() {
-		delete_option( InDesign_Exporter::PLATFORM_OPTION );
-
-		$this->set_request_user_agent( 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15' );
-		$this->assertSame( 'win', InDesign_Exporter::resolve_platform() );
-	}
-
-	/**
-	 * Test that the 'auto' setting resolves the platform from the User-Agent.
-	 *
-	 * Retained to document the behavior of a site that explicitly stored 'auto'.
-	 * It is no longer the default — see
-	 * test_resolve_platform_default_ignores_mac_user_agent().
-	 */
-	public function test_resolve_platform_auto_sniffs_user_agent() {
-		update_option( InDesign_Exporter::PLATFORM_OPTION, 'auto' );
-
-		$this->set_request_user_agent( 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)' );
-		$this->assertSame( 'mac', InDesign_Exporter::resolve_platform() );
-
-		$this->set_request_user_agent( 'Mozilla/5.0 (Windows NT 10.0; Win64; x64)' );
-		$this->assertSame( 'win', InDesign_Exporter::resolve_platform() );
-	}
-
-	/**
-	 * Test that the platform filter can override the resolved value, and that a
-	 * non-'mac' return normalizes to 'win' instead of leaking an invalid platform.
-	 */
-	public function test_resolve_platform_filter_overrides_and_normalizes() {
-		update_option( InDesign_Exporter::PLATFORM_OPTION, 'win' );
-
-		$to_mac = static function () {
-			return 'mac';
-		};
-		add_filter( 'newspack_indesign_export_platform', $to_mac );
-		$this->assertSame( 'mac', InDesign_Exporter::resolve_platform() );
-		remove_filter( 'newspack_indesign_export_platform', $to_mac );
-
-		$to_auto = static function () {
-			return 'auto';
-		};
-		add_filter( 'newspack_indesign_export_platform', $to_auto );
-		$this->assertSame( 'win', InDesign_Exporter::resolve_platform() );
-		remove_filter( 'newspack_indesign_export_platform', $to_auto );
-	}
-
-	/**
-	 * Test that the platform filter receives the resolved platform, the stored
-	 * setting, and the sanitized User-Agent.
-	 */
-	public function test_resolve_platform_filter_receives_context() {
-		update_option( InDesign_Exporter::PLATFORM_OPTION, 'auto' );
-		$this->set_request_user_agent( 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5)' );
-
-		$captured = [];
-		$callback = static function ( $platform, $setting, $user_agent ) use ( &$captured ) {
-			$captured = compact( 'platform', 'setting', 'user_agent' );
-			return $platform;
-		};
-		add_filter( 'newspack_indesign_export_platform', $callback, 10, 3 );
-		InDesign_Exporter::resolve_platform();
-		remove_filter( 'newspack_indesign_export_platform', $callback, 10 );
-
-		$this->assertSame( 'mac', $captured['platform'] );
-		$this->assertSame( 'auto', $captured['setting'] );
-		$this->assertStringContainsString( 'Macintosh', $captured['user_agent'] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/indesign-exporter/indesign-exporter.php
+++ b/plugins/newspack-plugin/tests/unit-tests/indesign-exporter/indesign-exporter.php
@@ -99,10 +99,40 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that the default export declares a header matching the line endings
+	 * it actually writes.
+	 *
+	 * The tagged-text start tag describes the file, not the machine running
+	 * InDesign: <ASCII-WIN> means CRLF-delimited, <ASCII-MAC> means bare-CR.
+	 * The converter joins every part with CRLF unconditionally, so <ASCII-WIN>
+	 * is the only header that describes the bytes. Declaring <ASCII-MAC> over
+	 * CRLF leaves an orphan LF at the head of each paragraph, which pushes the
+	 * <pstyle:...> tag off the paragraph start and makes InDesign render the
+	 * markup literally (NPPM-3098).
+	 */
+	public function test_convert_post_default_header_matches_line_endings() {
+		$post_id = $this->factory->post->create(
+			[
+				'post_title'   => 'Test Post',
+				'post_content' => '<p>First paragraph.</p><p>Second paragraph.</p>',
+			]
+		);
+
+		$converter = new InDesign_Converter();
+		$content   = $converter->convert_post( $post_id );
+
+		$this->assertStringContainsString( '<ASCII-WIN>', $content );
+		$this->assertStringContainsString( "\r\n", $content );
+		// Every CR belongs to a CRLF pair — no bare-CR (Mac-format) terminators.
+		$this->assertSame( substr_count( $content, "\r\n" ), substr_count( $content, "\r" ) );
+	}
+
+	/**
 	 * Test that the Mac platform option emits the <ASCII-MAC> header.
 	 *
-	 * InDesign on macOS requires the file to begin with <ASCII-MAC> for the
-	 * tagged text to be interpreted as markup rather than literal content.
+	 * Note this only swaps the declared header — the converter still writes CRLF
+	 * line endings, so a 'mac' export misdescribes its own format. See
+	 * test_convert_post_default_header_matches_line_endings().
 	 */
 	public function test_convert_post_mac_platform() {
 		$post_id = $this->factory->post->create(
@@ -136,11 +166,14 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Test that the platform setting defaults to 'auto' when unset.
+	 * Test that the platform setting defaults to 'win' when unset.
+	 *
+	 * The exporter always writes CRLF-delimited files, so 'win' is the only
+	 * default that describes them accurately (NPPM-3098).
 	 */
 	public function test_platform_setting_default() {
 		delete_option( InDesign_Exporter::PLATFORM_OPTION );
-		$this->assertSame( 'auto', InDesign_Exporter::get_platform_setting() );
+		$this->assertSame( 'win', InDesign_Exporter::get_platform_setting() );
 	}
 
 	/**
@@ -162,10 +195,10 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	 */
 	public function test_platform_setting_rejects_invalid_value() {
 		update_option( InDesign_Exporter::PLATFORM_OPTION, 'linux' );
-		$this->assertSame( 'auto', InDesign_Exporter::get_platform_setting() );
+		$this->assertSame( 'win', InDesign_Exporter::get_platform_setting() );
 
 		update_option( InDesign_Exporter::PLATFORM_OPTION, '' );
-		$this->assertSame( 'auto', InDesign_Exporter::get_platform_setting() );
+		$this->assertSame( 'win', InDesign_Exporter::get_platform_setting() );
 	}
 
 	/**
@@ -1104,7 +1137,27 @@ class Newspack_Test_InDesign_Exporter extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test that an unconfigured site resolves to 'win' for a Mac client.
+	 *
+	 * Regression guard for NPPM-3098: the header describes the file's own
+	 * format, not the OS the reader runs on, so the requesting browser must not
+	 * influence it on a site that never picked a platform. Exports reaching Mac
+	 * users had been declaring <ASCII-MAC> over CRLF bytes, which InDesign
+	 * imports as literal markup.
+	 */
+	public function test_resolve_platform_default_ignores_mac_user_agent() {
+		delete_option( InDesign_Exporter::PLATFORM_OPTION );
+
+		$this->set_request_user_agent( 'Mozilla/5.0 (Macintosh; Intel Mac OS X 14_5) AppleWebKit/605.1.15' );
+		$this->assertSame( 'win', InDesign_Exporter::resolve_platform() );
+	}
+
+	/**
 	 * Test that the 'auto' setting resolves the platform from the User-Agent.
+	 *
+	 * Retained to document the behavior of a site that explicitly stored 'auto'.
+	 * It is no longer the default — see
+	 * test_resolve_platform_default_ignores_mac_user_agent().
 	 */
 	public function test_resolve_platform_auto_sniffs_user_agent() {
 		update_option( InDesign_Exporter::PLATFORM_OPTION, 'auto' );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Exports place into InDesign as literal markup instead of formatted copy. Two tickets reported this with **opposite** manual fixes: NPPM-2813 needed the header changed to `<ASCII-MAC>`, NPPM-3098 needed `<ASCII-WIN>`. Both publishers were on Mac.

The header was never the cause. It declares the file's own line endings — `<ASCII-WIN>` promises CRLF, `<ASCII-MAC>` promises bare CR — and the exporter's endings varied with the shape of the post. `clean_whitespace()` collapsed blank lines with `/\n{2,}/`, which is not CRLF-aware: it consumed the LF of a CRLF pair and stranded the CR, emitting `\r\r\n`. Classic content hit that path and needed `<ASCII-MAC>`; block content stayed uniform and needed `<ASCII-WIN>`.

Line endings are now normalized to CRLF, so `<ASCII-WIN>` is accurate for every post. The Header platform setting, its User-Agent detection, and the `newspack_indesign_export_platform` filter are removed — they configured a header that has one correct value.

Closes NPPM-3098. Closes NPPM-2813.

### How to test the changes in this Pull Request:

1. Enable the module at **Newspack > Settings > Print > Adobe InDesign**.
2. Confirm the "Header platform" section is gone. "Available post types" and "Photo captions" still render.
3. Change a setting in each remaining section. Both persist across a reload.
4. Publish a post written in the block editor. Export it from the posts list.
5. Run `xxd` on the download. Every line ends `0d 0a`, with no bare `0d` or `0a`.
6. Publish a post using the classic editor, or paste newline-separated `<p>` tags into a Custom HTML block. Export it.
7. Run `xxd` on that download. It also ends every line `0d 0a` — on `main` this file contains `0d 0d 0a`.
8. Place both exports in InDesign on a Mac. Paragraph styles apply instead of appearing as literal text.
9. Run `wp option update newspack_indesign_export_platform mac`, then re-export. The header is still `<ASCII-WIN>`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally? Full `newspack-plugin` suite green (2592 tests).

Step 8 is the one check I could not run — I have no InDesign. The byte-level behavior is covered by a data-provider test across seven content shapes; four of them emit a bare CR on `main`. Confirmation from a publisher on the classic-content path would be worth having before release.

The `newspack_indesign_export_platform` filter is a public extension point, added in #463 three weeks ago. No consumers exist in the monorepo or in `repos/`. Stored option rows are left in place; they are no longer read.
