### PR TITLE
Newsletters: Add ability to select draft/scheduled/pending posts in Posts Inserter

### DIFF
--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/consts.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/consts.js
@@ -1,2 +1,10 @@
 export const POSTS_INSERTER_BLOCK_NAME = 'newspack-newsletters/posts-inserter';
 export const POSTS_INSERTER_STORE_NAME = 'newspack-newsletters/posts-inserter-block';
+
+/**
+ * Post statuses a hand-picked post may have.
+ *
+ * Used both by the "Add posts" search and by the lookup of posts already saved on the
+ * block. Private posts are deliberately left out.
+ */
+export const SEARCHABLE_STATUSES = [ 'publish', 'future', 'draft', 'pending' ];

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/index.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/index.js
@@ -41,6 +41,7 @@ import blockDefinition from './block.json';
 import { getTemplateBlocks, convertBlockSerializationFormat } from './utils';
 import QueryControlsSettings from './query-controls';
 import { POSTS_INSERTER_BLOCK_NAME, POSTS_INSERTER_STORE_NAME } from './consts';
+import { SEARCHABLE_STATUSES } from './post-search';
 import PostsPreview from './posts-preview';
 
 const PostsInserterBlock = ( {
@@ -367,8 +368,10 @@ const PostsInserterBlockWithSelect = compose( [
 		};
 
 		if ( ! isDisplayingSpecificPosts || isHandlingSpecificPosts ) {
+			// Specific posts are hand-picked, so honour whichever status they were picked at.
+			// The automatic query stays published-only.
 			const postListQuery = isDisplayingSpecificPosts
-				? { include: specificPosts.map( post => post.id ) }
+				? { include: specificPosts.map( post => post.id ), status: SEARCHABLE_STATUSES }
 				: pickBy( query, value => ! isUndefined( value ) );
 
 			posts = getEntityRecords( 'postType', postType, postListQuery ) || [];

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/index.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/index.js
@@ -41,7 +41,7 @@ import blockDefinition from './block.json';
 import { getTemplateBlocks, convertBlockSerializationFormat } from './utils';
 import QueryControlsSettings from './query-controls';
 import { POSTS_INSERTER_BLOCK_NAME, POSTS_INSERTER_STORE_NAME } from './consts';
-import { SEARCHABLE_STATUSES } from './post-search';
+import { selectSpecificPosts } from './specific-posts';
 import PostsPreview from './posts-preview';
 
 const PostsInserterBlock = ( {
@@ -367,14 +367,14 @@ const PostsInserterBlockWithSelect = compose( [
 			exclude_sponsors: displaySponsoredPosts ? 0 : 1,
 		};
 
-		if ( ! isDisplayingSpecificPosts || isHandlingSpecificPosts ) {
-			// Specific posts are hand-picked, so honour whichever status they were picked at.
+		if ( isHandlingSpecificPosts ) {
+			// Hand-picked posts are honoured at whichever status they were picked at.
+			const specificPostIds = specificPosts.map( post => post.id );
+			posts = selectSpecificPosts( select, postType, specificPostIds ) || [];
+		} else if ( ! isDisplayingSpecificPosts ) {
 			// The automatic query stays published-only.
-			const postListQuery = isDisplayingSpecificPosts
-				? { include: specificPosts.map( post => post.id ), status: SEARCHABLE_STATUSES }
-				: pickBy( query, value => ! isUndefined( value ) );
-
-			posts = getEntityRecords( 'postType', postType, postListQuery ) || [];
+			const autoQuery = pickBy( query, value => ! isUndefined( value ) );
+			posts = getEntityRecords( 'postType', postType, autoQuery ) || [];
 		}
 
 		// Order posts in the order as they appear in the input

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/post-search.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/post-search.js
@@ -5,16 +5,15 @@ import { __, _x, sprintf } from '@wordpress/i18n';
 import { addQueryArgs } from '@wordpress/url';
 
 /**
- * Post statuses the "Add posts" search offers.
- *
- * Core's `/wp/v2/search` handler is hardcoded to published posts, so the search runs
- * against the post type's own collection endpoint instead, which accepts `status`.
- * Private posts are deliberately left out.
+ * Internal dependencies
  */
-export const SEARCHABLE_STATUSES = [ 'publish', 'future', 'draft', 'pending' ];
+import { SEARCHABLE_STATUSES } from './consts';
 
 /**
  * REST path for the "Add posts" search.
+ *
+ * Core's `/wp/v2/search` handler is hardcoded to published posts, so the search runs
+ * against the post type's own collection endpoint instead, which accepts `status`.
  *
  * @param {string}  restBase        REST base of the post type being searched.
  * @param {string}  search          Search term.
@@ -31,40 +30,6 @@ export const getPostSearchPath = ( restBase, search, includeStatuses = true ) =>
 		_fields: 'id,title,status',
 		...( includeStatuses ? { status: SEARCHABLE_STATUSES } : {} ),
 	} );
-
-/**
- * REST path for looking up the current status of already-selected posts, so a post that
- * gets published stops being labelled as a draft.
- *
- * @param {string}   restBase REST base of the post type.
- * @param {number[]} ids      Post IDs to look up.
- * @return {string} REST path.
- */
-export const getPostStatusPath = ( restBase, ids ) =>
-	addQueryArgs( `/wp/v2/${ restBase }`, {
-		include: ids,
-		per_page: 100,
-		_fields: 'id,status',
-		status: SEARCHABLE_STATUSES,
-	} );
-
-/**
- * Fold a status lookup response into the known statuses.
- *
- * Requested posts absent from the response — trashed, private, or otherwise unreadable —
- * are recorded with an empty status. Without that they would count as unknown forever and
- * the lookup would run on every render.
- *
- * @param {Object}   known        Statuses keyed by post ID.
- * @param {number[]} requestedIds Post IDs the lookup asked for.
- * @param {Object[]} posts        Posts returned by the lookup.
- * @return {Object} Updated statuses keyed by post ID.
- */
-export const mergePostStatuses = ( known, requestedIds, posts ) => ( {
-	...known,
-	...requestedIds.reduce( ( all, id ) => ( { ...all, [ id ]: '' } ), {} ),
-	...posts.reduce( ( all, post ) => ( { ...all, [ post.id ]: post.status } ), {} ),
-} );
 
 /**
  * Human-readable name for an unpublished status. Published posts get none.

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/post-search.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/post-search.js
@@ -1,0 +1,109 @@
+/**
+ * WordPress dependencies
+ */
+import { __, _x, sprintf } from '@wordpress/i18n';
+import { addQueryArgs } from '@wordpress/url';
+
+/**
+ * Post statuses the "Add posts" search offers.
+ *
+ * Core's `/wp/v2/search` handler is hardcoded to published posts, so the search runs
+ * against the post type's own collection endpoint instead, which accepts `status`.
+ * Private posts are deliberately left out.
+ */
+export const SEARCHABLE_STATUSES = [ 'publish', 'future', 'draft', 'pending' ];
+
+/**
+ * REST path for the "Add posts" search.
+ *
+ * @param {string}  restBase        REST base of the post type being searched.
+ * @param {string}  search          Search term.
+ * @param {boolean} includeStatuses Whether to ask for unpublished posts. Core rejects the
+ *                                  whole request when the user can't edit the post type,
+ *                                  so the caller retries with this off.
+ * @return {string} REST path.
+ */
+export const getPostSearchPath = ( restBase, search, includeStatuses = true ) =>
+	addQueryArgs( `/wp/v2/${ restBase }`, {
+		search,
+		per_page: 20,
+		orderby: 'relevance',
+		_fields: 'id,title,status',
+		...( includeStatuses ? { status: SEARCHABLE_STATUSES } : {} ),
+	} );
+
+/**
+ * REST path for looking up the current status of already-selected posts, so a post that
+ * gets published stops being labelled as a draft.
+ *
+ * @param {string}   restBase REST base of the post type.
+ * @param {number[]} ids      Post IDs to look up.
+ * @return {string} REST path.
+ */
+export const getPostStatusPath = ( restBase, ids ) =>
+	addQueryArgs( `/wp/v2/${ restBase }`, {
+		include: ids,
+		per_page: 100,
+		_fields: 'id,status',
+		status: SEARCHABLE_STATUSES,
+	} );
+
+/**
+ * Fold a status lookup response into the known statuses.
+ *
+ * Requested posts absent from the response — trashed, private, or otherwise unreadable —
+ * are recorded with an empty status. Without that they would count as unknown forever and
+ * the lookup would run on every render.
+ *
+ * @param {Object}   known        Statuses keyed by post ID.
+ * @param {number[]} requestedIds Post IDs the lookup asked for.
+ * @param {Object[]} posts        Posts returned by the lookup.
+ * @return {Object} Updated statuses keyed by post ID.
+ */
+export const mergePostStatuses = ( known, requestedIds, posts ) => ( {
+	...known,
+	...requestedIds.reduce( ( all, id ) => ( { ...all, [ id ]: '' } ), {} ),
+	...posts.reduce( ( all, post ) => ( { ...all, [ post.id ]: post.status } ), {} ),
+} );
+
+/**
+ * Human-readable name for an unpublished status. Published posts get none.
+ *
+ * @param {string} status Post status.
+ * @return {string} Status name, or an empty string.
+ */
+const getStatusLabel = status => {
+	switch ( status ) {
+		case 'future':
+			return __( 'Scheduled', 'newspack-newsletters' );
+		case 'draft':
+			return __( 'Draft', 'newspack-newsletters' );
+		case 'pending':
+			return __( 'Pending', 'newspack-newsletters' );
+		default:
+			return '';
+	}
+};
+
+/**
+ * Post title as shown in the "Add posts" field, with its status appended when the post
+ * isn't published.
+ *
+ * @param {string} title  Post title.
+ * @param {string} status Post status. May be undefined while it's still being looked up.
+ * @return {string} Title for display.
+ */
+export const formatPostLabel = ( title, status ) => {
+	const label = getStatusLabel( status );
+
+	if ( ! label ) {
+		return title;
+	}
+
+	return sprintf(
+		/* translators: 1: post title. 2: post status, such as Draft or Scheduled. */
+		_x( '%1$s — %2$s', 'post title with status', 'newspack-newsletters' ),
+		title,
+		label
+	);
+};

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/post-search.test.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/post-search.test.js
@@ -1,4 +1,4 @@
-import { formatPostLabel, getPostSearchPath, getPostStatusPath, mergePostStatuses } from './post-search';
+import { formatPostLabel, getPostSearchPath } from './post-search';
 
 describe( 'getPostSearchPath', () => {
 	it( 'searches the given post type collection endpoint', () => {
@@ -27,59 +27,6 @@ describe( 'getPostSearchPath', () => {
 
 		expect( path ).not.toContain( 'status[' );
 		expect( path ).toContain( 'search=election' );
-	} );
-} );
-
-describe( 'getPostStatusPath', () => {
-	it( 'looks up only the id and status of the given posts', () => {
-		const path = decodeURIComponent( getPostStatusPath( 'posts', [ 12, 34 ] ) );
-
-		expect( path ).toContain( '/wp/v2/posts?' );
-		expect( path ).toContain( 'include[0]=12' );
-		expect( path ).toContain( 'include[1]=34' );
-		expect( path ).toContain( '_fields=id,status' );
-	} );
-
-	it( 'covers the same statuses the search offers', () => {
-		const path = decodeURIComponent( getPostStatusPath( 'posts', [ 12 ] ) );
-
-		expect( path ).toContain( 'status[0]=publish' );
-		expect( path ).toContain( 'status[3]=pending' );
-		expect( path ).not.toContain( 'private' );
-	} );
-} );
-
-describe( 'mergePostStatuses', () => {
-	it( 'records the status of every post in the response', () => {
-		const merged = mergePostStatuses(
-			{},
-			[ 12, 34 ],
-			[
-				{ id: 12, status: 'draft' },
-				{ id: 34, status: 'publish' },
-			]
-		);
-
-		expect( merged ).toEqual( { 12: 'draft', 34: 'publish' } );
-	} );
-
-	it( 'keeps statuses it already knew about', () => {
-		const merged = mergePostStatuses( { 9: 'future' }, [ 12 ], [ { id: 12, status: 'draft' } ] );
-
-		expect( merged[ 9 ] ).toBe( 'future' );
-	} );
-
-	it( 'marks requested posts missing from the response as looked up, so they are not requested forever', () => {
-		const merged = mergePostStatuses( {}, [ 12, 99 ], [ { id: 12, status: 'draft' } ] );
-
-		expect( merged ).toHaveProperty( '99' );
-		expect( formatPostLabel( 'Deleted post', merged[ 99 ] ) ).toBe( 'Deleted post' );
-	} );
-
-	it( 'lets a fresh response correct a status it already knew', () => {
-		const merged = mergePostStatuses( { 12: 'draft' }, [ 12 ], [ { id: 12, status: 'publish' } ] );
-
-		expect( merged[ 12 ] ).toBe( 'publish' );
 	} );
 } );
 

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/post-search.test.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/post-search.test.js
@@ -1,0 +1,106 @@
+import { formatPostLabel, getPostSearchPath, getPostStatusPath, mergePostStatuses } from './post-search';
+
+describe( 'getPostSearchPath', () => {
+	it( 'searches the given post type collection endpoint', () => {
+		expect( getPostSearchPath( 'newspack_nl_cpt', 'election' ) ).toContain( '/wp/v2/newspack_nl_cpt?' );
+	} );
+
+	it( 'asks for scheduled, draft and pending posts alongside published ones', () => {
+		const path = decodeURIComponent( getPostSearchPath( 'posts', 'election' ) );
+
+		expect( path ).toContain( 'status[0]=publish' );
+		expect( path ).toContain( 'status[1]=future' );
+		expect( path ).toContain( 'status[2]=draft' );
+		expect( path ).toContain( 'status[3]=pending' );
+	} );
+
+	it( 'never asks for private posts', () => {
+		expect( decodeURIComponent( getPostSearchPath( 'posts', 'election' ) ) ).not.toContain( 'private' );
+	} );
+
+	it( 'requests the status field so suggestions can be labelled', () => {
+		expect( decodeURIComponent( getPostSearchPath( 'posts', 'election' ) ) ).toContain( '_fields=id,title,status' );
+	} );
+
+	it( 'drops the status filter when asked to fall back', () => {
+		const path = decodeURIComponent( getPostSearchPath( 'posts', 'election', false ) );
+
+		expect( path ).not.toContain( 'status[' );
+		expect( path ).toContain( 'search=election' );
+	} );
+} );
+
+describe( 'getPostStatusPath', () => {
+	it( 'looks up only the id and status of the given posts', () => {
+		const path = decodeURIComponent( getPostStatusPath( 'posts', [ 12, 34 ] ) );
+
+		expect( path ).toContain( '/wp/v2/posts?' );
+		expect( path ).toContain( 'include[0]=12' );
+		expect( path ).toContain( 'include[1]=34' );
+		expect( path ).toContain( '_fields=id,status' );
+	} );
+
+	it( 'covers the same statuses the search offers', () => {
+		const path = decodeURIComponent( getPostStatusPath( 'posts', [ 12 ] ) );
+
+		expect( path ).toContain( 'status[0]=publish' );
+		expect( path ).toContain( 'status[3]=pending' );
+		expect( path ).not.toContain( 'private' );
+	} );
+} );
+
+describe( 'mergePostStatuses', () => {
+	it( 'records the status of every post in the response', () => {
+		const merged = mergePostStatuses(
+			{},
+			[ 12, 34 ],
+			[
+				{ id: 12, status: 'draft' },
+				{ id: 34, status: 'publish' },
+			]
+		);
+
+		expect( merged ).toEqual( { 12: 'draft', 34: 'publish' } );
+	} );
+
+	it( 'keeps statuses it already knew about', () => {
+		const merged = mergePostStatuses( { 9: 'future' }, [ 12 ], [ { id: 12, status: 'draft' } ] );
+
+		expect( merged[ 9 ] ).toBe( 'future' );
+	} );
+
+	it( 'marks requested posts missing from the response as looked up, so they are not requested forever', () => {
+		const merged = mergePostStatuses( {}, [ 12, 99 ], [ { id: 12, status: 'draft' } ] );
+
+		expect( merged ).toHaveProperty( '99' );
+		expect( formatPostLabel( 'Deleted post', merged[ 99 ] ) ).toBe( 'Deleted post' );
+	} );
+
+	it( 'lets a fresh response correct a status it already knew', () => {
+		const merged = mergePostStatuses( { 12: 'draft' }, [ 12 ], [ { id: 12, status: 'publish' } ] );
+
+		expect( merged[ 12 ] ).toBe( 'publish' );
+	} );
+} );
+
+describe( 'formatPostLabel', () => {
+	it( 'leaves published posts unlabelled', () => {
+		expect( formatPostLabel( 'City budget passes', 'publish' ) ).toBe( 'City budget passes' );
+	} );
+
+	it( 'labels scheduled posts', () => {
+		expect( formatPostLabel( 'Election night live blog', 'future' ) ).toBe( 'Election night live blog — Scheduled' );
+	} );
+
+	it( 'labels drafts', () => {
+		expect( formatPostLabel( 'Mayor race preview', 'draft' ) ).toBe( 'Mayor race preview — Draft' );
+	} );
+
+	it( 'labels posts awaiting review', () => {
+		expect( formatPostLabel( 'Election guide 2026', 'pending' ) ).toBe( 'Election guide 2026 — Pending' );
+	} );
+
+	it( 'leaves the title alone when the status is not yet known', () => {
+		expect( formatPostLabel( 'City budget passes', undefined ) ).toBe( 'City budget passes' );
+	} );
+} );

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/query-controls.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/query-controls.js
@@ -16,20 +16,24 @@ import { Fragment, useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
 import { decodeEntities } from '@wordpress/html-entities';
 
-const fetchPostSuggestions = postType => search =>
-	apiFetch( {
-		path: addQueryArgs( '/wp/v2/search', {
-			search,
-			per_page: 20,
-			_fields: 'id,title',
-			subtype: postType,
-		} ),
-	} ).then( posts =>
-		posts.map( post => ( {
-			id: post.id,
-			title: decodeEntities( post.title ) || __( '(no title)', 'newspack-newsletters' ),
-		} ) )
-	);
+/**
+ * Internal dependencies
+ */
+import { formatPostLabel, getPostSearchPath, getPostStatusPath, mergePostStatuses } from './post-search';
+
+const fetchPostSuggestions = ( restBase, search ) =>
+	apiFetch( { path: getPostSearchPath( restBase, search ) } )
+		// Core rejects the whole request when the user can't edit this post type. Fall back
+		// to published posts rather than leaving the search empty.
+		.catch( () => apiFetch( { path: getPostSearchPath( restBase, search, false ) } ) )
+		.then( posts =>
+			posts.map( post => ( {
+				id: post.id,
+				title: decodeEntities( post.title?.rendered ) || __( '(no title)', 'newspack-newsletters' ),
+				status: post.status,
+			} ) )
+		)
+		.catch( () => [] );
 
 const SEPARATOR = '--';
 const encodePosts = posts => posts.map( post => [ post.id, post.title ].join( SEPARATOR ) );
@@ -45,9 +49,12 @@ const decodePost = encodedPost => {
 const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 	const [ categoriesList, setCategoriesList ] = useState( [] );
 	const [ postTypesList, setPostTypesList ] = useState( [ { value: 'post', label: 'Posts' } ] );
+	const [ postTypeRestBases, setPostTypeRestBases ] = useState( { post: 'posts' } );
+	const [ postStatuses, setPostStatuses ] = useState( {} );
 	const [ showAdvancedFilters, setShowAdvancedFilters ] = useState( false );
 
 	const { categoryExclusions, tags, tagExclusions } = attributes;
+	const restBase = postTypeRestBases[ attributes.postType ];
 
 	useEffect( () => {
 		apiFetch( {
@@ -55,7 +62,15 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 				per_page: -1,
 			} ),
 		} ).then( setCategoriesList );
-		fetchPostTypes().then( setPostTypesList );
+		fetchPostTypes().then( postTypes => {
+			setPostTypesList(
+				postTypes.map( postType => ( {
+					value: postType.slug,
+					label: decodeEntities( postType.name ) || __( '(no title)', 'newspack-newsletters' ),
+				} ) )
+			);
+			setPostTypeRestBases( postTypes.reduce( ( all, postType ) => ( { ...all, [ postType.slug ]: postType.rest_base } ), {} ) );
+		} );
 	}, [] );
 
 	const categorySuggestions = categoriesList.reduce(
@@ -105,15 +120,29 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 	const [ isFetchingPosts, setIsFetchingPosts ] = useState( false );
 	const [ foundPosts, setFoundPosts ] = useState( [] );
 	const handleSpecificPostsInput = search => {
-		if ( isFetchingPosts || search.length === 0 ) {
+		if ( isFetchingPosts || search.length === 0 || ! restBase ) {
 			return;
 		}
 		setIsFetchingPosts( true );
-		fetchPostSuggestions( attributes.postType )( search ).then( posts => {
+		fetchPostSuggestions( restBase, search ).then( posts => {
 			setIsFetchingPosts( false );
 			setFoundPosts( posts );
+			setPostStatuses( known => mergePostStatuses( known, [], posts ) );
 		} );
 	};
+
+	// Look up the status of posts already saved on the block, so a draft that has since
+	// been published stops being labelled as one.
+	const unknownPostIds = attributes.specificPosts.map( post => post.id ).filter( id => undefined === postStatuses[ id ] );
+
+	useEffect( () => {
+		if ( ! restBase || 0 === unknownPostIds.length ) {
+			return;
+		}
+		apiFetch( { path: getPostStatusPath( restBase, unknownPostIds ) } )
+			.then( posts => setPostStatuses( known => mergePostStatuses( known, unknownPostIds, posts ) ) )
+			.catch( () => setPostStatuses( known => mergePostStatuses( known, unknownPostIds, [] ) ) );
+	}, [ restBase, unknownPostIds.join() ] );
 
 	const handleSpecificPostsSelection = postTitles => {
 		setAttributes( {
@@ -145,12 +174,7 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 		return apiFetch( {
 			path: addQueryArgs( '/wp/v2/types', { context: 'edit' } ),
 		} ).then( postTypes => {
-			return Object.values( postTypes )
-				.filter( postType => postType.viewable === true && postType.visibility?.show_ui === true )
-				.map( postType => ( {
-					value: postType.slug,
-					label: decodeEntities( postType.name ) || __( '(no title)', 'newspack-newsletters' ),
-				} ) );
+			return Object.values( postTypes ).filter( postType => postType.viewable === true && postType.visibility?.show_ui === true );
 		} );
 	};
 
@@ -235,7 +259,7 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 					suggestions={ encodePosts( foundPosts ) }
 					displayTransform={ string => {
 						const [ id, title ] = decodePost( string );
-						return title || id || '';
+						return formatPostLabel( title || id || '', postStatuses[ id ] );
 					} }
 					onInputChange={ debounce( handleSpecificPostsInput, 400 ) }
 				/>

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/query-controls.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/query-controls.js
@@ -143,7 +143,10 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 
 	// Statuses for the saved tokens and for the current suggestions alike. A post still being
 	// looked up simply has none yet, and shows as an unlabelled title.
-	const postStatuses = [ ...foundPosts, ...( savedPosts || [] ) ].reduce( ( all, post ) => ( { ...all, [ post.id ]: post.status } ), {} );
+	const postStatuses = [ ...foundPosts, ...( savedPosts || [] ) ].reduce( ( all, post ) => {
+		all[ post.id ] = post.status;
+		return all;
+	}, {} );
 
 	const handleSpecificPostsSelection = postTitles => {
 		setAttributes( {

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/query-controls.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/query-controls.js
@@ -14,18 +14,26 @@ import { Button, QueryControls, FormTokenField, SelectControl, ToggleControl, Sp
 import { addQueryArgs } from '@wordpress/url';
 import { Fragment, useState, useEffect } from '@wordpress/element';
 import apiFetch from '@wordpress/api-fetch';
+import { useSelect } from '@wordpress/data';
 import { decodeEntities } from '@wordpress/html-entities';
 
 /**
  * Internal dependencies
  */
-import { formatPostLabel, getPostSearchPath, getPostStatusPath, mergePostStatuses } from './post-search';
+import { formatPostLabel, getPostSearchPath } from './post-search';
+import { selectSpecificPosts } from './specific-posts';
 
 const fetchPostSuggestions = ( restBase, search ) =>
 	apiFetch( { path: getPostSearchPath( restBase, search ) } )
-		// Core rejects the whole request when the user can't edit this post type. Fall back
-		// to published posts rather than leaving the search empty.
-		.catch( () => apiFetch( { path: getPostSearchPath( restBase, search, false ) } ) )
+		.catch( error => {
+			// Core rejects the whole request when the user can't edit this post type. Fall back
+			// to published posts rather than leaving the search empty. Any other failure — no
+			// network, a broken endpoint — is not worth a second attempt.
+			if ( 'rest_forbidden_status' !== error?.code ) {
+				throw error;
+			}
+			return apiFetch( { path: getPostSearchPath( restBase, search, false ) } );
+		} )
 		.then( posts =>
 			posts.map( post => ( {
 				id: post.id,
@@ -48,13 +56,15 @@ const decodePost = encodedPost => {
 // NOTE: Mostly copied from Gutenberg's Posts Inserter block.
 const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 	const [ categoriesList, setCategoriesList ] = useState( [] );
-	const [ postTypesList, setPostTypesList ] = useState( [ { value: 'post', label: 'Posts' } ] );
-	const [ postTypeRestBases, setPostTypeRestBases ] = useState( { post: 'posts' } );
-	const [ postStatuses, setPostStatuses ] = useState( {} );
+	const [ postTypes, setPostTypes ] = useState( [ { slug: 'post', name: 'Posts', rest_base: 'posts' } ] );
 	const [ showAdvancedFilters, setShowAdvancedFilters ] = useState( false );
 
 	const { categoryExclusions, tags, tagExclusions } = attributes;
-	const restBase = postTypeRestBases[ attributes.postType ];
+	const restBase = postTypes.find( postType => attributes.postType === postType.slug )?.rest_base;
+	const postTypeOptions = postTypes.map( postType => ( {
+		value: postType.slug,
+		label: decodeEntities( postType.name ) || __( '(no title)', 'newspack-newsletters' ),
+	} ) );
 
 	useEffect( () => {
 		apiFetch( {
@@ -62,15 +72,7 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 				per_page: -1,
 			} ),
 		} ).then( setCategoriesList );
-		fetchPostTypes().then( postTypes => {
-			setPostTypesList(
-				postTypes.map( postType => ( {
-					value: postType.slug,
-					label: decodeEntities( postType.name ) || __( '(no title)', 'newspack-newsletters' ),
-				} ) )
-			);
-			setPostTypeRestBases( postTypes.reduce( ( all, postType ) => ( { ...all, [ postType.slug ]: postType.rest_base } ), {} ) );
-		} );
+		fetchPostTypes().then( setPostTypes );
 	}, [] );
 
 	const categorySuggestions = categoriesList.reduce(
@@ -127,22 +129,21 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 		fetchPostSuggestions( restBase, search ).then( posts => {
 			setIsFetchingPosts( false );
 			setFoundPosts( posts );
-			setPostStatuses( known => mergePostStatuses( known, [], posts ) );
 		} );
 	};
 
-	// Look up the status of posts already saved on the block, so a draft that has since
-	// been published stops being labelled as one.
-	const unknownPostIds = attributes.specificPosts.map( post => post.id ).filter( id => undefined === postStatuses[ id ] );
+	// The block already fetches the posts saved on it, so reading their statuses back out of
+	// core-data costs no extra request — and a draft that has since been published stops
+	// being labelled as one.
+	const specificPostIds = attributes.specificPosts.map( post => post.id );
+	const savedPosts = useSelect(
+		select => selectSpecificPosts( select, attributes.postType, specificPostIds ),
+		[ attributes.postType, specificPostIds.join() ]
+	);
 
-	useEffect( () => {
-		if ( ! restBase || 0 === unknownPostIds.length ) {
-			return;
-		}
-		apiFetch( { path: getPostStatusPath( restBase, unknownPostIds ) } )
-			.then( posts => setPostStatuses( known => mergePostStatuses( known, unknownPostIds, posts ) ) )
-			.catch( () => setPostStatuses( known => mergePostStatuses( known, unknownPostIds, [] ) ) );
-	}, [ restBase, unknownPostIds.join() ] );
+	// Statuses for the saved tokens and for the current suggestions alike. A post still being
+	// looked up simply has none yet, and shows as an unlabelled title.
+	const postStatuses = [ ...foundPosts, ...( savedPosts || [] ) ].reduce( ( all, post ) => ( { ...all, [ post.id ]: post.status } ), {} );
 
 	const handleSpecificPostsSelection = postTitles => {
 		setAttributes( {
@@ -173,8 +174,8 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 	const fetchPostTypes = () => {
 		return apiFetch( {
 			path: addQueryArgs( '/wp/v2/types', { context: 'edit' } ),
-		} ).then( postTypes => {
-			return Object.values( postTypes ).filter( postType => postType.viewable === true && postType.visibility?.show_ui === true );
+		} ).then( fetchedPostTypes => {
+			return Object.values( fetchedPostTypes ).filter( postType => postType.viewable === true && postType.visibility?.show_ui === true );
 		} );
 	};
 
@@ -229,7 +230,7 @@ const QueryControlsSettings = ( { attributes, setAttributes } ) => {
 		<div className="newspack-newsletters-query-controls">
 			<SelectControl
 				label={ __( 'Post type', 'newspack-newsletters' ) }
-				options={ postTypesList }
+				options={ postTypeOptions }
 				value={ attributes.postType }
 				onChange={ postType => setAttributes( { postType } ) }
 				__next40pxDefaultSize

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/specific-posts.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/specific-posts.js
@@ -1,0 +1,45 @@
+/**
+ * Internal dependencies
+ */
+import { SEARCHABLE_STATUSES } from './consts';
+
+/**
+ * `getEntityRecords` query for the posts hand-picked on a block.
+ *
+ * @param {number[]} ids Post IDs.
+ * @return {Object} Query args.
+ */
+export const getSpecificPostsQuery = ids => ( { include: ids, status: SEARCHABLE_STATUSES } );
+
+/**
+ * Posts hand-picked on a block, unpublished ones included.
+ *
+ * Core rejects the whole request — every status, not just the unpublished ones — when the
+ * user can't edit the post type being queried, so a rejected lookup is retried with core's
+ * default published-only filter. Posts picked by a more privileged user then drop out of
+ * the list rather than blanking it, which is how the "Add posts" search degrades too.
+ *
+ * The block and its inspector both call this with the same arguments, so core-data serves
+ * them from a single request.
+ *
+ * @param {Function} select   Data registry `select`.
+ * @param {string}   postType Post type slug.
+ * @param {number[]} ids      Post IDs.
+ * @return {?Object[]} Posts, or null/undefined while the lookup is in flight.
+ */
+export const selectSpecificPosts = ( select, postType, ids ) => {
+	// An empty `include` is no filter at all, so core would answer with the whole
+	// collection. Nothing is picked yet, so nothing is what we want.
+	if ( 0 === ids.length ) {
+		return [];
+	}
+
+	const { getEntityRecords, hasResolutionFailed } = select( 'core' );
+	const query = getSpecificPostsQuery( ids );
+
+	if ( hasResolutionFailed( 'getEntityRecords', [ 'postType', postType, query ] ) ) {
+		return getEntityRecords( 'postType', postType, { include: ids } );
+	}
+
+	return getEntityRecords( 'postType', postType, query );
+};

--- a/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/specific-posts.test.js
+++ b/plugins/newspack-newsletters/src/editor/blocks/posts-inserter/specific-posts.test.js
@@ -1,0 +1,79 @@
+import { getSpecificPostsQuery, selectSpecificPosts } from './specific-posts';
+
+/**
+ * Stand-in for the data registry's `select`.
+ *
+ * @param {Object}   options              Options.
+ * @param {boolean}  options.statusesFail Whether core rejected the status-filtered lookup.
+ * @param {Object[]} options.records      Records to return.
+ * @return {Object} The fake `select` plus the queries it was called with.
+ */
+const createSelect = ( { statusesFail = false, records = [] } = {} ) => {
+	const queries = [];
+	const select = () => ( {
+		getEntityRecords: ( kind, name, query ) => {
+			queries.push( query );
+			return records;
+		},
+		hasResolutionFailed: ( selectorName, args ) => statusesFail && 'getEntityRecords' === selectorName && undefined !== args[ 2 ].status,
+	} );
+
+	return { select, queries };
+};
+
+describe( 'selectSpecificPosts', () => {
+	it( 'asks for unpublished posts alongside published ones', () => {
+		const { select, queries } = createSelect();
+
+		selectSpecificPosts( select, 'post', [ 12, 34 ] );
+
+		expect( queries ).toEqual( [ { include: [ 12, 34 ], status: [ 'publish', 'future', 'draft', 'pending' ] } ] );
+	} );
+
+	it( 'asks for nothing when nothing is picked, rather than the whole collection', () => {
+		const { select, queries } = createSelect();
+
+		expect( selectSpecificPosts( select, 'post', [] ) ).toEqual( [] );
+		expect( queries ).toEqual( [] );
+	} );
+
+	it( 'returns the posts it found', () => {
+		const records = [ { id: 12, status: 'draft' } ];
+		const { select } = createSelect( { records } );
+
+		expect( selectSpecificPosts( select, 'post', [ 12 ] ) ).toBe( records );
+	} );
+
+	it( 'falls back to published posts when core rejected the status filter', () => {
+		const { select, queries } = createSelect( { statusesFail: true } );
+
+		selectSpecificPosts( select, 'product', [ 12 ] );
+
+		expect( queries[ queries.length - 1 ] ).toEqual( { include: [ 12 ] } );
+	} );
+
+	it( 'checks the rejection against the post type actually being queried', () => {
+		let checkedArgs;
+		const select = () => ( {
+			getEntityRecords: () => [],
+			hasResolutionFailed: ( selectorName, args ) => {
+				checkedArgs = args;
+				return false;
+			},
+		} );
+
+		selectSpecificPosts( select, 'product', [ 12 ] );
+
+		expect( checkedArgs ).toEqual( [ 'postType', 'product', getSpecificPostsQuery( [ 12 ] ) ] );
+	} );
+} );
+
+describe( 'getSpecificPostsQuery', () => {
+	it( 'never asks for private posts', () => {
+		expect( getSpecificPostsQuery( [ 12 ] ).status ).not.toContain( 'private' );
+	} );
+
+	it( 'requests full records, so the inspector can reuse the same cached request', () => {
+		expect( getSpecificPostsQuery( [ 12 ] ) ).not.toHaveProperty( '_fields' );
+	} );
+} );


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

<!-- Describe the changes made to this Pull Request, and the reason for such changes. -->

Closes NPMIG-2996.

As advertised, this PR adds the ability to search for and select draft/scheduled/pending posts in the Posts Inserter block when using the "Display specific posts" toggle.

It does **not** include draft/scheduled/pending posts in the latests posts mode of the block. That seems like it would have a lot of edge cases, it would make it difficult to do an accurate preview (unless you know when the newsletter will send, you don't know which scheduled posts will actually be live), and it would probably lead to a number of accidental newsletter sends with unpublished stories.

### How to test the changes in this Pull Request:

1. Add a Posts Inserter block in a newsletter. The auto-populating Latest X stories mode should only contain published stories.
2. Toggle on "Display specific posts" on the block. Search for a draft post and/or a scheduled post. Observe they show up in results and have a helpful label about their status:

<img width="317" height="200" alt="Screenshot 2026-08-11 at 3 00 22 PM" src="https://github.com/user-attachments/assets/528eb81a-ef98-441f-a616-d7b7f4e6a313" />

4. Select the post. It should insert and preview nicely in the block:

<img width="709" height="562" alt="Screenshot 2026-08-11 at 3 00 38 PM" src="https://github.com/user-attachments/assets/38cdfbd3-372e-4526-b88f-0ec87a68c7e9" />

6. Send a test email. It should include the draft/scheduled posts. If you click through a story, it should have a URL of the type `?p=181` which resolves nicely for staff when the story is unpublished and for readers if the story is published:

<img width="649" height="506" alt="Screenshot 2026-08-11 at 3 02 19 PM" src="https://github.com/user-attachments/assets/9f70fe4c-0474-47a0-926b-590e3fec569f" />

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
