### PR TITLE
fix(content-gate): prevent restrict_post re-entry via wp_reset_postdata

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -642,14 +642,21 @@ class Content_Gate {
 	}
 
 	/**
-	 * Public method for marking the gate as rendered.
+	 * Public method for marking the gate render as claimed.
+	 *
+	 * Every render path sets this BEFORE producing output, so the flag acts as
+	 * a once-per-request re-entrancy lock, not a signal that gate markup
+	 * already exists.
 	 */
 	public static function mark_gate_as_rendered() {
 		self::$gate_rendered = true;
 	}
 
 	/**
-	 * Whether the gate has rendered.
+	 * Whether a gate render has been claimed for this request.
+	 *
+	 * True from the moment a render path commits to rendering (see
+	 * mark_gate_as_rendered()), which may be before any markup is output.
 	 */
 	public static function has_rendered() {
 		return self::$gate_rendered;

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -236,6 +236,13 @@ class Content_Gate {
 		self::$is_gated          = true;
 		self::$is_content_locked = true;
 
+		// Mark before rendering: the renders below run the post content and the
+		// gate layout through the block pipeline, and any block that runs a
+		// secondary loop ends it with wp_reset_postdata(), which re-fires
+		// `the_post` for the main post. The has_rendered() guard above must
+		// already be set by then, or this method re-enters itself unboundedly.
+		self::mark_gate_as_rendered();
+
 		$content = self::get_restricted_post_excerpt( $post );
 
 		$post->post_content   = $content . self::get_inline_gate_html();
@@ -244,8 +251,6 @@ class Content_Gate {
 		$post->comment_count  = 0;
 
 		self::$restricted_content[ $post->ID ] = $post->post_content;
-
-		self::mark_gate_as_rendered();
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-restrict-reentry.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-restrict-reentry.php
@@ -17,6 +17,8 @@ use Newspack\Content_Restriction_Control;
 
 /**
  * Gate render re-entrancy tests.
+ *
+ * @group content-gate
  */
 class Test_Gate_Restrict_Reentry extends \WP_UnitTestCase {
 
@@ -44,7 +46,8 @@ class Test_Gate_Restrict_Reentry extends \WP_UnitTestCase {
 	private $loop_block_renders = 0;
 
 	/**
-	 * Define the Content Gates feature flag for this test class only.
+	 * Define the Content Gates feature flag (process-wide once defined) so the
+	 * gate code paths are active for these tests.
 	 */
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
@@ -195,15 +198,23 @@ class Test_Gate_Restrict_Reentry extends \WP_UnitTestCase {
 
 		// Production wiring: restrict_post() listens on `the_post`, which is
 		// how wp_reset_postdata() re-enters it. Content_Gate::init() hooks are
-		// not registered in the test bootstrap, so wire it explicitly.
-		add_action( 'the_post', [ Content_Gate::class, 'restrict_post' ], 10, 2 );
+		// not registered in the test bootstrap, so wire it explicitly — but
+		// only add (and later remove) the hook if it isn't already registered,
+		// so this test never strips a production-registered listener.
+		$hook_added = false;
+		if ( false === has_action( 'the_post', [ Content_Gate::class, 'restrict_post' ] ) ) {
+			add_action( 'the_post', [ Content_Gate::class, 'restrict_post' ], 10, 2 );
+			$hook_added = true;
+		}
 
 		try {
 			$this->go_to( get_permalink( $post_id ) );
 			$post = get_post( $post_id );
 			Content_Gate::restrict_post( $post, $GLOBALS['wp_query'] );
 		} finally {
-			remove_action( 'the_post', [ Content_Gate::class, 'restrict_post' ], 10 );
+			if ( $hook_added ) {
+				remove_action( 'the_post', [ Content_Gate::class, 'restrict_post' ], 10 );
+			}
 			remove_filter( 'newspack_gate_layout_content', $counter );
 		}
 

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-restrict-reentry.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-restrict-reentry.php
@@ -1,0 +1,215 @@
+<?php
+/**
+ * Tests that Content_Gate::restrict_post() is not re-entered while it renders.
+ *
+ * NPPD-2166: a gated article containing a block that runs a secondary loop and
+ * calls wp_reset_postdata() (e.g. Homepage Posts) re-fires the `the_post`
+ * action for the main post mid-render. Without a re-entrancy guard the gate
+ * renders recursively until memory is exhausted on large sites.
+ *
+ * @package Newspack\Tests\Content_Gate
+ */
+
+namespace Newspack\Tests\Content_Gate;
+
+use Newspack\Content_Gate;
+use Newspack\Content_Restriction_Control;
+
+/**
+ * Gate render re-entrancy tests.
+ */
+class Test_Gate_Restrict_Reentry extends \WP_UnitTestCase {
+
+	const LOOP_BLOCK = 'newspack-tests/secondary-loop';
+
+	/**
+	 * Gate IDs created per test.
+	 *
+	 * @var int[]
+	 */
+	protected $gate_ids = [];
+
+	/**
+	 * Post IDs created per test.
+	 *
+	 * @var int[]
+	 */
+	protected $post_ids = [];
+
+	/**
+	 * How many times the secondary-loop block rendered.
+	 *
+	 * @var int
+	 */
+	private $loop_block_renders = 0;
+
+	/**
+	 * Define the Content Gates feature flag for this test class only.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+	}
+
+	/**
+	 * Test set up: a published gate restricting posts, a pool of posts for the
+	 * secondary loop, and a dynamic block that mimics Homepage Posts (secondary
+	 * WP_Query + wp_reset_postdata).
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$gate_id          = Content_Gate::create_gate( [ 'title' => 'Reentry Gate' ] );
+		$this->gate_ids[] = $gate_id;
+		Content_Gate::update_gate_settings(
+			$gate_id,
+			[
+				'title'         => 'Reentry Gate',
+				'status'        => 'publish',
+				'priority'      => 0,
+				'content_rules' => [
+					[
+						'slug'  => 'post_types',
+						'value' => [ 'post' ],
+					],
+				],
+				'registration'  => [
+					'active'               => true,
+					'metering'             => [
+						'enabled' => false,
+						'count'   => 0,
+						'period'  => 'month',
+					],
+					'require_verification' => false,
+					'gate_id'              => 0,
+				],
+			]
+		);
+
+		// Pool of posts for the secondary loop to list.
+		$this->post_ids = array_merge( $this->post_ids, $this->factory->post->create_many( 3 ) );
+
+		// A block that runs a secondary loop and resets postdata, like
+		// newspack-blocks/homepage-articles and other listing blocks do.
+		// Capped so a re-entrancy regression fails the assertion instead of
+		// recursing without bound.
+		$this->loop_block_renders = 0;
+		register_block_type(
+			self::LOOP_BLOCK,
+			[
+				'render_callback' => function () {
+					$this->loop_block_renders++;
+					if ( $this->loop_block_renders > 5 ) {
+						return '';
+					}
+					$query = new \WP_Query(
+						[
+							'post_type'      => 'post',
+							'posts_per_page' => 2,
+							'post__in'       => array_slice( $this->post_ids, 0, 2 ),
+						]
+					);
+					while ( $query->have_posts() ) {
+						$query->the_post();
+					}
+					\wp_reset_postdata();
+					return '<div class="secondary-loop">related</div>';
+				},
+			]
+		);
+	}
+
+	/**
+	 * Teardown after tests.
+	 */
+	public function tear_down() {
+		unregister_block_type( self::LOOP_BLOCK );
+		foreach ( $this->gate_ids as $gate_id ) {
+			wp_delete_post( $gate_id, true );
+		}
+		foreach ( $this->post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		$this->gate_ids = [];
+		$this->post_ids = [];
+		$this->reset_restriction_cache();
+		$this->reset_gate_render_state();
+		parent::tear_down();
+	}
+
+	/**
+	 * Reset restriction caches (mirrors content-gates.php).
+	 */
+	private function reset_restriction_cache() {
+		foreach ( [ 'post_gate_id_map', 'post_gate_layout_id_map', 'post_gates_map', 'term_descendants_map' ] as $prop ) {
+			$reflection = new \ReflectionProperty( Content_Restriction_Control::class, $prop );
+			$reflection->setAccessible( true );
+			$reflection->setValue( null, [] );
+		}
+	}
+
+	/**
+	 * Reset the render-time static flags on Content_Gate.
+	 */
+	private function reset_gate_render_state() {
+		foreach ( [ 'gate_rendered', 'is_gated', 'is_content_locked' ] as $prop ) {
+			$reflection = new \ReflectionProperty( Content_Gate::class, $prop );
+			$reflection->setAccessible( true );
+			$reflection->setValue( null, false );
+		}
+		$reflection = new \ReflectionProperty( Content_Gate::class, 'restricted_content' );
+		$reflection->setAccessible( true );
+		$reflection->setValue( null, [] );
+	}
+
+	/**
+	 * Restricting a post whose content runs a secondary loop must render the
+	 * gate exactly once: wp_reset_postdata() re-fires `the_post` for the main
+	 * post while restrict_post() is still rendering, and without a re-entrancy
+	 * guard the gate recurses (unboundedly, on sites with enough posts).
+	 */
+	public function test_restrict_post_is_not_reentered_by_secondary_loops() {
+		$post_id          = $this->factory->post->create(
+			[
+				'post_content' => '<!-- wp:paragraph --><p>First paragraph.</p><!-- /wp:paragraph -->'
+					. '<!-- wp:paragraph --><p>Second paragraph.</p><!-- /wp:paragraph -->'
+					. '<!-- wp:' . self::LOOP_BLOCK . ' /-->'
+					. '<!-- wp:paragraph --><p>Premium paragraph.</p><!-- /wp:paragraph -->',
+			]
+		);
+		$this->post_ids[] = $post_id;
+
+		wp_set_current_user( 0 );
+		$this->reset_gate_render_state();
+		$this->assertNotFalse( Content_Gate::is_post_restricted( $post_id ), 'Post should be restricted for the logged-out reader' );
+
+		// Count gate layout renders: one per restrict_post() render pass.
+		$layout_renders = 0;
+		$counter        = function ( $content ) use ( &$layout_renders ) {
+			$layout_renders++;
+			return $content;
+		};
+		add_filter( 'newspack_gate_layout_content', $counter );
+
+		// Production wiring: restrict_post() listens on `the_post`, which is
+		// how wp_reset_postdata() re-enters it. Content_Gate::init() hooks are
+		// not registered in the test bootstrap, so wire it explicitly.
+		add_action( 'the_post', [ Content_Gate::class, 'restrict_post' ], 10, 2 );
+
+		try {
+			$this->go_to( get_permalink( $post_id ) );
+			$post = get_post( $post_id );
+			Content_Gate::restrict_post( $post, $GLOBALS['wp_query'] );
+		} finally {
+			remove_action( 'the_post', [ Content_Gate::class, 'restrict_post' ], 10 );
+			remove_filter( 'newspack_gate_layout_content', $counter );
+		}
+
+		$this->assertSame( 1, $layout_renders, 'Gate layout must render exactly once — more means restrict_post() was re-entered by the secondary loop\'s wp_reset_postdata()' );
+		$this->assertSame( 1, $this->loop_block_renders, 'The article body must be rendered through the gate pipeline exactly once' );
+		$this->assertSame( 1, substr_count( $post->post_content, 'newspack-content-gate__inline-gate' ), 'Restricted content must contain exactly one inline gate' );
+		$this->assertStringNotContainsString( 'Premium paragraph', $post->post_content, 'Restricted content should be truncated' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-synced-pattern-layout.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-synced-pattern-layout.php
@@ -168,7 +168,7 @@ class Test_Gate_Synced_Pattern_Layout extends \WP_UnitTestCase {
 			$count++;
 			if ( $count > $threshold ) {
 				throw new \RuntimeException(
-					'newspack_gate_content re-entered more than ' . esc_html( (string) $threshold ) . ' times — unbounded gate render recursion.'
+					sprintf( 'newspack_gate_content re-entered more than %d times — unbounded gate render recursion.', (int) $threshold )
 				);
 			}
 			return $content;

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-synced-pattern-layout.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-synced-pattern-layout.php
@@ -1,0 +1,222 @@
+<?php
+/**
+ * Tests for content gate layouts containing a synced pattern (core/block reference).
+ *
+ * @package Newspack\Tests\Content_Gate
+ */
+
+namespace Newspack\Tests\Content_Gate;
+
+use Newspack\Content_Gate;
+use Newspack\Content_Restriction_Control;
+
+/**
+ * Tests that a gate layout referencing a synced pattern renders without
+ * re-entering the gate render pipeline (NPPD-2166: memory exhaustion when the
+ * paid access layout ends with a synced pattern).
+ */
+class Test_Gate_Synced_Pattern_Layout extends \WP_UnitTestCase {
+
+	/**
+	 * Gate IDs created per test.
+	 *
+	 * @var int[]
+	 */
+	protected $gate_ids = [];
+
+	/**
+	 * Post IDs created per test.
+	 *
+	 * @var int[]
+	 */
+	protected $post_ids = [];
+
+	/**
+	 * Define the Content Gates feature flag for this test class only.
+	 */
+	public static function setUpBeforeClass(): void {
+		parent::setUpBeforeClass();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+	}
+
+	/**
+	 * Test set up: a published gate restricting all posts, and a gated post.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$gate_id          = Content_Gate::create_gate( [ 'title' => 'Synced Pattern Gate' ] );
+		$this->gate_ids[] = $gate_id;
+		Content_Gate::update_gate_settings(
+			$gate_id,
+			[
+				'title'         => 'Synced Pattern Gate',
+				'status'        => 'publish',
+				'priority'      => 0,
+				'content_rules' => [
+					[
+						'slug'  => 'post_types',
+						'value' => [ 'post' ],
+					],
+				],
+				'registration'  => [
+					'active'               => true,
+					'metering'             => [
+						'enabled' => false,
+						'count'   => 0,
+						'period'  => 'month',
+					],
+					'require_verification' => false,
+					'gate_id'              => 0,
+				],
+			]
+		);
+		$this->post_ids[] = $this->factory->post->create(
+			[
+				'post_content' => '<!-- wp:paragraph --><p>First paragraph.</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>Second paragraph.</p><!-- /wp:paragraph --><!-- wp:paragraph --><p>Premium paragraph.</p><!-- /wp:paragraph -->',
+			]
+		);
+	}
+
+	/**
+	 * Teardown after tests.
+	 */
+	public function tear_down() {
+		foreach ( $this->gate_ids as $gate_id ) {
+			wp_delete_post( $gate_id, true );
+		}
+		foreach ( $this->post_ids as $post_id ) {
+			wp_delete_post( $post_id, true );
+		}
+		$this->gate_ids = [];
+		$this->post_ids = [];
+		$this->reset_restriction_cache();
+		$this->reset_gate_render_state();
+		parent::tear_down();
+	}
+
+	/**
+	 * Reset restriction caches (mirrors content-gates.php).
+	 */
+	private function reset_restriction_cache() {
+		foreach ( [ 'post_gate_id_map', 'post_gate_layout_id_map', 'post_gates_map', 'term_descendants_map' ] as $prop ) {
+			$reflection = new \ReflectionProperty( Content_Restriction_Control::class, $prop );
+			$reflection->setAccessible( true );
+			$reflection->setValue( null, [] );
+		}
+	}
+
+	/**
+	 * Reset the render-time static flags on Content_Gate.
+	 */
+	private function reset_gate_render_state() {
+		foreach ( [ 'gate_rendered', 'is_gated', 'is_content_locked', 'restricted_content' ] as $prop ) {
+			$reflection = new \ReflectionProperty( Content_Gate::class, $prop );
+			$reflection->setAccessible( true );
+			$reflection->setValue( null, 'restricted_content' === $prop ? [] : false );
+		}
+	}
+
+	/**
+	 * Create a synced pattern (wp_block post) and point the gate layout at it.
+	 *
+	 * @return array{pattern_id: int, layout_id: int} IDs.
+	 */
+	private function create_pattern_backed_layout() {
+		$pattern_id = wp_insert_post(
+			[
+				'post_type'    => 'wp_block',
+				'post_status'  => 'publish',
+				'post_title'   => 'Offer cards',
+				'post_content' => '<!-- wp:paragraph --><p>Synced offer card content.</p><!-- /wp:paragraph -->',
+			]
+		);
+		$this->post_ids[] = $pattern_id;
+
+		$gate      = Content_Gate::get_gate( $this->gate_ids[0] );
+		$layout_id = $gate['registration']['gate_layout_id'];
+		wp_update_post(
+			[
+				'ID'           => $layout_id,
+				'post_content' => '<!-- wp:paragraph --><p>Subscribe to keep reading.</p><!-- /wp:paragraph --><!-- wp:block {"ref":' . $pattern_id . '} /-->',
+			]
+		);
+		update_post_meta( $layout_id, 'style', 'inline' );
+
+		return [
+			'pattern_id' => $pattern_id,
+			'layout_id'  => $layout_id,
+		];
+	}
+
+	/**
+	 * Install a guard that converts unbounded gate-render re-entry into a
+	 * diagnosable exception (instead of exhausting memory like production).
+	 *
+	 * @param int $threshold Number of allowed applications of the filter.
+	 * @return callable Remover.
+	 */
+	private function install_reentry_guard( $threshold = 10 ) {
+		$count = 0;
+		$guard = function ( $content ) use ( &$count, $threshold ) {
+			$count++;
+			if ( $count > $threshold ) {
+				throw new \RuntimeException(
+					'newspack_gate_content re-entered more than ' . esc_html( (string) $threshold ) . ' times — unbounded gate render recursion.'
+				);
+			}
+			return $content;
+		};
+		add_filter( 'newspack_gate_content', $guard, 1 );
+		return function () use ( $guard ) {
+			remove_filter( 'newspack_gate_content', $guard, 1 );
+		};
+	}
+
+	/**
+	 * A gate layout referencing a synced pattern must render the pattern's
+	 * content exactly once — directly through the gate content pipeline.
+	 */
+	public function test_inline_gate_renders_synced_pattern_content() {
+		$ids     = $this->create_pattern_backed_layout();
+		$remover = $this->install_reentry_guard();
+
+		try {
+			$html = Content_Gate::get_inline_gate_content_for_post( $ids['layout_id'] );
+			$html = apply_filters( 'newspack_gate_content', $html );
+		} finally {
+			$remover();
+		}
+
+		$this->assertStringContainsString( 'Subscribe to keep reading', $html, 'Gate layout content should render' );
+		$this->assertStringContainsString( 'Synced offer card content', $html, 'Synced pattern content should render inside the gate' );
+	}
+
+	/**
+	 * Full front-end flow: a restricted post rendered through restrict_post()
+	 * and the_content must produce the gate with the pattern content, without
+	 * re-entering the gate render pipeline.
+	 */
+	public function test_restricted_post_renders_gate_with_synced_pattern() {
+		$ids     = $this->create_pattern_backed_layout();
+		$post_id = $this->post_ids[0];
+
+		wp_set_current_user( 0 );
+		$this->reset_gate_render_state();
+		$this->assertNotFalse( Content_Gate::is_post_restricted( $post_id ), 'Post should be restricted for the logged-out reader' );
+
+		$remover = $this->install_reentry_guard();
+		try {
+			$this->go_to( get_permalink( $post_id ) );
+			$post = get_post( $post_id );
+			Content_Gate::restrict_post( $post, $GLOBALS['wp_query'] );
+			$content = apply_filters( 'the_content', $post->post_content );
+		} finally {
+			$remover();
+		}
+
+		$this->assertStringContainsString( 'Synced offer card content', $content, 'Synced pattern content should render inside the gate on a restricted post' );
+		$this->assertStringNotContainsString( 'Premium paragraph', $content, 'Restricted content should be truncated' );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-synced-pattern-layout.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-synced-pattern-layout.php
@@ -11,9 +11,13 @@ use Newspack\Content_Gate;
 use Newspack\Content_Restriction_Control;
 
 /**
- * Tests that a gate layout referencing a synced pattern renders without
- * re-entering the gate render pipeline (NPPD-2166: memory exhaustion when the
- * paid access layout ends with a synced pattern).
+ * Characterization tests pinning synced-pattern (core/block) rendering inside
+ * gate layouts — the surface NPPD-2166 originally suspected. These pass with
+ * or without the re-entrancy fix (a synced pattern alone runs no secondary
+ * loop); the regression proof for the fix lives in gate-restrict-reentry.php.
+ * The re-entry guard here future-proofs the pattern path against recursion.
+ *
+ * @group content-gate
  */
 class Test_Gate_Synced_Pattern_Layout extends \WP_UnitTestCase {
 
@@ -32,7 +36,8 @@ class Test_Gate_Synced_Pattern_Layout extends \WP_UnitTestCase {
 	protected $post_ids = [];
 
 	/**
-	 * Define the Content Gates feature flag for this test class only.
+	 * Define the Content Gates feature flag (process-wide once defined) so the
+	 * gate code paths are active for these tests.
 	 */
 	public static function setUpBeforeClass(): void {
 		parent::setUpBeforeClass();
@@ -195,8 +200,9 @@ class Test_Gate_Synced_Pattern_Layout extends \WP_UnitTestCase {
 
 	/**
 	 * Full front-end flow: a restricted post rendered through restrict_post()
-	 * and the_content must produce the gate with the pattern content, without
-	 * re-entering the gate render pipeline.
+	 * and the_content must produce the gate with the pattern content. The
+	 * re-entry guard is a safety net for the assertions, not the subject under
+	 * test — see gate-restrict-reentry.php for the re-entrancy coverage.
 	 */
 	public function test_restricted_post_renders_gate_with_synced_pattern() {
 		$ids     = $this->create_pattern_backed_layout();


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Gated article pages could exhaust PHP memory (512M) and white-screen for readers whose meter had run out, when the article's content contained a block that runs a secondary posts loop (Homepage Posts and similar listing blocks). Closes NPPD-2166.

The mechanism: `Content_Gate::restrict_post()` (hooked to `the_post`) renders the restricted excerpt by running the full article through the gate content pipeline. A listing block ends its loop with `wp_reset_postdata()`, which re-fires `the_post` for the main post while `restrict_post()` is still rendering. The "already rendered" guard was only set after the render, so `restrict_post()` re-entered itself; Homepage Posts deduplication feeds each round fresh posts, so on sites with a large post pool the recursion continues until memory is exhausted.

The fix moves `mark_gate_as_rendered()` above the render, so the re-fired hook bails at the existing `has_rendered()` guard. This matches the before-render order already used by the metering, overlay, and legacy Memberships render paths. The flag's docblocks now describe it as a once-per-request re-entrancy lock; a grep across the monorepo and standalone repos found no consumer of `has_rendered()` other than the guard itself.

Two test files accompany the fix:

- `gate-restrict-reentry.php` — the regression proof. A test block mimics a listing block (secondary `WP_Query` + `wp_reset_postdata()`, capped so a regression fails an assertion instead of recursing); on the previous code the gate layout renders 6 times, with the fix exactly once.
- `gate-synced-pattern-layout.php` — characterization tests pinning that a synced pattern (`core/block`) inside a gate layout renders correctly. The original report suspected the synced pattern; these tests pass with or without the fix and document that the pattern is not the trigger.

### How to test the changes in this Pull Request:

1. On the base branch, run the new test: `phpunit --filter Test_Gate_Restrict_Reentry` (with only the test files applied). It fails with `Failed asserting that 6 is identical to 1` — the gate rendered 6 times.
2. With this branch, run the same test. It passes: the gate layout renders exactly once, the restricted content contains a single inline gate, and the premium paragraph is truncated.
3. Optional live check: in a dev env with content gates enabled and metering exhausted for a logged-in reader, view a gated post whose content includes a Homepage Posts block. Before the fix the page balloons (nested gates, one `the_post` firing per listed post per round, growing with the number of published posts); with the fix the page renders normally with one gate and no premium content leaked.
4. Full suite: `phpunit` in `plugins/newspack-plugin` — 2366 tests green.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?