### PR TITLE
fix(reader-activation): treat an autofilled honeypot as a reader, not a bot

### DIFF
--- a/plugins/newspack-newsletters/src/blocks/subscribe/index.php
+++ b/plugins/newspack-newsletters/src/blocks/subscribe/index.php
@@ -89,7 +89,8 @@ function get_form_id() {
  * `display:none` as a fallback for a policy that strips the style attribute.
  *
  * newspack-plugin renders its own copy of this field in
- * `Newspack\Reader_Activation::render_honeypot_field()`. Changes here belong
+ * `Newspack\Reader_Activation::render_honeypot_field()`. Only the markup is
+ * duplicated — the submit-side rule defers to that plugin. Changes here belong
  * there too.
  *
  * Not rendered if reCAPTCHA is enabled as it's a superior spam protection.
@@ -107,6 +108,66 @@ function render_honeypot_field( $placeholder = '' ) {
 	?>
 	<input class="nphp" tabindex="-1" aria-hidden="true" name="email" type="email" autocomplete="off" data-1p-ignore data-lpignore="true" data-form-type="other" style="display:none;" placeholder="<?php echo \esc_attr( $placeholder ); ?>" />
 	<?php
+}
+
+/**
+ * The request fields belonging to the submission itself.
+ *
+ * The block's script posts, but the form carries no `method`, so a submission without
+ * JS arrives as a GET and that path is first-class — `send_form_response()` has its own
+ * GET branch. Reading only `$_POST` would leave those submissions unchecked, which is
+ * exactly the population that doesn't run JS. Reading `$_REQUEST` instead would let a
+ * query string fill a field the body left empty, so take the transport the submission
+ * actually used and read only that.
+ *
+ * @return array The submitted fields, still slashed.
+ */
+function get_submitted_fields() {
+	$method = \sanitize_text_field( \wp_unslash( $_SERVER['REQUEST_METHOD'] ?? '' ) );
+	// phpcs:ignore WordPress.Security.NonceVerification
+	return 'POST' === strtoupper( $method ) ? $_POST : $_GET;
+}
+
+/**
+ * Whether a submitted honeypot value should be read as a bot.
+ *
+ * A browser that autofills the form puts the reader's own address in both the decoy
+ * and the real field, so a decoy matching `npe` is autofill rather than a bot. Reading
+ * it as a bot reports a subscription that never happened, silently on both sides.
+ *
+ * Newspack owns this rule; this defers to it and keeps a local copy only for sites
+ * running a newspack-plugin that predates the shared helper. The local branch must
+ * stay in step with `Newspack\Reader_Activation::is_honeypot_tripped()`.
+ *
+ * @param string|null|false $honeypot Value submitted in the honeypot field (`email`).
+ * @param string|null|false $email    Value submitted in the real email field (`npe`).
+ *
+ * @return bool Whether to treat the submission as a bot.
+ */
+function is_honeypot_tripped( $honeypot, $email ) {
+	if ( method_exists( '\Newspack\Reader_Activation', 'is_honeypot_tripped' ) ) {
+		return \Newspack\Reader_Activation::is_honeypot_tripped( $honeypot, $email );
+	}
+
+	// Not `empty()`: a decoy filled with "0" is filled.
+	$honeypot = is_scalar( $honeypot ) ? trim( (string) $honeypot ) : '';
+	if ( '' === $honeypot ) {
+		return false;
+	}
+
+	$email = is_scalar( $email ) ? trim( (string) $email ) : '';
+	if ( '' === $email ) {
+		return true;
+	}
+
+	if ( strtolower( $honeypot ) === strtolower( $email ) ) {
+		return false;
+	}
+
+	$honeypot_as_email = strtolower( trim( (string) \sanitize_email( $honeypot ) ) );
+	$email_as_email    = strtolower( trim( (string) \sanitize_email( $email ) ) );
+
+	return '' === $honeypot_as_email || $honeypot_as_email !== $email_as_email;
 }
 
 /**
@@ -466,9 +527,24 @@ function process_form() {
 		return;
 	}
 
-	// Honeypot trap.
-	if ( ! empty( $_REQUEST['email'] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		return send_form_response( [ 'email' => \sanitize_email( $_REQUEST['email'] ) ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	// Honeypot trap. The decoy is read as text, not as an email: a bot fills it with
+	// whatever it likes, and email-sanitizing first would blank a non-address value
+	// and let the submission through.
+	//
+	// Read both fields from the transport the submission actually used, rather than
+	// from `$_REQUEST`. The block's script posts, but the form carries no `method`, so
+	// a submission without JS arrives as a GET — reading only `$_POST` would leave the
+	// decoy unchecked there. Reading `$_REQUEST` has the opposite problem: on a site
+	// with reCAPTCHA the decoy isn't rendered, so a POST carries no `email` field and a
+	// query string appended to the page URL would fill the slot, making every
+	// subscription from that link report success and record nobody.
+	$submitted = get_submitted_fields();
+	// phpcs:disable WordPress.Security.NonceVerification
+	$honeypot_trap = isset( $submitted['email'] ) && is_scalar( $submitted['email'] ) ? \sanitize_text_field( \wp_unslash( $submitted['email'] ) ) : '';
+	$real_email    = isset( $submitted['npe'] ) && is_scalar( $submitted['npe'] ) ? \sanitize_text_field( \wp_unslash( $submitted['npe'] ) ) : '';
+	// phpcs:enable WordPress.Security.NonceVerification
+	if ( is_honeypot_tripped( $honeypot_trap, $real_email ) ) {
+		return send_form_response( [ 'email' => \sanitize_email( $honeypot_trap ) ] );
 	}
 
 	// reCAPTCHA test.

--- a/plugins/newspack-newsletters/tests/test-subscribe-block-honeypot.php
+++ b/plugins/newspack-newsletters/tests/test-subscribe-block-honeypot.php
@@ -68,4 +68,108 @@ class Subscribe_Block_Honeypot_Test extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'name="email"', $markup, 'The honeypot must stay named `email`.' );
 		$this->assertStringContainsString( 'type="email"', $markup, 'The honeypot must stay an email input.' );
 	}
+
+	/**
+	 * Call the submit-side predicate.
+	 *
+	 * This bootstrap doesn't load newspack-plugin, so these exercise the local
+	 * fallback rather than the delegating branch. newspack-plugin owns the canonical
+	 * tests for the shared helper; these keep the fallback from drifting from it.
+	 *
+	 * @param mixed $honeypot Decoy value.
+	 * @param mixed $email    Real address value.
+	 *
+	 * @return bool
+	 */
+	private static function tripped( $honeypot, $email ) {
+		return Newspack_Newsletters\Blocks\Subscribe\is_honeypot_tripped( $honeypot, $email );
+	}
+
+	/**
+	 * An empty decoy is the normal case and never a bot.
+	 */
+	public function test_empty_honeypot_is_not_tripped() {
+		$this->assertFalse( self::tripped( '', 'reader@example.test' ) );
+		$this->assertFalse( self::tripped( null, 'reader@example.test' ) );
+	}
+
+	/**
+	 * A decoy matching the real field is autofill, not a bot.
+	 */
+	public function test_honeypot_matching_the_real_email_is_not_tripped() {
+		$this->assertFalse( self::tripped( 'reader@example.test', 'reader@example.test' ) );
+		$this->assertFalse( self::tripped( ' Reader@Example.test ', 'reader@example.test' ) );
+	}
+
+	/**
+	 * A decoy that differs from the real field is still a bot.
+	 */
+	public function test_honeypot_differing_from_the_real_email_is_tripped() {
+		$this->assertTrue( self::tripped( 'bot@spam.test', 'reader@example.test' ) );
+		$this->assertTrue( self::tripped( 'bot@spam.test', '' ) );
+	}
+
+	/**
+	 * A decoy filled with something that isn't an address is still a bot.
+	 *
+	 * This is the case that regressed once already: email-sanitizing the decoy before
+	 * testing whether it was filled blanks every non-address value, which is most of
+	 * what bots put in it.
+	 */
+	public function test_non_email_honeypot_is_tripped() {
+		$this->assertTrue( self::tripped( 'buy-cheap-pills', 'reader@example.test' ) );
+		$this->assertTrue( self::tripped( 'John Smith', 'reader@example.test' ) );
+		$this->assertTrue( self::tripped( 'https://spam.test', 'reader@example.test' ) );
+		$this->assertTrue( self::tripped( '0', 'reader@example.test' ) );
+	}
+
+	/**
+	 * Non-scalar input is not a filled decoy.
+	 */
+	public function test_non_scalar_input_is_handled() {
+		$this->assertFalse( self::tripped( [ 'bot@spam.test' ], 'reader@example.test' ) );
+		$this->assertTrue( self::tripped( 'bot@spam.test', [ 'reader@example.test' ] ) );
+	}
+
+	/**
+	 * A decoy written in a non-Latin script is still a bot.
+	 *
+	 * Email sanitizers strip every character an address can't contain, which blanks a
+	 * non-Latin string entirely. Whichever implementation runs, the decoy has to be
+	 * read as text for this to trip.
+	 */
+	public function test_non_latin_honeypot_is_tripped() {
+		$this->assertTrue( self::tripped( '买便宜药', 'reader@example.test' ) );
+		$this->assertTrue( self::tripped( 'дешевые таблетки', 'reader@example.test' ) );
+	}
+
+	/**
+	 * A non-ASCII address matching the real field is still autofill.
+	 *
+	 * Pins the local fallback's second comparison, which the delegating branch would
+	 * otherwise be the only thing covering.
+	 */
+	public function test_non_ascii_match_is_not_tripped() {
+		$this->assertFalse( self::tripped( 'réader@example.test', sanitize_email( 'réader@example.test' ) ) );
+	}
+
+	/**
+	 * The decoy is read from the transport the submission used.
+	 *
+	 * Reading only `$_POST` leaves a no-JS GET submission unchecked; reading
+	 * `$_REQUEST` lets a query string fill a decoy slot the POST body left empty.
+	 * This line has been wrong in both directions, so it is pinned.
+	 */
+	public function test_submitted_fields_follow_the_request_method() {
+		$_POST['probe'] = 'from-post';
+		$_GET['probe']  = 'from-get';
+
+		$_SERVER['REQUEST_METHOD'] = 'POST';
+		$this->assertSame( 'from-post', Newspack_Newsletters\Blocks\Subscribe\get_submitted_fields()['probe'] );
+
+		$_SERVER['REQUEST_METHOD'] = 'GET';
+		$this->assertSame( 'from-get', Newspack_Newsletters\Blocks\Subscribe\get_submitted_fields()['probe'] );
+
+		unset( $_POST['probe'], $_GET['probe'], $_SERVER['REQUEST_METHOD'] );
+	}
 }

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -1427,7 +1427,9 @@ final class Reader_Activation {
 	 * field, in exchange for readers never being locked out of their accounts.
 	 *
 	 * newspack-newsletters renders its own copy of this field in its Subscribe block
-	 * (`src/blocks/subscribe/index.php`). Changes here belong there too.
+	 * (`src/blocks/subscribe/index.php`). The markup is duplicated; the submit-side
+	 * rule is not, since that copy defers to `is_honeypot_tripped()` below. Markup
+	 * changes here belong there too.
 	 *
 	 * Not rendered if reCAPTCHA is enabled as it's a superior spam protection.
 	 *
@@ -1444,6 +1446,65 @@ final class Reader_Activation {
 		?>
 		<input class="nphp" tabindex="-1" aria-hidden="true" name="email" type="email" autocomplete="off" data-1p-ignore data-lpignore="true" data-form-type="other" style="display:none;" placeholder="<?php echo \esc_attr( $placeholder ); ?>" />
 		<?php
+	}
+
+	/**
+	 * Whether a submitted honeypot value should be read as a bot.
+	 *
+	 * Hiding the decoy from browsers is the first defence, but it depends on
+	 * browser internals we don't control. This is the second: a browser that
+	 * autofills the form puts the reader's own address in both the decoy and the
+	 * real field, so a decoy value matching what the reader submitted is autofill
+	 * rather than a bot. Reading it as a bot is what tells a reader they're signed
+	 * in while creating no session.
+	 *
+	 * The trade is deliberate. A bot that fills every field it recognises with one
+	 * address gets past this, and that is the cheaper failure: the decoy is not the
+	 * only defence against spam, while a reader locked out of their account has no
+	 * way to diagnose or recover from it.
+	 *
+	 * Callers reach this through different sanitizers — the decoy arrives as text, the
+	 * real address as a sanitized email — and those disagree on anything non-ASCII
+	 * (`sanitize_email()` drops the accent in `réader@example.test`). So both sides are
+	 * normalized here rather than at the call sites, and a match on either the raw or
+	 * the email-sanitized form counts. Sanitizing the decoy as an email before the
+	 * emptiness test would be worse than useless: it blanks any value that isn't
+	 * address-shaped, so a bot writing junk into the decoy would pass unnoticed.
+	 *
+	 * A filled decoy with no address alongside it counts as a bot. That deliberately
+	 * also catches the reader whose address is entirely non-ASCII, since
+	 * `sanitize_email()` blanks it — they can't register through Newspack either way,
+	 * so the decoy is not what stands between them and an account.
+	 *
+	 * @param string|null|false $honeypot Value submitted in the honeypot field (`email`).
+	 * @param string|null|false $email    Value submitted in the real email field (`npe`).
+	 *
+	 * @return bool Whether to treat the submission as a bot.
+	 */
+	public static function is_honeypot_tripped( $honeypot, $email ) {
+		// Not `empty()`: a decoy filled with "0" is filled.
+		$honeypot = \is_scalar( $honeypot ) ? trim( (string) $honeypot ) : '';
+		if ( '' === $honeypot ) {
+			return false;
+		}
+
+		$email = \is_scalar( $email ) ? trim( (string) $email ) : '';
+		if ( '' === $email ) {
+			return true;
+		}
+
+		// Autofill puts the same address in both fields.
+		if ( strtolower( $honeypot ) === strtolower( $email ) ) {
+			return false;
+		}
+
+		$honeypot_as_email = strtolower( trim( (string) \sanitize_email( $honeypot ) ) );
+		$email_as_email    = strtolower( trim( (string) \sanitize_email( $email ) ) );
+		if ( '' !== $honeypot_as_email && $honeypot_as_email === $email_as_email ) {
+			return false;
+		}
+
+		return true;
 	}
 
 	/**
@@ -2137,7 +2198,7 @@ final class Reader_Activation {
 		$redirect = ! empty( $redirect_url ) ? $redirect_url : $current_page_url;
 
 		// Honeypot trap.
-		if ( ! empty( $honeypot ) ) {
+		if ( self::is_honeypot_tripped( $honeypot, $email ) ) {
 			return self::send_auth_form_response(
 				[
 					'email'         => $honeypot,

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-registration.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-registration.php
@@ -429,8 +429,10 @@ final class Reader_Registration {
 		}
 
 		// Step 5: Honeypot — the `email` field must be empty. Real email is in `npe`.
+		// A decoy value matching `npe` is autofill rather than a bot; see
+		// Reader_Activation::is_honeypot_tripped().
 		$honeypot = $request->get_param( 'email' );
-		if ( ! empty( $honeypot ) ) {
+		if ( Reader_Activation::is_honeypot_tripped( $honeypot, $request->get_param( 'npe' ) ) ) {
 			// Return fake success to avoid revealing the honeypot to bots.
 			// @todo Consider returning the npe value instead of the honeypot value to make
 			// the fake response indistinguishable from a real one.

--- a/plugins/newspack-plugin/src/blocks/reader-registration/index.php
+++ b/plugins/newspack-plugin/src/blocks/reader-registration/index.php
@@ -456,10 +456,15 @@ function process_form() {
 		return;
 	}
 
-	$honeypot_trap = filter_input( INPUT_POST, 'email', FILTER_SANITIZE_EMAIL );
+	// Read the decoy as text, not as an email. `FILTER_SANITIZE_EMAIL` strips every
+	// character an address can't contain, so a decoy written in a non-Latin script
+	// blanks out entirely and the submission stops looking like a bot.
+	// phpcs:ignore WordPress.Security.NonceVerification.Missing
+	$honeypot_trap = isset( $_POST['email'] ) && is_scalar( $_POST['email'] ) ? \sanitize_text_field( \wp_unslash( $_POST['email'] ) ) : '';
 
-	// Honeypot trap.
-	if ( ! empty( $honeypot_trap ) ) {
+	// Honeypot trap. A decoy value matching the real field is autofill, not a bot —
+	// see Reader_Activation::is_honeypot_tripped().
+	if ( Reader_Activation::is_honeypot_tripped( $honeypot_trap, filter_input( INPUT_POST, 'npe', FILTER_SANITIZE_EMAIL ) ) ) {
 		return send_form_response(
 			[
 				'email'         => \sanitize_email( $honeypot_trap ),

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation-honeypot.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation-honeypot.php
@@ -85,6 +85,93 @@ class Newspack_Test_Reader_Activation_Honeypot extends WP_UnitTestCase {
 	}
 
 	/**
+	 * An empty decoy is the normal case and never a bot.
+	 */
+	public function test_empty_honeypot_is_not_tripped() {
+		$this->assertFalse( Reader_Activation::is_honeypot_tripped( '', 'reader@example.test' ) );
+		$this->assertFalse( Reader_Activation::is_honeypot_tripped( null, 'reader@example.test' ) );
+	}
+
+	/**
+	 * A decoy matching the real field is autofill, not a bot.
+	 *
+	 * This is the second line of defence behind the markup: a browser fills both
+	 * fields from one profile entry, so identical values are the autofill signature.
+	 */
+	public function test_honeypot_matching_the_real_email_is_not_tripped() {
+		$this->assertFalse( Reader_Activation::is_honeypot_tripped( 'reader@example.test', 'reader@example.test' ) );
+	}
+
+	/**
+	 * Matching is insensitive to case and surrounding whitespace.
+	 */
+	public function test_honeypot_match_ignores_case_and_whitespace() {
+		$this->assertFalse( Reader_Activation::is_honeypot_tripped( ' Reader@Example.test ', 'reader@example.test' ) );
+	}
+
+	/**
+	 * A decoy that differs from the real field is still a bot.
+	 */
+	public function test_honeypot_differing_from_the_real_email_is_tripped() {
+		$this->assertTrue( Reader_Activation::is_honeypot_tripped( 'bot@spam.test', 'reader@example.test' ) );
+	}
+
+	/**
+	 * A decoy filled with no real address is still a bot.
+	 *
+	 * Filling only the decoy is the behaviour the trap was built for, and nothing
+	 * about autofill produces it.
+	 */
+	public function test_honeypot_without_a_real_email_is_tripped() {
+		$this->assertTrue( Reader_Activation::is_honeypot_tripped( 'bot@spam.test', '' ) );
+	}
+
+	/**
+	 * A decoy filled with something that isn't an address is still a bot.
+	 *
+	 * Bots spray one canned string into every field they find, so most decoy values
+	 * are not addresses at all. Normalizing the decoy as an email before testing it
+	 * would blank those and let the submission through.
+	 */
+	public function test_non_email_honeypot_is_tripped() {
+		$this->assertTrue( Reader_Activation::is_honeypot_tripped( 'buy-cheap-pills', 'reader@example.test' ) );
+		$this->assertTrue( Reader_Activation::is_honeypot_tripped( 'John Smith', 'reader@example.test' ) );
+		$this->assertTrue( Reader_Activation::is_honeypot_tripped( 'https://spam.test', 'reader@example.test' ) );
+	}
+
+	/**
+	 * A decoy filled with "0" is filled.
+	 */
+	public function test_zero_string_honeypot_is_tripped() {
+		$this->assertTrue( Reader_Activation::is_honeypot_tripped( '0', 'reader@example.test' ) );
+	}
+
+	/**
+	 * The two sides reach this method through different sanitizers.
+	 *
+	 * `process_auth_form()` hands over a text-sanitized decoy and an email-sanitized
+	 * address, and those disagree on non-ASCII: `sanitize_email()` drops the accent.
+	 * Comparing them without normalizing would leave the reader locked out — the very
+	 * bug this guard exists to prevent.
+	 */
+	public function test_honeypot_match_survives_mismatched_sanitizers() {
+		$this->assertFalse(
+			Reader_Activation::is_honeypot_tripped( 'réader@example.test', sanitize_email( 'réader@example.test' ) ),
+			'A decoy and address that differ only by what sanitize_email() strips are the same reader.'
+		);
+	}
+
+	/**
+	 * Non-scalar input is not a filled decoy.
+	 *
+	 * `email[]=x` makes the decoy an array. It must not reach a string function.
+	 */
+	public function test_non_scalar_input_is_handled() {
+		$this->assertFalse( Reader_Activation::is_honeypot_tripped( [ 'bot@spam.test' ], 'reader@example.test' ) );
+		$this->assertTrue( Reader_Activation::is_honeypot_tripped( 'bot@spam.test', [ 'reader@example.test' ] ) );
+	}
+
+	/**
 	 * The honeypot gives way to reCAPTCHA, which supersedes it.
 	 */
 	public function test_honeypot_is_not_rendered_when_recaptcha_is_active() {

--- a/plugins/newspack-plugin/tests/unit-tests/reader-registration-endpoint.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-registration-endpoint.php
@@ -370,6 +370,29 @@ class Newspack_Test_Frontend_Registration_Endpoint extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test an autofilled honeypot registers the reader instead of faking success.
+	 *
+	 * A browser fills the decoy and the real field from one profile entry, so matching
+	 * values are a reader, not a bot. This is the user-facing half of the honeypot
+	 * contract: its sibling above covers the bot case.
+	 */
+	public function test_honeypot_matching_the_real_email_registers_the_reader() {
+		$response = $this->do_register_request(
+			[
+				'npe'             => self::$reader_email,
+				'email'           => self::$reader_email,
+				'integration_id'  => self::$integration_id,
+				'integration_key' => self::generate_key( self::$integration_id ),
+			]
+		);
+		// 201 Created, where the bot case returns a 200 carrying a fake success.
+		$this->assertEquals( 201, $response->get_status() );
+		$data = $response->get_data();
+		$this->assertTrue( $data['success'] );
+		$this->assertInstanceOf( 'WP_User', get_user_by( 'email', self::$reader_email ) );
+	}
+
+	/**
 	 * Test logged-in user returns current reader data.
 	 */
 	public function test_register_while_logged_in() {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

> **Stacked on #802 — review and merge that first.** This PR's base is `hotfix/auth-honeypot-autofill`, so its diff shows only the server-side change.
>
> **This one is a proposal, not a defect fix.** It trades away some spam protection. Read the trade-off section before approving; declining it is a reasonable outcome and leaves #802 standing on its own.

#802 stops browsers autofilling the anti-bot decoy on the reader sign-in and newsletter subscribe forms. That fixes the reported bug, but it works by making the field invisible to autofill — which depends on browser internals we don't control and can't fully verify. If any browser or password manager fills the decoy anyway, the reader is told they're signed in, no session is created, and they have no way to diagnose or recover from it.

This adds a second line of defence that doesn't depend on browser behaviour. `Reader_Activation::is_honeypot_tripped( $honeypot, $email )` is used at all four trap sites — `process_auth_form()`, the reader-registration block, the REST registration endpoint, and the Newsletters Subscribe block. A browser autofills the decoy and the real field from **one profile entry**, so a decoy value matching the submitted address is autofill rather than a bot. Everything else still trips: a differing value, a decoy filled with junk, a decoy filled with no address alongside it.

Two details worth knowing:

- **The decoy is compared as text, never sanitized as an email first.** Email sanitizers blank anything that isn't address-shaped — `John Smith`, `buy-cheap-pills`, a URL, or any non-Latin string — which is most of what bots put in a honeypot. Sanitizing before testing whether the field was filled would silently disable the trap for exactly that population.
- **Both sides are normalized inside the helper.** The call sites reach it through different sanitizers, and those disagree on non-ASCII (`sanitize_email( 'réader@example.test' )` returns `rader@example.test`). Comparing them unnormalized would leave readers with accented addresses locked out — the very failure this exists to prevent.

The Subscribe block defers to the shared helper under a `method_exists` guard, keeping one authoritative implementation without a hard dependency on a newspack-plugin version. It also reads the decoy from the transport the submission actually used: the block's script posts, but its form carries no `method`, so a submission without JS arrives as a GET.

### ⚠️ The trade-off: this reduces spam protection

**A bot that puts the same address in every field it recognises now gets past the honeypot.** That is the most common naive-bot behaviour, so this is not a hypothetical.

What that costs, concretely, on a site **without** reCAPTCHA — the only sites where the decoy renders at all:

- The decoy is the only gate in front of the form-post sign-in and registration handler.
- That handler has **no per-IP rate limit**. (The REST registration path does, via `check_registration_rate_limit()`; the form-post path doesn't.)
- So a submission that gets past the decoy can create a reader account and send outbound authentication mail.

The argument for accepting it: a reader locked out of their own account has no way to understand or fix what happened, while spam registrations are visible, cleanable, and not solely defended by this decoy. A bot that echoes one address into every field is also one that a per-IP limit would stop — which is the durable answer, and is filed as a follow-up rather than done here.

The argument against: it is a real reduction in a live defence, on sites that have no other one, taken to guard against a browser behaviour we haven't observed since #802 landed.

**If this isn't wanted, close it.** #802 fixes the reported bug on its own.

**If it does land, watch new registration volume on reCAPTCHA-less sites for a few weeks.** A step change there is the signal that the decoy has been worked around, and it is the only signal available, since a skipped decoy looks identical to a real signup.

### How to test the changes in this Pull Request:

On a site with reader activation enabled and reCAPTCHA off:

1. **The fix.** Submit the sign-in form with the **same** address in both `npe` and `email` (via devtools) — that's what autofill produces. Before this change the response was a 200 with `authenticated: 1` and the modal showed "Success! You're signed in." with no session. Now it proceeds to the normal flow, byte-identical to a submission with no decoy value at all.
2. **The trap still works.** Submit with **different** values in `npe` and `email`. Still returns the fake success.
3. **Junk still trips it.** Submit with `email=buy-cheap-pills`, or a non-Latin string such as `email=买便宜药`. Both still return the fake success.
4. **Decoy alone still trips it.** Submit with `email` filled and `npe` empty.
5. Repeat 1–4 against the Newsletters Subscribe block (`newspack_newsletters_subscribe=1`), including as a **GET** submission — the no-JS path.
6. Tests: `n test-php --group auth-honeypot` and `--group subscribe_honeypot`.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Full suites green — newspack-plugin 2359 tests / 6693 assertions, newspack-newsletters 713 / 2967 — and CI-parity PHPCS clean. Every scenario above was exercised against a running site, not only unit-tested.

**Follow-ups (not in this PR):**
- A per-IP limit on the form-post sign-in/registration handler, matching the one the REST path already has. This is the durable defence, and this PR makes it more load-bearing.
- The fake-success response still claims `authenticated: 1` on a path that creates no session. This PR stops autofill from reaching it; returning something that doesn't claim a session would make the whole class harmless.
- `email[]=x` bypasses the trap entirely, since `sanitize_text_field()` returns `''` for arrays. Pre-existing and unchanged here.
- The REST route's `args` declare `'type' => 'string'` but have no `validate_callback`, and `register_rest_route()` doesn't attach one, so `npe[]=x` can reach `sanitize_email( array )`. Pre-existing; the endpoint requires a valid integration key.
- No test exercises the three form handlers directly. Both regressions this change went through during review lived at a call site, not in the predicate.
