### PR TITLE
fix(plugin-manager): use centralized download URLs for plugin updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,17 @@
 
 The Newspack monorepo. All product [plugins](plugins), [themes](themes), and shared [packages](packages) live here. It also ships a Docker-based local development environment, so the dependencies needed to run the projects and their tests live inside the container, independent of your local machine.
 
+## Download and Install
+
+**This is a development repository.** If you are looking to download and install Newspack plugins or themes on your WordPress site, you need the **built packages**, not the source code in this repository.
+
+Built packages are available in two places:
+
+- **[Newspack Download Center](https://newspack.com/downloads)** — Easy links to the latest stable releases of all Newspack plugins and themes
+- **[GitHub Releases](https://github.com/Automattic/newspack-workspace/releases)** — All releases, including pre-releases and historical versions
+
+Download the `.zip` file for the plugin or theme you want, then install it on your WordPress site via the WordPress admin interface (Plugins → Add New → Upload Plugin, or Appearance → Themes → Add New → Upload Theme).
+
 ## Getting started
 
 ### Clone this repository

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ The Newspack monorepo. All product [plugins](plugins), [themes](themes), and sha
 
 Built packages are available in two places:
 
-- **[Newspack Download Center](https://newspack.com/downloads)** — Easy links to the latest stable releases of all Newspack plugins and themes
+- **[Newspack Download Center](https://help.newspack.com/download-center/)** — Easy links to the latest stable releases
 - **[GitHub Releases](https://github.com/Automattic/newspack-workspace/releases)** — All releases, including pre-releases and historical versions
 
 Download the `.zip` file for the plugin or theme you want, then install it on your WordPress site via the WordPress admin interface (Plugins → Add New → Upload Plugin, or Appearance → Themes → Add New → Upload Theme).

--- a/plugins/newspack-plugin/includes/class-plugin-manager.php
+++ b/plugins/newspack-plugin/includes/class-plugin-manager.php
@@ -104,7 +104,7 @@ class Plugin_Manager {
 				'Author'      => \esc_html__( 'Automattic', 'newspack-plugin' ),
 				'PluginURI'   => \esc_url( 'https://newspack.com' ),
 				'AuthorURI'   => \esc_url( 'https://automattic.com' ),
-				'Download'    => 'https://github.com/Automattic/newspack-ads/releases/latest/download/newspack-ads.zip',
+				'Download'    => 'https://newspack.com/downloads/newspack-ads/latest',
 			],
 			'newspack-blocks'             => [
 				'Name'        => \esc_html__( 'Newspack Blocks', 'newspack-plugin' ),
@@ -112,7 +112,7 @@ class Plugin_Manager {
 				'Author'      => \esc_html__( 'Automattic', 'newspack-plugin' ),
 				'PluginURI'   => \esc_url( 'https://newspack.com' ),
 				'AuthorURI'   => \esc_url( 'https://automattic.com' ),
-				'Download'    => 'https://github.com/Automattic/newspack-blocks/releases/latest/download/newspack-blocks.zip',
+				'Download'    => 'https://newspack.com/downloads/newspack-blocks/latest',
 			],
 			'newspack-content-converter'  => [
 				'Name'        => \esc_html__( 'Newspack Content Converter', 'newspack-plugin' ),
@@ -129,7 +129,7 @@ class Plugin_Manager {
 				'Author'      => \esc_html__( 'Automattic', 'newspack-plugin' ),
 				'PluginURI'   => \esc_url( 'https://newspack.com' ),
 				'AuthorURI'   => \esc_url( 'https://automattic.com' ),
-				'Download'    => 'https://github.com/Automattic/newspack-multibranded-site/releases/latest/download/newspack-multibranded-site.zip',
+				'Download'    => 'https://newspack.com/downloads/newspack-multibranded-site/latest',
 				'Quiet'       => true,
 			],
 			'newspack-network'            => [
@@ -138,7 +138,7 @@ class Plugin_Manager {
 				'Author'      => \esc_html__( 'Automattic', 'newspack-plugin' ),
 				'PluginURI'   => \esc_url( 'https://newspack.com' ),
 				'AuthorURI'   => \esc_url( 'https://automattic.com' ),
-				'Download'    => 'https://github.com/Automattic/newspack-network/releases/latest/download/newspack-network.zip',
+				'Download'    => 'https://newspack.com/downloads/newspack-network/latest',
 				'Quiet'       => true,
 			],
 			'newspack-newsletters'        => [
@@ -147,7 +147,7 @@ class Plugin_Manager {
 				'Author'      => \esc_html__( 'Automattic', 'newspack-plugin' ),
 				'PluginURI'   => \esc_url( 'https://newspack.com' ),
 				'AuthorURI'   => \esc_url( 'https://automattic.com' ),
-				'Download'    => 'https://github.com/Automattic/newspack-newsletters/releases/latest/download/newspack-newsletters.zip',
+				'Download'    => 'https://newspack.com/downloads/newspack-newsletters/latest',
 			],
 			'newspack-popups'             => [
 				'Name'        => \esc_html__( 'Newspack Campaigns', 'newspack-plugin' ),
@@ -155,7 +155,7 @@ class Plugin_Manager {
 				'Author'      => \esc_html__( 'Automattic', 'newspack-plugin' ),
 				'PluginURI'   => \esc_url( 'https://newspack.com' ),
 				'AuthorURI'   => \esc_url( 'https://automattic.com' ),
-				'Download'    => 'https://github.com/Automattic/newspack-popups/releases/latest/download/newspack-popups.zip',
+				'Download'    => 'https://newspack.com/downloads/newspack-popups/latest',
 			],
 			'newspack-sponsors'           => [
 				'Name'        => \esc_html__( 'Newspack Sponsors', 'newspack-plugin' ),
@@ -163,7 +163,7 @@ class Plugin_Manager {
 				'Author'      => \esc_html__( 'Automattic', 'newspack-plugin' ),
 				'PluginURI'   => \esc_url( 'https://newspack.com' ),
 				'AuthorURI'   => \esc_url( 'https://automattic.com' ),
-				'Download'    => 'https://github.com/Automattic/newspack-sponsors/releases/latest/download/newspack-sponsors.zip',
+				'Download'    => 'https://newspack.com/downloads/newspack-sponsors/latest',
 			],
 			'newspack-listings'           => [
 				'Name'        => \esc_html__( 'Newspack Listings', 'newspack-plugin' ),
@@ -171,7 +171,7 @@ class Plugin_Manager {
 				'Author'      => \esc_html__( 'Automattic', 'newspack-plugin' ),
 				'PluginURI'   => \esc_url( 'https://newspack.com' ),
 				'AuthorURI'   => \esc_url( 'https://automattic.com' ),
-				'Download'    => 'https://github.com/Automattic/newspack-listings/releases/latest/download/newspack-listings.zip',
+				'Download'    => 'https://newspack.com/downloads/newspack-listings/latest',
 			],
 			'newspack-theme'              => [
 				'Name'        => \esc_html__( 'Newspack Theme', 'newspack-plugin' ),


### PR DESCRIPTION
## Summary
- Switches plugin download URLs from direct GitHub releases to the Newspack download center
- Affects all managed plugins: newspack-ads, newspack-blocks, newspack-multibranded-site, newspack-network, newspack-newsletters, newspack-popups, newspack-sponsors, and newspack-listings
- Provides better control over plugin distribution and versioning

**This is a hotfix** targeting the `release` branch.

## Test plan
- [ ] Verify plugin installation works with new download URLs
- [ ] Test plugin updates through the plugin manager
- [ ] Confirm all affected plugins can be downloaded from newspack.com/downloads

🤖 Generated with [Claude Code](https://claude.com/claude-code)