### PR TITLE
feat(analytics): show GA4 segment reach in the segments list

### DIFF
--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -230,6 +230,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-gravityforms.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit-logger.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-ga4-client.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-ga4-custom-dimensions.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-mailchimp-for-woocommerce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';

--- a/plugins/newspack-plugin/includes/class-newspack.php
+++ b/plugins/newspack-plugin/includes/class-newspack.php
@@ -232,6 +232,7 @@ final class Newspack {
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-googlesitekit-logger.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-ga4-client.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-ga4-custom-dimensions.php';
+		include_once NEWSPACK_ABSPATH . 'includes/plugins/google-site-kit/class-ga4-segment-reach.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-mailchimp-for-woocommerce.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-onesignal.php';
 		include_once NEWSPACK_ABSPATH . 'includes/plugins/class-organic-profile-block.php';

--- a/plugins/newspack-plugin/includes/oauth/class-google-oauth-ga4-client.php
+++ b/plugins/newspack-plugin/includes/oauth/class-google-oauth-ga4-client.php
@@ -149,7 +149,8 @@ final class Google_OAuth_GA4_Client {
 	 * @throws \RuntimeException On HTTP or API error.
 	 */
 	public function run_report( $property_id, array $request ) {
-		return $this->request( 'POST', self::DATA_BASE_URL . "/properties/$property_id:runReport", $request );
+		// The `:runReport` suffix stays outside the encoded segment.
+		return $this->request( 'POST', self::DATA_BASE_URL . '/properties/' . rawurlencode( $property_id ) . ':runReport', $request );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/oauth/class-google-oauth-ga4-client.php
+++ b/plugins/newspack-plugin/includes/oauth/class-google-oauth-ga4-client.php
@@ -21,6 +21,12 @@ final class Google_OAuth_GA4_Client {
 	const BASE_URL = 'https://analyticsadmin.googleapis.com/v1beta';
 
 	/**
+	 * Base URL for the GA4 Data API, which serves reports (the Admin API
+	 * above serves configuration).
+	 */
+	const DATA_BASE_URL = 'https://analyticsdata.googleapis.com/v1beta';
+
+	/**
 	 * OAuth scope required to create GA4 custom dimensions via the Admin API.
 	 */
 	const EDIT_SCOPE = 'https://www.googleapis.com/auth/analytics.edit';
@@ -132,6 +138,21 @@ final class Google_OAuth_GA4_Client {
 	}
 
 	/**
+	 * Run a GA4 Data API report.
+	 *
+	 * Reads need only the base `analytics` scope, which every stored token
+	 * carries — unlike the Admin API writes above.
+	 *
+	 * @param string $property_id GA4 property ID.
+	 * @param array  $request     runReport request body.
+	 * @return array Decoded response.
+	 * @throws \RuntimeException On HTTP or API error.
+	 */
+	public function run_report( $property_id, array $request ) {
+		return $this->request( 'POST', self::DATA_BASE_URL . "/properties/$property_id:runReport", $request );
+	}
+
+	/**
 	 * Issue an authenticated request to the Analytics Admin API.
 	 *
 	 * @param string     $method HTTP method.
@@ -163,7 +184,7 @@ final class Google_OAuth_GA4_Client {
 			$message = is_array( $decoded ) && isset( $decoded['error']['message'] )
 				? $decoded['error']['message']
 				: 'HTTP ' . $code;
-			throw new \RuntimeException( esc_html( "Analytics Admin API error ($code): $message" ) );
+			throw new \RuntimeException( esc_html( "Analytics API error ($code): $message" ) );
 		}
 		return is_array( $decoded ) ? $decoded : [];
 	}

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-client.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-client.php
@@ -1,0 +1,150 @@
+<?php
+/**
+ * Shared access to authenticated GA4 API clients.
+ *
+ * Extracted from the custom-dimension provisioner so read-side consumers
+ * (segment reach) reuse the same auth routing: prefer Newspack's own Google
+ * OAuth, fall back to Site Kit's authenticated client.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+use Google\Site_Kit\Context;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * GA4 client routing.
+ */
+final class GA4_Client {
+
+	const LOGGER_HEADER = 'NEWSPACK-GA4-CLIENT';
+
+	/**
+	 * Read the connected GA4 property ID from Site Kit's stored settings.
+	 *
+	 * @return string|false
+	 */
+	public static function get_property_id() {
+		$settings = get_option( 'googlesitekit_analytics-4_settings', [] );
+		if ( empty( $settings['propertyID'] ) ) {
+			return false;
+		}
+		return (string) $settings['propertyID'];
+	}
+
+	/**
+	 * Run a callable with an authenticated GA4 API client.
+	 *
+	 * Tries Newspack's own Google OAuth first. Its tokens hit the proxy's GCP
+	 * project, which has the Analytics APIs enabled. If Newspack OAuth is not
+	 * configured or the callback throws/returns a WP_Error, falls back to Site
+	 * Kit's client (which stores tokens keyed on user ID).
+	 *
+	 * Switches the current user to a capable one if none is set (e.g. in
+	 * WP-Cron) so permission checks in `Google_OAuth::get_oauth2_credentials()`
+	 * and Site Kit's `User_Options` can resolve credentials. Restores the
+	 * previous user before returning so we don't leak an unexpected identity
+	 * into subsequent operations in the same process.
+	 *
+	 * Writes require the `analytics.edit` scope on the Newspack OAuth token,
+	 * which many publishers have not granted — callers doing writes keep the
+	 * default `require_edit_scope => true` so a scope-less token is skipped
+	 * rather than failing with a 403. Reads are covered by the base `analytics`
+	 * scope the token always carries, so read callers pass `false`.
+	 *
+	 * The callback is invoked as `$callback( $client, $source )` where
+	 * `$source` is either 'newspack' or 'sitekit'.
+	 *
+	 * If every route fails, the returned WP_Error names each route that was
+	 * tried and why it failed, so a 403 on writes (the common "publisher never
+	 * granted analytics.edit to Site Kit" case) is self-explanatory rather than
+	 * buried in the log.
+	 *
+	 * @param callable $callback Called with `( $client, string $source )`.
+	 * @param array    $args     Options. `require_edit_scope` (bool, default true).
+	 * @return mixed|\WP_Error The callback's return value, or WP_Error.
+	 */
+	public static function with_admin_client( callable $callback, array $args = [] ) {
+		$require_edit_scope = $args['require_edit_scope'] ?? true;
+		$previous_user_id   = get_current_user_id();
+		$switched_user      = false;
+
+		if ( ! $previous_user_id ) {
+			$settings = get_option( 'googlesitekit_analytics-4_settings', [] );
+			$owner_id = isset( $settings['ownerID'] ) ? (int) $settings['ownerID'] : 0;
+			if ( $owner_id <= 0 ) {
+				return new \WP_Error( 'newspack_ga4_client', 'No user context available to authenticate GA4 API calls.' );
+			}
+			wp_set_current_user( $owner_id );
+			$switched_user = true;
+		}
+
+		// Route name => why it was skipped or failed, used to compose the error
+		// if nothing works.
+		$attempts = [];
+
+		try {
+			// Prefer Newspack's own OAuth. Returns null if not configured or no
+			// credentials are saved; for writes, skip it outright if its token
+			// predates the analytics.edit scope, since writes would just 403.
+			$np_client = Google_OAuth_GA4_Client::build();
+			if ( ! $np_client ) {
+				$attempts['Newspack OAuth'] = 'not configured';
+				Logger::log( 'Newspack OAuth not available; trying Site Kit.', self::LOGGER_HEADER );
+			} elseif ( $require_edit_scope && ! Google_OAuth_GA4_Client::has_edit_scope() ) {
+				$attempts['Newspack OAuth'] = 'stored token lacks the analytics.edit scope (reconnect Google in the Newspack settings to grant it)';
+				Logger::log( 'Newspack OAuth token lacks analytics.edit; trying Site Kit.', self::LOGGER_HEADER );
+			} else {
+				try {
+					$result = $callback( $np_client, 'newspack' );
+					if ( ! is_wp_error( $result ) ) {
+						return $result;
+					}
+					$attempts['Newspack OAuth'] = $result->get_error_message();
+				} catch ( \Throwable $e ) {
+					$attempts['Newspack OAuth'] = $e->getMessage();
+				}
+				Logger::log( 'Newspack OAuth path failed (' . $attempts['Newspack OAuth'] . '); trying Site Kit.', self::LOGGER_HEADER );
+			}
+
+			// Fall back to Site Kit.
+			if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) || ! class_exists( __NAMESPACE__ . '\\GoogleSiteKitAnalytics' ) ) {
+				$attempts['Site Kit'] = 'not available';
+				return new \WP_Error( 'newspack_ga4_client', self::describe_auth_failure( $attempts ) );
+			}
+			try {
+				$module = new GoogleSiteKitAnalytics( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
+				$result = $callback( $module, 'sitekit' );
+				if ( ! is_wp_error( $result ) ) {
+					return $result;
+				}
+				$attempts['Site Kit'] = $result->get_error_message();
+			} catch ( \Throwable $e ) {
+				$attempts['Site Kit'] = $e->getMessage();
+			}
+			return new \WP_Error( 'newspack_ga4_client', self::describe_auth_failure( $attempts ) );
+		} finally {
+			if ( $switched_user ) {
+				wp_set_current_user( $previous_user_id );
+			}
+		}
+	}
+
+	/**
+	 * Compose a human-readable failure message from a map of auth route =>
+	 * failure reason.
+	 *
+	 * @param array<string,string> $attempts Route name => reason.
+	 * @return string
+	 */
+	private static function describe_auth_failure( array $attempts ) {
+		$parts = [];
+		foreach ( $attempts as $route => $reason ) {
+			$parts[] = "$route – $reason";
+		}
+		return 'Could not reach the GA4 API. Tried: ' . implode( '; ', $parts ) . '.';
+	}
+}

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -3,17 +3,14 @@
  * Provisions Newspack's standard GA4 custom dimensions on the publisher's
  * connected GA4 property.
  *
- * Prefers Newspack's own Google OAuth credentials (whose tokens carry the
- * `analytics.edit` scope) and falls back to Site Kit's authenticated client
- * when Newspack OAuth is not configured, its token lacks that scope, or a call
- * through it fails.
+ * Auth routing lives in GA4_Client: Newspack's own Google OAuth credentials
+ * first (whose tokens carry the `analytics.edit` scope these writes need),
+ * falling back to Site Kit's authenticated client.
  *
  * @package Newspack
  */
 
 namespace Newspack;
-
-use Google\Site_Kit\Context;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -177,120 +174,20 @@ final class GA4_Custom_Dimensions {
 	 * @return string|false
 	 */
 	private static function get_property_id() {
-		$settings = get_option( 'googlesitekit_analytics-4_settings', [] );
-		if ( empty( $settings['propertyID'] ) ) {
-			return false;
-		}
-		return (string) $settings['propertyID'];
+		return GA4_Client::get_property_id();
 	}
 
 	/**
 	 * Run a callable with an authenticated GA4 Admin API client.
 	 *
-	 * Tries Newspack's own Google OAuth first. Its tokens already carry
-	 * `analytics.edit` and the call hits the proxy's GCP project, which has
-	 * the Admin API enabled. If Newspack OAuth is not configured or the
-	 * callback throws/returns a WP_Error, falls back to Site Kit's client
-	 * (which stores tokens keyed on user ID and requires `analytics.edit`
-	 * to have been granted — which many publishers have not done).
-	 *
-	 * Switches the current user to a capable one if none is set (e.g. in
-	 * WP-Cron) so permission checks in `Google_OAuth::get_oauth2_credentials()`
-	 * and Site Kit's `User_Options` can resolve credentials. Restores the
-	 * previous user before returning so we don't leak an unexpected identity
-	 * into subsequent operations in the same process.
-	 *
-	 * The callback is invoked as `$callback( $client, $source )` where
-	 * `$source` is either 'newspack' or 'sitekit'. Both client types expose
-	 * `list_custom_dimensions()` and `create_custom_dimension()` with
-	 * matching signatures.
-	 *
-	 * If every route fails, the returned WP_Error names each route that was
-	 * tried and why it failed, so a 403 on writes (the common "publisher never
-	 * granted analytics.edit to Site Kit" case) is self-explanatory rather than
-	 * buried in the log.
+	 * Provisioning writes dimensions, so the `analytics.edit` scope is
+	 * required — see GA4_Client for the routing and the scope rationale.
 	 *
 	 * @param callable $callback Called with `( $client, string $source )`.
 	 * @return mixed|\WP_Error The callback's return value, or WP_Error.
 	 */
 	private static function with_admin_client( callable $callback ) {
-		$previous_user_id = get_current_user_id();
-		$switched_user    = false;
-
-		if ( ! $previous_user_id ) {
-			$settings = get_option( 'googlesitekit_analytics-4_settings', [] );
-			$owner_id = isset( $settings['ownerID'] ) ? (int) $settings['ownerID'] : 0;
-			if ( $owner_id <= 0 ) {
-				return new \WP_Error( 'newspack_ga4_dimensions', 'No user context available to authenticate GA4 Admin API calls.' );
-			}
-			wp_set_current_user( $owner_id );
-			$switched_user = true;
-		}
-
-		// Route name => why it was skipped or failed, used to compose the error
-		// if nothing works.
-		$attempts = [];
-
-		try {
-			// Prefer Newspack's own OAuth. Returns null if not configured or no
-			// credentials are saved; skip it outright if its token predates the
-			// analytics.edit scope, since writes would just 403.
-			$np_client = Google_OAuth_GA4_Client::build();
-			if ( ! $np_client ) {
-				$attempts['Newspack OAuth'] = 'not configured';
-				Logger::log( 'Newspack OAuth not available; trying Site Kit.', self::LOGGER_HEADER );
-			} elseif ( ! Google_OAuth_GA4_Client::has_edit_scope() ) {
-				$attempts['Newspack OAuth'] = 'stored token lacks the analytics.edit scope (reconnect Google in the Newspack settings to grant it)';
-				Logger::log( 'Newspack OAuth token lacks analytics.edit; trying Site Kit.', self::LOGGER_HEADER );
-			} else {
-				try {
-					$result = $callback( $np_client, 'newspack' );
-					if ( ! is_wp_error( $result ) ) {
-						return $result;
-					}
-					$attempts['Newspack OAuth'] = $result->get_error_message();
-				} catch ( \Throwable $e ) {
-					$attempts['Newspack OAuth'] = $e->getMessage();
-				}
-				Logger::log( 'Newspack OAuth path failed (' . $attempts['Newspack OAuth'] . '); trying Site Kit.', self::LOGGER_HEADER );
-			}
-
-			// Fall back to Site Kit.
-			if ( ! defined( 'GOOGLESITEKIT_PLUGIN_MAIN_FILE' ) || ! class_exists( __NAMESPACE__ . '\\GoogleSiteKitAnalytics' ) ) {
-				$attempts['Site Kit'] = 'not available';
-				return new \WP_Error( 'newspack_ga4_dimensions', self::describe_auth_failure( $attempts ) );
-			}
-			try {
-				$module = new GoogleSiteKitAnalytics( new Context( GOOGLESITEKIT_PLUGIN_MAIN_FILE ) );
-				$result = $callback( $module, 'sitekit' );
-				if ( ! is_wp_error( $result ) ) {
-					return $result;
-				}
-				$attempts['Site Kit'] = $result->get_error_message();
-			} catch ( \Throwable $e ) {
-				$attempts['Site Kit'] = $e->getMessage();
-			}
-			return new \WP_Error( 'newspack_ga4_dimensions', self::describe_auth_failure( $attempts ) );
-		} finally {
-			if ( $switched_user ) {
-				wp_set_current_user( $previous_user_id );
-			}
-		}
-	}
-
-	/**
-	 * Compose a human-readable failure message from a map of auth route =>
-	 * failure reason.
-	 *
-	 * @param array<string,string> $attempts Route name => reason.
-	 * @return string
-	 */
-	private static function describe_auth_failure( array $attempts ) {
-		$parts = [];
-		foreach ( $attempts as $route => $reason ) {
-			$parts[] = "$route – $reason";
-		}
-		return 'Could not reach the GA4 Admin API. Tried: ' . implode( '; ', $parts ) . '.';
+		return GA4_Client::with_admin_client( $callback, [ 'require_edit_scope' => true ] );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-custom-dimensions.php
@@ -341,6 +341,13 @@ final class GA4_Custom_Dimensions {
 
 		update_option( self::PROVISIONED_OPTION, $summary, false );
 
+		// A run that adds a dimension is what makes a report querying it
+		// possible, so let the segment-reach fetch start over rather than
+		// stay given-up until the property changes.
+		if ( ! empty( $created ) ) {
+			GA4_Segment_Reach::reset_failures();
+		}
+
 		Logger::log(
 			sprintf(
 				'GA4 dimension provisioning complete for property %s. Created: %d, existed: %d, errors: %d',

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-segment-reach.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-segment-reach.php
@@ -4,9 +4,16 @@
  * Campaigns segments list.
  *
  * Reads back the events newspack-popups sends (np_segment_matched /
- * np_segment_won, one per segment per GA4 session), so `eventCount` is the
- * "sessions matching segment" figure directly. One runReport a day covers
- * every segment.
+ * np_segment_won). The report asks for `sessions` rather than `eventCount`:
+ * the client aims for one event per segment per session but cannot guarantee
+ * it — np_segment_won fires again when a session's priority winner changes,
+ * and a reader whose localStorage is unwritable dispatches on every pageview —
+ * so counting events would overstate both figures. GA4 deduplicates sessions
+ * itself.
+ *
+ * One runReport a day covers every segment, and its TOTAL aggregation carries
+ * the denominator: the deduplicated count of sessions where segmentation ran,
+ * which the list reads each segment's share against.
  *
  * @package Newspack
  */
@@ -203,25 +210,41 @@ final class GA4_Segment_Reach {
 		// off; cleared on success so a property switch minutes later gets its
 		// immediate fetch rather than waiting out the hour.
 		set_transient( self::LAST_ATTEMPT_TRANSIENT, time(), HOUR_IN_SECONDS );
-		$request  = [
-			'dateRanges'      => [
+		$request = [
+			'dateRanges'         => [
 				[
 					'startDate' => self::RANGE_DAYS . 'daysAgo',
 					'endDate'   => 'yesterday',
 				],
 			],
-			'dimensions'      => [
+			'dimensions'         => [
 				[ 'name' => 'customEvent:segment_id' ],
 				[ 'name' => 'eventName' ],
 			],
-			'metrics'         => [ [ 'name' => 'eventCount' ] ],
-			'dimensionFilter' => [
+			// `sessions`, not `eventCount`. The events are deduplicated per
+			// session by the client, but only on a best effort: a reader whose
+			// localStorage is unwritable falls back to dispatching on every
+			// pageview, and np_segment_won fires once per *segment* per session,
+			// so a session whose priority winner changes — a reader registering
+			// mid-session, say — emits more than one. Counting events would
+			// inflate both figures by however much of that happens. GA4
+			// deduplicates `sessions` itself, so the numbers mean what the UI
+			// says they mean regardless of dispatch volume.
+			'metrics'            => [ [ 'name' => 'sessions' ] ],
+			// `sessions` is non-additive, so GA4 computes this total over the
+			// underlying data rather than summing the rows — the deduplicated
+			// count of sessions touched by either event. Every session where
+			// segmentation ran emits at least one np_segment_matched (a real
+			// segment, or `none`), which makes this the denominator: the
+			// audience Campaigns could actually see and classify.
+			'metricAggregations' => [ 'TOTAL' ],
+			'dimensionFilter'    => [
 				'filter' => [
 					'fieldName'    => 'eventName',
 					'inListFilter' => [ 'values' => [ 'np_segment_matched', 'np_segment_won' ] ],
 				],
 			],
-			'limit'           => '10000',
+			'limit'              => '10000',
 		];
 		$response = GA4_Client::with_admin_client(
 			function ( $client, $source ) use ( $property_id, $request ) {
@@ -274,16 +297,35 @@ final class GA4_Segment_Reach {
 		update_option(
 			self::OPTION,
 			[
-				'property_id' => $property_id,
-				'fetched_at'  => time(),
-				'range_days'  => self::RANGE_DAYS,
-				'as_of'       => self::report_end_date( $response ),
-				'rows'        => $rows,
+				'property_id'    => $property_id,
+				'fetched_at'     => time(),
+				'range_days'     => self::RANGE_DAYS,
+				'as_of'          => self::report_end_date( $response ),
+				'total_sessions' => self::report_total( $response ),
+				'rows'           => $rows,
 			],
 			false
 		);
 		self::reset_failures();
 		Logger::log( sprintf( 'Stored reach for %d segment IDs on property %s.', count( $rows ), $property_id ), self::LOGGER_HEADER );
+	}
+
+	/**
+	 * Total sessions where segmentation ran — the denominator the percentages
+	 * are read against.
+	 *
+	 * The `TOTAL` aggregation requested above, not a sum of the rows: a session
+	 * matching three segments appears in three rows, so summing would count it
+	 * three times. GA4 computes the total for a non-additive metric over the
+	 * underlying data, deduplicated.
+	 *
+	 * @param array $response Decoded runReport response.
+	 * @return int Sessions, or 0 when the total is absent.
+	 */
+	private static function report_total( array $response ) {
+		return isset( $response['totals'][0]['metricValues'][0]['value'] )
+			? (int) $response['totals'][0]['metricValues'][0]['value']
+			: 0;
 	}
 
 	/**
@@ -360,16 +402,22 @@ final class GA4_Segment_Reach {
 		$as_of = $cache['as_of'] ?? gmdate( 'Y-m-d', ( isset( $cache['fetched_at'] ) ? (int) $cache['fetched_at'] : time() ) - DAY_IN_SECONDS );
 		// Surfaced so the label can name the window instead of hardcoding it.
 		$range_days = isset( $cache['range_days'] ) ? (int) $cache['range_days'] : self::RANGE_DAYS;
+		// Raw counts and the denominator both travel; the percentages are
+		// computed for display. Storing the ratio instead would fix the
+		// presentation at fetch time and lose the sample size, which is what
+		// tells a publisher whether a share is worth acting on.
+		$total = isset( $cache['total_sessions'] ) ? (int) $cache['total_sessions'] : 0;
 		foreach ( $segments as &$segment ) {
 			if ( ! is_array( $segment ) || ! isset( $segment['id'] ) ) {
 				continue;
 			}
 			$row              = $cache['rows'][ (string) $segment['id'] ] ?? null;
 			$segment['reach'] = [
-				'matched'    => $row ? (int) $row['matched'] : null,
-				'won'        => $row ? (int) $row['won'] : null,
-				'as_of'      => $as_of,
-				'range_days' => $range_days,
+				'matched'        => $row ? (int) $row['matched'] : null,
+				'won'            => $row ? (int) $row['won'] : null,
+				'total_sessions' => $total,
+				'as_of'          => $as_of,
+				'range_days'     => $range_days,
 			];
 		}
 		// The loop variable stays bound to the last element, so a caller that

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-segment-reach.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-segment-reach.php
@@ -21,12 +21,26 @@ defined( 'ABSPATH' ) || exit;
 final class GA4_Segment_Reach {
 
 	const OPTION                 = 'newspack_ga4_segment_reach';
+	const FAILURE_OPTION         = 'newspack_ga4_segment_reach_failures';
 	const REFRESH_ACTION         = 'newspack_ga4_segment_reach_refresh';
 	const GROUP                  = 'newspack';
 	const ASYNC_GROUP            = 'newspack-async';
 	const LAST_ATTEMPT_TRANSIENT = 'newspack_ga4_segment_reach_attempt';
 	const LOGGER_HEADER          = 'NEWSPACK-GA4-REACH';
 	const RANGE_DAYS             = 7;
+
+	/**
+	 * Consecutive failed refreshes after which this site stops trying.
+	 *
+	 * A report that cannot succeed — most commonly because the `segment_id`
+	 * custom dimension is not on the property yet — would otherwise retry on
+	 * the daily schedule plus once an hour of admin traffic, forever, with
+	 * nothing to observe it: the only record is a `Logger::log` call, which
+	 * compiles out unless the site defines `NEWSPACK_LOG_LEVEL`. Give up after
+	 * a handful of attempts and record why; connecting a different property or
+	 * a fresh dimension provisioning run clears the count.
+	 */
+	const MAX_FAILURES = 5;
 
 	/**
 	 * Register hooks.
@@ -68,6 +82,53 @@ final class GA4_Segment_Reach {
 	}
 
 	/**
+	 * The consecutive-failure record for the currently connected property.
+	 *
+	 * Scoped to a property for the same reason the cache is: a count carried
+	 * over from a property that no longer exists here says nothing about this
+	 * one, so connecting a different property starts from zero.
+	 *
+	 * @param string $property_id Connected property.
+	 * @return array `count` (int) and `last_error` (string).
+	 */
+	private static function get_failures( $property_id ) {
+		$record = get_option( self::FAILURE_OPTION, false );
+		if ( ! is_array( $record ) || ( $record['property_id'] ?? '' ) !== $property_id ) {
+			return [
+				'count'      => 0,
+				'last_error' => '',
+			];
+		}
+		return [
+			'count'      => isset( $record['count'] ) ? (int) $record['count'] : 0,
+			'last_error' => isset( $record['last_error'] ) ? (string) $record['last_error'] : '',
+		];
+	}
+
+	/**
+	 * Whether this site has stopped trying for the connected property.
+	 *
+	 * @param string $property_id Connected property.
+	 * @return bool
+	 */
+	private static function has_given_up( $property_id ) {
+		return self::get_failures( $property_id )['count'] >= self::MAX_FAILURES;
+	}
+
+	/**
+	 * Clear the failure record so refreshes resume.
+	 *
+	 * Called on a successful fetch, and by GA4_Custom_Dimensions after a
+	 * provisioning run — a run that adds the `segment_id` dimension is exactly
+	 * what makes a previously impossible report possible, so it should not
+	 * have to wait for a property switch.
+	 */
+	public static function reset_failures() {
+		delete_option( self::FAILURE_OPTION );
+		delete_transient( self::LAST_ATTEMPT_TRANSIENT );
+	}
+
+	/**
 	 * Keep a daily refresh scheduled while a GA4 property is connected, drop
 	 * it when none is, and enqueue an immediate first fetch when there is no
 	 * usable cache yet — a fresh site, or one just pointed at a new property,
@@ -78,26 +139,40 @@ final class GA4_Segment_Reach {
 		if ( ! function_exists( 'as_schedule_recurring_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
 			return;
 		}
-		$is_scheduled = as_has_scheduled_action( self::REFRESH_ACTION, [], self::GROUP );
-		$property_id  = GA4_Client::get_property_id();
+		// `admin_init` also fires on admin-ajax.php, authenticated or not, so
+		// this runs on every heartbeat tick, autosave and nopriv AJAX hit.
+		// Rescheduling only needs to happen when someone who could have
+		// changed the GA4 connection is looking at the admin.
+		if ( wp_doing_ajax() ) {
+			return;
+		}
+		// Cheap check first: a non-autoloaded, object-cached get_option, so
+		// sites with no GA4 property never pay for a query against
+		// actionscheduler_actions (a large table on busy sites).
+		$property_id = GA4_Client::get_property_id();
 		if ( ! $property_id ) {
-			if ( $is_scheduled && function_exists( 'as_unschedule_all_actions' ) ) {
+			if (
+				function_exists( 'as_unschedule_all_actions' )
+				&& as_has_scheduled_action( self::REFRESH_ACTION, [], self::GROUP )
+			) {
 				as_unschedule_all_actions( self::REFRESH_ACTION, [], self::GROUP );
 			}
 			return;
 		}
-		if ( ! $is_scheduled ) {
+		if ( ! as_has_scheduled_action( self::REFRESH_ACTION, [], self::GROUP ) ) {
 			as_schedule_recurring_action( time() + DAY_IN_SECONDS, DAY_IN_SECONDS, self::REFRESH_ACTION, [], self::GROUP );
 			Logger::log( 'Scheduled daily GA4 segment reach refresh.', self::LOGGER_HEADER );
 		}
 		// First fetch, also covering a switch to a new property: a cache from
 		// the old one is not usable (see get_valid_cache), and waiting a day
 		// for the recurring refresh would leave the list blank meanwhile. The
-		// transient backs off retries while the fetch keeps failing (e.g. no
-		// auth route), so a broken site attempts at most once an hour rather
-		// than on every admin page load.
+		// transient backs off while the fetch keeps failing (e.g. no auth
+		// route), so a broken site attempts at most once an hour rather than
+		// on every admin page load — and the failure ceiling stops it entirely
+		// once the report looks impossible rather than merely unlucky.
 		if (
 			null === self::get_valid_cache( $property_id )
+			&& ! self::has_given_up( $property_id )
 			&& false === get_transient( self::LAST_ATTEMPT_TRANSIENT )
 			&& function_exists( 'as_enqueue_async_action' )
 			&& ! as_has_scheduled_action( self::REFRESH_ACTION, [], self::ASYNC_GROUP )
@@ -117,6 +192,16 @@ final class GA4_Segment_Reach {
 		if ( ! $property_id ) {
 			return;
 		}
+		// Stop calling Google once the report looks impossible rather than
+		// merely unlucky. The recurring action stays scheduled so a later
+		// reset_failures() — a property switch, or a provisioning run that
+		// adds the missing dimension — resumes it without rescheduling.
+		if ( self::has_given_up( $property_id ) ) {
+			return;
+		}
+		// Armed before the call so a refresh that dies mid-flight still backs
+		// off; cleared on success so a property switch minutes later gets its
+		// immediate fetch rather than waiting out the hour.
 		set_transient( self::LAST_ATTEMPT_TRANSIENT, time(), HOUR_IN_SECONDS );
 		$request  = [
 			'dateRanges'      => [
@@ -149,7 +234,18 @@ final class GA4_Segment_Reach {
 			[ 'require_edit_scope' => false ]
 		);
 		if ( is_wp_error( $response ) ) {
-			Logger::log( 'Reach refresh failed: ' . $response->get_error_message(), self::LOGGER_HEADER );
+			self::record_failure( $property_id, $response->get_error_message() );
+			return;
+		}
+		// A response that is not a report must not overwrite good numbers.
+		// Both client paths can hand back a non-error, non-report value: the
+		// OAuth client returns [] for a 2xx carrying a non-JSON body (an edge
+		// error page, a proxy interstitial), and the Site Kit client returns
+		// null if the re-encode fails. Either would parse to zero rows and
+		// blank every segment for a day. A report always carries `rows` or,
+		// when it genuinely found nothing, `rowCount`.
+		if ( ! is_array( $response ) || ( ! isset( $response['rows'] ) && ! isset( $response['rowCount'] ) ) ) {
+			self::record_failure( $property_id, 'Response was not a report.' );
 			return;
 		}
 
@@ -181,11 +277,61 @@ final class GA4_Segment_Reach {
 				'property_id' => $property_id,
 				'fetched_at'  => time(),
 				'range_days'  => self::RANGE_DAYS,
+				'as_of'       => self::report_end_date( $response ),
 				'rows'        => $rows,
 			],
 			false
 		);
+		self::reset_failures();
 		Logger::log( sprintf( 'Stored reach for %d segment IDs on property %s.', count( $rows ), $property_id ), self::LOGGER_HEADER );
+	}
+
+	/**
+	 * The last calendar day the report covers.
+	 *
+	 * The request asks for `yesterday`, which GA4 resolves against the
+	 * property's own reporting timezone — not ours. Deriving the label from
+	 * our clock disagrees with what GA actually counted whenever the two are
+	 * on different days: a refresh at 01:00 UTC against a Los Angeles property
+	 * covers through the 5th locally while a UTC derivation says the 6th. The
+	 * report response carries the property timezone, so use it; fall back to
+	 * the UTC derivation only when it is absent.
+	 *
+	 * @param array $response Decoded runReport response.
+	 * @return string `Y-m-d`.
+	 */
+	private static function report_end_date( array $response ) {
+		$timezone = $response['metadata']['timeZone'] ?? '';
+		if ( $timezone ) {
+			try {
+				$yesterday = new \DateTimeImmutable( 'yesterday', new \DateTimeZone( $timezone ) );
+				return $yesterday->format( 'Y-m-d' );
+			} catch ( \Exception $e ) {
+				Logger::log( "Unusable report timezone '$timezone'; falling back to UTC.", self::LOGGER_HEADER );
+			}
+		}
+		return gmdate( 'Y-m-d', time() - DAY_IN_SECONDS );
+	}
+
+	/**
+	 * Record a failed refresh and log why.
+	 *
+	 * @param string $property_id Connected property.
+	 * @param string $message     Failure reason.
+	 */
+	private static function record_failure( $property_id, $message ) {
+		$count = self::get_failures( $property_id )['count'] + 1;
+		update_option(
+			self::FAILURE_OPTION,
+			[
+				'property_id' => $property_id,
+				'count'       => $count,
+				'last_error'  => $message,
+				'last_failed' => time(),
+			],
+			false
+		);
+		Logger::log( sprintf( 'Reach refresh failed (%d/%d): %s', $count, self::MAX_FAILURES, $message ), self::LOGGER_HEADER );
 	}
 
 	/**
@@ -208,19 +354,28 @@ final class GA4_Segment_Reach {
 		if ( null === $cache ) {
 			return $segments;
 		}
-		// The report range ends the day before the fetch.
-		$as_of = gmdate( 'Y-m-d', ( isset( $cache['fetched_at'] ) ? (int) $cache['fetched_at'] : time() ) - DAY_IN_SECONDS );
+		// Recorded at fetch time from the property's own reporting timezone
+		// (see report_end_date). Caches written before that was stored fall
+		// back to the old derivation: the range ends the day before the fetch.
+		$as_of = $cache['as_of'] ?? gmdate( 'Y-m-d', ( isset( $cache['fetched_at'] ) ? (int) $cache['fetched_at'] : time() ) - DAY_IN_SECONDS );
+		// Surfaced so the label can name the window instead of hardcoding it.
+		$range_days = isset( $cache['range_days'] ) ? (int) $cache['range_days'] : self::RANGE_DAYS;
 		foreach ( $segments as &$segment ) {
 			if ( ! is_array( $segment ) || ! isset( $segment['id'] ) ) {
 				continue;
 			}
 			$row              = $cache['rows'][ (string) $segment['id'] ] ?? null;
 			$segment['reach'] = [
-				'matched' => $row ? (int) $row['matched'] : null,
-				'won'     => $row ? (int) $row['won'] : null,
-				'as_of'   => $as_of,
+				'matched'    => $row ? (int) $row['matched'] : null,
+				'won'        => $row ? (int) $row['won'] : null,
+				'as_of'      => $as_of,
+				'range_days' => $range_days,
 			];
 		}
+		// The loop variable stays bound to the last element, so a caller that
+		// copies the result and writes to that element would also mutate this
+		// array. Costs one line to close.
+		unset( $segment );
 		return $segments;
 	}
 }

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-segment-reach.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-segment-reach.php
@@ -1,0 +1,198 @@
+<?php
+/**
+ * Fetches and caches per-segment reach from GA4, for display in the
+ * Campaigns segments list.
+ *
+ * Reads back the events newspack-popups sends (np_segment_matched /
+ * np_segment_won, one per segment per GA4 session), so `eventCount` is the
+ * "sessions matching segment" figure directly. One runReport a day covers
+ * every segment.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * GA4 segment reach cache.
+ */
+final class GA4_Segment_Reach {
+
+	const OPTION                 = 'newspack_ga4_segment_reach';
+	const REFRESH_ACTION         = 'newspack_ga4_segment_reach_refresh';
+	const GROUP                  = 'newspack';
+	const ASYNC_GROUP            = 'newspack-async';
+	const LAST_ATTEMPT_TRANSIENT = 'newspack_ga4_segment_reach_attempt';
+	const LOGGER_HEADER          = 'NEWSPACK-GA4-REACH';
+	const RANGE_DAYS             = 7;
+
+	/**
+	 * Register hooks.
+	 */
+	public static function init() {
+		add_action( self::REFRESH_ACTION, [ __CLASS__, 'refresh' ] );
+		add_action( 'admin_init', [ __CLASS__, 'maybe_schedule' ] );
+	}
+
+	/**
+	 * Keep a daily refresh scheduled while a GA4 property is connected, drop
+	 * it when none is, and enqueue an immediate first fetch when no cache
+	 * exists yet — a fresh site should see numbers on the next cron tick, not
+	 * after a day. Idempotent; runs on every admin page load.
+	 */
+	public static function maybe_schedule() {
+		if ( ! function_exists( 'as_schedule_recurring_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
+			return;
+		}
+		$is_scheduled = as_has_scheduled_action( self::REFRESH_ACTION, [], self::GROUP );
+		if ( ! GA4_Client::get_property_id() ) {
+			if ( $is_scheduled && function_exists( 'as_unschedule_all_actions' ) ) {
+				as_unschedule_all_actions( self::REFRESH_ACTION, [], self::GROUP );
+			}
+			return;
+		}
+		if ( ! $is_scheduled ) {
+			as_schedule_recurring_action( time() + DAY_IN_SECONDS, DAY_IN_SECONDS, self::REFRESH_ACTION, [], self::GROUP );
+			Logger::log( 'Scheduled daily GA4 segment reach refresh.', self::LOGGER_HEADER );
+		}
+		// First fetch. The transient backs off retries while the fetch keeps
+		// failing (e.g. no auth route), so a broken site attempts at most once
+		// an hour instead of on every admin page load.
+		if (
+			false === get_option( self::OPTION, false )
+			&& false === get_transient( self::LAST_ATTEMPT_TRANSIENT )
+			&& function_exists( 'as_enqueue_async_action' )
+			&& ! as_has_scheduled_action( self::REFRESH_ACTION, [], self::ASYNC_GROUP )
+		) {
+			as_enqueue_async_action( self::REFRESH_ACTION, [], self::ASYNC_GROUP );
+		}
+	}
+
+	/**
+	 * Fetch the last week of reach from GA4 and cache the parsed counts.
+	 *
+	 * One report: sessions per (segment, event) pair. A failure keeps the
+	 * previous cache — the list shows staler numbers, never none.
+	 */
+	public static function refresh() {
+		$property_id = GA4_Client::get_property_id();
+		if ( ! $property_id ) {
+			return;
+		}
+		set_transient( self::LAST_ATTEMPT_TRANSIENT, time(), HOUR_IN_SECONDS );
+		$request  = [
+			'dateRanges'      => [
+				[
+					'startDate' => self::RANGE_DAYS . 'daysAgo',
+					'endDate'   => 'yesterday',
+				],
+			],
+			'dimensions'      => [
+				[ 'name' => 'customEvent:segment_id' ],
+				[ 'name' => 'eventName' ],
+			],
+			'metrics'         => [ [ 'name' => 'eventCount' ] ],
+			'dimensionFilter' => [
+				'filter' => [
+					'fieldName'    => 'eventName',
+					'inListFilter' => [ 'values' => [ 'np_segment_matched', 'np_segment_won' ] ],
+				],
+			],
+			'limit'           => '10000',
+		];
+		$response = GA4_Client::with_admin_client(
+			function ( $client, $source ) use ( $property_id, $request ) {
+				try {
+					return $client->run_report( $property_id, $request );
+				} catch ( \Throwable $e ) {
+					return new \WP_Error( 'newspack_ga4_segment_reach', 'Failed running reach report: ' . $e->getMessage() );
+				}
+			},
+			[ 'require_edit_scope' => false ]
+		);
+		if ( is_wp_error( $response ) ) {
+			Logger::log( 'Reach refresh failed: ' . $response->get_error_message(), self::LOGGER_HEADER );
+			return;
+		}
+
+		$rows      = [];
+		$row_items = isset( $response['rows'] ) && is_array( $response['rows'] ) ? $response['rows'] : [];
+		foreach ( $row_items as $row ) {
+			$segment_id = isset( $row['dimensionValues'][0]['value'] ) ? (string) $row['dimensionValues'][0]['value'] : '';
+			$event_name = isset( $row['dimensionValues'][1]['value'] ) ? (string) $row['dimensionValues'][1]['value'] : '';
+			$count      = isset( $row['metricValues'][0]['value'] ) ? (int) $row['metricValues'][0]['value'] : 0;
+			if ( '' === $segment_id ) {
+				continue;
+			}
+			if ( ! isset( $rows[ $segment_id ] ) ) {
+				$rows[ $segment_id ] = [
+					'matched' => 0,
+					'won'     => 0,
+				];
+			}
+			if ( 'np_segment_matched' === $event_name ) {
+				$rows[ $segment_id ]['matched'] = $count;
+			} elseif ( 'np_segment_won' === $event_name ) {
+				$rows[ $segment_id ]['won'] = $count;
+			}
+		}
+
+		update_option(
+			self::OPTION,
+			[
+				'property_id' => $property_id,
+				'fetched_at'  => time(),
+				'range_days'  => self::RANGE_DAYS,
+				'rows'        => $rows,
+			],
+			false
+		);
+		Logger::log( sprintf( 'Stored reach for %d segment IDs on property %s.', count( $rows ), $property_id ), self::LOGGER_HEADER );
+	}
+
+	/**
+	 * Attach cached reach to the segments payload the wizard returns.
+	 *
+	 * Three states, deliberately distinct for the UI: no valid same-property
+	 * cache — payload untouched, so the feature stays invisible where the
+	 * pipeline cannot work; cache with a row — numbers; cache without a row —
+	 * explicit nulls, rendered as "no data yet" rather than zero (a young
+	 * segment and GA thresholding look the same from here).
+	 *
+	 * @param mixed $segments Segments array from the configuration manager.
+	 * @return mixed Decorated segments, or the input untouched.
+	 */
+	public static function decorate_segments( $segments ) {
+		if ( ! is_array( $segments ) ) {
+			return $segments;
+		}
+		$cache       = get_option( self::OPTION, false );
+		$property_id = GA4_Client::get_property_id();
+		if (
+			! is_array( $cache )
+			|| ! isset( $cache['rows'] )
+			|| ! is_array( $cache['rows'] )
+			|| ! $property_id
+			|| ( $cache['property_id'] ?? '' ) !== $property_id
+		) {
+			return $segments;
+		}
+		// The report range ends the day before the fetch.
+		$as_of = gmdate( 'Y-m-d', ( isset( $cache['fetched_at'] ) ? (int) $cache['fetched_at'] : time() ) - DAY_IN_SECONDS );
+		foreach ( $segments as &$segment ) {
+			if ( ! is_array( $segment ) || ! isset( $segment['id'] ) ) {
+				continue;
+			}
+			$row              = $cache['rows'][ (string) $segment['id'] ] ?? null;
+			$segment['reach'] = [
+				'matched' => $row ? (int) $row['matched'] : null,
+				'won'     => $row ? (int) $row['won'] : null,
+				'as_of'   => $as_of,
+			];
+		}
+		return $segments;
+	}
+}
+GA4_Segment_Reach::init();

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-segment-reach.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-segment-reach.php
@@ -37,17 +37,50 @@ final class GA4_Segment_Reach {
 	}
 
 	/**
+	 * The cached reach for the currently connected property, if any.
+	 *
+	 * A cache left over from a previously connected property is not "the
+	 * cache" — its numbers describe a different site's audience. Both the
+	 * display path and the scheduling path treat it as absent, which is why
+	 * this lives in one place: if only the display path discounted it, a
+	 * property switch would show nothing until the next daily refresh.
+	 *
+	 * @param string|false $property_id Connected property, or false to look it up.
+	 * @return array|null Cache payload for the connected property, or null.
+	 */
+	private static function get_valid_cache( $property_id = false ) {
+		if ( false === $property_id ) {
+			$property_id = GA4_Client::get_property_id();
+		}
+		if ( ! $property_id ) {
+			return null;
+		}
+		$cache = get_option( self::OPTION, false );
+		if (
+			! is_array( $cache )
+			|| ! isset( $cache['rows'] )
+			|| ! is_array( $cache['rows'] )
+			|| ( $cache['property_id'] ?? '' ) !== $property_id
+		) {
+			return null;
+		}
+		return $cache;
+	}
+
+	/**
 	 * Keep a daily refresh scheduled while a GA4 property is connected, drop
-	 * it when none is, and enqueue an immediate first fetch when no cache
-	 * exists yet — a fresh site should see numbers on the next cron tick, not
-	 * after a day. Idempotent; runs on every admin page load.
+	 * it when none is, and enqueue an immediate first fetch when there is no
+	 * usable cache yet — a fresh site, or one just pointed at a new property,
+	 * should see numbers on the next cron tick, not after a day. Idempotent;
+	 * runs on every admin page load.
 	 */
 	public static function maybe_schedule() {
 		if ( ! function_exists( 'as_schedule_recurring_action' ) || ! function_exists( 'as_has_scheduled_action' ) ) {
 			return;
 		}
 		$is_scheduled = as_has_scheduled_action( self::REFRESH_ACTION, [], self::GROUP );
-		if ( ! GA4_Client::get_property_id() ) {
+		$property_id  = GA4_Client::get_property_id();
+		if ( ! $property_id ) {
 			if ( $is_scheduled && function_exists( 'as_unschedule_all_actions' ) ) {
 				as_unschedule_all_actions( self::REFRESH_ACTION, [], self::GROUP );
 			}
@@ -57,11 +90,14 @@ final class GA4_Segment_Reach {
 			as_schedule_recurring_action( time() + DAY_IN_SECONDS, DAY_IN_SECONDS, self::REFRESH_ACTION, [], self::GROUP );
 			Logger::log( 'Scheduled daily GA4 segment reach refresh.', self::LOGGER_HEADER );
 		}
-		// First fetch. The transient backs off retries while the fetch keeps
-		// failing (e.g. no auth route), so a broken site attempts at most once
-		// an hour instead of on every admin page load.
+		// First fetch, also covering a switch to a new property: a cache from
+		// the old one is not usable (see get_valid_cache), and waiting a day
+		// for the recurring refresh would leave the list blank meanwhile. The
+		// transient backs off retries while the fetch keeps failing (e.g. no
+		// auth route), so a broken site attempts at most once an hour rather
+		// than on every admin page load.
 		if (
-			false === get_option( self::OPTION, false )
+			null === self::get_valid_cache( $property_id )
 			&& false === get_transient( self::LAST_ATTEMPT_TRANSIENT )
 			&& function_exists( 'as_enqueue_async_action' )
 			&& ! as_has_scheduled_action( self::REFRESH_ACTION, [], self::ASYNC_GROUP )
@@ -168,15 +204,8 @@ final class GA4_Segment_Reach {
 		if ( ! is_array( $segments ) ) {
 			return $segments;
 		}
-		$cache       = get_option( self::OPTION, false );
-		$property_id = GA4_Client::get_property_id();
-		if (
-			! is_array( $cache )
-			|| ! isset( $cache['rows'] )
-			|| ! is_array( $cache['rows'] )
-			|| ! $property_id
-			|| ( $cache['property_id'] ?? '' ) !== $property_id
-		) {
+		$cache = self::get_valid_cache();
+		if ( null === $cache ) {
 			return $segments;
 		}
 		// The report range ends the day before the fetch.

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-segment-reach.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-ga4-segment-reach.php
@@ -29,6 +29,7 @@ final class GA4_Segment_Reach {
 
 	const OPTION                 = 'newspack_ga4_segment_reach';
 	const FAILURE_OPTION         = 'newspack_ga4_segment_reach_failures';
+	const PRIORITY_OPTION        = 'newspack_ga4_segment_reach_priority_changed';
 	const REFRESH_ACTION         = 'newspack_ga4_segment_reach_refresh';
 	const GROUP                  = 'newspack';
 	const ASYNC_GROUP            = 'newspack-async';
@@ -55,6 +56,69 @@ final class GA4_Segment_Reach {
 	public static function init() {
 		add_action( self::REFRESH_ACTION, [ __CLASS__, 'refresh' ] );
 		add_action( 'admin_init', [ __CLASS__, 'maybe_schedule' ] );
+		// Segment priority lives in term meta, and Campaigns writes it from
+		// several paths — the drag-reorder, a single-segment save, and the
+		// reindex that follows a deletion. Watching the meta key catches all
+		// of them, including changes made outside the wizard.
+		add_action( 'updated_term_meta', [ __CLASS__, 'record_priority_change' ], 10, 3 );
+		add_action( 'added_term_meta', [ __CLASS__, 'record_priority_change' ], 10, 3 );
+	}
+
+	/**
+	 * Note when segment priority last changed.
+	 *
+	 * Reordering is the moment someone most expects these numbers to move, and
+	 * it is the one thing that cannot move them: the report still covers the
+	 * same days, most of which ran under the previous order. Recording the day
+	 * lets the list say so rather than showing figures that quietly answer a
+	 * different question.
+	 *
+	 * @param int    $meta_id  Meta row ID (unused).
+	 * @param int    $term_id  Term the meta belongs to.
+	 * @param string $meta_key Meta key.
+	 */
+	public static function record_priority_change( $meta_id, $term_id, $meta_key ) {
+		if ( 'priority' !== $meta_key ) {
+			return;
+		}
+		// Campaigns owns the taxonomy, so prefer its constant; the literal
+		// keeps this working (and testable) when newspack-popups is not
+		// loaded, where the hook simply never matches a real segment.
+		$taxonomy = class_exists( 'Newspack_Segments_Model' ) ? \Newspack_Segments_Model::TAX_SLUG : 'popup_segment';
+		$term     = get_term( $term_id );
+		if ( ! $term || is_wp_error( $term ) || $taxonomy !== $term->taxonomy ) {
+			return;
+		}
+		// A reorder rewrites every segment's priority, so this fires once per
+		// segment. Each write carries the same timestamp within a second, and
+		// update_option short-circuits an unchanged value, so the burst costs
+		// at most a couple of writes to a non-autoloaded option. Cheaper than
+		// a per-request static, which would also swallow a second legitimate
+		// change in a long-running WP-CLI process.
+		update_option( self::PRIORITY_OPTION, time(), false );
+	}
+
+	/**
+	 * The day priority last changed, when that falls inside the reported
+	 * window — otherwise null, since a change older than the window no longer
+	 * describes any of these sessions.
+	 *
+	 * A change *after* the window still counts: the whole report then predates
+	 * the current order, which is the most misleading case of all.
+	 *
+	 * @param string $as_of      Last day the report covers, `Y-m-d`.
+	 * @param int    $range_days Days the report covers.
+	 * @return string|null `Y-m-d`, or null.
+	 */
+	private static function priority_change_in_window( $as_of, $range_days ) {
+		$changed_at = (int) get_option( self::PRIORITY_OPTION, 0 );
+		if ( ! $changed_at ) {
+			return null;
+		}
+		$changed_on   = gmdate( 'Y-m-d', $changed_at );
+		$window_start = gmdate( 'Y-m-d', strtotime( $as_of . ' -' . max( 0, $range_days - 1 ) . ' days' ) );
+		// Both are Y-m-d, which compares correctly as a string.
+		return $changed_on < $window_start ? null : $changed_on;
 	}
 
 	/**
@@ -407,17 +471,22 @@ final class GA4_Segment_Reach {
 		// presentation at fetch time and lose the sample size, which is what
 		// tells a publisher whether a share is worth acting on.
 		$total = isset( $cache['total_sessions'] ) ? (int) $cache['total_sessions'] : 0;
+		// Site-wide rather than per-segment: reordering changes which segment
+		// wins for a shared set of readers, so a change anywhere in the list
+		// qualifies every row's prompt figure, not just the moved segment's.
+		$priority_changed = self::priority_change_in_window( $as_of, $range_days );
 		foreach ( $segments as &$segment ) {
 			if ( ! is_array( $segment ) || ! isset( $segment['id'] ) ) {
 				continue;
 			}
 			$row              = $cache['rows'][ (string) $segment['id'] ] ?? null;
 			$segment['reach'] = [
-				'matched'        => $row ? (int) $row['matched'] : null,
-				'won'            => $row ? (int) $row['won'] : null,
-				'total_sessions' => $total,
-				'as_of'          => $as_of,
-				'range_days'     => $range_days,
+				'matched'          => $row ? (int) $row['matched'] : null,
+				'won'              => $row ? (int) $row['won'] : null,
+				'total_sessions'   => $total,
+				'as_of'            => $as_of,
+				'range_days'       => $range_days,
+				'priority_changed' => $priority_changed,
 			];
 		}
 		// The loop variable stays bound to the last element, so a caller that

--- a/plugins/newspack-plugin/includes/plugins/google-site-kit/class-googlesitekitanalytics.php
+++ b/plugins/newspack-plugin/includes/plugins/google-site-kit/class-googlesitekitanalytics.php
@@ -14,6 +14,8 @@ use Google\Site_Kit\Core\Modules\Module;
 use Google\Site_Kit\Core\Authentication\Clients\Google_Site_Kit_Client;
 use Google\Site_Kit_Dependencies\Google\Service\GoogleAnalyticsAdmin as Google_Service_GoogleAnalyticsAdmin;
 use Google\Site_Kit_Dependencies\Google\Service\GoogleAnalyticsAdmin\GoogleAnalyticsAdminV1betaCustomDimension;
+use Google\Site_Kit_Dependencies\Google\Service\AnalyticsData as Google_Service_AnalyticsData;
+use Google\Site_Kit_Dependencies\Google\Service\AnalyticsData\RunReportRequest;
 
 defined( 'ABSPATH' ) || exit;
 
@@ -37,7 +39,27 @@ class GoogleSiteKitAnalytics extends Module {
 	protected function setup_services( Google_Site_Kit_Client $client ) {
 		return array(
 			'analyticsadmin' => new Google_Service_GoogleAnalyticsAdmin( $client ),
+			'analyticsdata'  => new Google_Service_AnalyticsData( $client ),
 		);
+	}
+
+	/**
+	 * Run a GA4 Data API report through Site Kit's authenticated client.
+	 *
+	 * Mirrors `Google_OAuth_GA4_Client::run_report()` so the auth router's
+	 * callback can call either client without knowing which it holds.
+	 *
+	 * @param string $property_id GA4 property ID.
+	 * @param array  $request     runReport request body (Data API shape).
+	 * @return array Decoded response as an associative array.
+	 */
+	public function run_report( $property_id, array $request ) {
+		$analyticsdata = $this->get_service( 'analyticsdata' );
+		$response      = $analyticsdata->properties->runReport(
+			'properties/' . $property_id,
+			new RunReportRequest( $request )
+		);
+		return json_decode( wp_json_encode( $response->toSimpleObject() ), true );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-campaigns.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-campaigns.php
@@ -492,7 +492,7 @@ class Audience_Campaigns extends Wizard {
 				},
 				$newspack_popups_configuration_manager->get_prompts( true, true )
 			);
-			$response['segments']  = $newspack_popups_configuration_manager->get_segments( true );
+			$response['segments']  = GA4_Segment_Reach::decorate_segments( $newspack_popups_configuration_manager->get_segments( true ) );
 			$response['settings']  = $newspack_popups_configuration_manager->get_settings();
 			$response['campaigns'] = $newspack_popups_configuration_manager->get_campaigns();
 		}
@@ -704,7 +704,7 @@ class Audience_Campaigns extends Wizard {
 	 */
 	public function api_get_segments() {
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
-		$response                              = $newspack_popups_configuration_manager->get_segments();
+		$response                              = GA4_Segment_Reach::decorate_segments( $newspack_popups_configuration_manager->get_segments() );
 		return $response;
 	}
 

--- a/plugins/newspack-plugin/includes/wizards/audience/class-audience-campaigns.php
+++ b/plugins/newspack-plugin/includes/wizards/audience/class-audience-campaigns.php
@@ -492,7 +492,7 @@ class Audience_Campaigns extends Wizard {
 				},
 				$newspack_popups_configuration_manager->get_prompts( true, true )
 			);
-			$response['segments']  = GA4_Segment_Reach::decorate_segments( $newspack_popups_configuration_manager->get_segments( true ) );
+			$response['segments']  = self::with_reach( $newspack_popups_configuration_manager->get_segments( true ) );
 			$response['settings']  = $newspack_popups_configuration_manager->get_settings();
 			$response['campaigns'] = $newspack_popups_configuration_manager->get_campaigns();
 		}
@@ -704,8 +704,27 @@ class Audience_Campaigns extends Wizard {
 	 */
 	public function api_get_segments() {
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
-		$response                              = GA4_Segment_Reach::decorate_segments( $newspack_popups_configuration_manager->get_segments() );
-		return $response;
+		return self::with_reach( $newspack_popups_configuration_manager->get_segments() );
+	}
+
+	/**
+	 * Attach cached GA4 reach to a segments payload.
+	 *
+	 * Every endpoint below returns the *whole* segments list, not just the one
+	 * that changed, and the wizard writes those responses straight into the
+	 * list's state. So they all have to decorate: if only the reads did, the
+	 * reach line would disappear from every row the first time a publisher
+	 * toggled, deleted, or reordered a segment, and stay gone until a reload.
+	 * Errors pass through untouched.
+	 *
+	 * @param mixed $segments Segments payload, or a WP_Error.
+	 * @return mixed
+	 */
+	private static function with_reach( $segments ) {
+		if ( is_wp_error( $segments ) ) {
+			return $segments;
+		}
+		return GA4_Segment_Reach::decorate_segments( $segments );
 	}
 
 	/**
@@ -723,7 +742,7 @@ class Audience_Campaigns extends Wizard {
 				'configuration' => $request['configuration'],
 			]
 		);
-		return $response;
+		return self::with_reach( $response );
 	}
 
 	/**
@@ -742,7 +761,7 @@ class Audience_Campaigns extends Wizard {
 				'configuration' => $request['configuration'],
 			]
 		);
-		return $response;
+		return self::with_reach( $response );
 	}
 
 	/**
@@ -754,7 +773,7 @@ class Audience_Campaigns extends Wizard {
 	public function api_delete_segment( $request ) {
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
 		$response                              = $newspack_popups_configuration_manager->delete_segment( $request['id'] );
-		return $response;
+		return self::with_reach( $response );
 	}
 
 	/**
@@ -766,7 +785,7 @@ class Audience_Campaigns extends Wizard {
 	public function api_sort_segments( $request ) {
 		$newspack_popups_configuration_manager = Configuration_Managers::configuration_manager_class_for_plugin_slug( 'newspack-popups' );
 		$response                              = $newspack_popups_configuration_manager->sort_segments( $request['segmentIds'] );
-		return $response;
+		return self::with_reach( $response );
 	}
 
 	/**

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/segments/segments-list.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/segments/segments-list.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import { Card, CardSortableList, Notice, Router } from '../../../../../../packages/components/src';
-import { segmentDescription, segmentReachDescription } from '../utils';
+import { segmentDescription, segmentReachCaveat, segmentReachDescription, segmentReachNotice } from '../utils';
 
 const { useHistory } = Router;
 
@@ -98,17 +98,22 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 			segments.map( segment => {
 				const criteriaDescription = segmentDescription( segment );
 				const reachLine = segmentReachDescription( segment );
+				// Only meaningful next to numbers it qualifies.
+				const reachCaveat = reachLine ? segmentReachCaveat( segment ) : null;
 				return {
 					id: segment.id,
 					title: segment.name,
 					// segmentDescription returns React nodes (NPPD-1852), so compose
 					// as nodes rather than joining strings. The reach line, when the
-					// site reports it, sits on its own line below the criteria.
+					// site reports it, sits on its own line below the criteria, with
+					// the priority caveat under that when one applies.
 					description: reachLine ? (
 						<Fragment>
 							{ criteriaDescription }
 							{ criteriaDescription && <br /> }
 							{ reachLine }
+							{ reachCaveat && <br /> }
+							{ reachCaveat }
 						</Fragment>
 					) : (
 						criteriaDescription
@@ -132,6 +137,7 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 			} ),
 		[ segments, toggleSegmentStatus, deleteSegment, history ]
 	);
+	const reachNotice = useMemo( () => segmentReachNotice( segments ), [ segments ] );
 
 	if ( segments === null ) {
 		return null;
@@ -143,6 +149,7 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 			<Card headerActions noBorder>
 				<h2>{ __( 'Audience segments', 'newspack-plugin' ) }</h2>
 			</Card>
+			{ reachNotice && <Notice noticeText={ reachNotice } isHelp /> }
 			<CardSortableList disabled={ inFlight || isLoading > 0 } items={ items } onDragCallback={ sortSegments } />
 		</Fragment>
 	) : (

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/segments/segments-list.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/segments/segments-list.js
@@ -9,7 +9,7 @@ import { __ } from '@wordpress/i18n';
  * Internal dependencies.
  */
 import { Card, CardSortableList, Notice, Router } from '../../../../../../packages/components/src';
-import { segmentDescription } from '../utils';
+import { segmentDescription, segmentReachDescription } from '../utils';
 
 const { useHistory } = Router;
 
@@ -95,26 +95,41 @@ const SegmentsList = ( { wizardApiFetch, segments, setSegments, isLoading } ) =>
 	};
 	const items = useMemo(
 		() =>
-			segments.map( segment => ( {
-				id: segment.id,
-				title: segment.name,
-				description: segmentDescription( segment ),
-				badgeLevel: segment.is_criteria_duplicated ? 'warning' : 'default',
-				badgeText: segment.is_criteria_duplicated ? __( 'Duplicate', 'newspack-plugin' ) : undefined,
-				toggleChecked: ! segment.configuration.is_disabled,
-				onToggleChange: () => toggleSegmentStatus( segment ),
-				actions: [
-					{
-						label: __( 'Edit', 'newspack-plugin' ),
-						action: () => history.push( `/segments/${ segment.id }` ),
-					},
-					{
-						label: __( 'Delete', 'newspack-plugin' ),
-						action: () => deleteSegment( segment ),
-						destructive: true,
-					},
-				],
-			} ) ),
+			segments.map( segment => {
+				const criteriaDescription = segmentDescription( segment );
+				const reachLine = segmentReachDescription( segment );
+				return {
+					id: segment.id,
+					title: segment.name,
+					// segmentDescription returns React nodes (NPPD-1852), so compose
+					// as nodes rather than joining strings. The reach line, when the
+					// site reports it, sits on its own line below the criteria.
+					description: reachLine ? (
+						<Fragment>
+							{ criteriaDescription }
+							{ criteriaDescription && <br /> }
+							{ reachLine }
+						</Fragment>
+					) : (
+						criteriaDescription
+					),
+					badgeLevel: segment.is_criteria_duplicated ? 'warning' : 'default',
+					badgeText: segment.is_criteria_duplicated ? __( 'Duplicate', 'newspack-plugin' ) : undefined,
+					toggleChecked: ! segment.configuration.is_disabled,
+					onToggleChange: () => toggleSegmentStatus( segment ),
+					actions: [
+						{
+							label: __( 'Edit', 'newspack-plugin' ),
+							action: () => history.push( `/segments/${ segment.id }` ),
+						},
+						{
+							label: __( 'Delete', 'newspack-plugin' ),
+							action: () => deleteSegment( segment ),
+							destructive: true,
+						},
+					],
+				};
+			} ),
 		[ segments, toggleSegmentStatus, deleteSegment, history ]
 	);
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
@@ -226,15 +226,34 @@ const reachShare = ( value, total ) => {
 };
 
 /**
+ * Format a `Y-m-d` day from the reach payload.
+ *
+ * These label calendar days rather than marking moments, so they must read the
+ * same everywhere: anchor to UTC midnight and format in UTC. Site time would
+ * shift the day for negative offsets (`dateI18n` renders 2026-08-06 as "Aug 5"
+ * at UTC-5).
+ *
+ * @param {string} day Date as `Y-m-d`.
+ * @return {string} Formatted day, e.g. "Aug 6".
+ */
+const reachDay = day => gmdateI18n( 'M j', `${ day }T00:00:00+00:00` );
+
+/**
  * One-line reach summary for a segment row, from the GA4 numbers the segments
  * endpoint attaches (GA4_Segment_Reach::decorate_segments).
  *
  * `matched` counts sessions where the reader satisfied the segment's criteria;
- * `won` counts the subset where the segment won the priority match, which is
- * the audience its prompts can actually reach. Both read as a share of the
- * sessions segmentation evaluated — a raw session count says little without
- * knowing how big the week was, and the gap between the two shares is what
- * shows higher-priority segments absorbing readers.
+ * `won` counts the subset where the segment won the priority match, so its
+ * prompts were the ones shown. Both read as a share of the sessions
+ * segmentation evaluated — a raw session count says little without knowing how
+ * big the week was, and the gap between the two shares is what shows
+ * higher-priority segments absorbing readers.
+ *
+ * Written as a record, not a capability: the window leads and every verb is
+ * past tense. These numbers describe sessions that already happened, and
+ * reordering segments changes which prompts readers see from here on without
+ * moving them at all — a "prompt audience: 9%" reads like a live figure that
+ * ought to jump when a segment is dragged to the top, and it does not.
  *
  * The denominator stays on the line rather than being folded away: 34% of 40
  * sessions and 34% of 40,000 support very different decisions, and a segment
@@ -258,20 +277,66 @@ export const segmentReachDescription = segment => {
 		return __( 'No reach data yet', 'newspack-plugin' );
 	}
 	return sprintf(
-		/* Translators: %1$d: number of days the report covers. %2$s: share of the audience the segment reached, e.g. 34%. %3$s: total session count. %4$s: share the segment's prompts can reach. %5$s: date of the data. */
-		__( 'Reach (%1$dd): %2$s of %3$s sessions · prompt audience: %4$s · as of %5$s', 'newspack-plugin' ),
+		/* Translators: %1$d: number of days the report covers. %2$s: last day of the report, e.g. Aug 6. %3$s: share of the audience that matched, e.g. 34%. %4$s: total session count. %5$s: share that was shown this segment's prompts. */
+		__( '%1$d days to %2$s: matched %3$s of %4$s sessions · prompts reached %5$s', 'newspack-plugin' ),
 		// The window is a server-side constant, passed through so the label
 		// can't drift from the report it describes.
 		Number( reach.range_days ) || 7,
+		reachDay( reach.as_of ),
 		reachShare( Number( reach.matched ), total ),
 		total.toLocaleString(),
-		reachShare( Number( reach.won ), total ),
-		// `as_of` is the last calendar day the report covers, computed in UTC.
-		// It labels a day rather than marking a moment, so it must read the
-		// same everywhere: anchor it to UTC midnight and format in UTC. Site
-		// time would shift it a day for negative offsets (`dateI18n` renders
-		// 2026-08-06 as "Aug 5" at UTC-5).
-		gmdateI18n( 'M j', `${ reach.as_of }T00:00:00+00:00` )
+		reachShare( Number( reach.won ), total )
+	);
+};
+
+/**
+ * The caveat shown under a segment whose priority moved inside the reported
+ * window.
+ *
+ * Reordering is exactly when someone expects these numbers to move, and it is
+ * the one thing that cannot move them: the report still covers the same days,
+ * most of which ran under the previous order. Saying so at the row is what
+ * catches the misreading — a standing note above the list is easy to skim past
+ * and is not on screen at the moment the segment gets dragged.
+ *
+ * @param {Object} segment Segment, possibly carrying a `reach` object.
+ * @return {string|null} The caveat, or null when priority held all window.
+ */
+export const segmentReachCaveat = segment => {
+	const changedOn = segment?.reach?.priority_changed;
+	if ( ! changedOn ) {
+		return null;
+	}
+	return sprintf(
+		/* Translators: %s: the day priority last changed, e.g. Aug 5. */
+		__( 'Priority changed %s. Part of this window ran under the previous order.', 'newspack-plugin' ),
+		reachDay( changedOn )
+	);
+};
+
+/**
+ * The standing explainer above the segments list.
+ *
+ * Says the two things the per-row line cannot carry on its own: where the
+ * numbers come from and how often they move, and that reordering segments
+ * changes future prompts rather than this record.
+ *
+ * @param {Array} segments Segments, possibly carrying `reach` objects.
+ * @return {string|null} The notice, or null when nothing reports reach.
+ */
+export const segmentReachNotice = segments => {
+	const reach = segments?.find( segment => Number( segment?.reach?.total_sessions ) > 0 )?.reach;
+	if ( ! reach ) {
+		return null;
+	}
+	return sprintf(
+		/* Translators: %1$d: number of days the report covers. %2$s: last day of the report, e.g. Aug 6. */
+		__(
+			'Figures come from Google Analytics for the %1$d days to %2$s and refresh once a day. They record what already happened: reordering segments changes which prompts readers see from now on, not these numbers.',
+			'newspack-plugin'
+		),
+		Number( reach.range_days ) || 7,
+		reachDay( reach.as_of )
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
@@ -4,7 +4,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
-import { dateI18n } from '@wordpress/date';
+import { gmdateI18n } from '@wordpress/date';
 import { addQueryArgs } from '@wordpress/url';
 import { applyFilters, addFilter } from '@wordpress/hooks';
 import { useEffect, useState, Fragment } from '@wordpress/element';
@@ -232,7 +232,12 @@ export const segmentReachDescription = segment => {
 		__( 'Reach (7d): %1$s sessions · prompt audience: %2$s · as of %3$s', 'newspack-plugin' ),
 		Number( reach.matched ).toLocaleString(),
 		Number( reach.won ).toLocaleString(),
-		dateI18n( 'M j', reach.as_of )
+		// `as_of` is the last calendar day the report covers, computed in UTC.
+		// It labels a day rather than marking a moment, so it must read the
+		// same everywhere: anchor it to UTC midnight and format in UTC. Site
+		// time would shift it a day for negative offsets (`dateI18n` renders
+		// 2026-08-06 as "Aug 5" at UTC-5).
+		gmdateI18n( 'M j', `${ reach.as_of }T00:00:00+00:00` )
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
@@ -4,6 +4,7 @@
  */
 import apiFetch from '@wordpress/api-fetch';
 import { __, sprintf } from '@wordpress/i18n';
+import { dateI18n } from '@wordpress/date';
 import { addQueryArgs } from '@wordpress/url';
 import { applyFilters, addFilter } from '@wordpress/hooks';
 import { useEffect, useState, Fragment } from '@wordpress/element';
@@ -201,6 +202,37 @@ export const segmentDescription = segment => {
 				</Fragment>
 			) ) }
 		</Fragment>
+	);
+};
+
+/**
+ * One-line reach summary for a segment row, from the GA4 numbers the segments
+ * endpoint attaches (GA4_Segment_Reach::decorate_segments).
+ *
+ * `matched` counts sessions where the reader satisfied the segment's criteria;
+ * `won` counts the subset where the segment won the priority match, which is
+ * the audience its prompts can actually reach.
+ *
+ * @param {Object} segment Segment, possibly carrying a `reach` object.
+ * @return {string|null} The line, or null when reach reporting is inactive.
+ */
+export const segmentReachDescription = segment => {
+	const reach = segment?.reach;
+	if ( ! reach ) {
+		return null;
+	}
+	// Null numbers mean the cache exists but this segment has no rows yet — a
+	// young segment, no traffic, or GA thresholding. All honestly "no data
+	// yet"; rendering 0 would overclaim.
+	if ( null === reach.matched || undefined === reach.matched ) {
+		return __( 'No reach data yet', 'newspack-plugin' );
+	}
+	return sprintf(
+		// Translators: %1$s: sessions count. %2$s: prompt-audience sessions count. %3$s: date of the data.
+		__( 'Reach (7d): %1$s sessions · prompt audience: %2$s · as of %3$s', 'newspack-plugin' ),
+		Number( reach.matched ).toLocaleString(),
+		Number( reach.won ).toLocaleString(),
+		dateI18n( 'M j', reach.as_of )
 	);
 };
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
@@ -228,8 +228,11 @@ export const segmentReachDescription = segment => {
 		return __( 'No reach data yet', 'newspack-plugin' );
 	}
 	return sprintf(
-		// Translators: %1$s: sessions count. %2$s: prompt-audience sessions count. %3$s: date of the data.
-		__( 'Reach (7d): %1$s sessions · prompt audience: %2$s · as of %3$s', 'newspack-plugin' ),
+		/* Translators: %1$d: number of days the report covers. %2$s: sessions count. %3$s: prompt-audience sessions count. %4$s: date of the data. */
+		__( 'Reach (%1$dd): %2$s sessions · prompt audience: %3$s · as of %4$s', 'newspack-plugin' ),
+		// The window is a server-side constant, passed through so the label
+		// can't drift from the report it describes.
+		Number( reach.range_days ) || 7,
 		Number( reach.matched ).toLocaleString(),
 		Number( reach.won ).toLocaleString(),
 		// `as_of` is the last calendar day the report covers, computed in UTC.

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.js
@@ -206,12 +206,39 @@ export const segmentDescription = segment => {
 };
 
 /**
+ * A count as a share of the segmented audience.
+ *
+ * Rounds to whole percent, which is as much precision as a weekly sample
+ * supports — with one exception: a segment that reached somebody must not
+ * round down to a flat `0%`, which reads as "nobody" and is the one thing
+ * these numbers exist to distinguish.
+ *
+ * @param {number} value Sessions for this segment.
+ * @param {number} total Sessions where segmentation ran.
+ * @return {string} Formatted percentage.
+ */
+const reachShare = ( value, total ) => {
+	if ( 0 === value ) {
+		return '0%';
+	}
+	const percent = ( value / total ) * 100;
+	return percent < 1 ? '<1%' : `${ Math.round( percent ) }%`;
+};
+
+/**
  * One-line reach summary for a segment row, from the GA4 numbers the segments
  * endpoint attaches (GA4_Segment_Reach::decorate_segments).
  *
  * `matched` counts sessions where the reader satisfied the segment's criteria;
  * `won` counts the subset where the segment won the priority match, which is
- * the audience its prompts can actually reach.
+ * the audience its prompts can actually reach. Both read as a share of the
+ * sessions segmentation evaluated — a raw session count says little without
+ * knowing how big the week was, and the gap between the two shares is what
+ * shows higher-priority segments absorbing readers.
+ *
+ * The denominator stays on the line rather than being folded away: 34% of 40
+ * sessions and 34% of 40,000 support very different decisions, and a segment
+ * list is exactly where someone decides what to target.
  *
  * @param {Object} segment Segment, possibly carrying a `reach` object.
  * @return {string|null} The line, or null when reach reporting is inactive.
@@ -221,20 +248,24 @@ export const segmentReachDescription = segment => {
 	if ( ! reach ) {
 		return null;
 	}
+	const total = Number( reach.total_sessions );
 	// Null numbers mean the cache exists but this segment has no rows yet — a
 	// young segment, no traffic, or GA thresholding. All honestly "no data
-	// yet"; rendering 0 would overclaim.
-	if ( null === reach.matched || undefined === reach.matched ) {
+	// yet"; rendering 0 would overclaim. A missing or zero denominator is the
+	// same story from the other side: a week GA reported nothing for, where
+	// every share would divide by zero.
+	if ( null === reach.matched || undefined === reach.matched || ! total ) {
 		return __( 'No reach data yet', 'newspack-plugin' );
 	}
 	return sprintf(
-		/* Translators: %1$d: number of days the report covers. %2$s: sessions count. %3$s: prompt-audience sessions count. %4$s: date of the data. */
-		__( 'Reach (%1$dd): %2$s sessions · prompt audience: %3$s · as of %4$s', 'newspack-plugin' ),
+		/* Translators: %1$d: number of days the report covers. %2$s: share of the audience the segment reached, e.g. 34%. %3$s: total session count. %4$s: share the segment's prompts can reach. %5$s: date of the data. */
+		__( 'Reach (%1$dd): %2$s of %3$s sessions · prompt audience: %4$s · as of %5$s', 'newspack-plugin' ),
 		// The window is a server-side constant, passed through so the label
 		// can't drift from the report it describes.
 		Number( reach.range_days ) || 7,
-		Number( reach.matched ).toLocaleString(),
-		Number( reach.won ).toLocaleString(),
+		reachShare( Number( reach.matched ), total ),
+		total.toLocaleString(),
+		reachShare( Number( reach.won ), total ),
 		// `as_of` is the last calendar day the report covers, computed in UTC.
 		// It labels a day rather than marking a moment, so it must read the
 		// same everywhere: anchor it to UTC midnight and format in UTC. Site

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
@@ -78,6 +78,8 @@ describe( 'segmentDescription', () => {
 
 describe( 'segmentReachDescription', () => {
 	let segmentReachDescription;
+	let segmentReachCaveat;
+	let segmentReachNotice;
 	let baseDateSettings;
 
 	beforeAll( async () => {
@@ -86,7 +88,7 @@ describe( 'segmentReachDescription', () => {
 			criteria: CRITERIA,
 		};
 		baseDateSettings = getSettings();
-		( { segmentReachDescription } = await import( './utils' ) );
+		( { segmentReachDescription, segmentReachCaveat, segmentReachNotice } = await import( './utils' ) );
 	} );
 
 	afterEach( () => {
@@ -102,7 +104,22 @@ describe( 'segmentReachDescription', () => {
 			id: '12',
 			reach: { matched: 1240, won: 320, total_sessions: 3620, as_of: '2026-08-06', range_days: 7 },
 		} );
-		expect( line ).toBe( `Reach (7d): 34% of ${ ( 3620 ).toLocaleString() } sessions · prompt audience: 9% · as of Aug 6` );
+		expect( line ).toBe( `7 days to Aug 6: matched 34% of ${ ( 3620 ).toLocaleString() } sessions · prompts reached 9%` );
+	} );
+
+	it( 'reads as a record of past sessions, not a live capability', () => {
+		// Reordering segments changes which prompts readers see from here on
+		// and cannot move these numbers, so the line must not read as a
+		// standing "this segment can reach X" figure. The window leads and
+		// every verb is past tense.
+		const line = segmentReachDescription( {
+			id: '12',
+			reach: { matched: 1240, won: 320, total_sessions: 3620, as_of: '2026-08-06', range_days: 7 },
+		} );
+		expect( line ).toMatch( /^7 days to Aug 6:/ );
+		expect( line ).toContain( 'matched' );
+		expect( line ).toContain( 'prompts reached' );
+		expect( line ).not.toContain( 'prompt audience' );
 	} );
 
 	it( 'keeps the denominator visible so a small sample reads as one', () => {
@@ -123,8 +140,8 @@ describe( 'segmentReachDescription', () => {
 			id: '12',
 			reach: { matched: 8, won: 0, total_sessions: 4000, as_of: '2026-08-06', range_days: 7 },
 		} );
-		expect( line ).toContain( 'Reach (7d): <1% of' );
-		expect( line ).toContain( 'prompt audience: 0%' );
+		expect( line ).toContain( 'matched <1% of' );
+		expect( line ).toContain( 'prompts reached 0%' );
 	} );
 
 	it( 'names the window the server reported rather than a fixed one', () => {
@@ -132,7 +149,7 @@ describe( 'segmentReachDescription', () => {
 			id: '12',
 			reach: { matched: 5, won: 1, total_sessions: 100, as_of: '2026-08-06', range_days: 28 },
 		} );
-		expect( line ).toContain( 'Reach (28d)' );
+		expect( line ).toContain( '28 days to Aug 6' );
 	} );
 
 	it( 'falls back to 7 days for a cache written before the window was reported', () => {
@@ -140,7 +157,7 @@ describe( 'segmentReachDescription', () => {
 			id: '12',
 			reach: { matched: 5, won: 1, total_sessions: 100, as_of: '2026-08-06' },
 		} );
-		expect( line ).toContain( 'Reach (7d)' );
+		expect( line ).toContain( '7 days to Aug 6' );
 	} );
 
 	it.each( [
@@ -155,7 +172,7 @@ describe( 'segmentReachDescription', () => {
 			id: '12',
 			reach: { matched: 1, won: 0, total_sessions: 100, as_of: '2026-08-06' },
 		} );
-		expect( line ).toContain( 'as of Aug 6' );
+		expect( line ).toContain( '7 days to Aug 6' );
 	} );
 
 	it( 'renders the no-data state distinctly from zero', () => {
@@ -174,5 +191,72 @@ describe( 'segmentReachDescription', () => {
 				reach: { matched: 0, won: 0, total_sessions: 0, as_of: '2026-08-06' },
 			} )
 		).toBe( 'No reach data yet' );
+	} );
+
+	describe( 'segmentReachCaveat', () => {
+		it( 'says nothing while priority held for the whole window', () => {
+			expect(
+				segmentReachCaveat( {
+					id: '12',
+					reach: { matched: 1240, won: 320, total_sessions: 3620, as_of: '2026-08-06', range_days: 7 },
+				} )
+			).toBeNull();
+		} );
+
+		it( 'names the day priority moved inside the reported window', () => {
+			// The moment someone drags a segment is the moment they expect
+			// these numbers to move, and it is the one thing that cannot move
+			// them: the window still spans days that ran under the old order.
+			const caveat = segmentReachCaveat( {
+				id: '12',
+				reach: {
+					matched: 1240,
+					won: 320,
+					total_sessions: 3620,
+					as_of: '2026-08-06',
+					range_days: 7,
+					priority_changed: '2026-08-05',
+				},
+			} );
+			expect( caveat ).toBe( 'Priority changed Aug 5. Part of this window ran under the previous order.' );
+		} );
+
+		it( 'reports the same day whatever the site timezone', () => {
+			setSettings( { ...baseDateSettings, timezone: { offset: -5, string: '', abbr: '' } } );
+			const caveat = segmentReachCaveat( {
+				id: '12',
+				reach: { matched: 1, won: 0, total_sessions: 100, as_of: '2026-08-06', priority_changed: '2026-08-05' },
+			} );
+			expect( caveat ).toContain( 'Aug 5' );
+		} );
+	} );
+
+	describe( 'segmentReachNotice', () => {
+		it( 'says nothing when no segment reports reach', () => {
+			expect( segmentReachNotice( [ { id: '12' }, { id: '13' } ] ) ).toBeNull();
+		} );
+
+		it( 'says nothing when the reported window found no sessions', () => {
+			expect( segmentReachNotice( [ { id: '12', reach: { matched: 0, won: 0, total_sessions: 0, as_of: '2026-08-06' } } ] ) ).toBeNull();
+		} );
+
+		it( 'names the source, the window, the refresh rate, and the reorder consequence', () => {
+			const notice = segmentReachNotice( [
+				{ id: '12', reach: { matched: 1240, won: 320, total_sessions: 3620, as_of: '2026-08-06', range_days: 7 } },
+			] );
+			expect( notice ).toContain( 'Google Analytics' );
+			expect( notice ).toContain( '7 days to Aug 6' );
+			expect( notice ).toContain( 'refresh once a day' );
+			expect( notice ).toContain( 'reordering segments changes which prompts readers see from now on' );
+		} );
+
+		it( 'reads the window off whichever segment has numbers', () => {
+			const notice = segmentReachNotice( [
+				{ id: '12' },
+				{ id: '13', reach: { matched: null, won: null, total_sessions: 0, as_of: '2026-08-06' } },
+				{ id: '14', reach: { matched: 5, won: 1, total_sessions: 900, as_of: '2026-08-06', range_days: 28 } },
+			] );
+			expect( notice ).toContain( '28 days to Aug 6' );
+		} );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
@@ -98,8 +98,24 @@ describe( 'segmentReachDescription', () => {
 	} );
 
 	it( 'renders sessions, prompt audience, and the data date', () => {
-		const line = segmentReachDescription( { id: '12', reach: { matched: 1240, won: 320, as_of: '2026-08-06' } } );
+		const line = segmentReachDescription( {
+			id: '12',
+			reach: { matched: 1240, won: 320, as_of: '2026-08-06', range_days: 7 },
+		} );
 		expect( line ).toBe( `Reach (7d): ${ ( 1240 ).toLocaleString() } sessions · prompt audience: ${ ( 320 ).toLocaleString() } · as of Aug 6` );
+	} );
+
+	it( 'names the window the server reported rather than a fixed one', () => {
+		const line = segmentReachDescription( {
+			id: '12',
+			reach: { matched: 5, won: 1, as_of: '2026-08-06', range_days: 28 },
+		} );
+		expect( line ).toContain( 'Reach (28d)' );
+	} );
+
+	it( 'falls back to 7 days for a cache written before the window was reported', () => {
+		const line = segmentReachDescription( { id: '12', reach: { matched: 5, won: 1, as_of: '2026-08-06' } } );
+		expect( line ).toContain( 'Reach (7d)' );
 	} );
 
 	it.each( [

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
@@ -74,3 +74,28 @@ describe( 'segmentDescription', () => {
 		await waitFor( () => expect( container.textContent ).toContain( 'Weekly Digest' ) );
 	} );
 } );
+
+describe( 'segmentReachDescription', () => {
+	let segmentReachDescription;
+
+	beforeAll( async () => {
+		window.newspackAudienceCampaigns = window.newspackAudienceCampaigns || {
+			api: '/newspack/v1/wizard/newspack-audience-campaigns',
+			criteria: CRITERIA,
+		};
+		( { segmentReachDescription } = await import( './utils' ) );
+	} );
+
+	it( 'returns null when reach reporting is inactive', () => {
+		expect( segmentReachDescription( { id: '12' } ) ).toBeNull();
+	} );
+
+	it( 'renders sessions, prompt audience, and the data date', () => {
+		const line = segmentReachDescription( { id: '12', reach: { matched: 1240, won: 320, as_of: '2026-08-06' } } );
+		expect( line ).toBe( `Reach (7d): ${ ( 1240 ).toLocaleString() } sessions · prompt audience: ${ ( 320 ).toLocaleString() } · as of Aug 6` );
+	} );
+
+	it( 'renders the no-data state distinctly from zero', () => {
+		expect( segmentReachDescription( { id: '12', reach: { matched: null, won: null, as_of: '2026-08-06' } } ) ).toBe( 'No reach data yet' );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
@@ -97,24 +97,49 @@ describe( 'segmentReachDescription', () => {
 		expect( segmentReachDescription( { id: '12' } ) ).toBeNull();
 	} );
 
-	it( 'renders sessions, prompt audience, and the data date', () => {
+	it( 'renders both shares against the audience, with the sample size', () => {
 		const line = segmentReachDescription( {
 			id: '12',
-			reach: { matched: 1240, won: 320, as_of: '2026-08-06', range_days: 7 },
+			reach: { matched: 1240, won: 320, total_sessions: 3620, as_of: '2026-08-06', range_days: 7 },
 		} );
-		expect( line ).toBe( `Reach (7d): ${ ( 1240 ).toLocaleString() } sessions · prompt audience: ${ ( 320 ).toLocaleString() } · as of Aug 6` );
+		expect( line ).toBe( `Reach (7d): 34% of ${ ( 3620 ).toLocaleString() } sessions · prompt audience: 9% · as of Aug 6` );
+	} );
+
+	it( 'keeps the denominator visible so a small sample reads as one', () => {
+		// 34% of 41 sessions and 34% of 41,000 support very different calls;
+		// the share alone cannot tell them apart.
+		const line = segmentReachDescription( {
+			id: '12',
+			reach: { matched: 14, won: 4, total_sessions: 41, as_of: '2026-08-06', range_days: 7 },
+		} );
+		expect( line ).toContain( '34% of 41 sessions' );
+	} );
+
+	it( 'distinguishes a segment that reached somebody from one that reached nobody', () => {
+		// Rounding 0.2% to "0%" would erase the distinction these numbers
+		// exist to draw: a probation segment with a handful of readers is not
+		// the same as one with none.
+		const line = segmentReachDescription( {
+			id: '12',
+			reach: { matched: 8, won: 0, total_sessions: 4000, as_of: '2026-08-06', range_days: 7 },
+		} );
+		expect( line ).toContain( 'Reach (7d): <1% of' );
+		expect( line ).toContain( 'prompt audience: 0%' );
 	} );
 
 	it( 'names the window the server reported rather than a fixed one', () => {
 		const line = segmentReachDescription( {
 			id: '12',
-			reach: { matched: 5, won: 1, as_of: '2026-08-06', range_days: 28 },
+			reach: { matched: 5, won: 1, total_sessions: 100, as_of: '2026-08-06', range_days: 28 },
 		} );
 		expect( line ).toContain( 'Reach (28d)' );
 	} );
 
 	it( 'falls back to 7 days for a cache written before the window was reported', () => {
-		const line = segmentReachDescription( { id: '12', reach: { matched: 5, won: 1, as_of: '2026-08-06' } } );
+		const line = segmentReachDescription( {
+			id: '12',
+			reach: { matched: 5, won: 1, total_sessions: 100, as_of: '2026-08-06' },
+		} );
 		expect( line ).toContain( 'Reach (7d)' );
 	} );
 
@@ -126,11 +151,28 @@ describe( 'segmentReachDescription', () => {
 		// Formatting it in site time shifted the day westward: at UTC-5 this
 		// rendered "Aug 5" for an as_of of 2026-08-06.
 		setSettings( { ...baseDateSettings, timezone: { offset, string: '', abbr: '' } } );
-		const line = segmentReachDescription( { id: '12', reach: { matched: 1, won: 0, as_of: '2026-08-06' } } );
+		const line = segmentReachDescription( {
+			id: '12',
+			reach: { matched: 1, won: 0, total_sessions: 100, as_of: '2026-08-06' },
+		} );
 		expect( line ).toContain( 'as of Aug 6' );
 	} );
 
 	it( 'renders the no-data state distinctly from zero', () => {
-		expect( segmentReachDescription( { id: '12', reach: { matched: null, won: null, as_of: '2026-08-06' } } ) ).toBe( 'No reach data yet' );
+		expect(
+			segmentReachDescription( {
+				id: '12',
+				reach: { matched: null, won: null, total_sessions: 3620, as_of: '2026-08-06' },
+			} )
+		).toBe( 'No reach data yet' );
+	} );
+
+	it( 'reads as no data rather than dividing by an empty week', () => {
+		expect(
+			segmentReachDescription( {
+				id: '12',
+				reach: { matched: 0, won: 0, total_sessions: 0, as_of: '2026-08-06' },
+			} )
+		).toBe( 'No reach data yet' );
 	} );
 } );

--- a/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
+++ b/plugins/newspack-plugin/src/wizards/audience/views/campaigns/utils.test.js
@@ -17,6 +17,7 @@ import { render, waitFor } from '@testing-library/react';
  * WordPress dependencies
  */
 import apiFetch from '@wordpress/api-fetch';
+import { getSettings, setSettings } from '@wordpress/date';
 
 jest.mock( '@wordpress/api-fetch', () => jest.fn() );
 
@@ -77,13 +78,19 @@ describe( 'segmentDescription', () => {
 
 describe( 'segmentReachDescription', () => {
 	let segmentReachDescription;
+	let baseDateSettings;
 
 	beforeAll( async () => {
 		window.newspackAudienceCampaigns = window.newspackAudienceCampaigns || {
 			api: '/newspack/v1/wizard/newspack-audience-campaigns',
 			criteria: CRITERIA,
 		};
+		baseDateSettings = getSettings();
 		( { segmentReachDescription } = await import( './utils' ) );
+	} );
+
+	afterEach( () => {
+		setSettings( baseDateSettings );
 	} );
 
 	it( 'returns null when reach reporting is inactive', () => {
@@ -93,6 +100,18 @@ describe( 'segmentReachDescription', () => {
 	it( 'renders sessions, prompt audience, and the data date', () => {
 		const line = segmentReachDescription( { id: '12', reach: { matched: 1240, won: 320, as_of: '2026-08-06' } } );
 		expect( line ).toBe( `Reach (7d): ${ ( 1240 ).toLocaleString() } sessions · prompt audience: ${ ( 320 ).toLocaleString() } · as of Aug 6` );
+	} );
+
+	it.each( [
+		[ 'a negative offset', -5 ],
+		[ 'a positive offset', 13 ],
+	] )( 'reports the same calendar day on a site with %s', ( _label, offset ) => {
+		// `as_of` labels the last day the GA4 report covers, computed in UTC.
+		// Formatting it in site time shifted the day westward: at UTC-5 this
+		// rendered "Aug 5" for an as_of of 2026-08-06.
+		setSettings( { ...baseDateSettings, timezone: { offset, string: '', abbr: '' } } );
+		const line = segmentReachDescription( { id: '12', reach: { matched: 1, won: 0, as_of: '2026-08-06' } } );
+		expect( line ).toContain( 'as of Aug 6' );
 	} );
 
 	it( 'renders the no-data state distinctly from zero', () => {

--- a/plugins/newspack-plugin/tests/unit-tests/ga4-segment-reach.php
+++ b/plugins/newspack-plugin/tests/unit-tests/ga4-segment-reach.php
@@ -54,6 +54,7 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 
 		delete_option( 'newspack_ga4_segment_reach' );
 		delete_option( 'newspack_ga4_segment_reach_failures' );
+		delete_option( 'newspack_ga4_segment_reach_priority_changed' );
 		delete_transient( 'newspack_ga4_segment_reach_attempt' );
 		delete_option( self::SK_SETTINGS_OPTION );
 
@@ -598,6 +599,97 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 		// Cache for a different property is treated as absent.
 		$this->connect_property( 'PROP-OTHER' );
 		$this->assertSame( $segments, GA4_Segment_Reach::decorate_segments( $segments ) );
+	}
+
+	/**
+	 * Priority changing inside the reported window qualifies every row: the
+	 * figures still cover days that ran under the previous order, and no
+	 * refetch can change that. Reordering is exactly when someone expects the
+	 * numbers to move, so the list has to say why they did not.
+	 */
+	public function test_decorate_flags_a_priority_change_inside_the_window() {
+		$this->connect_property( 'PROP-REACH' );
+		$segments = [ [ 'id' => '12' ] ];
+		update_option(
+			'newspack_ga4_segment_reach',
+			[
+				'property_id'    => 'PROP-REACH',
+				'fetched_at'     => time(),
+				'range_days'     => 7,
+				'as_of'          => '2026-08-06',
+				'total_sessions' => 3620,
+				'rows'           => [
+					'12' => [
+						'matched' => 1240,
+						'won'     => 320,
+					],
+				],
+			],
+			false
+		);
+
+		// Window runs 2026-07-31 .. 2026-08-06.
+		$decorated = GA4_Segment_Reach::decorate_segments( $segments );
+		$this->assertNull( $decorated[0]['reach']['priority_changed'], 'No recorded change means nothing to caveat.' );
+
+		// A change the day before the window ends.
+		update_option( 'newspack_ga4_segment_reach_priority_changed', strtotime( '2026-08-05 12:00:00 UTC' ), false );
+		$decorated = GA4_Segment_Reach::decorate_segments( $segments );
+		$this->assertSame( '2026-08-05', $decorated[0]['reach']['priority_changed'] );
+
+		// A change on the first day of the window still counts.
+		update_option( 'newspack_ga4_segment_reach_priority_changed', strtotime( '2026-07-31 12:00:00 UTC' ), false );
+		$decorated = GA4_Segment_Reach::decorate_segments( $segments );
+		$this->assertSame( '2026-07-31', $decorated[0]['reach']['priority_changed'] );
+
+		// One day earlier is outside it: those sessions all ran under the
+		// current order, so there is nothing to warn about.
+		update_option( 'newspack_ga4_segment_reach_priority_changed', strtotime( '2026-07-30 12:00:00 UTC' ), false );
+		$decorated = GA4_Segment_Reach::decorate_segments( $segments );
+		$this->assertNull( $decorated[0]['reach']['priority_changed'] );
+
+		// A change AFTER the window is the most misleading case of all — the
+		// whole report predates the current order.
+		update_option( 'newspack_ga4_segment_reach_priority_changed', strtotime( '2026-08-07 12:00:00 UTC' ), false );
+		$decorated = GA4_Segment_Reach::decorate_segments( $segments );
+		$this->assertSame( '2026-08-07', $decorated[0]['reach']['priority_changed'] );
+	}
+
+	/**
+	 * Priority is written as term meta from several paths — the drag-reorder,
+	 * a single-segment save, and the reindex after a deletion — so the record
+	 * watches the meta key rather than any one endpoint. Meta on other
+	 * taxonomies, and other keys, must not trip it.
+	 */
+	public function test_priority_change_is_recorded_from_term_meta() {
+		// newspack-popups is not loaded in this suite, so register the
+		// taxonomy it owns and exercise the hook against it directly.
+		register_taxonomy( 'popup_segment', 'post' );
+		register_taxonomy( 'unrelated_tax', 'post' );
+		$segment = $this->factory()->term->create( [ 'taxonomy' => 'popup_segment' ] );
+		$other   = $this->factory()->term->create( [ 'taxonomy' => 'unrelated_tax' ] );
+
+		// Another key on a segment term is not a priority change.
+		add_term_meta( $segment, 'criteria', 'anything' );
+		$this->assertFalse( get_option( 'newspack_ga4_segment_reach_priority_changed' ) );
+
+		// Neither is `priority` on a term Campaigns does not own.
+		add_term_meta( $other, 'priority', 1 );
+		$this->assertFalse( get_option( 'newspack_ga4_segment_reach_priority_changed' ) );
+
+		add_term_meta( $segment, 'priority', 3 );
+		$recorded = get_option( 'newspack_ga4_segment_reach_priority_changed' );
+		$this->assertIsInt( $recorded );
+		$this->assertEqualsWithDelta( time(), $recorded, 60 );
+
+		// A later reorder moves the record forward rather than sticking at
+		// the first change ever seen.
+		update_option( 'newspack_ga4_segment_reach_priority_changed', time() - DAY_IN_SECONDS, false );
+		update_term_meta( $segment, 'priority', 1 );
+		$this->assertEqualsWithDelta( time(), get_option( 'newspack_ga4_segment_reach_priority_changed' ), 60 );
+
+		unregister_taxonomy( 'popup_segment' );
+		unregister_taxonomy( 'unrelated_tax' );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/ga4-segment-reach.php
+++ b/plugins/newspack-plugin/tests/unit-tests/ga4-segment-reach.php
@@ -53,6 +53,8 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 		add_filter( 'pre_http_request', [ $this, 'mock_http' ], 10, 3 );
 
 		delete_option( 'newspack_ga4_segment_reach' );
+		delete_option( 'newspack_ga4_segment_reach_failures' );
+		delete_transient( 'newspack_ga4_segment_reach_attempt' );
 		delete_option( self::SK_SETTINGS_OPTION );
 
 		if ( ! defined( 'NEWSPACK_MANAGER_API_KEY_OPTION_NAME' ) ) {
@@ -159,9 +161,10 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 	 * A canned Data API response: segment 12 matched in 1240 sessions and won
 	 * 320; segment 45 matched in 90 with no won rows; `none` matched in 500.
 	 *
+	 * @param string $timezone Property reporting timezone reported in metadata.
 	 * @return array
 	 */
-	private function report_response() {
+	private function report_response( $timezone = 'UTC' ) {
 		$row = function ( $segment_id, $event_name, $count ) {
 			return [
 				'dimensionValues' => [ [ 'value' => $segment_id ], [ 'value' => $event_name ] ],
@@ -169,12 +172,13 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 			];
 		};
 		return [
-			'rows' => [
+			'rows'     => [
 				$row( '12', 'np_segment_matched', 1240 ),
 				$row( '12', 'np_segment_won', 320 ),
 				$row( '45', 'np_segment_matched', 90 ),
 				$row( 'none', 'np_segment_matched', 500 ),
 			],
+			'metadata' => [ 'timeZone' => $timezone ],
 		];
 	}
 
@@ -248,10 +252,239 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 			$cache['rows']['45']
 		);
 		$this->assertSame( 500, $cache['rows']['none']['matched'] );
-		// The request went to the Data API with both event names filtered.
+
+		// The request shape is contract with a remote API that nothing local
+		// exercises, so assert it exactly: a wrong dimension name is a
+		// permanent 400 rather than an empty report, and a wrong metric or
+		// filter nesting fails just as silently.
 		$last = end( $this->http_log );
 		$this->assertStringContainsString( 'analyticsdata.googleapis.com', $last['url'] );
-		$this->assertStringContainsString( 'np_segment_won', $last['body'] );
+		$body = json_decode( $last['body'], true );
+		$this->assertSame(
+			[
+				[
+					'startDate' => '7daysAgo',
+					'endDate'   => 'yesterday',
+				],
+			],
+			$body['dateRanges']
+		);
+		$this->assertSame(
+			[
+				[ 'name' => 'customEvent:segment_id' ],
+				[ 'name' => 'eventName' ],
+			],
+			$body['dimensions']
+		);
+		$this->assertSame( [ [ 'name' => 'eventCount' ] ], $body['metrics'] );
+		$this->assertSame(
+			[
+				'filter' => [
+					'fieldName'    => 'eventName',
+					'inListFilter' => [ 'values' => [ 'np_segment_matched', 'np_segment_won' ] ],
+				],
+			],
+			$body['dimensionFilter']
+		);
+	}
+
+	/**
+	 * The stored `as_of` is yesterday in the *property's* reporting timezone,
+	 * which is what GA4 resolves the `yesterday` keyword against. Deriving it
+	 * from our own clock disagrees whenever the two are on different days.
+	 */
+	public function test_refresh_dates_the_report_in_the_property_timezone() {
+		$this->connect_property( 'PROP-REACH' );
+		$this->configure_newspack_oauth();
+		$this->http_routes[':runReport'] = $this->json_response( 200, $this->report_response( 'Pacific/Kiritimati' ) );
+
+		GA4_Segment_Reach::refresh();
+
+		$expected = ( new \DateTimeImmutable( 'yesterday', new \DateTimeZone( 'Pacific/Kiritimati' ) ) )->format( 'Y-m-d' );
+		$cache    = get_option( 'newspack_ga4_segment_reach' );
+		$this->assertSame( $expected, $cache['as_of'] );
+	}
+
+	/**
+	 * A 2xx that is not a report — a proxy interstitial decoding to `[]`, or a
+	 * failed re-encode yielding null — must not replace good numbers with an
+	 * empty set. Parsing it would blank every segment for a day, and the empty
+	 * payload would still pass the cache-validity check that gates the
+	 * out-of-band re-fetch, so nothing would repair it.
+	 */
+	public function test_refresh_ignores_a_response_that_is_not_a_report() {
+		$this->connect_property( 'PROP-REACH' );
+		$this->configure_newspack_oauth();
+		$previous = [
+			'property_id' => 'PROP-REACH',
+			'fetched_at'  => time() - DAY_IN_SECONDS,
+			'range_days'  => 7,
+			'rows'        => [
+				'12' => [
+					'matched' => 5,
+					'won'     => 1,
+				],
+			],
+		];
+		update_option( 'newspack_ga4_segment_reach', $previous, false );
+		// 2xx, valid JSON, but nothing that looks like a report.
+		$this->http_routes[':runReport'] = $this->json_response( 200, [ 'message' => 'service temporarily unavailable' ] );
+
+		GA4_Segment_Reach::refresh();
+
+		$this->assertSame( $previous, get_option( 'newspack_ga4_segment_reach' ) );
+	}
+
+	/**
+	 * A report that genuinely found nothing still overwrites: `rowCount` marks
+	 * it as a report, unlike the case above.
+	 */
+	public function test_refresh_stores_an_empty_report() {
+		$this->connect_property( 'PROP-REACH' );
+		$this->configure_newspack_oauth();
+		$this->http_routes[':runReport'] = $this->json_response(
+			200,
+			[
+				'rowCount' => 0,
+				'metadata' => [ 'timeZone' => 'UTC' ],
+			]
+		);
+
+		GA4_Segment_Reach::refresh();
+
+		$cache = get_option( 'newspack_ga4_segment_reach' );
+		$this->assertSame( 'PROP-REACH', $cache['property_id'] );
+		$this->assertSame( [], $cache['rows'] );
+	}
+
+	/**
+	 * A report that cannot succeed — most often because the `segment_id`
+	 * dimension is not on the property yet — stops being retried. Without a
+	 * ceiling this calls Google on the daily schedule plus once an hour of
+	 * admin traffic indefinitely, and the only record is a log line that
+	 * compiles out unless the site defines NEWSPACK_LOG_LEVEL.
+	 */
+	public function test_refresh_gives_up_after_repeated_failures() {
+		$this->connect_property( 'PROP-REACH' );
+		$this->configure_newspack_oauth();
+		$this->http_routes[':runReport'] = $this->json_response(
+			400,
+			[ 'error' => [ 'message' => 'Field customEvent:segment_id is not a valid dimension.' ] ]
+		);
+
+		for ( $i = 0; $i < GA4_Segment_Reach::MAX_FAILURES; $i++ ) {
+			delete_transient( 'newspack_ga4_segment_reach_attempt' );
+			GA4_Segment_Reach::refresh();
+		}
+
+		$failures = get_option( 'newspack_ga4_segment_reach_failures' );
+		$this->assertSame( GA4_Segment_Reach::MAX_FAILURES, $failures['count'] );
+		$this->assertStringContainsString( 'not a valid dimension', $failures['last_error'] );
+
+		// Past the ceiling, refresh stops calling Google entirely.
+		delete_transient( 'newspack_ga4_segment_reach_attempt' );
+		$this->http_log = [];
+		GA4_Segment_Reach::refresh();
+		$this->assertSame( [], $this->http_log );
+
+		// And the admin path stops enqueuing the immediate fetch.
+		if ( function_exists( 'as_has_scheduled_action' ) ) {
+			GA4_Segment_Reach::maybe_schedule();
+			$this->assertFalse( as_has_scheduled_action( GA4_Segment_Reach::REFRESH_ACTION, [], GA4_Segment_Reach::ASYNC_GROUP ) );
+		}
+	}
+
+	/**
+	 * Provisioning the missing dimension is what makes the report possible, so
+	 * it clears the give-up state rather than leaving the site waiting for a
+	 * property switch.
+	 */
+	public function test_reset_failures_resumes_refreshing() {
+		$this->connect_property( 'PROP-REACH' );
+		$this->configure_newspack_oauth();
+		update_option(
+			'newspack_ga4_segment_reach_failures',
+			[
+				'property_id' => 'PROP-REACH',
+				'count'       => GA4_Segment_Reach::MAX_FAILURES,
+				'last_error'  => 'Field customEvent:segment_id is not a valid dimension.',
+			],
+			false
+		);
+
+		GA4_Segment_Reach::reset_failures();
+		$this->http_routes[':runReport'] = $this->json_response( 200, $this->report_response() );
+		GA4_Segment_Reach::refresh();
+
+		$cache = get_option( 'newspack_ga4_segment_reach' );
+		$this->assertSame( 1240, $cache['rows']['12']['matched'] );
+		// A success clears the record, so a later hiccup starts from zero.
+		$this->assertFalse( get_option( 'newspack_ga4_segment_reach_failures' ) );
+	}
+
+	/**
+	 * The failure record is scoped to a property: connecting a different one
+	 * starts from zero rather than inheriting a give-up from a property that
+	 * is no longer connected here.
+	 */
+	public function test_failures_do_not_carry_across_a_property_switch() {
+		$this->connect_property( 'PROP-NEW' );
+		update_option(
+			'newspack_ga4_segment_reach_failures',
+			[
+				'property_id' => 'PROP-OLD',
+				'count'       => GA4_Segment_Reach::MAX_FAILURES,
+				'last_error'  => 'boom',
+			],
+			false
+		);
+		$this->configure_newspack_oauth();
+		$this->http_routes[':runReport'] = $this->json_response( 200, $this->report_response() );
+
+		GA4_Segment_Reach::refresh();
+
+		$cache = get_option( 'newspack_ga4_segment_reach' );
+		$this->assertSame( 'PROP-NEW', $cache['property_id'] );
+	}
+
+	/**
+	 * A successful refresh clears the hourly backoff, so a property switch
+	 * minutes later gets its immediate fetch instead of waiting out the hour
+	 * the previous run armed.
+	 */
+	public function test_successful_refresh_clears_the_backoff() {
+		$this->connect_property( 'PROP-REACH' );
+		$this->configure_newspack_oauth();
+		$this->http_routes[':runReport'] = $this->json_response( 200, $this->report_response() );
+
+		GA4_Segment_Reach::refresh();
+
+		$this->assertFalse( get_transient( 'newspack_ga4_segment_reach_attempt' ) );
+	}
+
+	/**
+	 * Provisioning writes dimensions, so it keeps requiring the analytics.edit
+	 * scope even though the shared router now takes a flag and the reach read
+	 * passes false. A stored token carrying only the base analytics scope is
+	 * skipped for writes and used for reads.
+	 */
+	public function test_provisioning_still_requires_the_edit_scope() {
+		$this->connect_property( 'PROP-REACH' );
+		// configure_newspack_oauth() deliberately stores a token WITHOUT
+		// analytics.edit, and Site Kit is not loaded in the test suite, so
+		// every write route is unavailable.
+		$this->configure_newspack_oauth();
+		$this->http_routes[':runReport']    = $this->json_response( 200, $this->report_response() );
+		$this->http_routes['customDimensions'] = $this->json_response( 200, [ 'customDimensions' => [] ] );
+
+		$provisioned = \Newspack\GA4_Custom_Dimensions::provision();
+		$this->assertTrue( is_wp_error( $provisioned ) );
+		$this->assertStringContainsString( 'analytics.edit', $provisioned->get_error_message() );
+
+		// The same token reads fine.
+		GA4_Segment_Reach::refresh();
+		$cache = get_option( 'newspack_ga4_segment_reach' );
+		$this->assertSame( 1240, $cache['rows']['12']['matched'] );
 	}
 
 	/**
@@ -320,14 +553,74 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 		$decorated = GA4_Segment_Reach::decorate_segments( $segments );
 		$this->assertSame( 1240, $decorated[0]['reach']['matched'] );
 		$this->assertSame( 320, $decorated[0]['reach']['won'] );
+		// No `as_of` recorded: fall back to the day before the fetch.
 		$this->assertSame( '2026-08-06', $decorated[0]['reach']['as_of'] );
+		// The window travels with the numbers so the label can't drift from
+		// the report it describes.
+		$this->assertSame( 7, $decorated[0]['reach']['range_days'] );
 		// Cache present, no row: explicit nulls — "no data yet", not zero.
 		$this->assertNull( $decorated[1]['reach']['matched'] );
 		$this->assertNull( $decorated[1]['reach']['won'] );
 
+		// A recorded `as_of` wins over the derivation.
+		$cache          = get_option( 'newspack_ga4_segment_reach' );
+		$cache['as_of'] = '2026-08-04';
+		update_option( 'newspack_ga4_segment_reach', $cache, false );
+		$decorated = GA4_Segment_Reach::decorate_segments( $segments );
+		$this->assertSame( '2026-08-04', $decorated[0]['reach']['as_of'] );
+
 		// Cache for a different property is treated as absent.
 		$this->connect_property( 'PROP-OTHER' );
 		$this->assertSame( $segments, GA4_Segment_Reach::decorate_segments( $segments ) );
+	}
+
+	/**
+	 * Decoration must not leave the returned array's last element aliased to
+	 * the by-reference loop variable: a caller that copies the result and
+	 * writes to that element would otherwise mutate this array too.
+	 */
+	public function test_decorate_segments_does_not_leak_a_reference() {
+		$this->connect_property( 'PROP-REACH' );
+		update_option(
+			'newspack_ga4_segment_reach',
+			[
+				'property_id' => 'PROP-REACH',
+				'fetched_at'  => time(),
+				'range_days'  => 7,
+				'rows'        => [],
+			],
+			false
+		);
+
+		$decorated = GA4_Segment_Reach::decorate_segments(
+			[
+				[ 'id' => '12' ],
+				[ 'id' => '99' ],
+			]
+		);
+		$copy               = $decorated;
+		$copy[1]['id']      = 'mutated';
+
+		$this->assertSame( '99', $decorated[1]['id'] );
+	}
+
+	/**
+	 * `admin_init` also fires on admin-ajax.php — authenticated or not — so
+	 * every heartbeat tick, autosave and nopriv AJAX hit would otherwise pay
+	 * for an actionscheduler_actions query, and an unauthenticated request
+	 * could be what enqueues the first fetch.
+	 */
+	public function test_schedule_skips_ajax_requests() {
+		if ( ! function_exists( 'as_has_scheduled_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available.' );
+		}
+		$this->connect_property( 'PROP-REACH' );
+		add_filter( 'wp_doing_ajax', '__return_true' );
+		GA4_Segment_Reach::maybe_schedule();
+		remove_filter( 'wp_doing_ajax', '__return_true' );
+
+		$this->assertFalse( as_has_scheduled_action( GA4_Segment_Reach::REFRESH_ACTION, [], GA4_Segment_Reach::GROUP ) );
+		$this->assertFalse( as_has_scheduled_action( GA4_Segment_Reach::REFRESH_ACTION, [], GA4_Segment_Reach::ASYNC_GROUP ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/tests/unit-tests/ga4-segment-reach.php
+++ b/plugins/newspack-plugin/tests/unit-tests/ga4-segment-reach.php
@@ -1,0 +1,220 @@
+<?php
+/**
+ * Tests for GA4 segment reach: Data API clients and the reach cache.
+ *
+ * Mocks the GA4 Data API at the HTTP layer (via `pre_http_request`), the same
+ * harness pattern as the custom-dimensions tests.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\GA4_Segment_Reach;
+use Newspack\Google_OAuth_GA4_Client;
+
+/**
+ * GA4 segment reach.
+ *
+ * @group ga4-segment-reach
+ */
+class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
+
+	const SK_SETTINGS_OPTION = 'googlesitekit_analytics-4_settings';
+
+	/**
+	 * Recorded HTTP requests, each `[ 'url' => string, 'method' => string, 'body' => string|null ]`.
+	 *
+	 * @var array
+	 */
+	private $http_log = [];
+
+	/**
+	 * URL-substring => response array or `callable( $url, $args )`.
+	 *
+	 * @var array
+	 */
+	private $http_routes = [];
+
+	/**
+	 * Administrator user id used as the Site Kit module owner.
+	 *
+	 * @var int
+	 */
+	private $owner_id;
+
+	/**
+	 * Set up fixtures.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->owner_id    = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		$this->http_log    = [];
+		$this->http_routes = [];
+		add_filter( 'pre_http_request', [ $this, 'mock_http' ], 10, 3 );
+
+		delete_option( 'newspack_ga4_segment_reach' );
+		delete_option( self::SK_SETTINGS_OPTION );
+
+		if ( ! defined( 'NEWSPACK_MANAGER_API_KEY_OPTION_NAME' ) ) {
+			define( 'NEWSPACK_MANAGER_API_KEY_OPTION_NAME', 'newspack_manager_api_key' );
+		}
+		if ( ! defined( 'NEWSPACK_GOOGLE_OAUTH_PROXY' ) ) {
+			define( 'NEWSPACK_GOOGLE_OAUTH_PROXY', 'https://oauth.example.test' );
+		}
+		delete_option( NEWSPACK_MANAGER_API_KEY_OPTION_NAME );
+		delete_option( '_newspack_google_oauth' );
+	}
+
+	/**
+	 * Tear down fixtures.
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_http_request', [ $this, 'mock_http' ], 10 );
+		parent::tear_down();
+	}
+
+	/**
+	 * `pre_http_request` handler: records the request and returns the first
+	 * registered route whose substring matches the URL, or a 404.
+	 *
+	 * @param mixed  $pre  Short-circuit value.
+	 * @param array  $args Request args.
+	 * @param string $url  Request URL.
+	 * @return array|WP_Error
+	 */
+	public function mock_http( $pre, $args, $url ) {
+		$method           = isset( $args['method'] ) ? strtoupper( $args['method'] ) : 'GET';
+		$this->http_log[] = [
+			'url'    => $url,
+			'method' => $method,
+			'body'   => isset( $args['body'] ) ? $args['body'] : null,
+		];
+		foreach ( $this->http_routes as $needle => $response ) {
+			if ( false !== strpos( $url, $needle ) ) {
+				return is_callable( $response ) ? call_user_func( $response, $url, $args ) : $response;
+			}
+		}
+		return $this->json_response( 404, [ 'error' => [ 'message' => "Unmocked request to $url" ] ] );
+	}
+
+	/**
+	 * Build an HTTP response array for `pre_http_request`.
+	 *
+	 * @param int   $code HTTP status code.
+	 * @param array $body Response body, JSON-encoded.
+	 * @return array
+	 */
+	private function json_response( $code, array $body ) {
+		return [
+			'response' => [
+				'code'    => $code,
+				'message' => '',
+			],
+			'body'     => wp_json_encode( $body ),
+			'headers'  => [],
+			'cookies'  => [],
+		];
+	}
+
+	/**
+	 * Make Newspack's Google OAuth count as configured. The reach path must
+	 * work without the analytics.edit scope, so the stored token deliberately
+	 * carries only the base analytics scope.
+	 */
+	private function configure_newspack_oauth() {
+		update_option( NEWSPACK_MANAGER_API_KEY_OPTION_NAME, 'test-key' );
+		update_option(
+			'_newspack_google_oauth',
+			[
+				'access_token'  => 'fake-access-token',
+				'expires_at'    => time() + HOUR_IN_SECONDS,
+				'refresh_token' => 'fake-refresh-token',
+			]
+		);
+		$this->http_routes['oauth2/v1/tokeninfo'] = $this->json_response(
+			200,
+			[
+				'scope' => 'https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/analytics',
+				'email' => 'owner@example.test',
+			]
+		);
+	}
+
+	/**
+	 * Record a connected GA4 property (and module owner) in Site Kit's settings.
+	 *
+	 * @param string $property_id GA4 property ID.
+	 */
+	private function connect_property( $property_id ) {
+		update_option(
+			self::SK_SETTINGS_OPTION,
+			[
+				'propertyID' => $property_id,
+				'ownerID'    => $this->owner_id,
+			]
+		);
+	}
+
+	/**
+	 * A canned Data API response: segment 12 matched in 1240 sessions and won
+	 * 320; segment 45 matched in 90 with no won rows; `none` matched in 500.
+	 *
+	 * @return array
+	 */
+	private function report_response() {
+		$row = function ( $segment_id, $event_name, $count ) {
+			return [
+				'dimensionValues' => [ [ 'value' => $segment_id ], [ 'value' => $event_name ] ],
+				'metricValues'    => [ [ 'value' => (string) $count ] ],
+			];
+		};
+		return [
+			'rows' => [
+				$row( '12', 'np_segment_matched', 1240 ),
+				$row( '12', 'np_segment_won', 320 ),
+				$row( '45', 'np_segment_matched', 90 ),
+				$row( 'none', 'np_segment_matched', 500 ),
+			],
+		];
+	}
+
+	/**
+	 * The OAuth client posts the request body to the Data API runReport
+	 * endpoint and returns the decoded response.
+	 */
+	public function test_oauth_client_runs_report() {
+		$this->configure_newspack_oauth();
+		$this->http_routes[':runReport'] = $this->json_response( 200, $this->report_response() );
+
+		wp_set_current_user( $this->owner_id );
+		$client   = Google_OAuth_GA4_Client::build();
+		$request  = [
+			'dateRanges' => [
+				[
+					'startDate' => '7daysAgo',
+					'endDate'   => 'yesterday',
+				],
+			],
+		];
+		$response = $client->run_report( 'PROP-1', $request );
+
+		$this->assertCount( 4, $response['rows'] );
+		$last = end( $this->http_log );
+		$this->assertStringContainsString( 'analyticsdata.googleapis.com/v1beta/properties/PROP-1:runReport', $last['url'] );
+		$this->assertSame( 'POST', $last['method'] );
+		$this->assertSame( $request, json_decode( $last['body'], true ) );
+	}
+
+	/**
+	 * A Data API error surfaces as the exception the auth router expects.
+	 */
+	public function test_oauth_client_throws_on_report_error() {
+		$this->configure_newspack_oauth();
+		$this->http_routes[':runReport'] = $this->json_response( 403, [ 'error' => [ 'message' => 'insufficient scopes' ] ] );
+
+		wp_set_current_user( $this->owner_id );
+		$client = Google_OAuth_GA4_Client::build();
+		$this->expectException( \RuntimeException::class );
+		$client->run_report( 'PROP-1', [] );
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/ga4-segment-reach.php
+++ b/plugins/newspack-plugin/tests/unit-tests/ga4-segment-reach.php
@@ -361,4 +361,39 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 		GA4_Segment_Reach::maybe_schedule();
 		$this->assertFalse( as_has_scheduled_action( GA4_Segment_Reach::REFRESH_ACTION, [], GA4_Segment_Reach::GROUP ) );
 	}
+
+	/**
+	 * Connecting a different GA4 property fetches immediately rather than
+	 * waiting out the daily refresh. The old property's cache is not usable —
+	 * decoration already hides it — so leaving it to the recurring action
+	 * would blank the segments list for up to a day.
+	 */
+	public function test_property_switch_fetches_without_waiting_for_the_daily_refresh() {
+		if ( ! function_exists( 'as_has_scheduled_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available.' );
+		}
+		$this->connect_property( 'PROP-OLD' );
+		update_option(
+			'newspack_ga4_segment_reach',
+			[
+				'property_id' => 'PROP-OLD',
+				'fetched_at'  => time(),
+				'range_days'  => 7,
+				'rows'        => [
+					'12' => [
+						'matched' => 1240,
+						'won'     => 320,
+					],
+				],
+			],
+			false
+		);
+		// A current, matching cache is no reason to fetch.
+		GA4_Segment_Reach::maybe_schedule();
+		$this->assertFalse( as_has_scheduled_action( GA4_Segment_Reach::REFRESH_ACTION, [], GA4_Segment_Reach::ASYNC_GROUP ) );
+
+		$this->connect_property( 'PROP-NEW' );
+		GA4_Segment_Reach::maybe_schedule();
+		$this->assertTrue( as_has_scheduled_action( GA4_Segment_Reach::REFRESH_ACTION, [], GA4_Segment_Reach::ASYNC_GROUP ) );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/ga4-segment-reach.php
+++ b/plugins/newspack-plugin/tests/unit-tests/ga4-segment-reach.php
@@ -217,4 +217,148 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 		$this->expectException( \RuntimeException::class );
 		$client->run_report( 'PROP-1', [] );
 	}
+
+	/**
+	 * Refresh runs the reach report through the read path — Newspack OAuth
+	 * WITHOUT the analytics.edit scope — and stores parsed per-segment counts.
+	 */
+	public function test_refresh_stores_parsed_reach() {
+		$this->connect_property( 'PROP-REACH' );
+		$this->configure_newspack_oauth();
+		$this->http_routes[':runReport'] = $this->json_response( 200, $this->report_response() );
+
+		GA4_Segment_Reach::refresh();
+
+		$cache = get_option( 'newspack_ga4_segment_reach' );
+		$this->assertSame( 'PROP-REACH', $cache['property_id'] );
+		$this->assertSame( 7, $cache['range_days'] );
+		$this->assertSame(
+			[
+				'matched' => 1240,
+				'won'     => 320,
+			],
+			$cache['rows']['12']
+		);
+		// A segment with no won rows records zero, not null: the report ran.
+		$this->assertSame(
+			[
+				'matched' => 90,
+				'won'     => 0,
+			],
+			$cache['rows']['45']
+		);
+		$this->assertSame( 500, $cache['rows']['none']['matched'] );
+		// The request went to the Data API with both event names filtered.
+		$last = end( $this->http_log );
+		$this->assertStringContainsString( 'analyticsdata.googleapis.com', $last['url'] );
+		$this->assertStringContainsString( 'np_segment_won', $last['body'] );
+	}
+
+	/**
+	 * A failed fetch preserves the previous cache — the UI shows staler
+	 * numbers, never none.
+	 */
+	public function test_refresh_failure_keeps_previous_cache() {
+		$this->connect_property( 'PROP-REACH' );
+		$this->configure_newspack_oauth();
+		$previous = [
+			'property_id' => 'PROP-REACH',
+			'fetched_at'  => time() - DAY_IN_SECONDS,
+			'range_days'  => 7,
+			'rows'        => [
+				'12' => [
+					'matched' => 5,
+					'won'     => 1,
+				],
+			],
+		];
+		update_option( 'newspack_ga4_segment_reach', $previous, false );
+		$this->http_routes[':runReport'] = $this->json_response( 500, [ 'error' => [ 'message' => 'boom' ] ] );
+
+		GA4_Segment_Reach::refresh();
+
+		$this->assertSame( $previous, get_option( 'newspack_ga4_segment_reach' ) );
+	}
+
+	/**
+	 * Decoration: numbers when a row exists, explicit nulls when the cache
+	 * exists without the segment, untouched payload when there is no cache or
+	 * the cache belongs to a different property.
+	 */
+	public function test_decorate_segments_states() {
+		$segments = [
+			[
+				'id'   => '12',
+				'name' => 'Donors',
+			],
+			[
+				'id'   => '99',
+				'name' => 'Young segment',
+			],
+		];
+
+		// No cache: payload untouched.
+		$this->assertSame( $segments, GA4_Segment_Reach::decorate_segments( $segments ) );
+
+		$this->connect_property( 'PROP-REACH' );
+		update_option(
+			'newspack_ga4_segment_reach',
+			[
+				'property_id' => 'PROP-REACH',
+				'fetched_at'  => strtotime( '2026-08-07 06:00:00' ),
+				'range_days'  => 7,
+				'rows'        => [
+					'12' => [
+						'matched' => 1240,
+						'won'     => 320,
+					],
+				],
+			],
+			false
+		);
+
+		$decorated = GA4_Segment_Reach::decorate_segments( $segments );
+		$this->assertSame( 1240, $decorated[0]['reach']['matched'] );
+		$this->assertSame( 320, $decorated[0]['reach']['won'] );
+		$this->assertSame( '2026-08-06', $decorated[0]['reach']['as_of'] );
+		// Cache present, no row: explicit nulls — "no data yet", not zero.
+		$this->assertNull( $decorated[1]['reach']['matched'] );
+		$this->assertNull( $decorated[1]['reach']['won'] );
+
+		// Cache for a different property is treated as absent.
+		$this->connect_property( 'PROP-OTHER' );
+		$this->assertSame( $segments, GA4_Segment_Reach::decorate_segments( $segments ) );
+	}
+
+	/**
+	 * The daily refresh follows the property: scheduled while connected,
+	 * dropped when disconnected. Skipped when Action Scheduler is absent.
+	 */
+	public function test_schedule_follows_property() {
+		if ( ! function_exists( 'as_has_scheduled_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler not available.' );
+		}
+		$this->connect_property( 'PROP-REACH' );
+		GA4_Segment_Reach::maybe_schedule();
+		$this->assertTrue( as_has_scheduled_action( GA4_Segment_Reach::REFRESH_ACTION, [], GA4_Segment_Reach::GROUP ) );
+		// With no cache yet, the first fetch is enqueued immediately — and the
+		// has-scheduled guard keeps a second pass from enqueuing another.
+		$this->assertTrue( as_has_scheduled_action( GA4_Segment_Reach::REFRESH_ACTION, [], GA4_Segment_Reach::ASYNC_GROUP ) );
+		GA4_Segment_Reach::maybe_schedule();
+		$this->assertCount(
+			1,
+			as_get_scheduled_actions(
+				[
+					'hook'   => GA4_Segment_Reach::REFRESH_ACTION,
+					'group'  => GA4_Segment_Reach::ASYNC_GROUP,
+					'status' => \ActionScheduler_Store::STATUS_PENDING,
+				],
+				'ids'
+			)
+		);
+
+		delete_option( self::SK_SETTINGS_OPTION );
+		GA4_Segment_Reach::maybe_schedule();
+		$this->assertFalse( as_has_scheduled_action( GA4_Segment_Reach::REFRESH_ACTION, [], GA4_Segment_Reach::GROUP ) );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/ga4-segment-reach.php
+++ b/plugins/newspack-plugin/tests/unit-tests/ga4-segment-reach.php
@@ -178,6 +178,16 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 				$row( '45', 'np_segment_matched', 90 ),
 				$row( 'none', 'np_segment_matched', 500 ),
 			],
+			// GA4's TOTAL aggregation for a non-additive metric: the
+			// deduplicated session count, deliberately NOT the sum of the rows
+			// above (1830), since a session matching several segments appears
+			// in several rows.
+			'totals'   => [
+				[
+					'dimensionValues' => [ [ 'value' => 'RESERVED_TOTAL' ], [ 'value' => 'RESERVED_TOTAL' ] ],
+					'metricValues'    => [ [ 'value' => '3620' ] ],
+				],
+			],
 			'metadata' => [ 'timeZone' => $timezone ],
 		];
 	}
@@ -252,6 +262,11 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 			$cache['rows']['45']
 		);
 		$this->assertSame( 500, $cache['rows']['none']['matched'] );
+		// The denominator comes from GA4's TOTAL aggregation, not from summing
+		// the rows: a session matching several segments appears in several
+		// rows, so the sum (1830) would over-count the audience and understate
+		// every segment's share.
+		$this->assertSame( 3620, $cache['total_sessions'] );
 
 		// The request shape is contract with a remote API that nothing local
 		// exercises, so assert it exactly: a wrong dimension name is a
@@ -276,7 +291,13 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 			],
 			$body['dimensions']
 		);
-		$this->assertSame( [ [ 'name' => 'eventCount' ] ], $body['metrics'] );
+		// `sessions`, not `eventCount`: the client's per-session dedupe is best
+		// effort (np_segment_won fires once per segment per session, and an
+		// unwritable localStorage falls back to per-pageview dispatch), so
+		// counting events would inflate both figures. GA4 deduplicates
+		// `sessions` itself.
+		$this->assertSame( [ [ 'name' => 'sessions' ] ], $body['metrics'] );
+		$this->assertSame( [ 'TOTAL' ], $body['metricAggregations'] );
 		$this->assertSame(
 			[
 				'filter' => [
@@ -537,10 +558,11 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 		update_option(
 			'newspack_ga4_segment_reach',
 			[
-				'property_id' => 'PROP-REACH',
-				'fetched_at'  => strtotime( '2026-08-07 06:00:00' ),
-				'range_days'  => 7,
-				'rows'        => [
+				'property_id'    => 'PROP-REACH',
+				'fetched_at'     => strtotime( '2026-08-07 06:00:00' ),
+				'range_days'     => 7,
+				'total_sessions' => 3620,
+				'rows'           => [
 					'12' => [
 						'matched' => 1240,
 						'won'     => 320,
@@ -551,6 +573,10 @@ class Newspack_Test_GA4_Segment_Reach extends WP_UnitTestCase {
 		);
 
 		$decorated = GA4_Segment_Reach::decorate_segments( $segments );
+		// Raw counts and the denominator both travel; the display computes the
+		// shares, so the sample size stays available to the UI.
+		$this->assertSame( 3620, $decorated[0]['reach']['total_sessions'] );
+		$this->assertSame( 3620, $decorated[1]['reach']['total_sessions'] );
 		$this->assertSame( 1240, $decorated[0]['reach']['matched'] );
 		$this->assertSame( 320, $decorated[0]['reach']['won'] );
 		// No `as_of` recorded: fall back to the day before the fetch.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Segment reach reported to Google Analytics only helps a publisher who leaves WordPress and knows which report to build. This brings the numbers to where segments are managed.

Each row in Audience → Campaigns → Segments now reads, for example: `Reach (7d): 1,240 sessions · prompt audience: 320 · as of Aug 6`. The first counts sessions where a reader satisfied the segment; the second, the subset where the segment won the priority match — the audience its prompts can reach. A gap between them means higher-priority segments are absorbing those readers, visible on the same screen where priority is reordered.

A daily background job runs one report covering every segment and caches it, so the wizard never calls Google while rendering. Sites where the pipeline can't work show nothing rather than a broken feature, and a segment with no rows yet reads "No reach data yet" rather than zero.

Closes NPPD-2151.

### How to test the changes in this Pull Request:

1. On a site with no GA4 property connected, open Audience → Campaigns → Segments. Rows look exactly as before, with no reach line.
2. Connect Site Kit with a GA4 property. Within a few minutes of any wp-admin page load, `wp option get newspack_ga4_segment_reach` shows a cached payload.
3. Reload the segments list. Segments with reported sessions show the reach line; segments with none show "No reach data yet".
4. Run `wp action-scheduler run --hooks=newspack_ga4_segment_reach_refresh`. The cache's `fetched_at` advances.
5. Disconnect the GA4 property. The reach line disappears from every row and the daily action unschedules.
6. Reconnect to a *different* GA4 property before the next refresh. No reach line appears until the refresh runs, so the old property's numbers are never shown.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Numbers only appear once #800's events are flowing on a provisioned property, and GA4 takes 24–48 hours to process a newly registered dimension. Same-day end-to-end verification isn't possible, so the automated coverage mocks the Data API at the HTTP layer and the manual steps above exercise the empty states.

The auth routing moved out of the dimension provisioner into a shared `GA4_Client` with a `require_edit_scope` flag. Provisioning keeps requiring `analytics.edit` and its 13 tests are unchanged; reach passes `false`, since reads are covered by the base `analytics` scope every stored token carries — the missing-edit-scope skip that shapes the provisioning fallback would wrongly reject a working read path.

`GoogleSiteKitAnalytics` and `GA4_Custom_Dimensions` are read by newspack-blocks and newspack-manager. This only adds methods and a service key, so no coordinated PR is needed.
