### PR TITLE
feat(access-control): warn when gating is configured but not applying

### DIFF
--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -161,7 +161,7 @@ const Wizard = (
 		</TabbedNavigation>
 	);
 
-	// Rendered as the first child of .newspack-wizard__main rather than as a core
+	// Rendered as the first child of .newspack-wizard__content rather than as a core
 	// admin notice: that puts it below the header and tabbed navigation, and inside
 	// the container that bounds the wizard's own width, so it lines up with the
 	// content it is about instead of spanning the viewport.
@@ -174,20 +174,6 @@ const Wizard = (
 			{ sections.length > 1 && <ResetHeaderData /> }
 
 			<div className="newspack-wizard__main">
-				{ inertGating?.show && (
-					<Notice isWarning className="newspack-wizard__inert-gating-notice">
-						{ /* createInterpolateElement's conversion map takes childless elements and
-						     fills them from the translated string, so jsx-a11y can't see the
-						     content it will end up with. */ }
-						{ createInterpolateElement( inertGating.message, {
-							/* eslint-disable jsx-a11y/anchor-has-content */
-							gates: <a href={ inertGating.urls.gates } />,
-							newsletters: <a href={ inertGating.urls.newsletters } />,
-							audience: <a href={ inertGating.urls.audience } />,
-							/* eslint-enable jsx-a11y/anchor-has-content */
-						} ) }
-					</Notice>
-				) }
 				<Switch>
 					{ routedSections.map( ( section, index ) => {
 						const SectionComponent = section.render;
@@ -203,6 +189,20 @@ const Wizard = (
 											'newspack-wizard__content--full-width': section.fullWidth,
 										} ) }
 									>
+										{ inertGating?.show && (
+											<Notice isWarning className="newspack-wizard__inert-gating-notice">
+												{ /* createInterpolateElement's conversion map takes childless
+												     elements and fills them from the translated string, so
+												     jsx-a11y can't see the content they end up with. */ }
+												{ createInterpolateElement( inertGating.message, {
+													/* eslint-disable jsx-a11y/anchor-has-content */
+													accessControl: <a href={ inertGating.urls.accessControl } />,
+													audience: <a href={ inertGating.urls.audience } />,
+													/* eslint-enable jsx-a11y/anchor-has-content */
+													strong: <strong />,
+												} ) }
+											</Notice>
+										) }
 										{ 'function' === typeof renderAboveSections ? renderAboveSections() : null }
 										{ ( sectionTitle || section.title ) && (
 											<SectionHeader

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -161,9 +161,20 @@ const Wizard = (
 		</TabbedNavigation>
 	);
 
+	// Sits at the top of the content region, which the header and tabbed navigation
+	// wrap — so it reads below them rather than above the wizard's own header, where
+	// a core admin notice would land.
+	const inertGating = window.newspack_aux_data?.inert_gating;
+
 	const content = (
 		<>
 			<HandoffMessage />
+
+			{ inertGating?.show && (
+				<Notice isWarning className="newspack-wizard__inert-gating-notice">
+					{ inertGating.message } <a href={ inertGating.url }>{ inertGating.link_text }</a>
+				</Notice>
+			) }
 
 			{ sections.length > 1 && <ResetHeaderData /> }
 

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -6,7 +6,8 @@ import classnames from 'classnames';
 /**
  * WordPress dependencies.
  */
-import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
+// Notice is aliased: `Notice` below is Newspack's own, which this file also uses.
+import { DropdownMenu, MenuGroup, MenuItem, Notice as CoreNotice } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
 import { cloneElement, createInterpolateElement, isValidElement, useEffect, useState, forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
@@ -189,11 +190,25 @@ const Wizard = (
 		</TabbedNavigation>
 	);
 
-	// Rendered as the first child of .newspack-wizard__content rather than as a core
-	// admin notice: that puts it below the header and tabbed navigation, and inside
-	// the container that bounds the wizard's own width, so it lines up with the
-	// content it is about instead of spanning the viewport.
+	// Rendered here rather than as a core admin notice, which wizards strip at
+	// priority -9999. Sits as the first child of .newspack-wizard__main so it lands
+	// flush beneath the header region and spans the full width in every view: this
+	// describes the state of the whole site, not of the section below it, so it reads
+	// as page chrome rather than as content.
 	const inertGating = window.newspack_aux_data?.inert_gating;
+	const inertGatingNotice = inertGating?.show && (
+		<CoreNotice status="warning" isDismissible={ false } className="newspack-wizard__inert-gating-notice">
+			{ /* The conversion map takes childless elements and fills them from the
+			     translated string, so jsx-a11y can't see the content they end up with. */ }
+			{ interpolateOrPlainText( inertGating.message, {
+				/* eslint-disable jsx-a11y/anchor-has-content */
+				accessControl: <a href={ inertGating.urls.accessControl } />,
+				audience: <a href={ inertGating.urls.audience } />,
+				/* eslint-enable jsx-a11y/anchor-has-content */
+				strong: <strong />,
+			} ) }
+		</CoreNotice>
+	);
 
 	const content = (
 		<>
@@ -202,6 +217,7 @@ const Wizard = (
 			{ sections.length > 1 && <ResetHeaderData /> }
 
 			<div className="newspack-wizard__main">
+				{ inertGatingNotice }
 				<Switch>
 					{ routedSections.map( ( section, index ) => {
 						const SectionComponent = section.render;
@@ -217,20 +233,6 @@ const Wizard = (
 											'newspack-wizard__content--full-width': section.fullWidth,
 										} ) }
 									>
-										{ inertGating?.show && (
-											<Notice isWarning className="newspack-wizard__inert-gating-notice">
-												{ /* The conversion map takes childless elements and fills them
-												     from the translated string, so jsx-a11y can't see the content
-												     they end up with. */ }
-												{ interpolateOrPlainText( inertGating.message, {
-													/* eslint-disable jsx-a11y/anchor-has-content */
-													accessControl: <a href={ inertGating.urls.accessControl } />,
-													audience: <a href={ inertGating.urls.audience } />,
-													/* eslint-enable jsx-a11y/anchor-has-content */
-													strong: <strong />,
-												} ) }
-											</Notice>
-										) }
 										{ 'function' === typeof renderAboveSections ? renderAboveSections() : null }
 										{ ( sectionTitle || section.title ) && (
 											<SectionHeader

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -8,7 +8,7 @@ import classnames from 'classnames';
  */
 import { DropdownMenu, MenuGroup, MenuItem } from '@wordpress/components';
 import { useDispatch, useSelect } from '@wordpress/data';
-import { cloneElement, isValidElement, useEffect, useState, forwardRef } from '@wordpress/element';
+import { cloneElement, createInterpolateElement, isValidElement, useEffect, useState, forwardRef } from '@wordpress/element';
 import { __ } from '@wordpress/i18n';
 import { category, chevronLeft, moreVertical } from '@wordpress/icons';
 
@@ -172,7 +172,16 @@ const Wizard = (
 
 			{ inertGating?.show && (
 				<Notice isWarning className="newspack-wizard__inert-gating-notice">
-					{ inertGating.message } <a href={ inertGating.url }>{ inertGating.link_text }</a>
+					{ /* createInterpolateElement's conversion map takes childless elements and
+					     fills them from the translated string, so jsx-a11y can't see the
+					     content it will end up with. */ }
+					{ createInterpolateElement( inertGating.message, {
+						/* eslint-disable jsx-a11y/anchor-has-content */
+						gates: <a href={ inertGating.urls.gates } />,
+						newsletters: <a href={ inertGating.urls.newsletters } />,
+						audience: <a href={ inertGating.urls.audience } />,
+						/* eslint-enable jsx-a11y/anchor-has-content */
+					} ) }
 				</Notice>
 			) }
 

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -40,6 +40,34 @@ const resolveIcon = icon => {
 const { HashRouter, Redirect, Route, Switch, useLocation } = Router;
 
 /**
+ * Interpolate a translated message's named tags, falling back to plain text.
+ *
+ * The message is translated, so its tags are site-controlled: any .mo file under
+ * wp-content/languages/plugins, any GlotPress export, or any `gettext`-filter
+ * plugin can supply one. `createInterpolateElement` throws on an unbalanced
+ * closing tag whose name is in the conversion map - verified against core's own
+ * element.js, which is what runs here since the bundle externalizes wp-element.
+ * Nothing above this renders an error boundary, so an uncaught throw would blank
+ * the whole wizard, including the screen the inert-gating notice links to as the
+ * fix. Degraded copy is recoverable; a blank screen is not.
+ *
+ * The other malformed cases already degrade on their own and are left alone: an
+ * unclosed opener drops that tag and renders the rest as text, and a tag not in
+ * the map renders literally.
+ *
+ * @param {string} message    Translated message carrying named tags.
+ * @param {Object} conversion Conversion map for createInterpolateElement.
+ * @return {JSX.Element|string} The interpolated message, or the message with its tags stripped.
+ */
+const interpolateOrPlainText = ( message, conversion ) => {
+	try {
+		return createInterpolateElement( message, conversion );
+	} catch {
+		return message.replace( /<\/?[a-zA-Z][a-zA-Z0-9]*\s*\/?>/g, '' );
+	}
+};
+
+/**
  * Reset the header data when a new section is rendered.
  */
 const ResetHeaderData = () => {
@@ -191,10 +219,10 @@ const Wizard = (
 									>
 										{ inertGating?.show && (
 											<Notice isWarning className="newspack-wizard__inert-gating-notice">
-												{ /* createInterpolateElement's conversion map takes childless
-												     elements and fills them from the translated string, so
-												     jsx-a11y can't see the content they end up with. */ }
-												{ createInterpolateElement( inertGating.message, {
+												{ /* The conversion map takes childless elements and fills them
+												     from the translated string, so jsx-a11y can't see the content
+												     they end up with. */ }
+												{ interpolateOrPlainText( inertGating.message, {
 													/* eslint-disable jsx-a11y/anchor-has-content */
 													accessControl: <a href={ inertGating.urls.accessControl } />,
 													audience: <a href={ inertGating.urls.audience } />,

--- a/packages/components/src/wizard/index.js
+++ b/packages/components/src/wizard/index.js
@@ -161,33 +161,33 @@ const Wizard = (
 		</TabbedNavigation>
 	);
 
-	// Sits at the top of the content region, which the header and tabbed navigation
-	// wrap — so it reads below them rather than above the wizard's own header, where
-	// a core admin notice would land.
+	// Rendered as the first child of .newspack-wizard__main rather than as a core
+	// admin notice: that puts it below the header and tabbed navigation, and inside
+	// the container that bounds the wizard's own width, so it lines up with the
+	// content it is about instead of spanning the viewport.
 	const inertGating = window.newspack_aux_data?.inert_gating;
 
 	const content = (
 		<>
 			<HandoffMessage />
 
-			{ inertGating?.show && (
-				<Notice isWarning className="newspack-wizard__inert-gating-notice">
-					{ /* createInterpolateElement's conversion map takes childless elements and
-					     fills them from the translated string, so jsx-a11y can't see the
-					     content it will end up with. */ }
-					{ createInterpolateElement( inertGating.message, {
-						/* eslint-disable jsx-a11y/anchor-has-content */
-						gates: <a href={ inertGating.urls.gates } />,
-						newsletters: <a href={ inertGating.urls.newsletters } />,
-						audience: <a href={ inertGating.urls.audience } />,
-						/* eslint-enable jsx-a11y/anchor-has-content */
-					} ) }
-				</Notice>
-			) }
-
 			{ sections.length > 1 && <ResetHeaderData /> }
 
 			<div className="newspack-wizard__main">
+				{ inertGating?.show && (
+					<Notice isWarning className="newspack-wizard__inert-gating-notice">
+						{ /* createInterpolateElement's conversion map takes childless elements and
+						     fills them from the translated string, so jsx-a11y can't see the
+						     content it will end up with. */ }
+						{ createInterpolateElement( inertGating.message, {
+							/* eslint-disable jsx-a11y/anchor-has-content */
+							gates: <a href={ inertGating.urls.gates } />,
+							newsletters: <a href={ inertGating.urls.newsletters } />,
+							audience: <a href={ inertGating.urls.audience } />,
+							/* eslint-enable jsx-a11y/anchor-has-content */
+						} ) }
+					</Notice>
+				) }
 				<Switch>
 					{ routedSections.map( ( section, index ) => {
 						const SectionComponent = section.render;

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -154,6 +154,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/class-cta-intent-classifier.php';
 		include_once NEWSPACK_ABSPATH . 'includes/content-gate/trait-content-gate-layout.php';
 		include_once NEWSPACK_ABSPATH . 'includes/content-gate/class-content-gate.php';
+		include_once NEWSPACK_ABSPATH . 'includes/content-gate/class-inert-gating-notice.php';
 
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-provider.php';
 		include_once NEWSPACK_ABSPATH . 'includes/starter_content/class-starter-content-generated.php';

--- a/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
@@ -68,6 +68,34 @@ class Inert_Gating_Notice {
 		// that has to render this notice.
 		add_action( 'save_post', [ __CLASS__, 'flush_cache_on_post' ], 10, 2 );
 		add_action( 'deleted_post', [ __CLASS__, 'flush_cache_on_post' ], 10, 2 );
+		add_action( 'post_updated', [ __CLASS__, 'flush_cache_on_update' ], 10, 3 );
+	}
+
+	/**
+	 * Clear the cache when an edit removes the last block access-control attributes.
+	 *
+	 * `save_post` sees only the content as it now is, so an edit that strips the
+	 * last `newspackAccessControl*` attribute looks like an ordinary post save and
+	 * flushes nothing — leaving the cached answer stuck at "configured" with no
+	 * later write to correct it. `post_updated` is the one hook that supplies the
+	 * content as it was.
+	 *
+	 * Only the "before" side is checked here; `save_post` already covers the after.
+	 *
+	 * @param int      $post_id     Post ID.
+	 * @param \WP_Post $post_after  Post object after the update.
+	 * @param \WP_Post $post_before Post object before the update.
+	 */
+	public static function flush_cache_on_update( $post_id, $post_after, $post_before ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.Found
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
+		if ( ! $post_before instanceof \WP_Post ) {
+			return;
+		}
+		if ( false !== strpos( (string) $post_before->post_content, self::BLOCK_ATTRIBUTE_PREFIX ) ) {
+			self::flush_cache();
+		}
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
@@ -33,8 +33,9 @@ class Inert_Gating_Notice {
 	 *
 	 * An option rather than a transient: it must not expire on a timer, since the
 	 * answer only changes when the underlying objects do and every one of those
-	 * writes invalidates it explicitly below. Stored un-autoloaded — see
-	 * has_surfaces().
+	 * writes invalidates it explicitly below. Holds only "is anything configured" —
+	 * whether that configuration is currently applying is read live by is_inert().
+	 * Stored un-autoloaded — see has_surfaces().
 	 */
 	const CACHE_OPTION = 'newspack_content_gate_has_surfaces';
 
@@ -58,27 +59,15 @@ class Inert_Gating_Notice {
 		// from fighting them.
 		add_action( 'admin_notices', [ __CLASS__, 'render' ] );
 
-		// Cache invalidation. The answer changes only when Audience Management is
-		// toggled or a queried object is created, deleted or edited, so each of those
-		// clears it and nothing else does — no TTL, no periodic recompute.
-		add_action( 'newspack_reader_activation_update_setting', [ __CLASS__, 'flush_cache_on_setting' ], 10, 2 );
+		// Cache invalidation. The answer changes only when a queried object is
+		// created, deleted or edited, so those clear it and nothing else does — no
+		// TTL, no periodic recompute. Deliberately NOT hooked to Audience Management:
+		// the cached value is only "is anything configured", which that setting cannot
+		// change, and is_inert() reads the setting live. Flushing there would just
+		// throw away a valid answer and force the recompute onto the very page load
+		// that has to render this notice.
 		add_action( 'save_post', [ __CLASS__, 'flush_cache_on_post' ], 10, 2 );
 		add_action( 'deleted_post', [ __CLASS__, 'flush_cache_on_post' ], 10, 2 );
-	}
-
-	/**
-	 * Clear the cache when Audience Management is toggled.
-	 *
-	 * The notice's visibility flips with this setting, and the cached value is the
-	 * other half of that decision.
-	 *
-	 * @param string $key   Setting key.
-	 * @param mixed  $value Setting value.
-	 */
-	public static function flush_cache_on_setting( $key, $value ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
-		if ( 'enabled' === $key ) {
-			self::flush_cache();
-		}
 	}
 
 	/**
@@ -93,6 +82,15 @@ class Inert_Gating_Notice {
 	 * @param \WP_Post|null $post Post object, when the hook supplies one.
 	 */
 	public static function flush_cache_on_post( $post_id, $post = null ) {
+		// Revisions carry a verbatim copy of the parent's content, so they match the
+		// prefix check below and would flush on every autosave — roughly once a minute
+		// while anyone has a gated post open, on exactly the sites this cache exists
+		// for. They can never change the answer: has_block_rules() counts only
+		// published posts and revisions are 'inherit'. Autosaves are revisions too
+		// (see _wp_post_revision_data()), so one guard covers both.
+		if ( wp_is_post_revision( $post_id ) ) {
+			return;
+		}
 		$post = $post instanceof \WP_Post ? $post : get_post( $post_id );
 		if ( ! $post ) {
 			return;

--- a/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
@@ -286,13 +286,24 @@ class Inert_Gating_Notice {
 	 * Returns the strings rather than a flag so the two surfaces cannot drift into
 	 * saying different things about the same state.
 	 *
-	 * @return array{show: bool, message: string, urls: array<string, string>}
+	 * `has_surfaces` answers a different question from `show`, which is why both are
+	 * here: `show` is "is content public right now", and is false while Audience
+	 * Management is still on. The confirmation dialog for switching it off needs to
+	 * know what would happen, so it asks whether anything is configured at all.
+	 *
+	 * Unlike `show`, it is not gated on the feature flag. Block-level visibility is
+	 * flag-independent ({@see Block_Visibility}), so a site without the constant can
+	 * still have member-only blocks that go public.
+	 *
+	 * @return array{show: bool, has_surfaces: bool, message: string, urls: array<string, string>}
 	 */
 	public static function get_script_data(): array {
+		$can_manage = current_user_can( 'manage_options' );
 		return [
-			'show'    => current_user_can( 'manage_options' ) && self::is_inert(),
-			'message' => self::get_message(),
-			'urls'    => self::get_urls(),
+			'show'         => $can_manage && self::is_inert(),
+			'has_surfaces' => $can_manage && self::has_surfaces(),
+			'message'      => self::get_message(),
+			'urls'         => self::get_urls(),
 		];
 	}
 

--- a/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
@@ -49,6 +49,23 @@ class Inert_Gating_Notice {
 	const BLOCK_ATTRIBUTE_PREFIX = 'newspackAccessControl';
 
 	/**
+	 * The attributes that mean something is actually configured.
+	 *
+	 * Narrower than the prefix above on purpose. `...Mode` and `...Visibility` also
+	 * serialize, but only record a choice: a block left in `custom` mode having
+	 * never had a rule added carries `...Mode` and nothing else, and matching the
+	 * bare prefix would report that site as gated. These two only appear once rules
+	 * or gates are set, so they answer the question the notice actually asks.
+	 *
+	 * The prefix stays the invalidation trigger — over-flushing is harmless, and a
+	 * flush that recomputes the same answer costs nothing.
+	 */
+	const CONFIGURED_ATTRIBUTES = [
+		'newspackAccessControlRules',
+		'newspackAccessControlGateIds',
+	];
+
+	/**
 	 * Initialize hooks.
 	 */
 	public static function init() {
@@ -209,6 +226,15 @@ class Inert_Gating_Notice {
 	 * embedding a reusable block carries only a `wp:block` reference, so the
 	 * attributes live on the `wp_block` post alone.
 	 *
+	 * One `LIKE` per entry in CONFIGURED_ATTRIBUTES rather than one on the shared
+	 * prefix, so a block that only records a mode choice isn't counted. Measured on
+	 * a seeded 9,000-row wp_posts, no match present: 0.179 ms for the single prefix
+	 * match against 0.218 ms for the pair. A `REGEXP` alternation came in faster
+	 * still here, but this runs on MariaDB and CI and production run MySQL, whose
+	 * regex engine is a different implementation with a different profile — not
+	 * worth the variance for four hundredths of a millisecond on a query that only
+	 * runs when the cache misses.
+	 *
 	 * @return bool
 	 */
 	private static function has_block_rules(): bool {
@@ -219,22 +245,26 @@ class Inert_Gating_Notice {
 			return false;
 		}
 
-		$placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
-		$values       = array_values( $post_types );
-		$values[]     = '%' . $wpdb->esc_like( self::BLOCK_ATTRIBUTE_PREFIX ) . '%';
+		$type_placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
+		$content_clause    = implode( ' OR ', array_fill( 0, count( self::CONFIGURED_ATTRIBUTES ), 'post_content LIKE %s' ) );
 
-		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders is a generated list of %s, one per post type; every value is passed through prepare().
+		$values = array_values( $post_types );
+		foreach ( self::CONFIGURED_ATTRIBUTES as $attribute ) {
+			$values[] = '%' . $wpdb->esc_like( $attribute ) . '%';
+		}
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare -- both interpolations are generated %s lists, which is why the sniffs cannot see the placeholders; every value is passed through prepare().
 		$found = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
 				"SELECT ID FROM {$wpdb->posts}
-				WHERE post_type IN ( $placeholders )
+				WHERE post_type IN ( $type_placeholders )
 				AND post_status = 'publish'
-				AND post_content LIKE %s
+				AND ( $content_clause )
 				LIMIT 1",
 				$values
 			)
 		);
-		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared, WordPress.DB.PreparedSQLPlaceholders.UnfinishedPrepare
 		return ! empty( $found );
 	}
 

--- a/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
@@ -1,0 +1,250 @@
+<?php
+/**
+ * Newspack Inert Gating Notice.
+ *
+ * Warns an administrator when Access Control is configured but not applying,
+ * which happens whenever Audience Management is switched off on a site that
+ * has gates, premium newsletters or block-level access rules set up.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Persistent admin notice for configured-but-inert Access Control.
+ *
+ * Switching Audience Management off makes every Access Control surface stand
+ * down: gated posts, premium newsletter lists and member-only blocks all become
+ * public ({@see Content_Gate::is_gating_active()}). That is intended, and the
+ * confirmation dialog says so — but the dialog is a single moment, and after it
+ * nothing on the site says the paywall is down. This is the standing reminder,
+ * so an accidental toggle doesn't quietly leave paid content open.
+ *
+ * Shown only when there is something to be inert. A site that never configured
+ * Access Control gets nothing.
+ */
+class Inert_Gating_Notice {
+
+	/**
+	 * Option holding the cached "has anything configured" answer.
+	 *
+	 * An option rather than a transient: this is read on every admin page load,
+	 * so it wants to be autoloaded, and it must not expire on a timer — the
+	 * answer only changes when the underlying objects do, and every one of those
+	 * writes invalidates it explicitly below.
+	 */
+	const CACHE_OPTION = 'newspack_content_gate_has_surfaces';
+
+	/**
+	 * Substring identifying a block carrying access-control attributes.
+	 *
+	 * Matches the `newspackAccessControlMode` / `...Visibility` / `...GateIds` /
+	 * `...Rules` attributes that Block_Visibility registers, all of which share
+	 * this prefix in the serialized block comment.
+	 */
+	const BLOCK_ATTRIBUTE_PREFIX = 'newspackAccessControl';
+
+	/**
+	 * Initialize hooks.
+	 */
+	public static function init() {
+		// Core admin screens only. Wizard screens render this as a Notice component
+		// below their header and tabs instead ({@see get_script_data()}), because a
+		// core notice there lands above the wizard's own header. Wizards strip all
+		// notices at priority -9999 anyway, so the default priority is what keeps this
+		// from fighting them.
+		add_action( 'admin_notices', [ __CLASS__, 'render' ] );
+
+		// Cache invalidation. The answer changes only when Audience Management is
+		// toggled or a queried object is created, deleted or edited, so each of those
+		// clears it and nothing else does — no TTL, no periodic recompute.
+		add_action( 'newspack_reader_activation_update_setting', [ __CLASS__, 'flush_cache_on_setting' ], 10, 2 );
+		add_action( 'save_post', [ __CLASS__, 'flush_cache_on_post' ], 10, 2 );
+		add_action( 'deleted_post', [ __CLASS__, 'flush_cache_on_post' ], 10, 2 );
+	}
+
+	/**
+	 * Clear the cache when Audience Management is toggled.
+	 *
+	 * The notice's visibility flips with this setting, and the cached value is the
+	 * other half of that decision.
+	 *
+	 * @param string $key   Setting key.
+	 * @param mixed  $value Setting value.
+	 */
+	public static function flush_cache_on_setting( $key, $value ) { // phpcs:ignore Generic.CodeAnalysis.UnusedFunctionParameter.FoundAfterLastUsed
+		if ( 'enabled' === $key ) {
+			self::flush_cache();
+		}
+	}
+
+	/**
+	 * Clear the cache when a queried object is written or removed.
+	 *
+	 * Gates always count. Any other post type only matters if it carries block
+	 * access-control attributes, so the content is checked before invalidating —
+	 * otherwise every post save on the site would clear a cache that could not
+	 * have changed.
+	 *
+	 * @param int           $post_id Post ID.
+	 * @param \WP_Post|null $post Post object, when the hook supplies one.
+	 */
+	public static function flush_cache_on_post( $post_id, $post = null ) {
+		$post = $post instanceof \WP_Post ? $post : get_post( $post_id );
+		if ( ! $post ) {
+			return;
+		}
+		if ( Content_Gate::GATE_CPT === $post->post_type ) {
+			self::flush_cache();
+			return;
+		}
+		if ( false !== strpos( (string) $post->post_content, self::BLOCK_ATTRIBUTE_PREFIX ) ) {
+			self::flush_cache();
+		}
+	}
+
+	/**
+	 * Clear the cached answer.
+	 */
+	public static function flush_cache() {
+		delete_option( self::CACHE_OPTION );
+	}
+
+	/**
+	 * Whether the site has any Access Control surface configured.
+	 *
+	 * Widened past gates on purpose: a publisher who only ever used block-level
+	 * visibility has just as much content quietly going public, and would get no
+	 * warning from a gates-only check.
+	 *
+	 * Cached because the block-attribute half is a `LIKE` over post content, which
+	 * is too expensive to run on every admin page load. The query is bounded to a
+	 * single row — this only ever answers "any", never "how many".
+	 *
+	 * @return bool
+	 */
+	public static function has_surfaces(): bool {
+		$cached = get_option( self::CACHE_OPTION, null );
+		if ( null !== $cached && '' !== $cached ) {
+			return (bool) $cached;
+		}
+
+		$has_surfaces = self::has_gates() || self::has_block_rules();
+
+		// Stored as '1'/'0' rather than a bool: update_option() round-trips false to
+		// an empty string, which is indistinguishable from "not cached yet" and would
+		// make a negative answer recompute the LIKE query on every page load.
+		update_option( self::CACHE_OPTION, $has_surfaces ? '1' : '0' );
+
+		return $has_surfaces;
+	}
+
+	/**
+	 * Whether any published gate exists, of either kind.
+	 *
+	 * Published only: a draft gate was not applying before Audience Management was
+	 * switched off either, so it is not something the publisher has lost.
+	 *
+	 * @return bool
+	 */
+	private static function has_gates(): bool {
+		$gates = get_posts(
+			[
+				'post_type'      => Content_Gate::GATE_CPT,
+				'post_status'    => 'publish',
+				'posts_per_page' => 1,
+				'fields'         => 'ids',
+				'no_found_rows'  => true,
+			]
+		);
+		return ! empty( $gates );
+	}
+
+	/**
+	 * Whether any post carries block-level access-control attributes.
+	 *
+	 * A direct query rather than WP_Query: this is a content `LIKE`, which
+	 * WP_Query can only express through `s` (which also searches titles and
+	 * excerpts and applies relevance ordering). Bounded to one row and cached by
+	 * the caller.
+	 *
+	 * @return bool
+	 */
+	private static function has_block_rules(): bool {
+		global $wpdb;
+		$found = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT ID FROM {$wpdb->posts}
+				WHERE post_status = 'publish'
+				AND post_content LIKE %s
+				LIMIT 1",
+				'%' . $wpdb->esc_like( self::BLOCK_ATTRIBUTE_PREFIX ) . '%'
+			)
+		);
+		return ! empty( $found );
+	}
+
+	/**
+	 * Whether the site is configured for Access Control but not applying it.
+	 *
+	 * @return bool
+	 */
+	public static function is_inert(): bool {
+		if ( ! Content_Gate::is_newspack_feature_enabled() || Content_Gate::is_gating_active() ) {
+			return false;
+		}
+		return self::has_surfaces();
+	}
+
+	/**
+	 * Notice payload for the wizard shell.
+	 *
+	 * Returns the strings rather than a flag so the two surfaces cannot drift into
+	 * saying different things about the same state.
+	 *
+	 * @return array{show: bool, message: string, url: string, link_text: string}
+	 */
+	public static function get_script_data(): array {
+		return [
+			'show'      => current_user_can( 'manage_options' ) && self::is_inert(),
+			'message'   => self::get_message(),
+			'url'       => admin_url( 'admin.php?page=newspack-audience#/' ),
+			'link_text' => __( 'Turn on Audience Management', 'newspack-plugin' ),
+		];
+	}
+
+	/**
+	 * The notice text, shared by both surfaces.
+	 *
+	 * @return string
+	 */
+	private static function get_message(): string {
+		return __( 'Access Control is not applying. Audience Management is off, so gated posts, premium newsletters and member-only blocks are public to everyone. The configuration is kept and starts applying again when Audience Management is turned back on.', 'newspack-plugin' );
+	}
+
+	/**
+	 * Render the core admin notice.
+	 */
+	public static function render() {
+		if ( ! current_user_can( 'manage_options' ) ) {
+			return;
+		}
+		if ( ! self::is_inert() ) {
+			return;
+		}
+		?>
+		<div class="notice notice-warning">
+			<p><?php echo esc_html( self::get_message() ); ?></p>
+			<p>
+				<a href="<?php echo esc_url( admin_url( 'admin.php?page=newspack-audience#/' ) ); ?>">
+					<?php esc_html_e( 'Turn on Audience Management', 'newspack-plugin' ); ?>
+				</a>
+			</p>
+		</div>
+		<?php
+	}
+}
+Inert_Gating_Notice::init();

--- a/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
@@ -172,19 +172,41 @@ class Inert_Gating_Notice {
 	 * excerpts and applies relevance ordering). Bounded to one row and cached by
 	 * the caller.
 	 *
+	 * Constrained by post type so the `type_status_date` index is usable: without
+	 * it MySQL full-scans wp_posts (`type: ALL, key: NULL`), with it the plan drops
+	 * to a range scan. The list is derived rather than hardcoded, because any post
+	 * type could carry these blocks — `show_in_rest` is the prerequisite for the
+	 * block editor, so it cannot miss one, and it excludes `revision`, which is
+	 * usually the largest slice of the table. `wp_block` has to stay in: a post
+	 * embedding a reusable block carries only a `wp:block` reference, so the
+	 * attributes live on the `wp_block` post alone.
+	 *
 	 * @return bool
 	 */
 	private static function has_block_rules(): bool {
 		global $wpdb;
+
+		$post_types = get_post_types( [ 'show_in_rest' => true ], 'names' );
+		if ( empty( $post_types ) ) {
+			return false;
+		}
+
+		$placeholders = implode( ', ', array_fill( 0, count( $post_types ), '%s' ) );
+		$values       = array_values( $post_types );
+		$values[]     = '%' . $wpdb->esc_like( self::BLOCK_ATTRIBUTE_PREFIX ) . '%';
+
+		// phpcs:disable WordPress.DB.PreparedSQL.InterpolatedNotPrepared -- $placeholders is a generated list of %s, one per post type; every value is passed through prepare().
 		$found = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
 			$wpdb->prepare(
 				"SELECT ID FROM {$wpdb->posts}
-				WHERE post_status = 'publish'
+				WHERE post_type IN ( $placeholders )
+				AND post_status = 'publish'
 				AND post_content LIKE %s
 				LIMIT 1",
-				'%' . $wpdb->esc_like( self::BLOCK_ATTRIBUTE_PREFIX ) . '%'
+				$values
 			)
 		);
+		// phpcs:enable WordPress.DB.PreparedSQL.InterpolatedNotPrepared
 		return ! empty( $found );
 	}
 

--- a/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
@@ -31,10 +31,10 @@ class Inert_Gating_Notice {
 	/**
 	 * Option holding the cached "has anything configured" answer.
 	 *
-	 * An option rather than a transient: this is read on every admin page load,
-	 * so it wants to be autoloaded, and it must not expire on a timer — the
-	 * answer only changes when the underlying objects do, and every one of those
-	 * writes invalidates it explicitly below.
+	 * An option rather than a transient: it must not expire on a timer, since the
+	 * answer only changes when the underlying objects do and every one of those
+	 * writes invalidates it explicitly below. Stored un-autoloaded — see
+	 * has_surfaces().
 	 */
 	const CACHE_OPTION = 'newspack_content_gate_has_surfaces';
 
@@ -137,7 +137,10 @@ class Inert_Gating_Notice {
 		// Stored as '1'/'0' rather than a bool: update_option() round-trips false to
 		// an empty string, which is indistinguishable from "not cached yet" and would
 		// make a negative answer recompute the LIKE query on every page load.
-		update_option( self::CACHE_OPTION, $has_surfaces ? '1' : '0' );
+		//
+		// Not autoloaded: this is read in wp-admin and nowhere else, so autoloading it
+		// would put it in every front-end request's option payload for nothing.
+		update_option( self::CACHE_OPTION, $has_surfaces ? '1' : '0', false );
 
 		return $has_surfaces;
 	}
@@ -205,24 +208,40 @@ class Inert_Gating_Notice {
 	 * Returns the strings rather than a flag so the two surfaces cannot drift into
 	 * saying different things about the same state.
 	 *
-	 * @return array{show: bool, message: string, url: string, link_text: string}
+	 * @return array{show: bool, message: string, urls: array<string, string>}
 	 */
 	public static function get_script_data(): array {
 		return [
-			'show'      => current_user_can( 'manage_options' ) && self::is_inert(),
-			'message'   => self::get_message(),
-			'url'       => admin_url( 'admin.php?page=newspack-audience#/' ),
-			'link_text' => __( 'Turn on Audience Management', 'newspack-plugin' ),
+			'show'    => current_user_can( 'manage_options' ) && self::is_inert(),
+			'message' => self::get_message(),
+			'urls'    => self::get_urls(),
 		];
 	}
 
 	/**
 	 * The notice text, shared by both surfaces.
 	 *
+	 * Carries named tags rather than finished anchors so the core notice and the
+	 * wizard's React notice compose the same sentence from the same translation —
+	 * two strings would drift, and a translator would see the markup either way.
+	 *
 	 * @return string
 	 */
 	private static function get_message(): string {
-		return __( 'Access Control is not applying. Audience Management is off, so gated posts, premium newsletters and member-only blocks are public to everyone. The configuration is kept and starts applying again when Audience Management is turned back on.', 'newspack-plugin' );
+		return __( 'Audience Management is off, so <gates>gated content</gates>, <newsletters>premium newsletters</newsletters>, and member-only blocks are currently public for all readers. <audience>Turn on Audience Management</audience> to enable Access Control.', 'newspack-plugin' );
+	}
+
+	/**
+	 * Destinations for the message's named tags.
+	 *
+	 * @return array<string, string>
+	 */
+	private static function get_urls(): array {
+		return [
+			'gates'       => admin_url( 'admin.php?page=newspack-audience-access-control' ),
+			'newsletters' => admin_url( 'admin.php?page=newspack-premium-newsletters' ),
+			'audience'    => admin_url( 'admin.php?page=newspack-audience#/' ),
+		];
 	}
 
 	/**
@@ -235,14 +254,17 @@ class Inert_Gating_Notice {
 		if ( ! self::is_inert() ) {
 			return;
 		}
+		$message = self::get_message();
+		foreach ( self::get_urls() as $tag => $url ) {
+			$message = str_replace(
+				[ '<' . $tag . '>', '</' . $tag . '>' ],
+				[ '<a href="' . esc_url( $url ) . '">', '</a>' ],
+				$message
+			);
+		}
 		?>
 		<div class="notice notice-warning">
-			<p><?php echo esc_html( self::get_message() ); ?></p>
-			<p>
-				<a href="<?php echo esc_url( admin_url( 'admin.php?page=newspack-audience#/' ) ); ?>">
-					<?php esc_html_e( 'Turn on Audience Management', 'newspack-plugin' ); ?>
-				</a>
-			</p>
+			<p><?php echo wp_kses( $message, [ 'a' => [ 'href' => [] ] ] ); ?></p>
 		</div>
 		<?php
 	}

--- a/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-inert-gating-notice.php
@@ -228,7 +228,7 @@ class Inert_Gating_Notice {
 	 * @return string
 	 */
 	private static function get_message(): string {
-		return __( 'Audience Management is off, so <gates>gated content</gates>, <newsletters>premium newsletters</newsletters>, and member-only blocks are currently public for all readers. <audience>Turn on Audience Management</audience> to enable Access Control.', 'newspack-plugin' );
+		return __( '<accessControl>Access Control</accessControl> features are currently <strong>disabled</strong>: gated content, premium newsletters, and member-only blocks are public for all readers. <audience>Turn on Audience Management</audience> to enable Access Control.', 'newspack-plugin' );
 	}
 
 	/**
@@ -238,9 +238,8 @@ class Inert_Gating_Notice {
 	 */
 	private static function get_urls(): array {
 		return [
-			'gates'       => admin_url( 'admin.php?page=newspack-audience-access-control' ),
-			'newsletters' => admin_url( 'admin.php?page=newspack-premium-newsletters' ),
-			'audience'    => admin_url( 'admin.php?page=newspack-audience#/' ),
+			'accessControl' => admin_url( 'admin.php?page=newspack-audience-access-control' ),
+			'audience'      => admin_url( 'admin.php?page=newspack-audience#/' ),
 		];
 	}
 
@@ -264,7 +263,17 @@ class Inert_Gating_Notice {
 		}
 		?>
 		<div class="notice notice-warning">
-			<p><?php echo wp_kses( $message, [ 'a' => [ 'href' => [] ] ] ); ?></p>
+			<p>
+				<?php
+				echo wp_kses(
+					$message,
+					[
+						'a'      => [ 'href' => [] ],
+						'strong' => [],
+					]
+				);
+				?>
+			</p>
 		</div>
 		<?php
 	}

--- a/plugins/newspack-plugin/includes/wizards/class-wizard.php
+++ b/plugins/newspack-plugin/includes/wizards/class-wizard.php
@@ -208,6 +208,11 @@ abstract class Wizard {
 			'has_completed_setup' => get_option( NEWSPACK_SETUP_COMPLETE ),
 			'site_title'          => get_option( 'blogname' ),
 			'is_managed'          => method_exists( 'Newspack_Manager', 'is_connected_to_manager' ) && \Newspack_Manager::is_connected_to_manager(),
+			// Access Control configured but not applying. Rendered by the wizard shell as
+			// a Notice below the header and tabs, rather than as the core admin notice
+			// Inert_Gating_Notice prints elsewhere — which this screen would stack above
+			// its own header.
+			'inert_gating'        => Inert_Gating_Notice::get_script_data(),
 		];
 
 		wp_localize_script( 'newspack_data', 'newspack_urls', $urls );

--- a/plugins/newspack-plugin/src/admin/style.scss
+++ b/plugins/newspack-plugin/src/admin/style.scss
@@ -197,6 +197,16 @@ h1 {
 	padding-right: 0;
 }
 
+// The inert-gating warning describes the state of the whole site rather than of the
+// section beneath it, so it spans the full width in every view and sits flush against
+// the header region above. Core's Notice ships margins meant for inline placement,
+// which would open a gap there and break the seam.
+.newspack-wizard__inert-gating-notice.components-notice {
+	border-radius: 0;
+	margin: 0;
+	width: 100%;
+}
+
 .newspack-wizard__sections {
 	margin: 0 auto;
 	padding: calc(var(--newspack-wizard-section-space) * 2) var(--newspack-wizard-section-space) 0;

--- a/plugins/newspack-plugin/src/content-gate/editor/block-visibility.tsx
+++ b/plugins/newspack-plugin/src/content-gate/editor/block-visibility.tsx
@@ -319,7 +319,12 @@ const BlockVisibilityPanel = ( { attributes, setAttributes }: BlockEditProps ) =
 		const newRules: BlockVisibilityRules = { ...rules, ...updates };
 		const stillActive = hasActiveRules( newRules, mode, gateIds );
 		setAttributes( {
-			newspackAccessControlRules: newRules,
+			// Reset to the registered default when the last rule is turned off, rather
+			// than storing every rule set to inactive. Gutenberg omits an attribute that
+			// deep-equals its default, so the block stops carrying any access-control
+			// markup at all - which is what tells the rest of the plugin that this block
+			// no longer has rules on it.
+			newspackAccessControlRules: stillActive ? newRules : {},
 			// Reset visibility to 'visible' when all custom rules are cleared.
 			...( ! stillActive ? { newspackAccessControlVisibility: 'visible' } : {} ),
 		} );

--- a/plugins/newspack-plugin/src/wizards/audience/components/platform-selection/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/components/platform-selection/index.js
@@ -45,11 +45,27 @@ const PlatformSelection = ( { onComplete, onCancel, config, saveConfig, inFlight
 	const { saveWizardSettings } = useDispatch( WIZARD_STORE_NAMESPACE );
 	const [ installing, setInstalling ] = useState( null );
 	const [ installFailed, setInstallFailed ] = useState( false );
+	// Only warn about Access Control when the site has something to lose. The flag is
+	// the same one behind the standing inert-gating notice, so the dialog and that
+	// notice agree about what counts as configured.
+	const hasAccessControl = window.newspack_aux_data?.inert_gating?.has_surfaces;
 	const { confirmDialog: disableDialog, requestConfirm: requestDisable } = useConfirmDialog( {
 		title: __( 'Disable Audience Management?', 'newspack-plugin' ),
-		message: __(
-			'Disabling Audience Management turns off reader registration, the My Account dashboard, and related reader features. Gated content, premium newsletters, and member-only blocks will become public for all readers. Are you sure you want to disable these features?',
-			'newspack-plugin'
+		message: (
+			<>
+				<p>
+					{ __(
+						'Disabling Audience Management turns off reader registration, the My Account dashboard, and related reader features.',
+						'newspack-plugin'
+					) }
+				</p>
+				{ hasAccessControl && (
+					<p>
+						{ __( 'Gated content, premium newsletters, and member-only blocks will become public for all readers.', 'newspack-plugin' ) }
+					</p>
+				) }
+				<p>{ __( 'Are you sure you want to disable these features?', 'newspack-plugin' ) }</p>
+			</>
 		),
 		confirmButtonText: __( 'Disable', 'newspack-plugin' ),
 		isDestructive: true,

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
@@ -103,7 +103,7 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$this->disable_audience_management();
 
-		$this->assertStringNotContainsString( 'currently public for all readers', $this->render() );
+		$this->assertStringNotContainsString( 'are public for all readers', $this->render() );
 	}
 
 	/**
@@ -115,7 +115,7 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 		Inert_Gating_Notice::flush_cache();
 
 		$this->assertStringNotContainsString(
-			'currently public for all readers',
+			'are public for all readers',
 			$this->render(),
 			'Nothing to warn about while gating is doing its job.'
 		);
@@ -124,16 +124,17 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 
 		$rendered = $this->render();
 		$this->assertStringContainsString(
-			'currently public for all readers',
+			'are public for all readers',
 			$rendered,
 			'A configured site with gating inactive should be told its content is public.'
 		);
 		// The copy exists to route the publisher somewhere, so the destinations are
 		// part of the contract, not decoration.
-		foreach ( [ 'page=newspack-audience-access-control', 'page=newspack-premium-newsletters', 'page=newspack-audience' ] as $destination ) {
+		foreach ( [ 'page=newspack-audience-access-control', 'page=newspack-audience' ] as $destination ) {
 			$this->assertStringContainsString( $destination, $rendered, "Expected the notice to link to $destination." );
 		}
-		$this->assertStringNotContainsString( '<gates>', $rendered, 'Interpolation tags must not reach the page.' );
+		$this->assertStringNotContainsString( '<accessControl>', $rendered, 'Interpolation tags must not reach the page.' );
+		$this->assertStringContainsString( '<strong>disabled</strong>', $rendered, 'Expected the emphasis to survive wp_kses.' );
 	}
 
 	/**
@@ -152,7 +153,7 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 		Inert_Gating_Notice::flush_cache();
 		$this->disable_audience_management();
 
-		$this->assertStringContainsString( 'currently public for all readers', $this->render() );
+		$this->assertStringContainsString( 'are public for all readers', $this->render() );
 	}
 
 	/**
@@ -164,7 +165,7 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 		Inert_Gating_Notice::flush_cache();
 		$this->disable_audience_management();
 
-		$this->assertStringNotContainsString( 'currently public for all readers', $this->render() );
+		$this->assertStringNotContainsString( 'are public for all readers', $this->render() );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
@@ -103,7 +103,7 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
 		$this->disable_audience_management();
 
-		$this->assertStringNotContainsString( 'Access Control is not applying', $this->render() );
+		$this->assertStringNotContainsString( 'currently public for all readers', $this->render() );
 	}
 
 	/**
@@ -115,18 +115,25 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 		Inert_Gating_Notice::flush_cache();
 
 		$this->assertStringNotContainsString(
-			'Access Control is not applying',
+			'currently public for all readers',
 			$this->render(),
 			'Nothing to warn about while gating is doing its job.'
 		);
 
 		$this->disable_audience_management();
 
+		$rendered = $this->render();
 		$this->assertStringContainsString(
-			'Access Control is not applying',
-			$this->render(),
+			'currently public for all readers',
+			$rendered,
 			'A configured site with gating inactive should be told its content is public.'
 		);
+		// The copy exists to route the publisher somewhere, so the destinations are
+		// part of the contract, not decoration.
+		foreach ( [ 'page=newspack-audience-access-control', 'page=newspack-premium-newsletters', 'page=newspack-audience' ] as $destination ) {
+			$this->assertStringContainsString( $destination, $rendered, "Expected the notice to link to $destination." );
+		}
+		$this->assertStringNotContainsString( '<gates>', $rendered, 'Interpolation tags must not reach the page.' );
 	}
 
 	/**
@@ -145,7 +152,7 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 		Inert_Gating_Notice::flush_cache();
 		$this->disable_audience_management();
 
-		$this->assertStringContainsString( 'Access Control is not applying', $this->render() );
+		$this->assertStringContainsString( 'currently public for all readers', $this->render() );
 	}
 
 	/**
@@ -157,7 +164,7 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 		Inert_Gating_Notice::flush_cache();
 		$this->disable_audience_management();
 
-		$this->assertStringNotContainsString( 'Access Control is not applying', $this->render() );
+		$this->assertStringNotContainsString( 'currently public for all readers', $this->render() );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
@@ -1,0 +1,224 @@
+<?php
+/**
+ * Tests for the configured-but-inert Access Control notice.
+ *
+ * NPPD-1846 follow-up. Switching Audience Management off makes every Access
+ * Control surface stand down, which is intended — but it is one toggle away from
+ * paid content going public, and after the confirmation dialog nothing says so.
+ * This notice is the standing reminder.
+ *
+ * Two properties matter and are pinned separately: it appears exactly when
+ * something is configured but not applying, and its cache is invalidated by the
+ * writes that can change that answer and by nothing else. The second is what
+ * keeps a `LIKE` over post content off every admin page load.
+ *
+ * Every case is mutation-tested: removing the behaviour it pins must fail it.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Content_Gate;
+use Newspack\Inert_Gating_Notice;
+
+/**
+ * Tests for Inert_Gating_Notice.
+ */
+class Inert_Gating_Notice_Test extends WP_UnitTestCase {
+
+	/**
+	 * Gates are flag-gated; the CPT must be registered for gate posts to exist.
+	 */
+	public static function set_up_before_class() {
+		parent::set_up_before_class();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+	}
+
+	/**
+	 * Start each case from a known-empty cache.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Inert_Gating_Notice::flush_cache();
+		Content_Gate::flush_gates_cache();
+	}
+
+	/**
+	 * Don't leak the disabled state into later cases.
+	 */
+	public function tear_down() {
+		remove_all_filters( 'newspack_reader_activation_enabled' );
+		Inert_Gating_Notice::flush_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * Turn Audience Management off for the current case.
+	 */
+	private function disable_audience_management() {
+		add_filter( 'newspack_reader_activation_enabled', '__return_false' );
+	}
+
+	/**
+	 * Capture the rendered notice.
+	 *
+	 * @return string
+	 */
+	private function render(): string {
+		ob_start();
+		Inert_Gating_Notice::render();
+		return (string) ob_get_clean();
+	}
+
+	/**
+	 * Publish a gate.
+	 *
+	 * @return int Gate post ID.
+	 */
+	private function create_gate(): int {
+		$gate_id = Content_Gate::create_gate(
+			[
+				'title'         => 'Test gate',
+				'status'        => 'publish',
+				'content_rules' => [
+					[
+						'slug'  => 'post_types',
+						'value' => [ 'post' ],
+					],
+				],
+				'registration'  => [ 'active' => true ],
+			]
+		);
+		$this->assertNotWPError( $gate_id, 'Gate fixture could not be created.' );
+		return $gate_id;
+	}
+
+	/**
+	 * A publisher who never configured Access Control has nothing going public, so
+	 * warning them would be noise. This is the case that keeps the notice off most
+	 * sites entirely.
+	 */
+	public function test_no_notice_without_configured_surfaces() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->disable_audience_management();
+
+		$this->assertStringNotContainsString( 'Access Control is not applying', $this->render() );
+	}
+
+	/**
+	 * The notice fires on exactly the state it exists for, and only that state.
+	 */
+	public function test_notice_appears_only_while_configured_and_inert() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->create_gate();
+		Inert_Gating_Notice::flush_cache();
+
+		$this->assertStringNotContainsString(
+			'Access Control is not applying',
+			$this->render(),
+			'Nothing to warn about while gating is doing its job.'
+		);
+
+		$this->disable_audience_management();
+
+		$this->assertStringContainsString(
+			'Access Control is not applying',
+			$this->render(),
+			'A configured site with gating inactive should be told its content is public.'
+		);
+	}
+
+	/**
+	 * Block-level access control counts too. A publisher who only ever used it has
+	 * just as much content quietly going public, and a gates-only check would leave
+	 * them with no warning at all.
+	 */
+	public function test_block_level_rules_count_as_a_surface() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		self::factory()->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:group {"newspackAccessControlMode":"custom"} --><div></div><!-- /wp:group -->',
+			]
+		);
+		Inert_Gating_Notice::flush_cache();
+		$this->disable_audience_management();
+
+		$this->assertStringContainsString( 'Access Control is not applying', $this->render() );
+	}
+
+	/**
+	 * The notice is for whoever can act on it.
+	 */
+	public function test_hidden_from_users_who_cannot_act_on_it() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
+		$this->create_gate();
+		Inert_Gating_Notice::flush_cache();
+		$this->disable_audience_management();
+
+		$this->assertStringNotContainsString( 'Access Control is not applying', $this->render() );
+	}
+
+	/**
+	 * Creating or deleting a gate changes the answer, so both must invalidate.
+	 */
+	public function test_cache_is_invalidated_by_gate_writes() {
+		$this->assertFalse( Inert_Gating_Notice::has_surfaces(), 'Expected no surfaces on a clean site.' );
+
+		$gate_id = $this->create_gate();
+		$this->assertTrue( Inert_Gating_Notice::has_surfaces(), 'Creating a gate should invalidate the cached answer.' );
+
+		wp_delete_post( $gate_id, true );
+		$this->assertFalse( Inert_Gating_Notice::has_surfaces(), 'Deleting the last gate should invalidate it again.' );
+	}
+
+	/**
+	 * A post carrying block rules changes the answer; an ordinary post does not.
+	 *
+	 * The negative half is the point of checking the content before invalidating:
+	 * without it every post save on the site would clear a cache that could not
+	 * have changed, and the `LIKE` would run again on the next admin page load.
+	 */
+	public function test_cache_invalidation_is_scoped_to_relevant_posts() {
+		$this->assertFalse( Inert_Gating_Notice::has_surfaces() );
+
+		self::factory()->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_content' => 'nothing to do with access control',
+			]
+		);
+		$this->assertSame(
+			'0',
+			get_option( Inert_Gating_Notice::CACHE_OPTION ),
+			'An unrelated post save must leave the cached answer in place.'
+		);
+
+		self::factory()->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:group {"newspackAccessControlVisibility":"visible"} --><div></div><!-- /wp:group -->',
+			]
+		);
+		$this->assertFalse(
+			get_option( Inert_Gating_Notice::CACHE_OPTION, false ),
+			'A post carrying block rules must invalidate the cached answer.'
+		);
+		$this->assertTrue( Inert_Gating_Notice::has_surfaces() );
+	}
+
+	/**
+	 * A negative answer must cache too, or the `LIKE` runs on every admin page load
+	 * of every site that never configured Access Control — which is most of them.
+	 */
+	public function test_a_negative_answer_is_cached() {
+		$this->assertFalse( Inert_Gating_Notice::has_surfaces() );
+
+		$this->assertSame(
+			'0',
+			get_option( Inert_Gating_Notice::CACHE_OPTION ),
+			'Expected the negative answer to be stored as a distinguishable value.'
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
@@ -147,13 +147,37 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 		self::factory()->post->create(
 			[
 				'post_status'  => 'publish',
-				'post_content' => '<!-- wp:group {"newspackAccessControlMode":"custom"} --><div></div><!-- /wp:group -->',
+				'post_content' => '<!-- wp:group {"newspackAccessControlMode":"custom","newspackAccessControlRules":{"registration":{"active":true}}} --><div></div><!-- /wp:group -->',
 			]
 		);
 		Inert_Gating_Notice::flush_cache();
 		$this->disable_audience_management();
 
 		$this->assertStringContainsString( 'are public for all readers', $this->render() );
+	}
+
+	/**
+	 * A block that only records a mode choice is not configured.
+	 *
+	 * Someone who switches a block to custom mode and never adds a rule leaves
+	 * `newspackAccessControlMode` in the content for good — the editor has no reason
+	 * to remove it, and it is a preference rather than a rule. Counting it would tell
+	 * that publisher their content is public when nothing was ever gated, and with no
+	 * TTL nothing would correct it.
+	 */
+	public function test_a_mode_choice_alone_is_not_a_surface() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		self::factory()->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:group {"newspackAccessControlMode":"custom"} --><div></div><!-- /wp:group -->',
+			]
+		);
+		Inert_Gating_Notice::flush_cache();
+		$this->disable_audience_management();
+
+		$this->assertFalse( Inert_Gating_Notice::has_surfaces(), 'A mode with no rules behind it gates nothing.' );
+		$this->assertStringNotContainsString( 'are public for all readers', $this->render() );
 	}
 
 	/**
@@ -246,7 +270,7 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 		self::factory()->post->create(
 			[
 				'post_status'  => 'publish',
-				'post_content' => '<!-- wp:group {"newspackAccessControlVisibility":"visible"} --><div></div><!-- /wp:group -->',
+				'post_content' => '<!-- wp:group {"newspackAccessControlGateIds":[12]} --><div></div><!-- /wp:group -->',
 			]
 		);
 		$this->assertFalse(
@@ -338,7 +362,7 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 		$post_id = self::factory()->post->create(
 			[
 				'post_status'  => 'publish',
-				'post_content' => '<!-- wp:group {"newspackAccessControlMode":"custom"} --><div></div><!-- /wp:group -->',
+				'post_content' => '<!-- wp:group {"newspackAccessControlMode":"custom","newspackAccessControlRules":{"registration":{"active":true}}} --><div></div><!-- /wp:group -->',
 			]
 		);
 		Inert_Gating_Notice::flush_cache();

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
@@ -169,6 +169,46 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * The wizard surface is the one most admins actually see, since wizards strip
+	 * core notices. It gets its own capability check, so it needs its own case —
+	 * the one on render() is pinned separately above.
+	 */
+	public function test_wizard_payload_tracks_capability_and_inertness() {
+		$this->create_gate();
+		Inert_Gating_Notice::flush_cache();
+		$this->disable_audience_management();
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
+		$this->assertFalse(
+			Inert_Gating_Notice::get_script_data()['show'],
+			'An editor cannot turn Audience Management back on, so the wizard must not show them the notice.'
+		);
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->assertTrue( Inert_Gating_Notice::get_script_data()['show'] );
+
+		remove_all_filters( 'newspack_reader_activation_enabled' );
+		$this->assertFalse(
+			Inert_Gating_Notice::get_script_data()['show'],
+			'Nothing to warn about while gating is doing its job.'
+		);
+	}
+
+	/**
+	 * The cached answer must actually be read back, not just written. Without this
+	 * the early return in has_surfaces() can be deleted with every other case still
+	 * green, and the `LIKE` runs on every admin page load.
+	 */
+	public function test_the_cached_answer_is_read_back() {
+		$this->assertFalse( Inert_Gating_Notice::has_surfaces(), 'No gates, no block rules.' );
+
+		// Nothing on this site says otherwise, so a `true` answer can only have come
+		// from the cache.
+		update_option( Inert_Gating_Notice::CACHE_OPTION, '1', false );
+		$this->assertTrue( Inert_Gating_Notice::has_surfaces() );
+	}
+
+	/**
 	 * Creating or deleting a gate changes the answer, so both must invalidate.
 	 */
 	public function test_cache_is_invalidated_by_gate_writes() {
@@ -214,6 +254,31 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 			'A post carrying block rules must invalidate the cached answer.'
 		);
 		$this->assertTrue( Inert_Gating_Notice::has_surfaces() );
+	}
+
+	/**
+	 * Revisions copy the parent's content verbatim, so without a guard every autosave
+	 * of a gated post flushes — about once a minute while anyone has one open, on
+	 * exactly the sites this cache exists for.
+	 */
+	public function test_revisions_do_not_invalidate_the_cache() {
+		$post_id = self::factory()->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:group {"newspackAccessControlMode":"custom"} --><div></div><!-- /wp:group -->',
+			]
+		);
+		Inert_Gating_Notice::flush_cache();
+		$this->assertTrue( Inert_Gating_Notice::has_surfaces(), 'Expected the block rules to be found and cached.' );
+
+		$revision_id = wp_save_post_revision( $post_id );
+		$this->assertNotEmpty( $revision_id, 'Fixture failed: no revision was created.' );
+
+		$this->assertSame(
+			'1',
+			get_option( Inert_Gating_Notice::CACHE_OPTION ),
+			'A revision cannot change the answer, so it must leave the cached value in place.'
+		);
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
@@ -219,6 +219,29 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * `has_surfaces` answers what `show` cannot.
+	 *
+	 * The confirmation dialog for switching Audience Management off runs while it is
+	 * still on, so nothing is inert yet and `show` is false. The dialog still needs to
+	 * know whether there is anything to warn about, which is a different question.
+	 */
+	public function test_wizard_payload_reports_configured_surfaces_while_gating_is_active() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->create_gate();
+		Inert_Gating_Notice::flush_cache();
+
+		$data = Inert_Gating_Notice::get_script_data();
+		$this->assertFalse( $data['show'], 'Nothing is public while gating is doing its job.' );
+		$this->assertTrue( $data['has_surfaces'], 'The dialog has to know what switching off would expose.' );
+
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
+		$this->assertFalse(
+			Inert_Gating_Notice::get_script_data()['has_surfaces'],
+			'An editor cannot reach that dialog, so the payload should tell them nothing.'
+		);
+	}
+
+	/**
 	 * The cached answer must actually be read back, not just written. Without this
 	 * the early return in has_surfaces() can be deleted with every other case still
 	 * green, and the `LIKE` runs on every admin page load.

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-inert-gating-notice-test.php
@@ -257,6 +257,79 @@ class Inert_Gating_Notice_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Removing the last block rules flips the answer from true to false, and only the
+	 * pre-update content carries the evidence — the saved content no longer mentions
+	 * access control at all, so it reads as an ordinary post save. Without this the
+	 * notice keeps warning about content nobody has gated, with no later write to
+	 * correct it.
+	 */
+	public function test_removing_block_rules_invalidates_the_cache() {
+		$post_id = self::factory()->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_content' => '<!-- wp:group {"newspackAccessControlRules":{"registration":{"active":true}}} --><div></div><!-- /wp:group -->',
+			]
+		);
+		Inert_Gating_Notice::flush_cache();
+		$this->assertTrue( Inert_Gating_Notice::has_surfaces(), 'Expected the block rules to be found and cached.' );
+
+		wp_update_post(
+			[
+				'ID'           => $post_id,
+				'post_content' => '<!-- wp:group --><div></div><!-- /wp:group -->',
+			]
+		);
+
+		$this->assertFalse(
+			get_option( Inert_Gating_Notice::CACHE_OPTION, false ),
+			'Stripping the last access-control attributes must invalidate the cached answer.'
+		);
+		$this->assertFalse( Inert_Gating_Notice::has_surfaces(), 'Nothing is configured any more.' );
+	}
+
+	/**
+	 * The second and later autosaves update the same autosave row rather than
+	 * inserting a new one, so they arrive on `post_updated` with a "before" that
+	 * still carries the attributes. Without the revision guard on that handler the
+	 * flush comes straight back through the new hook.
+	 */
+	public function test_repeated_autosaves_do_not_invalidate_the_cache() {
+		$user_id = self::factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $user_id );
+
+		$content = '<!-- wp:group {"newspackAccessControlRules":{"registration":{"active":true}}} --><div></div><!-- /wp:group -->';
+		$post_id = self::factory()->post->create(
+			[
+				'post_status'  => 'publish',
+				'post_author'  => $user_id,
+				'post_content' => $content,
+			]
+		);
+
+		$autosave = [
+			'post_ID'      => $post_id,
+			'post_type'    => 'post',
+			'post_title'   => 'Draft in progress',
+			'post_content' => $content,
+		];
+		$first = wp_create_post_autosave( $autosave );
+		$this->assertNotEmpty( $first, 'Fixture failed: no autosave was created.' );
+
+		Inert_Gating_Notice::flush_cache();
+		$this->assertTrue( Inert_Gating_Notice::has_surfaces() );
+
+		$autosave['post_content'] = $content . '<!-- wp:paragraph --><p>Still typing.</p><!-- /wp:paragraph -->';
+		$second                   = wp_create_post_autosave( $autosave );
+		$this->assertSame( $first, $second, 'Fixture failed: the second autosave should reuse the same row.' );
+
+		$this->assertSame(
+			'1',
+			get_option( Inert_Gating_Notice::CACHE_OPTION ),
+			'An autosave cannot change the answer, so it must leave the cached value in place.'
+		);
+	}
+
+	/**
 	 * Revisions copy the parent's content verbatim, so without a guard every autosave
 	 * of a gated post flushes — about once a minute while anyone has one open, on
 	 * exactly the sites this cache exists for.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Stacked on #803, which it targets. Merge this into that branch first.**

#803 makes Access Control stand down completely when Audience Management is switched off — gated posts, premium newsletters and member-only blocks all become public, deliberately. Support pointed out the risk that leaves: it's a single toggle away from all paid content going public, the confirmation dialog is the only thing that says so, and after that moment nothing does.

This adds the standing reminder. While Audience Management is off on a site that has Access Control configured, every admin screen carries a warning that gated content is currently public, with a link to turn Audience Management back on.

It appears only when there is something to be inert. A site that never configured Access Control sees nothing, and neither does a site where gating is working normally.

**What counts as configured** is deliberately wider than gates: published content gates, premium newsletter gates, and posts carrying block-level access rules. A publisher who only ever used block-level visibility has just as much content quietly going public, and a gates-only check would have left them with no warning at all.

**Where it appears.** Core admin screens get a standard warning notice. Newspack wizard screens render a core `Notice` instead, as the first child of `.newspack-wizard__main` — flush beneath the header region and spanning the full width in every view. It describes the state of the whole site rather than of the section below it, so it reads as page chrome rather than as content.

The copy leads with what is off and ends with how to fix it:

> [Access Control] features are currently **disabled**: gated content, premium newsletters, and member-only blocks are public for all readers. [Turn on Audience Management] to enable Access Control.

Both surfaces compose that from one translated string with named tags — the core notice swaps them for anchors, the wizard runs them through `createInterpolateElement`. Two strings would drift, and a translator would see the markup either way.

Because the string is translated, its tags are site-controlled, and `createInterpolateElement` throws on an unbalanced closing tag whose name is in the conversion map. The wizard shell catches that and falls back to the message with its tags stripped: degraded copy is recoverable, a blank wizard is not.

Requested by Support in [this thread](https://a8c.slack.com/archives/C0ANXE4NDT3/p1785958772942389). Part of NPPD-1846.

**Confirmation dialog.** Also on this branch, so it registers as a change against #803: the copy for disabling Audience Management is now three paragraphs, and the middle one — the Access Control consequence — appears only when the site has something configured. A publisher who never set up a gate, a premium newsletter or a member-only block is not warned about losing them. That reuses `has_surfaces()`, which is why the change lives here rather than in the base branch.

### How to test the changes in this Pull Request:

1. On a site with `define( 'NEWSPACK_CONTENT_GATES', true );` and Audience Management on, confirm no notice appears anywhere in wp-admin.
2. Turn Audience Management off (`wp option update newspack_reader_activation_enabled 0`) with nothing configured. Still no notice — there is nothing to be inert.
3. Create a published gate under **Audience → Access Control**, then turn Audience Management off. The Dashboard and other core screens show a warning notice; **Audience → Access Control** shows it below the header and tabs, bounded by the content container rather than full-width. Both link to Access Control and to Audience Management.
4. Turn Audience Management back on. The notice disappears from both.
5. Delete the gate, turn Audience Management off again. No notice.
6. Add a Group block with block-level access rules to any published post, then turn Audience Management off. The notice appears again, on the strength of the block alone.
7. Save an unrelated post with no access rules. The notice state does not change and no extra queries run.
8. With a gate in place, go to **Audience → Configuration → Reader Revenue Platform → Change** and switch Audience Management off. The dialog reads as three paragraphs and includes the line about gated content becoming public. Delete every gate and block rule, then try again — that middle paragraph is gone.

### Verification

Exercised in an isolated environment over authenticated requests.

Notice visibility, with a control in both directions:

```
AM OFF, nothing configured      hidden
AM ON,  gate exists             hidden
AM OFF, gate exists             SHOWN
AM OFF, gate deleted            hidden
AM OFF, block rules only        SHOWN
AM OFF, block mode only         hidden
AM ON,  block rules only        hidden
```

Surface split, over real admin requests:

```
AM OFF   core WP admin (Dashboard)   core notice SHOWN,  wizard payload —
AM OFF   Newspack wizard             core notice hidden, wizard payload show:true
AM ON    core WP admin (Dashboard)   core notice hidden, wizard payload —
AM ON    Newspack wizard             core notice hidden, wizard payload show:false
```

Cache invalidation, with no manual flushes:

```
create a gate                    invalidated
delete the gate                  invalidated
save an unrelated post           NOT invalidated
save a post with block rules     invalidated
edit it to remove those rules    invalidated
autosave it repeatedly           NOT invalidated
delete that post                 invalidated
```

```
PHP:   Tests: 2534, Assertions: 7209, Skipped: 6  (0 failures)
JS:    Test Suites: 59 passed, Tests: 541 passed
PHPCS + ESLint: clean
```

<details>
<summary>Implementation detail (for reviewers / agents)</summary>

Implementation detail for anyone picking this up. Living document, so keep it current as the code evolves.

**Files**

`includes/content-gate/class-inert-gating-notice.php` (new), included from `includes/class-newspack.php` right after `class-content-gate.php`. `includes/wizards/class-wizard.php` adds one key to the shared `newspack_aux_data` global. `packages/components/src/wizard/index.js` renders the wizard-side notice.

**Public surface**

- `Inert_Gating_Notice::is_inert()` — feature flag on, gating not active, and something configured.
- `Inert_Gating_Notice::has_surfaces()` — the cached half. Published gates of either kind, or any published post whose content carries a `newspackAccessControl` attribute.
- `Inert_Gating_Notice::get_script_data()` — the wizard payload. Returns the strings rather than a flag so the two surfaces cannot drift into saying different things about the same state. Carries `has_surfaces` alongside `show`, because they answer different questions: `show` is "is content public right now" and is false while Audience Management is still on, which is exactly when the disable-confirmation dialog runs. Unlike `show`, `has_surfaces` is not gated on the feature flag — block-level visibility is flag-independent, so a site without the constant can still have member-only blocks that go public.
- `Inert_Gating_Notice::flush_cache()` / `CACHE_OPTION` — `newspack_content_gate_has_surfaces`.

**Caching**

An option, not a transient: it must not expire on a timer, since the answer changes only when the underlying objects do. Not autoloaded — it is read in wp-admin and nowhere else, so autoloading it would put it in every front-end request's option payload for nothing. Stored as `'1'`/`'0'` because `update_option()` round-trips `false` to an empty string, which would be indistinguishable from "not cached" and would make a negative answer re-run the `LIKE` on every page load. That negative case is most sites, so it is the one that matters.

Invalidated by `save_post` and `deleted_post` — gates always; other post types only when the content carries the attribute prefix, otherwise every post save on the site would clear a cache that could not have changed. Revisions are skipped: they copy the parent's content verbatim, so without a guard every autosave would flush, roughly once a minute while anyone has a gated post open. They can never change the answer, since the query counts only published posts. Autosaves are revisions too, so one guard covers both.

`post_updated` covers the one case `save_post` cannot see: an edit that strips the last `newspackAccessControl*` attribute leaves content that reads as an ordinary post save, so only the pre-update content shows the answer changed. It carries the same revision guard, and that guard is load-bearing rather than defensive — the second and later autosaves update the same autosave row, so they arrive here with a "before" that still carries the attributes.

Deliberately **not** hooked to Audience Management. The cached value is only "is anything configured", which that setting cannot change, and `is_inert()` reads the setting live. Flushing there would discard a valid answer and force the recompute onto the very page load that has to render the notice.

**Block-level detection**

A direct `$wpdb` query rather than `WP_Query`: this is a content `LIKE`, which `WP_Query` can only express through `s`, which also searches titles and excerpts and applies relevance ordering. Bounded to one row — it only ever answers "any", never "how many" — and cached by the caller.

Constrained by post type so the `type_status_date` index is usable. The list is derived rather than hardcoded — `show_in_rest` is the prerequisite for the block editor, so it cannot miss a post type that could carry these blocks, and it excludes `revision`, usually the largest slice of the table. `wp_block` stays in: a post embedding a reusable block carries only a `wp:block` reference, so the attributes live on the `wp_block` post alone.

Measured against a seeded 4,600-row `wp_posts` shaped like a real site (revisions dominating):

```
                    plan                        rows examined
before   type=ALL    key=NULL                   4273
after    type=range  key=type_status_date        622
```

The editor also stops writing a rules object full of disabled rules: `updateRules()` now resets `newspackAccessControlRules` to its registered default when the last rule is turned off, so Gutenberg omits the attribute and the post stops looking configured. The query matches `…Rules` and `…GateIds` rather than the shared prefix, so a block that only records a mode or visibility choice - a preference, not a rule - is not counted as configured. Measured on a seeded 9,000-row `wp_posts` with no match present: 0.179 ms for the single prefix match against 0.218 ms for the pair, on a query that only runs when the cache misses. A `REGEXP` alternation was faster still locally, but this runs on MariaDB while CI and production run MySQL, whose regex engine is a different implementation - not worth the variance for four hundredths of a millisecond. The prefix stays the invalidation trigger, where over-flushing is harmless.

**The two surfaces**

`admin_notices` at the default priority for core screens. `Wizard::remove_notifications()` strips every notice from wizard screens at priority `-9999`, which is what keeps the core notice from appearing there; the wizard shell renders its own from `newspack_aux_data.inert_gating` instead, as the first child of `.newspack-wizard__main`.

That surface uses core's `Notice` from `@wordpress/components` rather than Newspack's, with `isDismissible` off so it cannot be waved away while the state persists. One SCSS rule zeroes the margin and radius core ships for inline placement, which would otherwise open a gap against `.newspack-page__header-region`. Measured live: 0 px to the header, notice width equal to `.newspack-wizard__main`, on the Dashboard, Settings and Access Control.

Wizards built on the legacy `withWizard` shell have no `.newspack-wizard__main`, so they get neither surface — Setup and Advertising, and the Audience → Setup route. Worth knowing, since that last one is where the notice's own call to action points.

The shell lives in `packages/components`, so the built output lands in `dist/commons.js` rather than a per-wizard bundle.

`interpolateOrPlainText()` wraps the interpolation. Verified against WordPress core's own `wp-includes/js/dist/element.js` — which is what runs, since the bundle externalizes `wp-element` — with the real conversion map:

```
                        before      after
correct string          renders     renders
stray closer, depth 0   THROW       plain text
duplicated closer       THROW       plain text
closer before opener    THROW       plain text
unclosed opener         plain text  plain text
renamed / unknown tag   literal     literal
```

Only the throwing case needed catching; the rest already degraded. There is no error boundary anywhere above the wizard shell, so an uncaught throw would have blanked every wizard — including the Audience Management screen this notice links to as the fix.

An earlier revision registered at `-10000` to slip under that strip and cover both surfaces with one hook. It worked, but put the notice above the wizard's own header, which is why the payload approach replaced it.

**Test surface**

`tests/unit-tests/content-gate/class-inert-gating-notice-test.php`, 14 cases. Every case is mutation-tested — dropping the block-rules half of the query fails two of them, and removing the content check before invalidating fails the scoping case.

</details>