### PR TITLE
fix(theme-json): accept Gutenberg data class in filter callbacks

### DIFF
--- a/plugins/newspack-newsletters/includes/email-renderers/class-email-defaults.php
+++ b/plugins/newspack-newsletters/includes/email-renderers/class-email-defaults.php
@@ -52,10 +52,16 @@ class Email_Defaults {
 	 * email-editor request. The default origin fires before _theme, so any
 	 * theme-origin radius still wins.
 	 *
-	 * @param \WP_Theme_JSON_Data $theme_json Incoming default theme.json data.
-	 * @return \WP_Theme_JSON_Data Potentially modified default theme.json data.
+	 * Left untyped on purpose: with the Gutenberg plugin active the filter carries
+	 * `WP_Theme_JSON_Data_Gutenberg`, a standalone class that does not extend
+	 * `WP_Theme_JSON_Data`. A core-only type declaration is checked before the body
+	 * runs, so it fatals past both guards on every request. Both classes expose
+	 * `update_with()`, which is all this needs.
+	 *
+	 * @param \WP_Theme_JSON_Data|\WP_Theme_JSON_Data_Gutenberg $theme_json Incoming default theme.json data.
+	 * @return \WP_Theme_JSON_Data|\WP_Theme_JSON_Data_Gutenberg Potentially modified default theme.json data.
 	 */
-	public static function inject_button_border_radius( \WP_Theme_JSON_Data $theme_json ): \WP_Theme_JSON_Data {
+	public static function inject_button_border_radius( $theme_json ) {
 		if ( ! Feature_Flag::is_enabled() ) {
 			return $theme_json;
 		}
@@ -88,10 +94,12 @@ class Email_Defaults {
 	 * (no post yet) fonts resolve via global → theme → fallback, so new newsletters
 	 * show theme fonts instead of the hardcoded builder defaults.
 	 *
-	 * @param \WP_Theme_JSON_Data $theme_json Incoming default theme.json data.
-	 * @return \WP_Theme_JSON_Data Potentially modified default theme.json data.
+	 * Untyped for the same Gutenberg-compatibility reason as inject_button_border_radius().
+	 *
+	 * @param \WP_Theme_JSON_Data|\WP_Theme_JSON_Data_Gutenberg $theme_json Incoming default theme.json data.
+	 * @return \WP_Theme_JSON_Data|\WP_Theme_JSON_Data_Gutenberg Potentially modified default theme.json data.
 	 */
-	public static function inject_fonts( \WP_Theme_JSON_Data $theme_json ): \WP_Theme_JSON_Data {
+	public static function inject_fonts( $theme_json ) {
 		if ( ! Feature_Flag::is_enabled() ) {
 			return $theme_json;
 		}

--- a/plugins/newspack-newsletters/tests/bootstrap.php
+++ b/plugins/newspack-newsletters/tests/bootstrap.php
@@ -71,6 +71,9 @@ require_once 'mocks/wc-memberships.php';
 // WC CLI mock.
 require_once 'mocks/wp-cli.php';
 
+// Gutenberg's standalone theme.json data class, which the plugin is not installed to provide.
+require_once 'mocks/theme-json-data-gutenberg.php';
+
 // Stubs for RDB methods.
 if ( ! class_exists( 'BlockBindings' ) ) {
 	require_once __DIR__ . '/mocks/class-blockbindings.php';

--- a/plugins/newspack-newsletters/tests/email-renderers/test-email-defaults.php
+++ b/plugins/newspack-newsletters/tests/email-renderers/test-email-defaults.php
@@ -355,4 +355,80 @@ class Test_Email_Defaults extends WP_UnitTestCase {
 			'A theme-origin button radius must override the Newspack default-origin fallback after merge.'
 		);
 	}
+
+	// -------------------------------------------------------------------------
+	// Gutenberg plugin compatibility.
+	// -------------------------------------------------------------------------
+
+	/**
+	 * Data provider: both callbacks registered on wp_theme_json_data_default.
+	 *
+	 * @return array<string,array{0:string}>
+	 */
+	public function callback_provider(): array {
+		return [
+			'button radius' => [ 'inject_button_border_radius' ],
+			'fonts'         => [ 'inject_fonts' ],
+		];
+	}
+
+	/**
+	 * With Gutenberg active the filter carries WP_Theme_JSON_Data_Gutenberg, which does NOT
+	 * extend WP_Theme_JSON_Data. The guards live inside the callback bodies, but PHP checks
+	 * the argument type BEFORE entering the function — so a core-only type declaration fatals
+	 * on every request regardless of the flag, including the whole frontend.
+	 *
+	 * @dataProvider callback_provider
+	 * @param string $callback Method name on Email_Defaults.
+	 */
+	public function test_accepts_gutenberg_data_object_when_guards_are_closed( string $callback ) {
+		// Flag off and not an email-editor request: the production frontend case.
+		$data = new \WP_Theme_JSON_Data_Gutenberg( [ 'version' => 3 ], 'default' );
+
+		$result = Email_Defaults::{$callback}( $data );
+
+		$this->assertSame(
+			$data,
+			$result,
+			"Email_Defaults::{$callback}() must pass a Gutenberg data object straight through instead of throwing a TypeError."
+		);
+	}
+
+	/**
+	 * The Gutenberg data object is not just tolerated but handled: with both guards open the
+	 * callback injects through it exactly as it does through the core class.
+	 */
+	public function test_injects_button_radius_into_gutenberg_data_object() {
+		update_option( Feature_Flag::OPTION, '1' );
+		$this->simulate_email_editor_request();
+
+		$data   = new \WP_Theme_JSON_Data_Gutenberg( [ 'version' => 3 ], 'default' );
+		$result = Email_Defaults::inject_button_border_radius( $data );
+
+		$raw = $result->get_data();
+
+		$this->assertSame(
+			Email_Defaults::DEFAULT_BUTTON_BORDER_RADIUS,
+			$raw['styles']['elements']['button']['border']['radius'] ?? null,
+			'inject_button_border_radius() must inject through a Gutenberg data object too.'
+		);
+	}
+
+	/**
+	 * Same for the font callback — proves the Gutenberg path is handled, not merely survived.
+	 */
+	public function test_injects_fonts_into_gutenberg_data_object() {
+		update_option( Feature_Flag::OPTION, '1' );
+		$this->simulate_email_editor_request();
+
+		$data   = new \WP_Theme_JSON_Data_Gutenberg( [ 'version' => 3 ], 'default' );
+		$result = Email_Defaults::inject_fonts( $data );
+
+		$raw = $result->get_data();
+
+		$this->assertNotEmpty(
+			$raw['styles']['typography']['fontFamily'] ?? null,
+			'inject_fonts() must inject through a Gutenberg data object too.'
+		);
+	}
 }

--- a/plugins/newspack-newsletters/tests/mocks/theme-json-data-gutenberg.php
+++ b/plugins/newspack-newsletters/tests/mocks/theme-json-data-gutenberg.php
@@ -1,0 +1,40 @@
+<?php // phpcs:disable Squiz.Commenting, Universal.Files, Generic.Files
+
+// Stands in for the Gutenberg plugin's WP_Theme_JSON_Data_Gutenberg.
+//
+// Gutenberg's theme.json resolver fires the same wp_theme_json_data_* filters as core
+// but passes its OWN data class, which is standalone — it does NOT extend core's
+// WP_Theme_JSON_Data. A callback that type-hints the core class therefore throws a
+// TypeError before its body ever runs, on every request, on any Gutenberg-active site.
+//
+// The test suite has no Gutenberg, so this stub reproduces the one thing that matters:
+// the same public surface, no inheritance from WP_Theme_JSON_Data. It wraps core's
+// WP_Theme_JSON so merge behavior stays real and assertions on the merged output hold.
+//
+// Declared under the real class name and guarded, so a test environment that does load
+// Gutenberg uses the real class instead.
+
+if ( ! class_exists( 'WP_Theme_JSON_Data_Gutenberg' ) ) {
+	class WP_Theme_JSON_Data_Gutenberg {
+		private $theme_json = null;
+		private $origin     = '';
+
+		public function __construct( $data = [ 'version' => 3 ], $origin = 'theme' ) {
+			$this->origin     = $origin;
+			$this->theme_json = new WP_Theme_JSON( $data, $this->origin );
+		}
+
+		public function update_with( $new_data ) {
+			$this->theme_json->merge( new WP_Theme_JSON( $new_data, $this->origin ) );
+			return $this;
+		}
+
+		public function get_data() {
+			return $this->theme_json->get_raw_data();
+		}
+
+		public function get_theme_json() {
+			return $this->theme_json;
+		}
+	}
+}

--- a/plugins/newspack-plugin/src/blocks/author-profile-social/class-author-profile-social-block.php
+++ b/plugins/newspack-plugin/src/blocks/author-profile-social/class-author-profile-social-block.php
@@ -63,10 +63,15 @@ final class Author_Profile_Social_Block {
 	 * This matches what newspack-block-theme does for core/social-links
 	 * but works with any block theme.
 	 *
-	 * @param WP_Theme_JSON_Data $theme_json Theme JSON data.
-	 * @return WP_Theme_JSON_Data
+	 * Left untyped on purpose: with the Gutenberg plugin active this filter carries
+	 * `WP_Theme_JSON_Data_Gutenberg`, a standalone class that does not extend
+	 * `WP_Theme_JSON_Data`. A core-only type declaration is checked before the body
+	 * runs, so it would fatal on every request. Both classes expose `update_with()`.
+	 *
+	 * @param WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg $theme_json Theme JSON data.
+	 * @return WP_Theme_JSON_Data|WP_Theme_JSON_Data_Gutenberg
 	 */
-	public static function set_default_block_gap( WP_Theme_JSON_Data $theme_json ): WP_Theme_JSON_Data {
+	public static function set_default_block_gap( $theme_json ) {
 		$theme_json->update_with(
 			[
 				'version' => 3,

--- a/plugins/newspack-plugin/tests/mocks/theme-json-data-gutenberg.php
+++ b/plugins/newspack-plugin/tests/mocks/theme-json-data-gutenberg.php
@@ -1,0 +1,40 @@
+<?php // phpcs:disable Squiz.Commenting, Universal.Files, Generic.Files
+
+// Stands in for the Gutenberg plugin's WP_Theme_JSON_Data_Gutenberg.
+//
+// Gutenberg's theme.json resolver fires the same wp_theme_json_data_* filters as core
+// but passes its OWN data class, which is standalone — it does NOT extend core's
+// WP_Theme_JSON_Data. A callback that type-hints the core class therefore throws a
+// TypeError before its body ever runs, on every request, on any Gutenberg-active site.
+//
+// The test suite has no Gutenberg, so this stub reproduces the one thing that matters:
+// the same public surface, no inheritance from WP_Theme_JSON_Data. It wraps core's
+// WP_Theme_JSON so merge behavior stays real and assertions on the merged output hold.
+//
+// Declared under the real class name and guarded, so a test environment that does load
+// Gutenberg uses the real class instead.
+
+if ( ! class_exists( 'WP_Theme_JSON_Data_Gutenberg' ) ) {
+	class WP_Theme_JSON_Data_Gutenberg {
+		private $theme_json = null;
+		private $origin     = '';
+
+		public function __construct( $data = [ 'version' => 3 ], $origin = 'theme' ) {
+			$this->origin     = $origin;
+			$this->theme_json = new WP_Theme_JSON( $data, $this->origin );
+		}
+
+		public function update_with( $new_data ) {
+			$this->theme_json->merge( new WP_Theme_JSON( $new_data, $this->origin ) );
+			return $this;
+		}
+
+		public function get_data() {
+			return $this->theme_json->get_raw_data();
+		}
+
+		public function get_theme_json() {
+			return $this->theme_json;
+		}
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/class-test-author-profile-social-block.php
+++ b/plugins/newspack-plugin/tests/unit-tests/class-test-author-profile-social-block.php
@@ -1,0 +1,90 @@
+<?php
+/**
+ * Tests for the Author Profile Social block's theme.json defaults.
+ *
+ * @package Newspack\Tests
+ * @covers \Newspack\Blocks\Author_Profile_Social\Author_Profile_Social_Block
+ */
+
+use Newspack\Blocks\Author_Profile_Social\Author_Profile_Social_Block;
+
+require_once __DIR__ . '/../mocks/theme-json-data-gutenberg.php';
+
+/**
+ * Test class for the block's wp_theme_json_data_blocks callback.
+ *
+ * @group author-profile-social
+ */
+class Newspack_Test_Author_Profile_Social_Block extends WP_UnitTestCase {
+
+	/**
+	 * Setup. The block file is only required by Blocks::init() under a block theme,
+	 * so load it directly.
+	 *
+	 * The block must also be registered: WP_Theme_JSON drops styles for unregistered
+	 * blocks, and in production wp_theme_json_data_blocks resolves after init, by which
+	 * point the block exists. Registering here mirrors that.
+	 */
+	public function set_up(): void {
+		parent::set_up();
+		require_once NEWSPACK_ABSPATH . 'src/blocks/author-profile-social/class-author-profile-social-block.php';
+
+		if ( ! \WP_Block_Type_Registry::get_instance()->is_registered( 'newspack/author-profile-social' ) ) {
+			Author_Profile_Social_Block::register_block();
+		}
+		wp_clean_theme_json_cache();
+	}
+
+	/**
+	 * Tear down: drop the block registration and the theme.json cache.
+	 */
+	public function tear_down(): void {
+		if ( \WP_Block_Type_Registry::get_instance()->is_registered( 'newspack/author-profile-social' ) ) {
+			unregister_block_type( 'newspack/author-profile-social' );
+		}
+		wp_clean_theme_json_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * Pull the block's blockGap out of theme.json data.
+	 *
+	 * @param object $data Theme.json data object.
+	 * @return mixed Block gap value, or null if absent.
+	 */
+	private function get_block_gap( $data ) {
+		$raw = $data->get_data();
+		return $raw['styles']['blocks']['newspack/author-profile-social']['spacing']['blockGap'] ?? null;
+	}
+
+	/**
+	 * Baseline: the callback injects a blockGap through core's data class.
+	 */
+	public function test_injects_block_gap_with_core_data_class(): void {
+		$data = new \WP_Theme_JSON_Data( [ 'version' => 3 ], 'blocks' );
+
+		$result = Author_Profile_Social_Block::set_default_block_gap( $data );
+
+		$this->assertNotNull(
+			$this->get_block_gap( $result ),
+			'set_default_block_gap() must inject a blockGap through the core data class.'
+		);
+	}
+
+	/**
+	 * With Gutenberg active, wp_theme_json_data_blocks carries WP_Theme_JSON_Data_Gutenberg,
+	 * which does NOT extend WP_Theme_JSON_Data. A core-only type declaration fatals on every
+	 * request — the same failure mode that took down newspack-newsletters 3.38.0 on the frontend.
+	 * This block only loads under a block theme, which is the only reason it has not fataled yet.
+	 */
+	public function test_accepts_gutenberg_data_object(): void {
+		$data = new \WP_Theme_JSON_Data_Gutenberg( [ 'version' => 3 ], 'blocks' );
+
+		$result = Author_Profile_Social_Block::set_default_block_gap( $data );
+
+		$this->assertNotNull(
+			$this->get_block_gap( $result ),
+			'set_default_block_gap() must inject through a Gutenberg data object instead of throwing a TypeError.'
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Sites running the Gutenberg plugin hit a fatal error on every front-end page view. This regressed in newspack-newsletters 3.38.0.

Gutenberg's theme.json resolver fires the `wp_theme_json_data_*` filters with its own `WP_Theme_JSON_Data_Gutenberg` class, which does not extend core's `WP_Theme_JSON_Data`. Two callbacks in `Email_Defaults` declared the core type, so PHP rejected the argument before the function body ran. The feature-flag and email-editor guards inside those bodies never got the chance to return early, which is why the front end broke whether or not the WooCommerce renderer was enabled.

Those callbacks now take the argument untyped and document both classes in the docblock. Both classes expose `update_with()`, which is all the code calls.

`Author_Profile_Social_Block::set_default_block_gap()` in newspack-plugin carried the same declaration on `wp_theme_json_data_blocks`. It only loads under a block theme, so no report has come in for it; it is fixed here as well.

### How to test the changes in this Pull Request:

1. Activate the Gutenberg plugin alongside newspack-newsletters. This is required — the bug needs Gutenberg's own data class.
2. On `main`, load any front-end page. A fatal `TypeError` appears in the error log.
3. Check out this branch and reload. The page renders.
4. Leave the WooCommerce renderer flag off and reload again. The page still renders.
5. Switch to a block theme and load a page containing the Author Profile Social block. No fatal error.
6. Turn the WooCommerce renderer flag on and open a newsletter in the editor. Buttons and fonts still pick up the Newspack defaults.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally? newspack-newsletters 714/714 and newspack-plugin 2678/2678 pass.

The newsletters half is an active production fatal, so this needs a hotfix release rather than the regular train. The tests stub Gutenberg's data class, since the test environment does not install the plugin.
