### PR TITLE
fix: accept Gutenberg theme.json data class in filter callbacks

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/class-email-defaults.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-email-defaults.php
@@ -17,6 +17,13 @@ defined( 'ABSPATH' ) || exit;
  *
  * The `wp_theme_json_data_default` hook fires globally; callbacks guard on the WC renderer
  * flag and the email-editor request context.
+ *
+ * The callbacks deliberately carry NO type declarations. Core passes a
+ * `WP_Theme_JSON_Data`, but with the Gutenberg plugin active the resolver passes
+ * `WP_Theme_JSON_Data_Gutenberg` — a sibling class, not a subclass — so a
+ * `WP_Theme_JSON_Data` declaration fatals with a TypeError on every theme.json
+ * resolution, front end included, before the guards below can run. Both classes
+ * expose `update_with()`, which is all these callbacks need.
  */
 class Email_Defaults {
 
@@ -52,10 +59,11 @@ class Email_Defaults {
 	 * email-editor request. The default origin fires before _theme, so any
 	 * theme-origin radius still wins.
 	 *
-	 * @param \WP_Theme_JSON_Data $theme_json Incoming default theme.json data.
+	 * @param \WP_Theme_JSON_Data $theme_json Incoming default theme.json data. Untyped:
+	 *                                        Gutenberg passes WP_Theme_JSON_Data_Gutenberg.
 	 * @return \WP_Theme_JSON_Data Potentially modified default theme.json data.
 	 */
-	public static function inject_button_border_radius( \WP_Theme_JSON_Data $theme_json ): \WP_Theme_JSON_Data {
+	public static function inject_button_border_radius( $theme_json ) {
 		if ( ! Feature_Flag::is_enabled() ) {
 			return $theme_json;
 		}
@@ -88,10 +96,11 @@ class Email_Defaults {
 	 * (no post yet) fonts resolve via global → theme → fallback, so new newsletters
 	 * show theme fonts instead of the hardcoded builder defaults.
 	 *
-	 * @param \WP_Theme_JSON_Data $theme_json Incoming default theme.json data.
+	 * @param \WP_Theme_JSON_Data $theme_json Incoming default theme.json data. Untyped:
+	 *                                        Gutenberg passes WP_Theme_JSON_Data_Gutenberg.
 	 * @return \WP_Theme_JSON_Data Potentially modified default theme.json data.
 	 */
-	public static function inject_fonts( \WP_Theme_JSON_Data $theme_json ): \WP_Theme_JSON_Data {
+	public static function inject_fonts( $theme_json ) {
 		if ( ! Feature_Flag::is_enabled() ) {
 			return $theme_json;
 		}

--- a/plugins/newspack-newsletters/includes/email-renderers/class-email-defaults.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-email-defaults.php
@@ -59,9 +59,8 @@ class Email_Defaults {
 	 * email-editor request. The default origin fires before _theme, so any
 	 * theme-origin radius still wins.
 	 *
-	 * @param \WP_Theme_JSON_Data $theme_json Incoming default theme.json data. Untyped:
-	 *                                        Gutenberg passes WP_Theme_JSON_Data_Gutenberg.
-	 * @return \WP_Theme_JSON_Data Potentially modified default theme.json data.
+	 * @param \WP_Theme_JSON_Data|\WP_Theme_JSON_Data_Gutenberg $theme_json Incoming default theme.json data.
+	 * @return \WP_Theme_JSON_Data|\WP_Theme_JSON_Data_Gutenberg Potentially modified default theme.json data.
 	 */
 	public static function inject_button_border_radius( $theme_json ) {
 		if ( ! Feature_Flag::is_enabled() ) {
@@ -96,9 +95,8 @@ class Email_Defaults {
 	 * (no post yet) fonts resolve via global → theme → fallback, so new newsletters
 	 * show theme fonts instead of the hardcoded builder defaults.
 	 *
-	 * @param \WP_Theme_JSON_Data $theme_json Incoming default theme.json data. Untyped:
-	 *                                        Gutenberg passes WP_Theme_JSON_Data_Gutenberg.
-	 * @return \WP_Theme_JSON_Data Potentially modified default theme.json data.
+	 * @param \WP_Theme_JSON_Data|\WP_Theme_JSON_Data_Gutenberg $theme_json Incoming default theme.json data.
+	 * @return \WP_Theme_JSON_Data|\WP_Theme_JSON_Data_Gutenberg Potentially modified default theme.json data.
 	 */
 	public static function inject_fonts( $theme_json ) {
 		if ( ! Feature_Flag::is_enabled() ) {

--- a/plugins/newspack-newsletters/tests/email-renderers/fixtures/class-foreign-theme-json-data.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/fixtures/class-foreign-theme-json-data.php
@@ -48,6 +48,10 @@ class Foreign_Theme_JSON_Data {
 	/**
 	 * Merge new data in, mirroring WP_Theme_JSON_Data::update_with().
 	 *
+	 * Left untyped on purpose: core's `WP_Theme_JSON_Data::update_with( $new_data )`
+	 * declares no parameter type, and a stand-in that is stricter than the class it
+	 * imitates would defeat the point of the fixture.
+	 *
 	 * @param array $new_data Data to merge in.
 	 * @return self
 	 */

--- a/plugins/newspack-newsletters/tests/email-renderers/fixtures/class-foreign-theme-json-data.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/fixtures/class-foreign-theme-json-data.php
@@ -1,0 +1,67 @@
+<?php
+/**
+ * Test fixture: a theme.json data object that is NOT a WP_Theme_JSON_Data.
+ *
+ * Stands in for `WP_Theme_JSON_Data_Gutenberg`, which the Gutenberg plugin
+ * passes to the `wp_theme_json_data_*` filters instead of core's class. It is a
+ * sibling implementation, NOT a subclass of `WP_Theme_JSON_Data`, so any
+ * callback that type-hints the core class fatals with a TypeError before its
+ * own guards can run.
+ *
+ * Lives in `fixtures/` and is required explicitly by the tests that need it.
+ *
+ * @package Newspack_Newsletters
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Duck-typed theme.json data object outside the WP_Theme_JSON_Data hierarchy.
+ */
+class Foreign_Theme_JSON_Data {
+
+	/**
+	 * Theme.json data.
+	 *
+	 * @var array
+	 */
+	private $data;
+
+	/**
+	 * Origin of the data ('default', 'blocks', 'theme', 'custom').
+	 *
+	 * @var string
+	 */
+	private $origin;
+
+	/**
+	 * Constructor.
+	 *
+	 * @param array  $data   Theme.json data.
+	 * @param string $origin Origin of the data.
+	 */
+	public function __construct( array $data = [], string $origin = 'default' ) {
+		$this->data   = $data;
+		$this->origin = $origin;
+	}
+
+	/**
+	 * Merge new data in, mirroring WP_Theme_JSON_Data::update_with().
+	 *
+	 * @param array $new_data Data to merge in.
+	 * @return self
+	 */
+	public function update_with( $new_data ) {
+		$this->data = array_replace_recursive( $this->data, $new_data );
+		return $this;
+	}
+
+	/**
+	 * Return the underlying data.
+	 *
+	 * @return array
+	 */
+	public function get_data() {
+		return $this->data;
+	}
+}

--- a/plugins/newspack-newsletters/tests/email-renderers/test-email-defaults.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-email-defaults.php
@@ -103,12 +103,25 @@ class Test_Email_Defaults extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Pull styles.elements.button.border.radius out of a WP_Theme_JSON_Data.
+	 * Build a theme.json data object outside the WP_Theme_JSON_Data hierarchy,
+	 * standing in for Gutenberg's WP_Theme_JSON_Data_Gutenberg.
 	 *
-	 * @param \WP_Theme_JSON_Data $data Theme.json data.
+	 * @return \Foreign_Theme_JSON_Data
+	 */
+	private function make_foreign_default_data() {
+		require_once __DIR__ . '/fixtures/class-foreign-theme-json-data.php';
+		return new \Foreign_Theme_JSON_Data( [ 'version' => 3 ], 'default' );
+	}
+
+	/**
+	 * Pull styles.elements.button.border.radius out of a theme.json data object.
+	 *
+	 * Not type-hinted: the filter also receives Gutenberg's sibling class.
+	 *
+	 * @param object $data Theme.json data.
 	 * @return string|null Radius value or null if absent.
 	 */
-	private function get_button_radius( \WP_Theme_JSON_Data $data ) {
+	private function get_button_radius( $data ) {
 		$raw = $data->get_data();
 		return $raw['styles']['elements']['button']['border']['radius'] ?? null;
 	}
@@ -218,13 +231,15 @@ class Test_Email_Defaults extends WP_UnitTestCase {
 	// -------------------------------------------------------------------------
 
 	/**
-	 * Pull a font-family out of a WP_Theme_JSON_Data.
+	 * Pull a font-family out of a theme.json data object.
 	 *
-	 * @param \WP_Theme_JSON_Data $data Theme.json data.
-	 * @param string              $side 'body' or 'header'.
+	 * Not type-hinted: the filter also receives Gutenberg's sibling class.
+	 *
+	 * @param object $data Theme.json data.
+	 * @param string $side 'body' or 'header'.
 	 * @return string|null Font family value or null if absent.
 	 */
-	private function get_font( \WP_Theme_JSON_Data $data, string $side ) {
+	private function get_font( $data, string $side ) {
 		$raw = $data->get_data();
 		if ( 'header' === $side ) {
 			return $raw['styles']['elements']['heading']['typography']['fontFamily'] ?? null;
@@ -310,6 +325,67 @@ class Test_Email_Defaults extends WP_UnitTestCase {
 			$result,
 			'A theme-origin body font must override the Newspack default-origin font after merge.'
 		);
+	}
+
+	// -------------------------------------------------------------------------
+	// Gutenberg compatibility: the filter argument is not always core's class.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * With the Gutenberg plugin active the `wp_theme_json_data_*` filters receive
+	 * `WP_Theme_JSON_Data_Gutenberg`, a sibling of core's `WP_Theme_JSON_Data` rather
+	 * than a subclass. A `WP_Theme_JSON_Data` type declaration therefore fatals with a
+	 * TypeError on every theme.json resolution — front end included — before the
+	 * callback's own guards can run.
+	 */
+	public function test_button_radius_accepts_foreign_theme_json_data_when_flag_off() {
+		// Flag off, so this is the state of every site that has not opted in.
+		$data   = $this->make_foreign_default_data();
+		$result = Email_Defaults::inject_button_border_radius( $data );
+
+		$this->assertSame( $data, $result, 'The incoming object must be returned untouched when the flag is off.' );
+		$this->assertNull( $this->get_button_radius( $result ), 'No radius must be injected when the flag is off.' );
+	}
+
+	/**
+	 * Flag ON + email-editor request → the radius is injected into a non-core data object too.
+	 */
+	public function test_button_radius_injects_into_foreign_theme_json_data() {
+		update_option( Feature_Flag::OPTION, '1' );
+		$this->simulate_email_editor_request();
+
+		$result = Email_Defaults::inject_button_border_radius( $this->make_foreign_default_data() );
+
+		$this->assertSame(
+			Email_Defaults::DEFAULT_BUTTON_BORDER_RADIUS,
+			$this->get_button_radius( $result ),
+			'The fallback radius must be injected regardless of which theme.json data class is passed.'
+		);
+	}
+
+	/**
+	 * The font callback carries the same type declaration and the same fatal.
+	 */
+	public function test_fonts_accept_foreign_theme_json_data_when_flag_off() {
+		$data   = $this->make_foreign_default_data();
+		$result = Email_Defaults::inject_fonts( $data );
+
+		$this->assertSame( $data, $result, 'The incoming object must be returned untouched when the flag is off.' );
+		$this->assertNull( $this->get_font( $result, 'body' ), 'No font must be injected when the flag is off.' );
+	}
+
+	/**
+	 * Flag ON + email-editor request → fonts are injected into a non-core data object too.
+	 */
+	public function test_fonts_inject_into_foreign_theme_json_data() {
+		update_option( Feature_Flag::OPTION, '1' );
+		$this->simulate_email_editor_request();
+
+		$result   = Email_Defaults::inject_fonts( $this->make_foreign_default_data() );
+		$expected = \Newspack\Newsletters\Email_Renderers\Fonts::resolve( get_post( self::$newsletter_post_id ) );
+
+		$this->assertSame( $expected['body'], $this->get_font( $result, 'body' ) );
+		$this->assertSame( $expected['header'], $this->get_font( $result, 'header' ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/src/blocks/author-profile-social/class-author-profile-social-block.php
+++ b/plugins/newspack-plugin/src/blocks/author-profile-social/class-author-profile-social-block.php
@@ -68,8 +68,8 @@ final class Author_Profile_Social_Block {
 	 * not a subclass — and a WP_Theme_JSON_Data declaration would fatal with a TypeError
 	 * on every theme.json resolution, front end included.
 	 *
-	 * @param WP_Theme_JSON_Data $theme_json Theme JSON data.
-	 * @return WP_Theme_JSON_Data
+	 * @param WP_Theme_JSON_Data|\WP_Theme_JSON_Data_Gutenberg $theme_json Theme JSON data.
+	 * @return WP_Theme_JSON_Data|\WP_Theme_JSON_Data_Gutenberg
 	 */
 	public static function set_default_block_gap( $theme_json ) {
 		$theme_json->update_with(

--- a/plugins/newspack-plugin/src/blocks/author-profile-social/class-author-profile-social-block.php
+++ b/plugins/newspack-plugin/src/blocks/author-profile-social/class-author-profile-social-block.php
@@ -63,10 +63,15 @@ final class Author_Profile_Social_Block {
 	 * This matches what newspack-block-theme does for core/social-links
 	 * but works with any block theme.
 	 *
+	 * No type declaration: core passes a WP_Theme_JSON_Data, but with the Gutenberg
+	 * plugin active the resolver passes WP_Theme_JSON_Data_Gutenberg — a sibling class,
+	 * not a subclass — and a WP_Theme_JSON_Data declaration would fatal with a TypeError
+	 * on every theme.json resolution, front end included.
+	 *
 	 * @param WP_Theme_JSON_Data $theme_json Theme JSON data.
 	 * @return WP_Theme_JSON_Data
 	 */
-	public static function set_default_block_gap( WP_Theme_JSON_Data $theme_json ): WP_Theme_JSON_Data {
+	public static function set_default_block_gap( $theme_json ) {
 		$theme_json->update_with(
 			[
 				'version' => 3,


### PR DESCRIPTION
## Summary

Fixes the frontend fatal reported on Dotcom sites running newspack-newsletters 3.38.1 (reported in p1785935990144689-slack-C055SRT7WN4):

```
PHP Fatal error:  Uncaught TypeError: Email_Defaults::inject_button_border_radius():
Argument #1 ($theme_json) must be of type WP_Theme_JSON_Data,
WP_Theme_JSON_Data_Gutenberg given
```

## Root cause

`Email_Defaults::inject_button_border_radius()` and `::inject_fonts()` hook `wp_theme_json_data_default` and declare their parameter as `WP_Theme_JSON_Data`. With the Gutenberg plugin active — which is every Dotcom/Atomic site — `WP_Theme_JSON_Resolver_Gutenberg` passes `WP_Theme_JSON_Data_Gutenberg` instead. That is a **sibling** class, not a subclass, so PHP throws a `TypeError` at call time.

Two things make this worse than it looks:

- The TypeError fires **before** the callbacks' own guards, so the WC-renderer feature flag being off does not protect anyone. Every site with the plugin active fatals.
- The filter runs on every theme.json resolution, so the fatal hits the **front end**, not just the newsletter editor.

## The fix

Drop the type declarations (param and return) on both callbacks. Both classes expose `update_with()`, which is all these callbacks use, and the guards inside are unchanged — behavior is identical, the function just no longer refuses the argument it is given.

### Also fixed: the same latent fatal in newspack-plugin

`Author_Profile_Social_Block::set_default_block_gap()` hooks `wp_theme_json_data_blocks` with the identical `WP_Theme_JSON_Data` declaration. It has not been reported because `includes/class-blocks.php` only loads that block behind `wp_is_block_theme()` — the reporting site is on a classic child theme. Any FSE site on Dotcom would fatal the same way, so it is fixed here rather than left to be found in production.

## Tests

New `Foreign_Theme_JSON_Data` fixture stands in for `WP_Theme_JSON_Data_Gutenberg` (duck-typed, deliberately outside the `WP_Theme_JSON_Data` hierarchy), plus four regression tests covering both callbacks in the flag-off passthrough path and the flag-on injection path.

Confirmed failing before the fix with the exact production error:

```
TypeError: Email_Defaults::inject_button_border_radius(): Argument #1 ($theme_json)
must be of type WP_Theme_JSON_Data, Foreign_Theme_JSON_Data given
```

Suites after the fix:

- `newspack-newsletters`: 706 tests, 2951 assertions, 3 skipped — OK
- `newspack-plugin`: 2345 tests, 6668 assertions, 9 skipped — OK
- PHPCS clean on all changed files

## Notes for review

- Targets `release` (3.38.1 is out; `main` and `alpha` carry the same code and will need this too).
- Not yet manually verified on a site with the Gutenberg plugin active — worth a smoke test on an env with Gutenberg installed before merge.
