### PR TITLE
fix(newsletters): drop unnamed ESP lists from the lists payload

### DIFF
--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
@@ -504,7 +504,11 @@ class Newspack_Newsletters_Subscription {
 				array_filter(
 					array_map(
 						function ( $list ) {
-							if ( ! isset( $list['id'], $list['name'] ) || empty( $list['id'] ) || empty( $list['name'] ) ) {
+							// Mirror the validation in Subscription_Lists::get_or_create_remote_list():
+							// it throws on a blank title rather than returning a WP_Error, and the
+							// outer catch would turn that into a WP_Error for the whole payload. It
+							// also accepts a title of "0", which `empty()` would reject.
+							if ( ! isset( $list['id'], $list['name'] ) || empty( $list['id'] ) || ! is_string( $list['name'] ) || '' === trim( $list['name'] ) ) {
 								return;
 							}
 

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
@@ -495,10 +495,11 @@ class Newspack_Newsletters_Subscription {
 			/**
 			 * We loop through the lists returned by the ESP.
 			 * Only remote lists that still exist in the ESP will be returned.
+			 *
+			 * Lists missing a name or an ID are dropped, and the array is then
+			 * reindexed: a sparse array is serialized as a JSON object, and the
+			 * admin screens map over the REST response as an array.
 			 */
-			// Drop lists that lack a name or ID, then reindex: a sparse array is
-			// serialized as a JSON object, and the admin screens map over the
-			// REST response as an array.
 			$return_lists = array_values(
 				array_filter(
 					array_map(
@@ -507,7 +508,7 @@ class Newspack_Newsletters_Subscription {
 								return;
 							}
 
-							// This is messy, when the ESP returns lists, it's name, when we get it from our UIs, it's title... we need both.
+							// The ESP calls this field 'name'; our own UIs call it 'title'. We need both.
 							$list['title'] = $list['name'];
 
 							$stored_list = Subscription_Lists::get_or_create_remote_list( $list );

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
@@ -496,24 +496,31 @@ class Newspack_Newsletters_Subscription {
 			 * We loop through the lists returned by the ESP.
 			 * Only remote lists that still exist in the ESP will be returned.
 			 */
-			$return_lists = array_map(
-				function ( $list ) {
-					if ( ! isset( $list['id'], $list['name'] ) || empty( $list['id'] ) || empty( $list['name'] ) ) {
-						return;
-					}
+			// Drop lists that lack a name or ID, then reindex: a sparse array is
+			// serialized as a JSON object, and the admin screens map over the
+			// REST response as an array.
+			$return_lists = array_values(
+				array_filter(
+					array_map(
+						function ( $list ) {
+							if ( ! isset( $list['id'], $list['name'] ) || empty( $list['id'] ) || empty( $list['name'] ) ) {
+								return;
+							}
 
-					// This is messy, when the ESP returns lists, it's name, when we get it from our UIs, it's title... we need both.
-					$list['title'] = $list['name'];
+							// This is messy, when the ESP returns lists, it's name, when we get it from our UIs, it's title... we need both.
+							$list['title'] = $list['name'];
 
-					$stored_list = Subscription_Lists::get_or_create_remote_list( $list );
+							$stored_list = Subscription_Lists::get_or_create_remote_list( $list );
 
-					if ( is_wp_error( $stored_list ) ) {
-						return;
-					}
+							if ( is_wp_error( $stored_list ) ) {
+								return;
+							}
 
-					return $stored_list->to_array();
-				},
-				$lists
+							return $stored_list->to_array();
+						},
+						$lists
+					)
+				)
 			);
 
 			/**

--- a/plugins/newspack-newsletters/tests/test-subscription-get-lists.php
+++ b/plugins/newspack-newsletters/tests/test-subscription-get-lists.php
@@ -125,6 +125,63 @@ class Subscription_Get_Lists_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A whitespace-only name must be dropped like an empty one. It is not
+	 * caught by `empty()`, so it would otherwise reach
+	 * Subscription_Lists::get_or_create_remote_list(), which throws rather
+	 * than returning a WP_Error — and the outer catch turns that into a
+	 * WP_Error for the whole payload, emptying the screen instead of dropping
+	 * one row.
+	 */
+	public function test_whitespace_named_list_is_dropped_without_failing_the_payload() {
+		$this->stub_provider_lists(
+			[
+				[
+					'id'   => '9001',
+					'name' => 'Weekly digest',
+				],
+				[
+					'id'   => '9002',
+					'name' => '   ',
+				],
+				[
+					'id'   => '9003',
+					'name' => 'Breaking news',
+				],
+			]
+		);
+
+		$result = Newspack_Newsletters_Subscription::get_lists();
+
+		$this->assertNotWPError( $result, 'One badly-named list must not fail the whole payload.' );
+
+		$ids = wp_list_pluck( $result, 'id' );
+		$this->assertContains( '9001', $ids );
+		$this->assertContains( '9003', $ids );
+		$this->assertNotContains( '9002', $ids, 'The whitespace-named list must not be returned.' );
+	}
+
+	/**
+	 * "0" is a legitimate list name that `empty()` rejects.
+	 * Subscription_Lists::get_or_create_remote_list() goes out of its way to
+	 * accept it, so this guard must not disagree.
+	 */
+	public function test_list_named_zero_is_kept() {
+		$this->stub_provider_lists(
+			[
+				[
+					'id'   => '9004',
+					'name' => '0',
+				],
+			]
+		);
+
+		$result = Newspack_Newsletters_Subscription::get_lists();
+
+		$this->assertNotWPError( $result );
+		$this->assertContains( '9004', wp_list_pluck( $result, 'id' ), 'A list named "0" must survive the guard.' );
+	}
+
+	/**
 	 * Install a provider double whose get_lists() returns a fixed payload.
 	 *
 	 * @param array[] $lists Lists the stubbed ESP should return.

--- a/plugins/newspack-newsletters/tests/test-subscription-get-lists.php
+++ b/plugins/newspack-newsletters/tests/test-subscription-get-lists.php
@@ -1,0 +1,161 @@
+<?php
+/**
+ * Tests Newspack_Newsletters_Subscription::get_lists().
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * The return value of get_lists() is served verbatim by the
+ * `newspack-newsletters/v1/lists` REST route and mapped over by the Newsletters
+ * settings and Audience configuration screens, so its shape is a contract: a
+ * JSON array of list objects, with no holes and no nulls.
+ */
+class Subscription_Get_Lists_Test extends WP_UnitTestCase {
+
+	/**
+	 * Provider slug the stubbed lists are stored under.
+	 */
+	const PROVIDER = 'active_campaign';
+
+	/**
+	 * Provider instance displaced by the test double, restored on tear down.
+	 *
+	 * @var mixed
+	 */
+	private $original_provider = null;
+
+	/**
+	 * Whether a test double is currently installed.
+	 *
+	 * @var bool
+	 */
+	private $provider_replaced = false;
+
+	/**
+	 * Point the plugin at the provider slug and start from a cold list cache.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Newspack_Newsletters::set_service_provider( self::PROVIDER );
+		$this->clear_lists_cache();
+	}
+
+	/**
+	 * Restore the real provider instance and leave no cached lists behind.
+	 */
+	public function tear_down() {
+		if ( $this->provider_replaced ) {
+			$this->provider_property()->setValue( null, $this->original_provider );
+			$this->provider_replaced = false;
+		}
+		$this->clear_lists_cache();
+		parent::tear_down();
+	}
+
+	/**
+	 * An ESP payload where a list in the middle carries an empty name, as
+	 * ActiveCampaign returns for an unnamed list.
+	 *
+	 * @return array[]
+	 */
+	private function lists_with_an_unnamed_list_in_the_middle() {
+		return [
+			[
+				'id'               => '9001',
+				'name'             => 'Weekly digest',
+				'subscriber_count' => 12,
+			],
+			[
+				'id'               => '9002',
+				'name'             => '',
+				'subscriber_count' => 0,
+			],
+			[
+				'id'               => '9003',
+				'name'             => 'Breaking news',
+				'subscriber_count' => 34,
+			],
+		];
+	}
+
+	/**
+	 * An unnamed list is dropped rather than passed through as a null entry.
+	 * The admin screens map over this payload and read `list.name` directly, so
+	 * a null in the array unmounts the whole settings page.
+	 */
+	public function test_unnamed_remote_list_is_dropped() {
+		$this->stub_provider_lists( $this->lists_with_an_unnamed_list_in_the_middle() );
+
+		$result = Newspack_Newsletters_Subscription::get_lists();
+
+		$this->assertNotWPError( $result );
+		$this->assertNotContains( null, $result, 'A list the ESP left unnamed must not survive as a null entry.' );
+
+		$ids = wp_list_pluck( $result, 'id' );
+		$this->assertContains( '9001', $ids );
+		$this->assertContains( '9003', $ids );
+		$this->assertNotContains( '9002', $ids, 'The unnamed list must not be returned.' );
+	}
+
+	/**
+	 * Dropping a list must not leave a hole in the array's keys: a sparse PHP
+	 * array is serialized as a JSON object, and the admin screens call .map()
+	 * on the response.
+	 */
+	public function test_result_is_still_a_json_array_after_a_list_is_dropped() {
+		$this->stub_provider_lists( $this->lists_with_an_unnamed_list_in_the_middle() );
+
+		$result = Newspack_Newsletters_Subscription::get_lists();
+
+		$this->assertNotWPError( $result );
+		$this->assertSame(
+			range( 0, count( $result ) - 1 ),
+			array_keys( $result ),
+			'Keys must stay sequential so the REST response is a JSON array.'
+		);
+		$this->assertStringStartsWith( '[', (string) wp_json_encode( $result ) );
+	}
+
+	/**
+	 * Install a provider double whose get_lists() returns a fixed payload.
+	 *
+	 * @param array[] $lists Lists the stubbed ESP should return.
+	 * @return void
+	 */
+	private function stub_provider_lists( array $lists ) {
+		$provider = $this->getMockBuilder( Newspack_Newsletters_Service_Provider::class )
+			->disableOriginalConstructor()
+			->onlyMethods( [ 'get_lists' ] )
+			->getMockForAbstractClass();
+		$provider->method( 'get_lists' )->willReturn( $lists );
+
+		// Newspack_Newsletters memoizes the provider in a protected static and
+		// only ever fills it from a registered slug, which would build a real
+		// ESP client. Reflection is the only seam for handing it a double.
+		$property                = $this->provider_property();
+		$this->original_provider = $property->getValue();
+		$property->setValue( null, $provider );
+		$this->provider_replaced = true;
+	}
+
+	/**
+	 * Accessor for the memoized provider property.
+	 *
+	 * @return ReflectionProperty
+	 */
+	private function provider_property() {
+		$property = new ReflectionProperty( Newspack_Newsletters::class, 'provider' );
+		$property->setAccessible( true );
+		return $property;
+	}
+
+	/**
+	 * Drop the cached list payload for the provider under test.
+	 *
+	 * @return void
+	 */
+	private function clear_lists_cache() {
+		delete_transient( Newspack_Newsletters_Subscription::LISTS_CACHE_PREFIX . self::PROVIDER );
+	}
+}

--- a/plugins/newspack-newsletters/tests/test-subscription-get-lists.php
+++ b/plugins/newspack-newsletters/tests/test-subscription-get-lists.php
@@ -34,10 +34,17 @@ class Subscription_Get_Lists_Test extends WP_UnitTestCase {
 
 	/**
 	 * Point the plugin at the provider slug and start from a cold list cache.
+	 *
+	 * The option is written directly rather than through set_service_provider(),
+	 * which also memoizes a provider instance in a static property. Static state
+	 * survives the per-test transaction, so touching it here would displace the
+	 * value stub_provider_lists() records as the original. The option itself
+	 * needs no restoring: WP_UnitTestCase_Base opens a transaction in set_up()
+	 * and rolls it back in tear_down().
 	 */
 	public function set_up() {
 		parent::set_up();
-		Newspack_Newsletters::set_service_provider( self::PROVIDER );
+		update_option( 'newspack_newsletters_service_provider', self::PROVIDER );
 		$this->clear_lists_cache();
 	}
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Keeps Newsletters > Settings and Audience > Configuration rendering when an ESP reports a list without a usable name.

`Newspack_Newsletters_Subscription::get_lists()` maps over the lists the ESP returns and skips any that arrive without an id or a name. The closure returned nothing for those, so every skipped list stayed in the payload as a `null`. That payload is served as-is by the `newspack-newsletters/v1/lists` route, and both admin screens map over it and read `list.name`. One unnamed list was enough to unmount the page right after it rendered, leaving the WordPress chrome and nothing else: `TypeError: Cannot read properties of null (reading 'name')`.

ActiveCampaign lets an account hold a list with an empty name, which is how NPPM-3114 surfaced.

Three parts:

* `array_filter` drops the skipped entries, so no nulls reach the client.
* `array_values` reindexes, because `array_filter` preserves keys. A sparse PHP array serializes as a JSON object, and calling `.map()` on an object throws a `TypeError` of its own. Without the reindex the page still breaks whenever the unnamed list isn't the last one the ESP returns.
* The guard now uses the same test as `Subscription_Lists::get_or_create_remote_list()` — `! is_string()` or an empty trimmed string, rather than `empty()`. The two disagreed in both directions. A whitespace-only name cleared `empty()`, reached the callee, and hit its `throw`; since the closure only handles `is_wp_error()`, that exception escaped to the outer `catch` and turned the **whole** payload into a `WP_Error` — emptying the screen instead of dropping one row. In the other direction, `empty( '0' )` is `true`, so a list legitimately named `0` was dropped, which the callee goes out of its way to allow.

Four unit tests cover all three: no nulls survive, the keys stay sequential, a whitespace-named list is dropped without failing the payload, and a list named `0` is kept.

Incidental: sites hitting this were calling `wp_list_pluck()` over the null entries, which fired a `_doing_it_wrong` notice on every cold-cache request. That stops too.

Deferred deliberately, to keep a `release`-targeted fix small — both filed rather than dropped:

* NPPM-3120 — a `WP_Error` from this function makes the content-gate rule sanitizer silently drop a gate's newsletter rule on save. Different subsystem, and not specific to ESP list naming.
* NPPM-3121 — the rest: a dropped list still takes its stored `newspack_nl_list` config with it via garbage collection, the transient keeps serving the old payload until it expires, there's no `is_array()` guard before `array_map`, nothing logs the drop, and the newspack-plugin consumer is still unguarded.

Closes NPPM-3114.

### How to test the changes in this Pull Request:

1. From `plugins/newspack-newsletters`, run `n test-php --filter Subscription_Get_Lists_Test`. Four tests pass.
2. Run the full plugin suite: `n test-php`. 721 tests pass, with the 3 pre-existing skips.
3. To see what the reindex prevents, remove the `array_values(` wrapper from `get_lists()` and re-run step 1. `test_result_is_still_a_json_array_after_a_list_is_dropped` fails, reporting keys `[0, 2]` where `[0, 1]` is expected.
4. To see what the guard change prevents, restore `empty( $list['name'] )` in place of the `is_string`/`trim` test and re-run step 1. `test_whitespace_named_list_is_dropped_without_failing_the_payload` fails with `WP_Error: Invalid list` — the whole payload, not one row — and `test_list_named_zero_is_kept` fails too.
5. On a site connected to an ESP, open Newsletters > Settings and Audience > Configuration. The subscription lists table renders, and toggling a list still saves.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
