### PR TITLE
fix(campaigns): keep the prompt CTA legible on the classic theme

### DIFF
--- a/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-render.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-render.php
@@ -24,7 +24,8 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Newspack_Popups_Contextual_Prompt_Render {
 	/**
-	 * Handle the classic-theme layout CSS is delivered on.
+	 * Handle the card's own inline CSS is delivered on — the classic-theme layout
+	 * rules, and on the Newspack classic theme its CTA's colour as well.
 	 */
 	const LAYOUT_STYLE_HANDLE = 'newspack-popups-contextual-prompt-layout';
 
@@ -110,25 +111,54 @@ final class Newspack_Popups_Contextual_Prompt_Render {
 	 * core emits as `!important` for a palette colour and inline for a custom
 	 * one.
 	 *
-	 * Outline buttons are left to inherit: their label sits on the card, not on a
-	 * filled background, so the card's text colour is the right one for it.
+	 * Only the button this plugin ships is restated: the colour below is the
+	 * theme's pair for the theme's button background, so it is the wrong answer
+	 * for a background a publisher chose. Core marks those on the link itself,
+	 * for a palette colour and a custom one alike, and they are left alone.
+	 *
+	 * Outline buttons are left alone too, for a different reason: the theme
+	 * already colours them, above the rule that would have them inherit. The
+	 * editor disagrees there — its own outline rule declares no colour, so the
+	 * label falls through to the filled one — but that is the theme's to
+	 * reconcile, not this card's.
 	 *
 	 * Named for the theme it compensates rather than for classic themes at large:
 	 * the variable below is that theme's, and on any other one an undefined
 	 * variable would drop the declaration and leave the label inheriting the very
-	 * colour this removes.
+	 * colour this removes. The filter is the way onto a theme this cannot name —
+	 * a fork under its own slug, or a child theme that would rather this stopped.
 	 *
 	 * @return string CSS, or an empty string off the Newspack classic theme.
 	 */
 	public static function get_button_color_css() {
-		if ( 'newspack-theme' !== get_template() ) {
-			return '';
+		$css = '';
+
+		if ( 'newspack-theme' === get_template() ) {
+			$filled = '.' . Newspack_Popups_Contextual_Prompt_Pattern::MARKER_CLASS
+				. ' .wp-block-button:not(.is-style-outline) > .wp-block-button__link:not(.is-style-outline):not(.has-background)';
+			$css    = $filled . '{color:var(--newspack-theme-color-against-secondary)}';
 		}
 
-		$filled = '.' . Newspack_Popups_Contextual_Prompt_Pattern::MARKER_CLASS
-			. ' .wp-block-button:not(.is-style-outline) > .wp-block-button__link:not(.is-style-outline)';
+		/**
+		 * Filters the CSS restating the Contextual Prompt CTA's label colour.
+		 *
+		 * Runs whether or not this theme is one the plugin compensates, so a theme
+		 * it does not name can opt in as readily as one it does can opt out.
+		 *
+		 * @param string $css The CSS, or an empty string.
+		 */
+		return (string) apply_filters( 'newspack_contextual_prompts_button_color_css', $css );
+	}
 
-		return $filled . '{color:var(--newspack-theme-color-against-secondary)}';
+	/**
+	 * Everything the card is delivered, whichever surface is asking. Both hooks
+	 * read this rather than composing their own, so neither can come to disagree
+	 * with the other through an edit to one of them.
+	 *
+	 * @return string
+	 */
+	private static function get_delivered_css() {
+		return self::get_layout_css() . self::get_button_color_css();
 	}
 
 	/**
@@ -136,7 +166,7 @@ final class Newspack_Popups_Contextual_Prompt_Render {
 	 * prints its styles and carries no file to version.
 	 */
 	public static function enqueue_layout_styles() {
-		$css = self::get_layout_css() . self::get_button_color_css();
+		$css = self::get_delivered_css();
 		if ( '' === $css ) {
 			return;
 		}
@@ -154,7 +184,7 @@ final class Newspack_Popups_Contextual_Prompt_Render {
 	 * @return array
 	 */
 	public static function add_editor_layout_styles( $settings ) {
-		$css = self::get_layout_css() . self::get_button_color_css();
+		$css = self::get_delivered_css();
 		if ( '' === $css ) {
 			return $settings;
 		}

--- a/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-render.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-render.php
@@ -24,8 +24,7 @@ defined( 'ABSPATH' ) || exit;
  */
 final class Newspack_Popups_Contextual_Prompt_Render {
 	/**
-	 * Handle the card's own inline CSS is delivered on — the classic-theme layout
-	 * rules, and on the Newspack classic theme its CTA's colour as well.
+	 * Handle the card's own inline CSS is delivered on.
 	 */
 	const LAYOUT_STYLE_HANDLE = 'newspack-popups-contextual-prompt-layout';
 
@@ -99,34 +98,17 @@ final class Newspack_Popups_Contextual_Prompt_Render {
 	}
 
 	/**
-	 * What the card's own text colour costs it on the Newspack classic theme.
+	 * Restates the CTA's label colour on the Newspack classic theme, where a link
+	 * inside a colour-carrying block inherits that colour above the theme's own
+	 * button rule, leaving the card's near-black label on a dark button. What a
+	 * publisher sets on the button still wins: core emits `!important` for a
+	 * palette colour and inline for a custom one.
 	 *
-	 * That theme makes every link inside a colour-carrying block inherit the
-	 * block's text colour, at a specificity above its own button rule. The card
-	 * carries one so its copy stays legible on the panel whatever the theme sets
-	 * for body text, so its CTA inherits that colour over the button's own
-	 * background: at the seeded design, near-black on the theme's dark button.
-	 * The button's colour is restated here, above the rule that would have it
-	 * inherit and below anything a publisher sets on the button itself, which
-	 * core emits as `!important` for a palette colour and inline for a custom
-	 * one.
-	 *
-	 * Only the button this plugin ships is restated: the colour below is the
-	 * theme's pair for the theme's button background, so it is the wrong answer
-	 * for a background a publisher chose. Core marks those on the link itself,
-	 * for a palette colour and a custom one alike, and they are left alone.
-	 *
-	 * Outline buttons are left alone too, for a different reason: the theme
-	 * already colours them, above the rule that would have them inherit. The
-	 * editor disagrees there — its own outline rule declares no colour, so the
-	 * label falls through to the filled one — but that is the theme's to
-	 * reconcile, not this card's.
-	 *
-	 * Named for the theme it compensates rather than for classic themes at large:
-	 * the variable below is that theme's, and on any other one an undefined
-	 * variable would drop the declaration and leave the label inheriting the very
-	 * colour this removes. The filter is the way onto a theme this cannot name —
-	 * a fork under its own slug, or a child theme that would rather this stopped.
+	 * The colour is the theme's pair for the theme's button background, so it is
+	 * wrong for a background a publisher chose and unnecessary for an outline
+	 * button the theme already colours. Gated on that theme because elsewhere the
+	 * variable is undefined, which would drop the declaration and restore the
+	 * inheritance.
 	 *
 	 * @return string CSS, or an empty string off the Newspack classic theme.
 	 */
@@ -142,8 +124,7 @@ final class Newspack_Popups_Contextual_Prompt_Render {
 		/**
 		 * Filters the CSS restating the Contextual Prompt CTA's label colour.
 		 *
-		 * Runs whether or not this theme is one the plugin compensates, so a theme
-		 * it does not name can opt in as readily as one it does can opt out.
+		 * Applied off the theme gate too, so a theme the check misses can opt in.
 		 *
 		 * @param string $css The CSS, or an empty string.
 		 */
@@ -151,9 +132,8 @@ final class Newspack_Popups_Contextual_Prompt_Render {
 	}
 
 	/**
-	 * Everything the card is delivered, whichever surface is asking. Both hooks
-	 * read this rather than composing their own, so neither can come to disagree
-	 * with the other through an edit to one of them.
+	 * Everything the card is delivered. Both hooks read this, so the editor and
+	 * the front end cannot drift apart through an edit to one of them.
 	 *
 	 * @return string
 	 */

--- a/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-render.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-render.php
@@ -98,11 +98,45 @@ final class Newspack_Popups_Contextual_Prompt_Render {
 	}
 
 	/**
+	 * What the card's own text colour costs it on the Newspack classic theme.
+	 *
+	 * That theme makes every link inside a colour-carrying block inherit the
+	 * block's text colour, at a specificity above its own button rule. The card
+	 * carries one so its copy stays legible on the panel whatever the theme sets
+	 * for body text, so its CTA inherits that colour over the button's own
+	 * background: at the seeded design, near-black on the theme's dark button.
+	 * The button's colour is restated here, above the rule that would have it
+	 * inherit and below anything a publisher sets on the button itself, which
+	 * core emits as `!important` for a palette colour and inline for a custom
+	 * one.
+	 *
+	 * Outline buttons are left to inherit: their label sits on the card, not on a
+	 * filled background, so the card's text colour is the right one for it.
+	 *
+	 * Named for the theme it compensates rather than for classic themes at large:
+	 * the variable below is that theme's, and on any other one an undefined
+	 * variable would drop the declaration and leave the label inheriting the very
+	 * colour this removes.
+	 *
+	 * @return string CSS, or an empty string off the Newspack classic theme.
+	 */
+	public static function get_button_color_css() {
+		if ( 'newspack-theme' !== get_template() ) {
+			return '';
+		}
+
+		$filled = '.' . Newspack_Popups_Contextual_Prompt_Pattern::MARKER_CLASS
+			. ' .wp-block-button:not(.is-style-outline) > .wp-block-button__link:not(.is-style-outline)';
+
+		return $filled . '{color:var(--newspack-theme-color-against-secondary)}';
+	}
+
+	/**
 	 * Front end: an inline stylesheet of its own, so it lands wherever the theme
 	 * prints its styles and carries no file to version.
 	 */
 	public static function enqueue_layout_styles() {
-		$css = self::get_layout_css();
+		$css = self::get_layout_css() . self::get_button_color_css();
 		if ( '' === $css ) {
 			return;
 		}
@@ -120,7 +154,7 @@ final class Newspack_Popups_Contextual_Prompt_Render {
 	 * @return array
 	 */
 	public static function add_editor_layout_styles( $settings ) {
-		$css = self::get_layout_css();
+		$css = self::get_layout_css() . self::get_button_color_css();
 		if ( '' === $css ) {
 			return $settings;
 		}

--- a/plugins/newspack-popups/tests/test-contextual-prompt-render.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-render.php
@@ -1203,9 +1203,8 @@ class ContextualPromptRenderTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'margin-block-start:var(--wp--preset--spacing--30,1rem)', $css );
 		$this->assertStringContainsString( 'flex-shrink:0', $css );
 
-		$delivered = $css . Newspack_Popups_Contextual_Prompt_Render::get_button_color_css();
-		$settings  = Newspack_Popups_Contextual_Prompt_Render::add_editor_layout_styles( [] );
-		$this->assertSame( [ [ 'css' => $delivered ] ], $settings['styles'], 'The editor canvas gets the same CSS.' );
+		$settings = Newspack_Popups_Contextual_Prompt_Render::add_editor_layout_styles( [] );
+		$this->assertSame( [ [ 'css' => $css ] ], $settings['styles'], 'The editor canvas gets the same CSS.' );
 
 		$this->switch_to_theme_family( true );
 
@@ -1218,27 +1217,97 @@ class ContextualPromptRenderTest extends WP_UnitTestCase {
 	 * link inside a coloured block that colour: the label would take it over the
 	 * button's own background. The colour is restated for a filled button, left
 	 * alone for an outline one, and never sent to a theme whose buttons the rule
-	 * does not describe.
+	 * does not describe. The theme is faulted in rather than switched to: no
+	 * Newspack theme is installed in the test environment.
 	 */
 	public function test_the_button_colour_css_is_newspack_classic_only() {
+		$css   = $this->under_theme( 'newspack-theme', [ Newspack_Popups_Contextual_Prompt_Render::class, 'get_button_color_css' ] );
+		$other = $this->under_theme( 'twentytwentyfour', [ Newspack_Popups_Contextual_Prompt_Render::class, 'get_button_color_css' ] );
+
+		$this->assertStringContainsString( '.newspack-contextual-prompt .wp-block-button:not(.is-style-outline)', $css );
+		$this->assertStringContainsString( '> .wp-block-button__link:not(.is-style-outline):not(.has-background)', $css );
+		$this->assertStringContainsString( '{color:var(--newspack-theme-color-against-secondary)}', $css );
+
+		$this->assertSame( '', $other, 'Another theme is left to colour its own buttons.' );
+	}
+
+	/**
+	 * A button whose background the publisher changed carries `has-background`,
+	 * and the colour restated here is the theme's pair for the theme's own
+	 * background — so that button is out of the selector's reach.
+	 */
+	public function test_a_publisher_background_is_out_of_reach() {
+		$css = $this->under_theme( 'newspack-theme', [ Newspack_Popups_Contextual_Prompt_Render::class, 'get_button_color_css' ] );
+
+		$this->assertStringContainsString( ':not(.has-background)', $css );
+	}
+
+	/**
+	 * The filter is how a theme this does not name opts in, and one it does opt
+	 * out — the only route onto a fork under its own slug.
+	 */
+	public function test_the_button_colour_css_is_filterable() {
+		$opt_in = static function () {
+			return '.custom{color:#fff}';
+		};
+
+		add_filter( 'newspack_contextual_prompts_button_color_css', $opt_in );
+		$forked   = $this->under_theme( 'some-fork', [ Newspack_Popups_Contextual_Prompt_Render::class, 'get_button_color_css' ] );
+		$newspack = $this->under_theme( 'newspack-theme', [ Newspack_Popups_Contextual_Prompt_Render::class, 'get_button_color_css' ] );
+		remove_filter( 'newspack_contextual_prompts_button_color_css', $opt_in );
+
+		$this->assertSame( '.custom{color:#fff}', $forked, 'A theme this does not name can opt in.' );
+		$this->assertSame( '.custom{color:#fff}', $newspack, 'And one it does can replace what it sends.' );
+	}
+
+	/**
+	 * Both surfaces are served the same string, and neither can lose the CTA's
+	 * colour to an edit that touches only the other. The front end is the one
+	 * that regressed, so it is read back off the handle it actually rides on.
+	 */
+	public function test_both_surfaces_are_delivered_the_same_css() {
+		$this->switch_to_theme_family( false );
+		wp_deregister_style( Newspack_Popups_Contextual_Prompt_Render::LAYOUT_STYLE_HANDLE );
+
 		$newspack = static function () {
 			return 'newspack-theme';
 		};
-		$other    = static function () {
-			return 'twentytwentyfour';
-		};
-
 		add_filter( 'template', $newspack );
-		$css = Newspack_Popups_Contextual_Prompt_Render::get_button_color_css();
+
+		$expected = Newspack_Popups_Contextual_Prompt_Render::get_layout_css()
+			. Newspack_Popups_Contextual_Prompt_Render::get_button_color_css();
+		$settings = Newspack_Popups_Contextual_Prompt_Render::add_editor_layout_styles( [] );
+		Newspack_Popups_Contextual_Prompt_Render::enqueue_layout_styles();
+		$inline = wp_styles()->get_data( Newspack_Popups_Contextual_Prompt_Render::LAYOUT_STYLE_HANDLE, 'after' );
+
 		remove_filter( 'template', $newspack );
 
-		$this->assertStringContainsString( '.newspack-contextual-prompt .wp-block-button:not(.is-style-outline)', $css );
-		$this->assertStringContainsString( '> .wp-block-button__link:not(.is-style-outline)', $css );
-		$this->assertStringContainsString( '{color:var(--newspack-theme-color-against-secondary)}', $css );
+		$this->assertStringContainsString( '{color:var(--newspack-theme-color-against-secondary)}', $expected, 'The colour rule is part of what is delivered.' );
+		$this->assertSame( [ [ 'css' => $expected ] ], $settings['styles'], 'The editor canvas gets it.' );
+		$this->assertIsArray( $inline );
+		$this->assertSame( $expected, implode( '', $inline ), 'And so does the front end.' );
+	}
 
-		add_filter( 'template', $other );
-		$this->assertSame( '', Newspack_Popups_Contextual_Prompt_Render::get_button_color_css(), 'Another theme is left to colour its own buttons.' );
-		remove_filter( 'template', $other );
+	/**
+	 * Run a callable with `get_template()` faulted to a given slug, leaving the
+	 * filter off whether the call succeeds or not.
+	 *
+	 * @param string   $template Theme slug to report.
+	 * @param callable $callback Callable to run.
+	 *
+	 * @return mixed The callable's return value.
+	 */
+	private function under_theme( $template, $callback ) {
+		$filter = static function () use ( $template ) {
+			return $template;
+		};
+
+		add_filter( 'template', $filter );
+		try {
+			return call_user_func( $callback );
+		} finally {
+			remove_filter( 'template', $filter );
+		}
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-contextual-prompt-render.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-render.php
@@ -1203,13 +1203,42 @@ class ContextualPromptRenderTest extends WP_UnitTestCase {
 		$this->assertStringContainsString( 'margin-block-start:var(--wp--preset--spacing--30,1rem)', $css );
 		$this->assertStringContainsString( 'flex-shrink:0', $css );
 
-		$settings = Newspack_Popups_Contextual_Prompt_Render::add_editor_layout_styles( [] );
-		$this->assertSame( [ [ 'css' => $css ] ], $settings['styles'], 'The editor canvas gets the same CSS.' );
+		$delivered = $css . Newspack_Popups_Contextual_Prompt_Render::get_button_color_css();
+		$settings  = Newspack_Popups_Contextual_Prompt_Render::add_editor_layout_styles( [] );
+		$this->assertSame( [ [ 'css' => $delivered ] ], $settings['styles'], 'The editor canvas gets the same CSS.' );
 
 		$this->switch_to_theme_family( true );
 
 		$this->assertSame( '', Newspack_Popups_Contextual_Prompt_Render::get_layout_css() );
 		$this->assertSame( [], Newspack_Popups_Contextual_Prompt_Render::add_editor_layout_styles( [] ), 'And the editor canvas gets nothing.' );
+	}
+
+	/**
+	 * The card's text colour is the CTA's problem on the theme that hands every
+	 * link inside a coloured block that colour: the label would take it over the
+	 * button's own background. The colour is restated for a filled button, left
+	 * alone for an outline one, and never sent to a theme whose buttons the rule
+	 * does not describe.
+	 */
+	public function test_the_button_colour_css_is_newspack_classic_only() {
+		$newspack = static function () {
+			return 'newspack-theme';
+		};
+		$other    = static function () {
+			return 'twentytwentyfour';
+		};
+
+		add_filter( 'template', $newspack );
+		$css = Newspack_Popups_Contextual_Prompt_Render::get_button_color_css();
+		remove_filter( 'template', $newspack );
+
+		$this->assertStringContainsString( '.newspack-contextual-prompt .wp-block-button:not(.is-style-outline)', $css );
+		$this->assertStringContainsString( '> .wp-block-button__link:not(.is-style-outline)', $css );
+		$this->assertStringContainsString( '{color:var(--newspack-theme-color-against-secondary)}', $css );
+
+		add_filter( 'template', $other );
+		$this->assertSame( '', Newspack_Popups_Contextual_Prompt_Render::get_button_color_css(), 'Another theme is left to colour its own buttons.' );
+		remove_filter( 'template', $other );
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-contextual-prompt-render.php
+++ b/plugins/newspack-popups/tests/test-contextual-prompt-render.php
@@ -1213,12 +1213,8 @@ class ContextualPromptRenderTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The card's text colour is the CTA's problem on the theme that hands every
-	 * link inside a coloured block that colour: the label would take it over the
-	 * button's own background. The colour is restated for a filled button, left
-	 * alone for an outline one, and never sent to a theme whose buttons the rule
-	 * does not describe. The theme is faulted in rather than switched to: no
-	 * Newspack theme is installed in the test environment.
+	 * The theme is faulted in rather than switched to: the test environment has no
+	 * Newspack theme installed.
 	 */
 	public function test_the_button_colour_css_is_newspack_classic_only() {
 		$css   = $this->under_theme( 'newspack-theme', [ Newspack_Popups_Contextual_Prompt_Render::class, 'get_button_color_css' ] );
@@ -1232,9 +1228,8 @@ class ContextualPromptRenderTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A button whose background the publisher changed carries `has-background`,
-	 * and the colour restated here is the theme's pair for the theme's own
-	 * background — so that button is out of the selector's reach.
+	 * The restated colour pairs with the theme's own button background, so a
+	 * background the publisher chose is left alone.
 	 */
 	public function test_a_publisher_background_is_out_of_reach() {
 		$css = $this->under_theme( 'newspack-theme', [ Newspack_Popups_Contextual_Prompt_Render::class, 'get_button_color_css' ] );
@@ -1243,8 +1238,7 @@ class ContextualPromptRenderTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The filter is how a theme this does not name opts in, and one it does opt
-	 * out — the only route onto a fork under its own slug.
+	 * The filter is the only route onto a theme the slug check misses.
 	 */
 	public function test_the_button_colour_css_is_filterable() {
 		$opt_in = static function () {
@@ -1261,9 +1255,8 @@ class ContextualPromptRenderTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Both surfaces are served the same string, and neither can lose the CTA's
-	 * colour to an edit that touches only the other. The front end is the one
-	 * that regressed, so it is read back off the handle it actually rides on.
+	 * Neither surface can lose the CTA's colour to an edit that touches only the
+	 * other. The front end is read back off the handle it rides on.
 	 */
 	public function test_both_surfaces_are_delivered_the_same_css() {
 		$this->switch_to_theme_family( false );
@@ -1289,8 +1282,7 @@ class ContextualPromptRenderTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Run a callable with `get_template()` faulted to a given slug, leaving the
-	 * filter off whether the call succeeds or not.
+	 * Run a callable with `get_template()` reporting a given slug.
 	 *
 	 * @param string   $template Theme slug to report.
 	 * @param callable $callback Callable to run.


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

On the classic theme, the Donate button in a Contextual Prompt rendered its label in the card's text colour rather than the button's own, so at the seeded design a reader saw near-black type on the theme's dark grey button. The editor showed it correctly, which made the two surfaces disagree about what publishes.

The card sets a text colour so its copy stays legible on the light panel whatever the theme uses for body text. The classic theme, in turn, has every link inside a colour-carrying block inherit that block's colour (`.entry-content .has-text-color a`), at a specificity above its own button rule — so the card's colour reached the CTA and beat the button's. The editor canvas has no `.entry-content` ancestor, so the rule never applied there.

This restates the button's colour from the feature's own classic-theme stylesheet, alongside the layout CSS the card already ships. It sits above the rule that would have the label inherit and below anything a publisher sets on the button, which core emits as `!important` for a palette colour and inline for a custom one, so Edit Design keeps full control.

Only the button the plugin ships is restated. The colour being restated is the theme's pair for the theme's own button background, so it is the wrong answer for a background a publisher chose — core marks those with `has-background` on the link, and they are left alone. Outline buttons are left alone too, for a different reason: the theme already colours them above the inheriting rule. A `newspack_contextual_prompts_button_color_css` filter runs whether or not the active theme is one the plugin compensates, so a fork under its own slug can opt in and a child theme can opt out.

Left: before. Right: after.

![Contextual Prompt card before and after: Donate label dark, then white](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/08/7oeogg95-cta-before-after.png)

### How to test the changes in this Pull Request:

1. On a site running the classic theme, turn on Contextual Prompts in Audience → Campaigns and add a prompt to a story.
2. View the story on the front end. The Donate label is white on the grey button, and the card's copy stays dark.
3. Open the story in the editor and compare. Both surfaces show the same button.
4. In Audience → Campaigns → Contextual Prompts, choose Edit Design, give the button a text colour of Primary, and save. The front end shows Primary, so a publisher's own colour still wins.
5. Back in Edit Design, clear that text colour and give the button a White background instead. The front end shows a dark label on the white button, not a white one.
6. Choose Reset Design. The label returns to white on the theme's grey button, on both surfaces.
7. Switch to the block theme and repeat step 2. Nothing is delivered there, and the button is unchanged.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally? The newspack-popups suite passes at 379 tests, and PHPCS is clean on both files.

<details>
<summary>For AI</summary>

`Newspack_Popups_Contextual_Prompt_Render::get_button_color_css()` in `plugins/newspack-popups/includes/class-newspack-popups-contextual-prompt-render.php` emits:

```css
.newspack-contextual-prompt .wp-block-button:not(.is-style-outline) > .wp-block-button__link:not(.is-style-outline):not(.has-background){color:var(--newspack-theme-color-against-secondary)}
```

Both hooks read `get_delivered_css()`, which composes `get_layout_css() . get_button_color_css()`, so the front end (`enqueue_layout_styles()`) and the canvas (`add_editor_layout_styles()`) cannot drift apart through an edit to one of them.

The gate is `get_template() === 'newspack-theme'`, which covers the base theme and its five child themes, rather than the `wp_is_block_theme()` check `get_layout_css()` uses. The variable named in the declaration is that theme's. On any other classic theme it would be undefined, the declaration would drop as invalid at computed-value time, and `color` being an inherited property would leave the label taking the card's colour — introducing the bug on a theme that never had it. The filter is applied outside that gate so a theme the slug check misses can still opt in.

Specificity is 0-6-0 against the theme rule's 0-2-1. Core's preset colour classes carry `!important` and a custom colour lands inline, so both publisher paths still outrank it.

The theme rule is at `themes/newspack-theme/newspack-theme/sass/blocks/_blocks.scss:1711-1714`. Fixing it there — adding a `:not()` for buttons, the way the cover-block rule at line 484 already does — would also cover the `core/file` download button and any other coloured block containing a link-button, but it changes a shared theme file for every classic-theme site, so it stayed out of this PR.

Outline buttons are excluded, and the two surfaces still disagree there: the front end colours an outline label at `--newspack-theme-color-secondary-against-white` (`_blocks.scss:795-800`, 0-4-0), while the canvas rule in `style-editor-base.scss:512-521` declares no colour, so the label falls through to the filled one. That is the theme's to reconcile.

Seeding and resetting write the identical string from `build_pattern_content()`, verified byte-for-byte on a local env, so this was never reset-specific: the seeded card carries `has-text-color has-dark-gray-color` and the front end took the inherited colour from the first insert.

</details>
