### PR TITLE
feat(reader-activation): inbound form capture integration (cherry-pick of #684)

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
+++ b/plugins/newspack-plugin/includes/plugins/woocommerce/my-account/class-woocommerce-my-account.php
@@ -734,10 +734,7 @@ class WooCommerce_My_Account {
 		}
 
 		// If the reader has intentionally saved a display name we consider generic, mark it as such.
-		if (
-			Reader_Activation::generate_user_nicename( $email ) === $display_name || // New generated construction (URL-sanitized version of the email address minus domain).
-			Reader_Activation::strip_email_domain( $email ) === $display_name // Legacy generated construction (just the email address minus domain).
-		) {
+		if ( Reader_Activation::is_display_name_derived_from_email( $display_name, $email ) ) {
 			\update_user_meta( $user_id, Reader_Activation::READER_SAVED_GENERIC_DISPLAY_NAME, 1 );
 		}
 	}

--- a/plugins/newspack-plugin/includes/reader-activation/class-comment-display-name.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-comment-display-name.php
@@ -68,10 +68,7 @@ final class Comment_Display_Name {
 
 		$user  = \wp_get_current_user();
 		$email = $user->user_email;
-		if (
-			Reader_Activation::generate_user_nicename( $email ) === $display_name ||
-			Reader_Activation::strip_email_domain( $email ) === $display_name
-		) {
+		if ( Reader_Activation::is_display_name_derived_from_email( $display_name, $email ) ) {
 			\wp_die(
 				esc_html__( 'Please choose a display name that is not derived from your email address.', 'newspack-plugin' ),
 				esc_html__( 'Comment Submission Failure', 'newspack-plugin' ),

--- a/plugins/newspack-plugin/includes/reader-activation/class-integrations.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-integrations.php
@@ -87,6 +87,7 @@ class Integrations {
 		require_once __DIR__ . '/integrations/class-integration.php';
 		require_once __DIR__ . '/integrations/class-contact-pull.php';
 		require_once __DIR__ . '/integrations/class-contact-cron.php';
+		require_once __DIR__ . '/integrations/class-form-capture.php';
 
 		add_action( 'init', [ __CLASS__, 'register_integrations' ], 5 );
 		add_action( 'init', [ __CLASS__, 'register_my_account_endpoints' ], 6 );
@@ -279,6 +280,7 @@ class Integrations {
 	public static function register_integrations() {
 		// Native integrations.
 		self::register( new Integrations\ESP() );
+		self::register( new Integrations\Form_Capture() );
 
 		// Hook for other plugins/code to register their integrations.
 		do_action( 'newspack_reader_activation_register_integrations' );
@@ -344,6 +346,11 @@ class Integrations {
 		}
 
 		$enabled[] = $integration_id;
+
+		// Put the registration key seed in place before any page can emit the
+		// key, so the write stays off the render path. Integrations enabled
+		// before this existed fall back to seeding on first read.
+		self::$integrations[ $integration_id ]->ensure_registration_key_seed();
 
 		return update_option( self::OPTION_NAME, $enabled );
 	}

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-activation.php
@@ -2581,9 +2581,17 @@ final class Reader_Activation {
 			}
 
 			// Don't send OTP email for newsletter signup, or if the reader has a password set.
-			if ( self::is_reader_without_password( $existing_user ) &&
-				( ! isset( $metadata['registration_method'] ) || false === strpos( $metadata['registration_method'], 'newsletters-subscription' ) )
-			) {
+			$should_send_magic_link = self::is_reader_without_password( $existing_user ) &&
+				( ! isset( $metadata['registration_method'] ) || false === strpos( $metadata['registration_method'], 'newsletters-subscription' ) );
+			/**
+			 * Filters whether to send a magic link to an existing reader attempting to register again.
+			 *
+			 * @param bool     $should_send_magic_link Whether to send the magic link email.
+			 * @param \WP_User $existing_user          The existing reader account.
+			 * @param array    $metadata               Registration metadata.
+			 */
+			$should_send_magic_link = \apply_filters( 'newspack_reader_activation_send_magic_link_on_reregistration', $should_send_magic_link, $existing_user, $metadata );
+			if ( $should_send_magic_link ) {
 				Logger::log( "User with $email already exists. Sending magic link." );
 				$redirect = isset( $metadata['current_page_url'] ) ? $metadata['current_page_url'] : '';
 				Magic_Link::send_email( $existing_user, $redirect );
@@ -2864,15 +2872,31 @@ final class Reader_Activation {
 			return true;
 		}
 
-		// If we generated the display name from the user's email address, treat it as generic.
-		if (
-			self::generate_user_nicename( $user->data->user_email ) === $user->data->display_name || // New generated construction (URL-sanitized version of the email address minus domain).
-			self::strip_email_domain( $user->data->user_email ) === $user->data->display_name // Legacy generated construction (just the email address minus domain).
-		) {
-			return true;
-		}
+		return self::is_display_name_derived_from_email( $user->data->display_name, $user->data->user_email );
+	}
 
-		return false;
+	/**
+	 * Whether a display name is one this plugin would have generated from an email address.
+	 *
+	 * The comparison alone, with none of the "should we treat it as generic?"
+	 * short-circuits: callers apply the ones their question needs.
+	 * reader_has_generic_display_name() adds the opt-out constant and the
+	 * reader's own saved-name meta; a caller deciding what to put on the wire
+	 * wants the meta but not the constant.
+	 *
+	 * @param string $display_name Display name to check.
+	 * @param string $email        Email address to compare against.
+	 *
+	 * @return bool True if the display name matches either generated construction.
+	 */
+	public static function is_display_name_derived_from_email( string $display_name, string $email ): bool {
+		// '' rather than empty(): a reader at 0@example.com whose display name
+		// is "0" is derived, and empty() would call it not-derived.
+		if ( '' === $display_name || '' === $email ) {
+			return false;
+		}
+		return self::generate_user_nicename( $email ) === $display_name // Current construction (URL-sanitized version of the email address minus domain).
+			|| self::strip_email_domain( $email ) === $display_name;   // Legacy construction (just the email address minus domain).
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/reader-activation/class-reader-registration.php
+++ b/plugins/newspack-plugin/includes/reader-activation/class-reader-registration.php
@@ -283,17 +283,42 @@ final class Reader_Registration {
 	}
 
 	/**
+	 * Get the rate-limit bucket name for an Integration-backed frontend registration.
+	 *
+	 * Each integration's registration traffic is counted in its own per-IP bucket,
+	 * so a high-traffic capture integration can neither starve nor be starved by
+	 * another integration's registrations. Integrations that size their own limit
+	 * via the `newspack_frontend_registration_rate_limit` filter must compare
+	 * against this same derivation.
+	 *
+	 * sanitize_key() preserves both dashes and underscores, so integrations whose
+	 * IDs differ only by separator get distinct buckets rather than silently
+	 * sharing a counter.
+	 *
+	 * @param string $integration_id Integration identifier.
+	 *
+	 * @return string Bucket name.
+	 */
+	public static function get_rate_limit_bucket_for( string $integration_id ): string {
+		return 'registration_' . \sanitize_key( $integration_id );
+	}
+
+	/**
 	 * Check and increment a per-IP rate-limit bucket for frontend registration traffic.
 	 *
-	 * Each bucket has its own per-IP counter at 10/hour. The /register endpoint and
-	 * the /check-email preflight use separate buckets so that:
+	 * Each bucket has its own per-IP counter at 10/hour by default. The /register
+	 * endpoint and the /check-email preflight use separate buckets so that:
 	 *   - A legitimate user submission (one preflight + one register) still buys 10
 	 *     full registrations per hour — neither endpoint can double-charge the other.
 	 *   - An attacker probing /check-email for email enumeration is rate-limited at
 	 *     10 requests/hour regardless of registration traffic, and vice versa.
+	 * Integration-backed registrations use a per-integration bucket (see
+	 * get_rate_limit_bucket_for()) so each integration's traffic is independently
+	 * bounded and can be sized via the filter below.
 	 *
-	 * @param string $bucket Bucket key. 'registration' for /register (default, preserves
-	 *                       the existing cache key), 'check_email' for the preflight.
+	 * @param string $bucket Bucket key. 'registration' for filter-only /register
+	 *                       traffic (preserves the existing cache key), 'check_email'
+	 *                       for the preflight, or a per-integration bucket.
 	 *
 	 * @return bool|\WP_Error True if under limit, WP_Error if exceeded.
 	 */
@@ -306,17 +331,35 @@ final class Reader_Registration {
 
 		// Bucket → cache-key prefix. Keep 'newspack_reg_ip_' for registration so any
 		// in-flight counters from prior releases continue to apply.
-		$prefix    = 'check_email' === $bucket ? 'newspack_check_email_ip_' : 'newspack_reg_ip_';
+		if ( 'registration' === $bucket ) {
+			$prefix = 'newspack_reg_ip_';
+		} elseif ( 'check_email' === $bucket ) {
+			$prefix = 'newspack_check_email_ip_';
+		} else {
+			$prefix = 'newspack_' . $bucket . '_ip_';
+		}
 		$cache_key = $prefix . md5( $ip );
 
 		/**
 		 * Filters the maximum number of frontend registration attempts per IP per hour.
 		 *
-		 * Applies independently to each bucket: 10/hr for /register, 10/hr for /check-email.
+		 * Applies independently to each bucket, all defaulting to 10/hr:
+		 *   - 'registration'      — /register traffic from filter-only integrations.
+		 *   - 'check_email'       — the /check-email preflight.
+		 *   - 'registration_<id>' — one per Integration-backed registration source,
+		 *                           derived by get_rate_limit_bucket_for(). Scope a
+		 *                           callback by comparing against that helper rather
+		 *                           than rebuilding the string.
+		 *
+		 * Built-in integrations size their own bucket from this filter at priority 5,
+		 * so a callback at the default priority sees the integration's limit, not 10 —
+		 * a callback that transforms the incoming value (`return $limit * 2;`) rather
+		 * than replacing it compounds off that. Form Capture, for instance, has
+		 * already raised its bucket to 100 by the time a default-priority callback runs.
 		 *
 		 * @param int    $limit  Maximum attempts. Default 10.
 		 * @param string $ip     The client IP address.
-		 * @param string $bucket Bucket name ('registration' or 'check_email').
+		 * @param string $bucket Bucket name (see above).
 		 */
 		$limit = \apply_filters( 'newspack_frontend_registration_rate_limit', 10, $ip, $bucket );
 
@@ -332,6 +375,23 @@ final class Reader_Registration {
 
 		if ( $attempts > $limit ) {
 			Logger::log( sprintf( 'Frontend registration rate limit exceeded for IP %1$s (bucket: %2$s)', $ip, $bucket ) );
+			// Remote-log once per crossing, not once per rejected request — an IP
+			// hammering the endpoint must not amplify into remote log traffic. A
+			// visitor-triggered condition, so 'debug' (logstash only), not 'error'.
+			// The hashed IP matches the bucket key and lets a burst be correlated
+			// without putting the raw client IP into the off-site log stream.
+			if ( $attempts === $limit + 1 ) {
+				Logger::newspack_log(
+					'newspack_frontend_registration_rate_limited',
+					'Frontend registration rate limit exceeded.',
+					[
+						'ip_hash'  => md5( $ip ),
+						'bucket'   => $bucket,
+						'attempts' => $attempts,
+					],
+					'debug'
+				);
+			}
 			return new \WP_Error(
 				'rate_limit_exceeded',
 				__( 'Too many registration attempts. Please try again later.', 'newspack-plugin' ),
@@ -340,6 +400,20 @@ final class Reader_Registration {
 		}
 
 		return true;
+	}
+
+	/**
+	 * Get the registration method string stamped on registrations from a
+	 * frontend integration. Integrations scope their behavior (metadata
+	 * filters, magic link suppression, sync decisions) by comparing against
+	 * this exact format, so both sides must derive it from this helper.
+	 *
+	 * @param string $integration_id The integration ID.
+	 *
+	 * @return string The registration method string.
+	 */
+	public static function get_registration_method_for( $integration_id ) {
+		return 'integration-registration-' . $integration_id;
 	}
 
 	/**
@@ -446,7 +520,13 @@ final class Reader_Registration {
 
 		// Step 6: Per-IP rate limit. Checked before reCAPTCHA to avoid
 		// triggering external verification calls for rate-limited IPs.
-		$rate_check = self::check_registration_rate_limit();
+		// Integration-backed registrations count in a per-integration bucket
+		// (sized via the newspack_frontend_registration_rate_limit filter);
+		// filter-only registrations keep the shared 'registration' bucket.
+		$bucket     = $integration_instance && $integration_instance->supports_frontend_registration()
+			? self::get_rate_limit_bucket_for( $integration_id )
+			: 'registration';
+		$rate_check = self::check_registration_rate_limit( $bucket );
 		if ( \is_wp_error( $rate_check ) ) {
 			return $rate_check;
 		}
@@ -461,6 +541,9 @@ final class Reader_Registration {
 			$captcha_result                = Recaptcha::verify_captcha();
 			unset( $_POST['g-recaptcha-response'] );
 			if ( \is_wp_error( $captcha_result ) ) {
+				// No log here: Recaptcha::verify_captcha() already remote-logs both
+				// its transport-error and rejection paths, and this path is driven
+				// by unauthenticated callers — a second entry would double volume.
 				return new \WP_Error(
 					'recaptcha_failed',
 					$captcha_result->get_error_message(),
@@ -472,6 +555,14 @@ final class Reader_Registration {
 		// Step 8: Validate email.
 		$email = $request->get_param( 'npe' );
 		if ( empty( $email ) ) {
+			// Visitor-triggered client condition (bots, malformed submissions) —
+			// routine once capture is live, so 'debug' (logstash only), not 'error'.
+			Logger::newspack_log(
+				'newspack_frontend_registration_invalid_email',
+				'Frontend registration rejected: missing or invalid email.',
+				[ 'integration_id' => $integration_id ],
+				'debug'
+			);
 			return new \WP_Error(
 				'invalid_email',
 				__( 'A valid email address is required.', 'newspack-plugin' ),
@@ -489,7 +580,7 @@ final class Reader_Registration {
 		$referer          = is_array( $referer ) ? $referer : [];
 		$current_page_url = ! empty( $referer['path'] ) ? \esc_url( \home_url( $referer['path'] ) ) : '';
 		$metadata         = [
-			'registration_method' => 'integration-registration-' . $integration_id,
+			'registration_method' => self::get_registration_method_for( $integration_id ),
 			'current_page_url'    => $current_page_url,
 		];
 
@@ -508,6 +599,15 @@ final class Reader_Registration {
 				);
 			}
 
+			Logger::newspack_log(
+				'newspack_frontend_registration_failed',
+				'Frontend registration failed in register_reader().',
+				[
+					'integration_id' => $integration_id,
+					'error'          => $result->get_error_message(),
+				],
+				'error'
+			);
 			return new \WP_Error(
 				'registration_failed',
 				$result->get_error_message(),

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/README.md
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/README.md
@@ -36,6 +36,15 @@ The registry class is `Newspack\Reader_Activation\Integrations` (parent namespac
 
 Syncs contacts and metadata fields with the active Newspack Newsletters service provider. Auto-registers and is enabled by default on new installs (and on legacy upgrades unless the legacy `newspack_reader_activation_sync_esp` option was explicitly disabled). Pulls custom merge fields back into Newspack for segmentation and access rules.
 
+### `form-capture`
+
+Registers readers from publisher-designated frontend forms built with any form tool (opt-in via the `newspack-form-capture` CSS class or configured selectors). Registered but disabled by default. It is the first capture-only built-in — neither a sync destination nor a pull source — which makes it the working reference for two patterns:
+
+- **Capability declarations over failing gates.** `supports_push()`/`supports_pull()` return `false` (no dead outbound/inbound controls, no bearing on `has_one_syncable_integration()`), while `can_sync()` succeeds — capture-only is a declared capability, not an error state.
+- **One switch for the frontend registration surface.** `supports_frontend_registration()` returns the integration's *enabled* state **and** its `get_unsupported_reason()` being null, so the page-emitted key, the endpoint acceptance, and the capture script share a single off switch — one that also closes when the site's configuration changes after enabling.
+
+It reports itself unsupported on reCAPTCHA v2, which cannot be pre-acquired for a page-navigating form submit, and sizes its own registration rate-limit bucket via the `newspack_frontend_registration_rate_limit` filter.
+
 ---
 
 ## Registering an Integration
@@ -129,9 +138,9 @@ class My_Integration extends Integration {
 | `pull_contact_data( $user_id )` | Fetch contact data from the external system. Return `array` of `field_key => value` or `WP_Error`. Defaults to `[]`. |
 | `get_available_incoming_fields()` | Return an array of `Incoming_Field` objects representing the schema available to pull. Required for any integration that supports pulling. |
 | `configure_incoming_field( $field )` | Enrich an `Incoming_Field` with display metadata and promotion flags (access rule / segment criteria). Called by the framework on every constructed field. |
-| `register_handlers()` | Register data event handlers (see [Data Event Handlers](#data-event-handlers)). Called once after all integrations have been registered. |
-| `supports_frontend_registration()` | Return `true` to expose this integration's registration key to the page and accept it on the frontend registration endpoint. |
-| `get_registration_key()` / `validate_registration_request()` | Override to implement custom registration key schemes. Default is timing-safe HMAC-SHA256 of the integration ID with the site's auth salt. |
+| `register_handlers()` | Register data event handlers (see [Data Event Handlers](#data-event-handlers)) and any WordPress hooks the integration needs. Called once per *accepted* instance after all integrations have been registered — hook here, not in the constructor, so a rejected duplicate registration never leaves live callbacks behind. |
+| `supports_frontend_registration()` | Return `true` to expose this integration's registration key to the page and accept it on the frontend registration endpoint. Built-ins gate this on the enabled state so key, endpoint and script share one switch. |
+| `get_registration_key()` / `validate_registration_request()` | Override to implement custom registration key schemes. Default is timing-safe HMAC-SHA256 of the integration ID and a stored per-integration seed with the site's auth salt; `rotate_registration_key()` regenerates the seed, revoking the key without touching `AUTH_SALT`. |
 | `handle_logged_in_user_registration( $user, $request )` | Called when a logged-in user attempts to register again via the frontend. Use to update user data, link the account, record a new event, etc. Default is a no-op. |
 | `get_my_account_menu_item()` | Return `[ 'slug' => ..., 'label' => ..., 'position' => ... ]` to add a tab to the WooCommerce My Account page. Default returns `null` (no tab). |
 | `render_my_account_page( $value )` | Echo markup for the integration's My Account page. Called inside the WooCommerce account template. |
@@ -504,8 +513,12 @@ Endpoints are only registered for integrations that are currently enabled.
 
 To allow an integration to drive frontend reader registration (e.g. a third-party signup form posting to Newspack):
 
-1. Override `supports_frontend_registration()` to return `true`. The framework will output the integration's registration key on the page and accept it on the registration endpoint.
-2. Optionally override `get_registration_key()` and `validate_registration_request()` to implement a custom key scheme (asymmetric keys, time-bounded tokens, etc.). The default is HMAC-SHA256 of the integration ID with the site's auth salt, compared in constant time.
+1. Override `supports_frontend_registration()` to return `true`. The framework will output the integration's registration key on the page and accept it on the registration endpoint. Prefer returning the integration's *enabled* state, plus any runtime prerequisite the integration has (as the built-in `form-capture` does, which also refuses when the site is on reCAPTCHA v2), so the key, the endpoint and any frontend script share a single off switch. Checking a prerequisite only when the integration is enabled leaves a site that changes the prerequisite afterwards emitting a key nothing can use.
+2. Optionally override `get_registration_key()` and `validate_registration_request()` to implement a custom key scheme (asymmetric keys, time-bounded tokens, etc.). The default is HMAC-SHA256 of the integration ID and a stored per-integration seed with the site's auth salt, compared in constant time; `rotate_registration_key()` regenerates the seed to revoke a key that is being abused (PHP-only — gate any admin surface for it on a capability check and a nonce). The pre-seed key is also accepted for one release, so pages cached before the upgrade keep validating until their TTL expires.
 3. Optionally override `handle_logged_in_user_registration( $user, $request )` to react when an already-logged-in reader submits a registration request — record a new donation, link an account, fire an analytics event, etc.
 
+Each integration's registration traffic is rate-limited per IP in its own bucket (see `Reader_Registration::get_rate_limit_bucket_for()`); integrations expecting more than the default 10/hour should size their bucket via the `newspack_frontend_registration_rate_limit` filter, as `form-capture` does.
+
 The built-in JS client (`newspackReaderActivation.register()`) always sends the value returned by `get_registration_key()`. Custom key schemes that diverge from this default need their own client-side code to compute and submit the key.
+
+The built-in `form-capture` integration ([class-form-capture.php](class-form-capture.php) and `src/reader-activation-form-capture/`) is the reference implementation of this section end to end: enabled-gated key emission, a capture script driving `register()`, magic-link suppression for repeat captures, and existing-reader sync scheduling.

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-form-capture.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-form-capture.php
@@ -1,0 +1,424 @@
+<?php
+/**
+ * Inbound Form Capture integration.
+ *
+ * Captures email submissions from publisher-designated frontend forms (built
+ * with any form tool) and registers them as readers via the frontend
+ * registration endpoint. Capture-only: neither a sync destination nor a
+ * pull source (see supports_push()/supports_pull()).
+ *
+ * Capture semantics publishers must understand before opting a form in:
+ * - Capture fires on the browser's submit event (native validity checked)
+ *   and is decoupled from the form tool's own validation and outcome — a
+ *   submission the vendor's JS or server later rejects may still have
+ *   registered the reader.
+ * - Programmatic HTMLFormElement.submit() dispatches no submit event and
+ *   is not captured.
+ * - Forms that collect somebody else's email address (e.g. "email a
+ *   friend") must never be opted in.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack\Reader_Activation\Integrations;
+
+use Newspack\Newspack;
+use Newspack\Reader_Activation;
+use Newspack\Reader_Registration;
+use Newspack\Reader_Activation\Integration;
+use Newspack\Reader_Activation\Integrations;
+use Newspack\Recaptcha;
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Inbound Form Capture integration class.
+ */
+class Form_Capture extends Integration {
+	/**
+	 * The integration ID.
+	 */
+	const ID = 'form-capture';
+
+	/**
+	 * CSS class that always opts a form into capture.
+	 */
+	const MARKER_CLASS = 'newspack-form-capture';
+
+	/**
+	 * Handle for the frontend capture script.
+	 */
+	const SCRIPT_HANDLE = 'newspack-form-capture';
+
+	/**
+	 * Default per-IP hourly limit for this integration's rate-limit bucket.
+	 * Sized for form traffic rather than explicit signup forms: capture fires
+	 * on every opted-in submission across the site, and on hosts where
+	 * REMOTE_ADDR is a proxy IP the bucket is effectively site-wide.
+	 */
+	const RATE_LIMIT_DEFAULT = 100;
+
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct(
+			self::ID,
+			__( 'Inbound Form Capture', 'newspack-plugin' ),
+			__( 'Register readers from email signup forms built with any form tool.', 'newspack-plugin' )
+		);
+	}
+
+	/**
+	 * Register hooks. Called once per accepted instance by the registry, so a
+	 * rejected duplicate registration never leaves live callbacks behind (which
+	 * hooking from the constructor would).
+	 */
+	public function register_handlers() {
+		\add_filter( 'newspack_reader_activation_send_magic_link_on_reregistration', [ $this, 'filter_send_magic_link' ], 10, 3 );
+		\add_action( 'newspack_registered_reader', [ $this, 'handle_registered_reader' ], 10, 5 );
+		\add_action( 'wp_enqueue_scripts', [ $this, 'enqueue_scripts' ], 20 );
+		// Priority 5 so a publisher's own filter at default priority wins.
+		\add_filter( 'newspack_frontend_registration_rate_limit', [ $this, 'filter_rate_limit' ], 5, 3 );
+	}
+
+	/**
+	 * The registration method string the frontend registration endpoint
+	 * stamps on registrations from this integration. Derived from the same
+	 * helper the endpoint uses, so the scoping predicates in this class
+	 * cannot drift from what register_reader() actually receives.
+	 *
+	 * @return string
+	 */
+	public static function get_registration_method() {
+		return Reader_Registration::get_registration_method_for( self::ID );
+	}
+
+	/**
+	 * Register settings fields.
+	 *
+	 * @return array Array of settings field declarations.
+	 */
+	public function register_settings_fields() {
+		return [
+			[
+				'key'         => 'selectors',
+				'type'        => 'textarea',
+				'label'       => __( 'Form selectors', 'newspack-plugin' ),
+				'description' => __( 'CSS selectors (one per line) of forms to capture, in addition to any form with the newspack-form-capture class. Bare tag selectors (e.g. "form") are ignored — they would opt in every form on the site. Only opt in forms whose submissions should always create a reader account: capture runs even if the form tool itself later rejects the submission, so submissions its spam checks would discard still create readers and count toward your ESP contacts. Captures are rate-limited per visitor IP (100/hour by default).', 'newspack-plugin' ),
+				'default'     => '',
+			],
+		];
+	}
+
+	/**
+	 * Why capture cannot operate with the site's current reCAPTCHA configuration.
+	 *
+	 * The v2 flow renders an interactive widget and awaits a callback the page
+	 * never delivers on a navigating form submit, so capture would silently
+	 * produce nothing. Only v3, whose token can be pre-acquired, is compatible.
+	 *
+	 * @return string|null Reason string when reCAPTCHA v2 is active, null otherwise.
+	 */
+	public function get_unsupported_reason() {
+		if ( Recaptcha::can_use_captcha() && ! Recaptcha::can_use_captcha( 'v3' ) ) {
+			return __( 'Requires reCAPTCHA v3', 'newspack-plugin' );
+		}
+		return null;
+	}
+
+	/**
+	 * The remedy for the v2 conflict: switch the reCAPTCHA version.
+	 *
+	 * @return string The action label.
+	 */
+	public function get_unsupported_action_label() {
+		return __( 'Change reCAPTCHA version', 'newspack-plugin' );
+	}
+
+	/**
+	 * Get the URL where reCAPTCHA is configured.
+	 *
+	 * @return string The Newspack settings page URL.
+	 */
+	public function get_setup_url() {
+		return \admin_url( 'admin.php?page=newspack-settings' );
+	}
+
+	/**
+	 * Size this integration's rate-limit bucket for form traffic. Hooked at
+	 * priority 5 so a publisher's own filter at default priority wins.
+	 *
+	 * @param int    $limit  Maximum attempts per IP per hour.
+	 * @param string $ip     The client IP address.
+	 * @param string $bucket Bucket name.
+	 *
+	 * @return int The limit.
+	 */
+	public function filter_rate_limit( $limit, $ip, $bucket ) {
+		if ( Reader_Registration::get_rate_limit_bucket_for( self::ID ) === $bucket ) {
+			return self::RATE_LIMIT_DEFAULT;
+		}
+		return $limit;
+	}
+
+	/**
+	 * Whether contacts can be synced. There are no prerequisites to gate, so
+	 * this never errors — the capture-only intent is expressed by
+	 * supports_push()/supports_pull(), not by failing this gate.
+	 *
+	 * @param bool $return_errors Optional. Whether to return a WP_Error object. Default false.
+	 *
+	 * @return bool|\WP_Error True, or an empty WP_Error when $return_errors is true.
+	 */
+	public function can_sync( $return_errors = false ) {
+		$errors = new \WP_Error();
+		if ( $return_errors ) {
+			return $errors;
+		}
+		return true;
+	}
+
+	/**
+	 * Push contact data. Deliberate no-op, kept only because the base class
+	 * declares the method abstract; supports_push() declares the capability
+	 * off.
+	 *
+	 * @param array      $contact          The contact data to push.
+	 * @param string     $context          Optional. The context of the sync.
+	 * @param array|null $existing_contact Optional. Existing contact data if available.
+	 *
+	 * @return true
+	 */
+	public function push_contact_data( $contact, $context = '', $existing_contact = null ) {
+		return true;
+	}
+
+	/**
+	 * Whether this integration can push (outbound) contact data to an
+	 * external destination. Form capture has none — push_contact_data() is a
+	 * deliberate no-op — so declare no push capability: no outbound sync
+	 * settings, no push dispatch, and no bearing on "has one syncable
+	 * integration".
+	 *
+	 * @return bool True if the integration can push contact data.
+	 */
+	public function supports_push(): bool {
+		return false;
+	}
+
+	/**
+	 * Whether this integration can pull (inbound) contact data from an
+	 * external source. Capture registers readers from on-site form
+	 * submissions — there is no external source to pull from, and
+	 * pull_contact_data()/get_available_incoming_fields() are not
+	 * implemented.
+	 *
+	 * @return bool True if the integration can pull contact data.
+	 */
+	public function supports_pull(): bool {
+		return false;
+	}
+
+	/**
+	 * Frontend registration is available while the integration is enabled and
+	 * the site's configuration supports capture. This gates the registration
+	 * endpoint, the page-emitted key, and the capture script together.
+	 *
+	 * The unsupported check runs here, not only at enable time: a site that
+	 * switches to reCAPTCHA v2 after enabling would otherwise keep emitting a
+	 * key that capture can never use, and go on capturing nothing silently.
+	 *
+	 * @return bool
+	 */
+	public function supports_frontend_registration(): bool {
+		return Integrations::is_enabled( self::ID ) && ! $this->get_unsupported_reason();
+	}
+
+	/**
+	 * Get the configured form selectors, always including the marker class.
+	 *
+	 * Selectors that name only element types (`form`, `body form`, `div > form`)
+	 * or the universal selector opt in every form on the page — comment forms,
+	 * search, checkout — which is never what a per-form opt-in means. A line
+	 * carrying one is dropped whole, including inside a comma-separated list,
+	 * since `form, #signup` matches everything `form` does. Applied at read
+	 * time so previously stored values are covered too.
+	 *
+	 * @return string[] CSS selectors.
+	 */
+	public function get_selectors() {
+		$value     = (string) $this->get_settings_field_value( 'selectors' );
+		$lines     = array_map( 'trim', preg_split( '/[\r\n]+/', $value ) );
+		$selectors = array_filter( array_map( [ __CLASS__, 'normalize_selector' ], $lines ) );
+		return array_values( array_unique( array_merge( [ '.' . self::MARKER_CLASS ], $selectors ) ) );
+	}
+
+	/**
+	 * Reduce one configured line to the selector the client should run, or ''
+	 * to drop it.
+	 *
+	 * Rebuilds the line from its non-empty parts rather than passing it through:
+	 * a trailing comma is a plausible copy-paste from a CSS rule, and an empty
+	 * slot makes the whole list invalid CSS — `querySelectorAll( '#signup,' )`
+	 * throws, so the client discards it and one stray comma takes every
+	 * selector on the line with it.
+	 *
+	 * @param string $line A configured line, possibly a comma-separated list.
+	 *
+	 * @return string The normalized selector, or '' when the line is rejected.
+	 */
+	private static function normalize_selector( string $line ): string {
+		$parts = [];
+		foreach ( explode( ',', $line ) as $part ) {
+			$part = trim( $part );
+			if ( '' === $part ) {
+				continue;
+			}
+			if ( self::is_over_broad_selector( $part ) ) {
+				return '';
+			}
+			$parts[] = $part;
+		}
+		return implode( ', ', $parts );
+	}
+
+	/**
+	 * Whether a single selector names nothing more specific than element types.
+	 *
+	 * Splits on combinators and checks every compound: a selector built only
+	 * from tag names and `*` matches every form on the page whatever its depth,
+	 * so `body form` and `div > form` are as broad as `form`. One class, id or
+	 * attribute anywhere in the selector makes it specific enough to keep.
+	 *
+	 * Attribute selectors are kept: `[method]` is as broad as `form`, but
+	 * `[data-newsletter-form]` is a precise opt-in and structurally identical,
+	 * so the distinction is semantic rather than something the guard can read.
+	 *
+	 * @param string $selector A single CSS selector (no commas).
+	 *
+	 * @return bool Whether the selector is too broad to opt a form in.
+	 */
+	private static function is_over_broad_selector( string $selector ): bool {
+		$compounds = preg_split( '/[\s>+~]+/', trim( $selector ), -1, PREG_SPLIT_NO_EMPTY );
+		if ( empty( $compounds ) ) {
+			return true;
+		}
+		foreach ( $compounds as $compound ) {
+			if ( '*' !== $compound && ! preg_match( '/^[a-z][a-z0-9-]*$/i', $compound ) ) {
+				return false;
+			}
+		}
+		return true;
+	}
+
+	/**
+	 * Enqueue the frontend capture script when the integration is active.
+	 */
+	public function enqueue_scripts() {
+		if ( ! Reader_Activation::is_enabled() || ! $this->supports_frontend_registration() ) {
+			return;
+		}
+		\wp_enqueue_script(
+			self::SCRIPT_HANDLE,
+			Newspack::plugin_url() . '/dist/form-capture.js',
+			[ Reader_Activation::SCRIPT_HANDLE ],
+			Newspack::asset_version( 'form-capture' ),
+			[
+				'strategy'  => 'defer',
+				'in_footer' => true,
+			]
+		);
+		\wp_localize_script(
+			self::SCRIPT_HANDLE,
+			'newspack_form_capture',
+			[
+				'selectors' => $this->get_selectors(),
+			]
+		);
+		\wp_script_add_data( self::SCRIPT_HANDLE, 'defer', true );
+		\wp_script_add_data( self::SCRIPT_HANDLE, 'amp-plus', true );
+	}
+
+	/**
+	 * Whether registration metadata originates from this integration's
+	 * frontend registration flow. Checks the enabled state so the behaviors
+	 * scoped by this predicate (magic-link suppression, existing-reader sync)
+	 * stay off when the integration is off, even if something else stamps the
+	 * method string (a replayed job, a CLI backfill).
+	 *
+	 * @param array $metadata Registration metadata.
+	 *
+	 * @return bool Whether the registration is a form capture.
+	 */
+	private function is_capture_registration( $metadata ) {
+		return Integrations::is_enabled( self::ID ) && ( $metadata['registration_method'] ?? '' ) === self::get_registration_method();
+	}
+
+	/**
+	 * Suppress the magic link email for repeat capture submissions — capture
+	 * is invisible, so an existing reader re-submitting an opted-in form must
+	 * not be emailed a login link every time.
+	 *
+	 * @param bool     $should_send   Whether the magic link would be sent.
+	 * @param \WP_User $existing_user The existing reader account.
+	 * @param array    $metadata      Registration metadata.
+	 *
+	 * @return bool Whether to send the magic link.
+	 */
+	public function filter_send_magic_link( $should_send, $existing_user, $metadata ) {
+		if ( $this->is_capture_registration( $metadata ) ) {
+			return false;
+		}
+		return $should_send;
+	}
+
+	/**
+	 * Whether a capture of an existing reader should trigger an explicit
+	 * contact sync. The reader_registered data event skips existing users,
+	 * so an explicit sync is the only way a repeat capture reaches the
+	 * contact record.
+	 *
+	 * @param false|\WP_User $existing_user The existing user object, if any.
+	 * @param array          $metadata      Registration metadata.
+	 *
+	 * @return bool Whether to sync the contact.
+	 */
+	public function should_sync_existing_reader( $existing_user, $metadata ) {
+		if ( ! $this->is_capture_registration( $metadata ) ) {
+			return false;
+		}
+		if ( ! $existing_user ) {
+			return false;
+		}
+		return true;
+	}
+
+	/**
+	 * After a capture registration, sync existing readers to the ESP so the
+	 * "upgrade a known reader" path reaches the contact record. The sync is
+	 * scheduled through Action Scheduler in this integration's group — off the
+	 * request thread, retryable, and inspectable in the Activity Logs UI. A
+	 * pending action for the same reader is reused, so repeat captures before
+	 * the sync runs collapse into one push.
+	 *
+	 * @param string         $email         Email address.
+	 * @param bool           $authenticate  Whether the registration authenticates the session.
+	 * @param false|int      $user_id       The created user id.
+	 * @param false|\WP_User $existing_user The existing user object.
+	 * @param array          $metadata      Registration metadata.
+	 */
+	public function handle_registered_reader( $email, $authenticate, $user_id, $existing_user, $metadata ) {
+		if ( ! $this->should_sync_existing_reader( $existing_user, $metadata ) ) {
+			return;
+		}
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			return;
+		}
+		$hook = 'newspack_scheduled_esp_sync';
+		$args = [ $existing_user->ID, 'Form Capture registration (existing reader)' ];
+		if ( false === \as_next_scheduled_action( $hook, $args, $this->get_action_group() ) ) {
+			\as_schedule_single_action( time() + MINUTE_IN_SECONDS, $hook, $args, $this->get_action_group() );
+		}
+	}
+}

--- a/plugins/newspack-plugin/includes/reader-activation/integrations/class-integration.php
+++ b/plugins/newspack-plugin/includes/reader-activation/integrations/class-integration.php
@@ -278,16 +278,89 @@ abstract class Integration {
 	}
 
 	/**
+	 * Option prefix for the per-integration registration key seed.
+	 */
+	const REGISTRATION_SEED_OPTION_PREFIX = 'newspack_integration_registration_seed_';
+
+	/**
 	 * Generate the registration key for this integration.
 	 *
-	 * The default implementation uses HMAC-SHA256 with the site's auth salt.
-	 * Subclasses can override this to implement custom key schemes
-	 * (e.g., asymmetric key pairs, time-bounded tokens).
+	 * The default implementation uses HMAC-SHA256 of the integration ID and a
+	 * stored per-integration random seed with the site's auth salt. The seed
+	 * makes the key revocable on its own: if a scripted client starts hammering
+	 * the key, rotate_registration_key() invalidates it without rotating
+	 * AUTH_SALT (which would log out every user on the site). Subclasses can
+	 * override this to implement custom key schemes (e.g., asymmetric key
+	 * pairs, time-bounded tokens).
 	 *
 	 * @return string The registration key.
 	 */
 	public function get_registration_key(): string {
-		return hash_hmac( 'sha256', $this->id, \wp_salt( 'auth' ) );
+		return $this->get_default_registration_key();
+	}
+
+	/**
+	 * Create the registration key seed if it doesn't exist yet.
+	 *
+	 * Called when an integration is enabled, so the seed is in place before any
+	 * page can emit the key — which keeps the write off the render path and out
+	 * of concurrent first requests.
+	 *
+	 * @return void
+	 */
+	final public function ensure_registration_key_seed(): void {
+		// Autoloaded on purpose, unlike this class's other options: the key is
+		// read on nearly every frontend render, so a non-autoloaded seed would
+		// add a query to each one.
+		\add_option( self::REGISTRATION_SEED_OPTION_PREFIX . $this->id, \wp_generate_password( 32, false ), '', true );
+	}
+
+	/**
+	 * Get the stored registration key seed, generating it on first use.
+	 *
+	 * Normally seeded by ensure_registration_key_seed() at enable time; this
+	 * lazy path covers integrations enabled before the seed existed. The
+	 * pre-check isn't atomic with the write, so two uncached first requests can
+	 * both generate: the loser's page carries a key that stops validating once
+	 * its cache expires. Narrow, self-healing, and avoided entirely for
+	 * integrations enabled through Integrations::enable().
+	 *
+	 * @param bool $create Whether to create the seed when none is stored.
+	 *                     Pass false on read-only paths; returns '' instead.
+	 *
+	 * @return string The seed, or '' when none is stored and $create is false.
+	 */
+	private function get_registration_key_seed( bool $create = true ): string {
+		$option_name = self::REGISTRATION_SEED_OPTION_PREFIX . $this->id;
+		$seed        = \get_option( $option_name );
+		if ( ! is_string( $seed ) || '' === $seed ) {
+			if ( ! $create ) {
+				return '';
+			}
+			$this->ensure_registration_key_seed();
+			$seed = (string) \get_option( $option_name );
+		}
+		return $seed;
+	}
+
+	/**
+	 * Rotate the registration key by regenerating its stored seed.
+	 *
+	 * Invalidates the key on every page emitted so far — cached pages keep
+	 * submitting the old key until their cache expires, and those requests are
+	 * rejected. That is the point: this is the incident-response lever for a
+	 * key being abused by scripted clients.
+	 *
+	 * PHP-only for now: there is no CLI command or admin surface, so operators
+	 * reach it through `wp eval`. Anything that wires it to a request — an admin
+	 * button, a REST route — must gate it on a capability check and a nonce
+	 * first; this method performs neither.
+	 *
+	 * @return string The new registration key.
+	 */
+	final public function rotate_registration_key(): string {
+		\update_option( self::REGISTRATION_SEED_OPTION_PREFIX . $this->id, \wp_generate_password( 32, false ), true );
+		return $this->get_registration_key();
 	}
 
 	/**
@@ -311,7 +384,68 @@ abstract class Integration {
 	 * @return bool Whether the registration request is valid.
 	 */
 	public function validate_registration_request( string $key, $request ): bool {
-		return hash_equals( $this->get_registration_key(), $key );
+		$current = $this->get_registration_key();
+		if ( hash_equals( $current, $key ) ) {
+			return true;
+		}
+		// Only integrations still on the framework's own key scheme get the
+		// transition allowance. A subclass with a custom scheme (a time-bounded
+		// token, an asymmetric pair) that inherits or calls this validator would
+		// otherwise accept the framework's static HMAC alongside its own, which
+		// is a permanent bypass of whatever bound it was enforcing.
+		//
+		// Read-only: this runs on an unauthenticated path, and a custom-scheme
+		// integration should not have a seed written for a key it never emits.
+		// A default-scheme one always has one by now — get_registration_key()
+		// above created it if needed — so a missing seed is itself the answer.
+		$default = $this->get_default_registration_key( false );
+		if ( '' === $default || ! hash_equals( $default, $current ) ) {
+			return false;
+		}
+		return hash_equals( $this->get_legacy_registration_key(), $key );
+	}
+
+	/**
+	 * The framework's own registration key derivation, as get_registration_key()
+	 * computes it before any subclass override.
+	 *
+	 * @param bool $create_seed Whether to create the seed when none is stored.
+	 *                          Pass false on read-only paths; returns '' instead.
+	 *
+	 * @return string The default-scheme registration key, or '' when no seed
+	 *                exists and $create_seed is false.
+	 */
+	private function get_default_registration_key( bool $create_seed = true ): string {
+		$seed = $this->get_registration_key_seed( $create_seed );
+		if ( '' === $seed ) {
+			return '';
+		}
+		return hash_hmac( 'sha256', $this->id . '|' . $seed, \wp_salt( 'auth' ) );
+	}
+
+	/**
+	 * The pre-seed registration key, still accepted during the transition.
+	 *
+	 * Adding the seed to the HMAC input changes every integration's key once on
+	 * upgrade. Pages already in a CDN or page cache carry the old key until
+	 * their TTL expires, and the capture client treats an invalid key as
+	 * permanent for the pageview — so without this the submission is lost
+	 * rather than retried. This matters in production today: the ESP
+	 * integration emits the legacy key on released sites and validates through
+	 * this method. (newspack-manager's Fundraise Up handler emits it too, but
+	 * replaces validate_registration_request() wholesale — it authenticates on
+	 * verified supporter identifiers rather than the key — so it never reaches
+	 * this branch and the allowance does nothing for it.)
+	 *
+	 * @todo Remove this method and its branch in validate_registration_request()
+	 *       once the seeded key has been in production for a release cycle
+	 *       (target: the first stable release after 2026-09-01). Until then
+	 *       rotation narrows a key rather than fully revoking it.
+	 *
+	 * @return string The legacy registration key.
+	 */
+	private function get_legacy_registration_key(): string {
+		return hash_hmac( 'sha256', $this->id, \wp_salt( 'auth' ) );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-metadata.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-metadata.php
@@ -7,6 +7,8 @@
 
 namespace Newspack\Reader_Activation\Sync;
 
+use Newspack\Reader_Activation;
+
 defined( 'ABSPATH' ) || exit;
 
 /**
@@ -116,15 +118,64 @@ abstract class Contact_Metadata {
 	}
 
 	/**
-	 * Get the full name for the contact from the WC_Customer billing name.
+	 * Get the full name for the contact, preferring the WC_Customer billing name.
+	 *
+	 * Falls back to the WP user's first/last name, then a display name the
+	 * reader actually has, so readers without a WooCommerce billing record
+	 * (e.g. created by frontend registration integrations) don't sync an empty
+	 * name that clears the ESP contact's name. A reader who registered with no
+	 * name at all has neither, and returns '' rather than a stand-in.
 	 *
 	 * @return string
 	 */
 	public function get_full_name() {
 		if ( $this->customer ) {
-			return trim( $this->customer->get_billing_first_name() . ' ' . $this->customer->get_billing_last_name() );
+			$name = trim( $this->customer->get_billing_first_name() . ' ' . $this->customer->get_billing_last_name() );
+			if ( $name ) {
+				return $name;
+			}
+		}
+		if ( $this->user ) {
+			$name = trim( $this->user->first_name . ' ' . $this->user->last_name );
+			if ( $name ) {
+				return $name;
+			}
+			if ( ! $this->has_email_derived_display_name() ) {
+				return (string) $this->user->display_name;
+			}
 		}
 		return '';
+	}
+
+	/**
+	 * Whether the user's display name is a placeholder generated from their email.
+	 *
+	 * Accounts are named after the email when the reader supplies no name, so
+	 * display_name is `jane-doe` for jane.doe@example.com. That is a
+	 * placeholder, not a name: syncing it would write the local part into the
+	 * ESP's first-name field, overwriting whatever is there — including a name
+	 * that arrived by list import.
+	 *
+	 * Applies the reader's own saved-name meta as a short-circuit, but not the
+	 * NEWSPACK_ALLOW_GENERIC_READER_DISPLAY_NAMES constant that
+	 * Reader_Activation::reader_has_generic_display_name() also honors: the
+	 * constant answers whether to stop prompting readers for a real name, and
+	 * a site setting it would otherwise put the placeholder back on the wire.
+	 *
+	 * @return bool
+	 */
+	private function has_email_derived_display_name(): bool {
+		$display_name = (string) $this->user->display_name;
+		$email        = (string) $this->user->user_email;
+		if ( '' === $display_name || '' === $email ) {
+			return true;
+		}
+		// A reader who deliberately saved a display name we would call generic
+		// has chosen it; it is their name, and it syncs.
+		if ( \get_user_meta( $this->user->ID, Reader_Activation::READER_SAVED_GENERIC_DISPLAY_NAME, true ) ) {
+			return false;
+		}
+		return Reader_Activation::is_display_name_derived_from_email( $display_name, $email );
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-contact-sync.php
@@ -1356,11 +1356,21 @@ class Contact_Sync extends Sync {
 
 		$contact = [
 			'email'    => $user->user_email,
-			'name'     => $user->display_name,
 			'metadata' => [],
 		];
 
 		if ( ! class_exists( '\WC_Customer' ) ) {
+			// Resolve the name through Core_Contact rather than reading
+			// display_name directly, so this path applies the same rules as the
+			// metadata-bearing one: no generated placeholder, and no empty
+			// string overwriting the name the contact already has at the
+			// provider. Only in this branch — below, get_contact_with_metadata()
+			// replaces $contact wholesale, and Core_Contact's constructor
+			// hydrates a WC_Customer whose result would be discarded.
+			$name = ( new Sync\Contact_Metadata\Core_Contact( $user ) )->get_full_name();
+			if ( '' !== $name ) {
+				$contact['name'] = $name;
+			}
 			return $contact;
 		}
 		$customer = new \WC_Customer( $user_id );

--- a/plugins/newspack-plugin/includes/reader-activation/sync/class-metadata.php
+++ b/plugins/newspack-plugin/includes/reader-activation/sync/class-metadata.php
@@ -506,11 +506,21 @@ class Metadata {
 			$metadata = array_merge( $metadata, $instance->get_metadata() );
 		}
 
-		return [
+		$contact = [
 			'email'    => $core_contact->get_email(),
-			'name'     => $core_contact->get_full_name(),
 			'metadata' => $metadata,
 		];
+
+		// Omit the key rather than sending an empty name: connectors branch on
+		// isset(), so an empty string is written over whatever name the contact
+		// already has at the provider — including one that arrived by list
+		// import. Mirrors Sync\WooCommerce::get_contact_from_customer().
+		$name = $core_contact->get_full_name();
+		if ( '' !== $name ) {
+			$contact['name'] = $name;
+		}
+
+		return $contact;
 	}
 
 	/**

--- a/plugins/newspack-plugin/src/reader-activation-form-capture/index.js
+++ b/plugins/newspack-plugin/src/reader-activation-form-capture/index.js
@@ -1,0 +1,165 @@
+/**
+ * Internal dependencies
+ */
+import '../shared/js/public-path';
+import { getMatchedForms, getEmailValue, getNameValues } from './utils';
+
+// v3 tokens expire at 120s; refresh with margin.
+const CAPTCHA_TOKEN_TTL = 100 * 1000;
+
+window.newspackRAS = window.newspackRAS || [];
+window.newspackRAS.push( readerActivation => {
+	const config = window.newspack_form_capture || {};
+	const selectors = Array.isArray( config.selectors ) ? config.selectors : [];
+	if ( ! selectors.length ) {
+		return;
+	}
+
+	const captured = new Set();
+	const attached = new WeakSet();
+	let warmToken = null;
+	let warming = false;
+
+	const rasConfig = window.newspack_ras_config || {};
+	const isV3 = 'v3' === rasConfig.captcha_version && rasConfig.captcha_site_key;
+
+	/**
+	 * Run a callback once the reCAPTCHA API is available. grecaptcha is a
+	 * deferred third-party script that can lose the race against a reader
+	 * focusing an above-the-fold form (especially on slow connections), so
+	 * when it hasn't landed yet, queue through Google's documented pre-load
+	 * hook — api.js drains window.___grecaptcha_cfg.fns on load — instead of
+	 * bailing with no retry.
+	 *
+	 * @param {Function} callback Called when the reCAPTCHA API is ready.
+	 */
+	const whenGrecaptchaReady = callback => {
+		if ( window.grecaptcha ) {
+			window.grecaptcha.ready( callback );
+			return;
+		}
+		window.___grecaptcha_cfg = window.___grecaptcha_cfg || {};
+		window.___grecaptcha_cfg.fns = window.___grecaptcha_cfg.fns || [];
+		window.___grecaptcha_cfg.fns.push( callback );
+	};
+
+	/**
+	 * Pre-acquire a reCAPTCHA v3 token while the reader interacts with a
+	 * matched form, so a token is ready at submit time — the submit-time
+	 * request must survive page navigation and cannot await acquisition.
+	 * v2 flows render an interactive widget and cannot be warmed; the
+	 * integration reports itself unsupported on v2 sites (see
+	 * Form_Capture::get_unsupported_reason()).
+	 */
+	const warmCaptcha = () => {
+		if ( ! isV3 ) {
+			return;
+		}
+		if ( warmToken && Date.now() - warmToken.timestamp < CAPTCHA_TOKEN_TTL ) {
+			return;
+		}
+		// The TTL check can't cover an acquisition still in flight — warmToken
+		// stays null until one resolves — so tabbing through a form's fields
+		// would queue a callback per focusin, each firing its own execute().
+		if ( warming ) {
+			return;
+		}
+		warming = true;
+		const releaseWarming = () => {
+			warming = false;
+		};
+		// try/catch, not only .finally(): a synchronous throw never produces a
+		// promise to attach to, and would otherwise leave the flag set for the
+		// rest of the pageview — no retry, and every later submit sent without
+		// a token. Both frames are guarded, since ready() can throw before the
+		// callback runs, and the callback can throw when ready() defers it.
+		try {
+			whenGrecaptchaReady( () => {
+				try {
+					window.grecaptcha
+						.execute( rasConfig.captcha_site_key, { action: 'integration_registration' } )
+						.then( token => {
+							warmToken = { token, timestamp: Date.now() };
+						} )
+						.catch( () => {} )
+						.finally( releaseWarming );
+				} catch ( err ) {
+					releaseWarming();
+				}
+			} );
+		} catch ( err ) {
+			releaseWarming();
+		}
+	};
+
+	const handleSubmit = event => {
+		const form = event.target;
+		if ( form.checkValidity && ! form.checkValidity() ) {
+			return;
+		}
+		const email = getEmailValue( form );
+		if ( ! email || captured.has( email ) ) {
+			return;
+		}
+		if ( readerActivation.getReader?.()?.email === email ) {
+			return;
+		}
+		captured.add( email );
+		const options = { keepalive: true };
+		if ( warmToken && Date.now() - warmToken.timestamp < CAPTCHA_TOKEN_TTL ) {
+			options.captchaToken = warmToken.token;
+			// v3 tokens are single-use.
+			warmToken = null;
+		}
+		readerActivation.register( email, 'form-capture', getNameValues( form ), options ).catch( error => {
+			// Only failures that can succeed on a retry within this pageview
+			// release the dedupe: a network error (the response never parsed,
+			// so no code) or a server-side registration failure. Everything
+			// else — existing reader, rate limit, invalid/rotated key, RAS
+			// disabled — is permanent here, and retrying a 429 would work
+			// against the rate limiter it just hit.
+			if ( ! error?.code || 'registration_failed' === error.code ) {
+				captured.delete( email );
+				// Re-arm the warm token alongside the email: the consumed one
+				// was single-use and nothing necessarily re-fires focusin
+				// before a resubmit.
+				warmCaptcha();
+			}
+		} );
+	};
+
+	const attach = () => {
+		getMatchedForms( selectors ).forEach( form => {
+			if ( attached.has( form ) ) {
+				return;
+			}
+			attached.add( form );
+			form.addEventListener( 'focusin', warmCaptcha );
+			// No capture flag: submit always fires at the form itself, where
+			// capture and bubble listeners run together in registration order,
+			// so a capturing listener here cannot front-run a vendor handler.
+			form.addEventListener( 'submit', handleSubmit );
+		} );
+	};
+
+	attach();
+	// Form plugins render/replace forms after load (multi-page, AJAX embeds).
+	// Coalesce mutation bursts (infinite scroll, ad refresh) into one scan.
+	let scanScheduled = false;
+	const observer = new MutationObserver( mutations => {
+		if ( scanScheduled ) {
+			return;
+		}
+		// Only added elements can introduce forms — ignore removals and
+		// text-only bursts so steady-state pages don't pay for re-scans.
+		if ( ! mutations.some( mutation => Array.from( mutation.addedNodes ).some( node => 1 === node.nodeType ) ) ) {
+			return;
+		}
+		scanScheduled = true;
+		setTimeout( () => {
+			scanScheduled = false;
+			attach();
+		}, 200 );
+	} );
+	observer.observe( document.body, { childList: true, subtree: true } );
+} );

--- a/plugins/newspack-plugin/src/reader-activation-form-capture/index.test.js
+++ b/plugins/newspack-plugin/src/reader-activation-form-capture/index.test.js
@@ -1,0 +1,253 @@
+import { getMatchedForms } from './utils';
+
+/**
+ * Harness for the capture client. window.newspackRAS is a plain callback
+ * array before RAS loads, so the client's bootstrap can be invoked directly
+ * with a fake readerActivation — no RAS internals involved.
+ *
+ * The DOM must be in place before loading: the client scans for opted-in
+ * forms at bootstrap (later additions go through a debounced
+ * MutationObserver rescan these tests don't rely on).
+ *
+ * @param {string} html      Markup for document.body.
+ * @param {Object} rasConfig window.newspack_ras_config value.
+ * @return {Object} The fake readerActivation, with a jest.fn() register.
+ */
+const loadCaptureClient = ( html, rasConfig = {} ) => {
+	document.body.innerHTML = html;
+	window.newspackRAS = [];
+	window.newspack_form_capture = { selectors: [ '.newspack-form-capture' ] };
+	window.newspack_ras_config = rasConfig;
+	jest.isolateModules( () => require( './index' ) );
+	const readerActivation = {
+		register: jest.fn( () => Promise.resolve( {} ) ),
+		getReader: jest.fn( () => ( {} ) ),
+	};
+	window.newspackRAS.forEach( callback => callback( readerActivation ) );
+	return readerActivation;
+};
+
+const submit = form => form.dispatchEvent( new Event( 'submit', { bubbles: true, cancelable: true } ) );
+const focusin = form => form.dispatchEvent( new Event( 'focusin', { bubbles: true } ) );
+const flush = () => new Promise( resolve => setTimeout( resolve, 0 ) );
+
+const FORM = `<form class="newspack-form-capture"><input type="email" value="reader@example.com"></form>`;
+const V3_CONFIG = { captcha_version: 'v3', captcha_site_key: 'site-key' };
+
+describe( 'form-capture client', () => {
+	afterEach( () => {
+		document.body.innerHTML = '';
+		delete window.newspackRAS;
+		delete window.newspack_form_capture;
+		delete window.newspack_ras_config;
+		delete window.grecaptcha;
+		delete window.___grecaptcha_cfg;
+	} );
+
+	it( 'captures an opted-in form submit once per email per pageview', () => {
+		const ras = loadCaptureClient( FORM );
+		const form = document.querySelector( 'form' );
+		submit( form );
+		submit( form );
+		expect( ras.register ).toHaveBeenCalledTimes( 1 );
+		expect( ras.register ).toHaveBeenCalledWith( 'reader@example.com', 'form-capture', expect.any( Object ), expect.any( Object ) );
+	} );
+
+	it( 'keeps the dedupe after an existing-reader conflict', async () => {
+		const ras = loadCaptureClient( FORM );
+		ras.register.mockImplementation( () => Promise.reject( Object.assign( new Error( 'Exists.' ), { code: 'reader_already_exists' } ) ) );
+		const form = document.querySelector( 'form' );
+		submit( form );
+		await flush();
+		submit( form );
+		expect( ras.register ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it.each( [ 'rate_limit_exceeded', 'invalid_integration_key', 'reader_activation_disabled', 'recaptcha_failed' ] )(
+		'keeps the dedupe after %s, which cannot succeed on retry',
+		async code => {
+			const ras = loadCaptureClient( FORM );
+			ras.register.mockImplementation( () => Promise.reject( Object.assign( new Error( 'Rejected.' ), { code } ) ) );
+			const form = document.querySelector( 'form' );
+			submit( form );
+			await flush();
+			submit( form );
+			expect( ras.register ).toHaveBeenCalledTimes( 1 );
+		}
+	);
+
+	it( 'releases the dedupe after a network failure (no error code)', async () => {
+		const ras = loadCaptureClient( FORM );
+		ras.register.mockImplementationOnce( () => Promise.reject( new Error( 'Network down.' ) ) );
+		const form = document.querySelector( 'form' );
+		submit( form );
+		await flush();
+		submit( form );
+		expect( ras.register ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'releases the dedupe after a server-side registration failure (5xx)', async () => {
+		const ras = loadCaptureClient( FORM );
+		ras.register.mockImplementationOnce( () => Promise.reject( Object.assign( new Error( 'Server error.' ), { code: 'registration_failed' } ) ) );
+		const form = document.querySelector( 'form' );
+		submit( form );
+		await flush();
+		submit( form );
+		expect( ras.register ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'skips forms whose email matches the current reader', () => {
+		const ras = loadCaptureClient( FORM );
+		ras.getReader.mockReturnValue( { email: 'reader@example.com' } );
+		submit( document.querySelector( 'form' ) );
+		expect( ras.register ).not.toHaveBeenCalled();
+	} );
+
+	it( 'passes the warm captcha token once and re-arms after a transient failure', async () => {
+		window.grecaptcha = {
+			ready: callback => callback(),
+			execute: jest.fn().mockResolvedValueOnce( 'warm-token-1' ).mockResolvedValueOnce( 'warm-token-2' ),
+		};
+		const ras = loadCaptureClient( FORM, V3_CONFIG );
+		ras.register.mockImplementationOnce( () => Promise.reject( new Error( 'Network down.' ) ) );
+		const form = document.querySelector( 'form' );
+
+		focusin( form );
+		await flush();
+		submit( form );
+		expect( ras.register.mock.calls[ 0 ][ 3 ].captchaToken ).toBe( 'warm-token-1' );
+
+		// The transient failure released the dedupe and re-armed the token —
+		// the consumed (single-use) token must not be reused on the resubmit.
+		await flush();
+		submit( form );
+		expect( ras.register ).toHaveBeenCalledTimes( 2 );
+		expect( ras.register.mock.calls[ 1 ][ 3 ].captchaToken ).toBe( 'warm-token-2' );
+		expect( window.grecaptcha.execute ).toHaveBeenCalledTimes( 2 );
+	} );
+
+	it( 'queues captcha warm-up until the reCAPTCHA API loads', async () => {
+		// grecaptcha is a deferred third-party script — a reader can focus the
+		// form before it lands. The warm-up must queue, not silently bail.
+		const ras = loadCaptureClient( FORM, V3_CONFIG );
+		const form = document.querySelector( 'form' );
+		focusin( form );
+		expect( window.___grecaptcha_cfg.fns ).toHaveLength( 1 );
+
+		// api.js lands and drains the documented pre-load queue.
+		window.grecaptcha = {
+			ready: callback => callback(),
+			execute: jest.fn( () => Promise.resolve( 'late-token' ) ),
+		};
+		window.___grecaptcha_cfg.fns.forEach( fn => fn() );
+		await flush();
+
+		submit( form );
+		expect( ras.register.mock.calls[ 0 ][ 3 ].captchaToken ).toBe( 'late-token' );
+	} );
+
+	it( 'queues one warm-up however many fields the reader tabs through', async () => {
+		// warmToken stays null until an acquisition resolves, so the TTL check
+		// can't cover the gap: without an in-flight flag every focusin before
+		// api.js lands would queue another callback, and the drain would fire
+		// one execute() per field touched.
+		const ras = loadCaptureClient( FORM, V3_CONFIG );
+		const form = document.querySelector( 'form' );
+		focusin( form );
+		focusin( form );
+		focusin( form );
+		expect( window.___grecaptcha_cfg.fns ).toHaveLength( 1 );
+
+		window.grecaptcha = {
+			ready: callback => callback(),
+			execute: jest.fn( () => Promise.resolve( 'one-token' ) ),
+		};
+		window.___grecaptcha_cfg.fns.forEach( fn => fn() );
+		await flush();
+		expect( window.grecaptcha.execute ).toHaveBeenCalledTimes( 1 );
+
+		submit( form );
+		expect( ras.register.mock.calls[ 0 ][ 3 ].captchaToken ).toBe( 'one-token' );
+	} );
+
+	it( 'recovers from a synchronous throw in ready()', async () => {
+		// Same failure class as the execute() throw below, one frame further
+		// out: the flag is set before the readiness call, so a throw there must
+		// release it too or warm-up never runs again this pageview.
+		let shouldThrow = true;
+		window.grecaptcha = {
+			ready: callback => {
+				if ( shouldThrow ) {
+					throw new Error( 'grecaptcha.ready exploded.' );
+				}
+				callback();
+			},
+			execute: jest.fn( () => Promise.resolve( 'later-token' ) ),
+		};
+		const ras = loadCaptureClient( FORM, V3_CONFIG );
+		const form = document.querySelector( 'form' );
+
+		focusin( form );
+		await flush();
+		expect( window.grecaptcha.execute ).not.toHaveBeenCalled();
+
+		shouldThrow = false;
+		focusin( form );
+		await flush();
+		expect( window.grecaptcha.execute ).toHaveBeenCalledTimes( 1 );
+
+		submit( form );
+		expect( ras.register.mock.calls[ 0 ][ 3 ].captchaToken ).toBe( 'later-token' );
+	} );
+
+	it( 'recovers from a synchronous throw in execute()', async () => {
+		// The in-flight flag must not survive a throw that never produces a
+		// promise: it would block every later warm-up, and each submit would
+		// go out without a token — the failure the flag exists to prevent.
+		let shouldThrow = true;
+		window.grecaptcha = {
+			ready: callback => callback(),
+			execute: jest.fn( () => {
+				if ( shouldThrow ) {
+					throw new Error( 'grecaptcha exploded.' );
+				}
+				return Promise.resolve( 'recovered-token' );
+			} ),
+		};
+		const ras = loadCaptureClient( FORM, V3_CONFIG );
+		const form = document.querySelector( 'form' );
+
+		focusin( form );
+		await flush();
+		expect( window.grecaptcha.execute ).toHaveBeenCalledTimes( 1 );
+
+		shouldThrow = false;
+		focusin( form );
+		await flush();
+		expect( window.grecaptcha.execute ).toHaveBeenCalledTimes( 2 );
+
+		submit( form );
+		expect( ras.register.mock.calls[ 0 ][ 3 ].captchaToken ).toBe( 'recovered-token' );
+	} );
+
+	it( 'does not warm captcha on v2 sites', () => {
+		window.grecaptcha = { ready: callback => callback(), execute: jest.fn() };
+		loadCaptureClient( FORM, { captcha_version: 'v2_invisible', captcha_site_key: 'site-key' } );
+		focusin( document.querySelector( 'form' ) );
+		expect( window.grecaptcha.execute ).not.toHaveBeenCalled();
+	} );
+
+	it( 'attaches to forms added after load via the mutation observer rescan', async () => {
+		const ras = loadCaptureClient( '<div id="root"></div>' );
+		document.getElementById( 'root' ).innerHTML = FORM;
+		// MutationObserver delivery is a microtask; the rescan is debounced 200ms.
+		await new Promise( resolve => setTimeout( resolve, 250 ) );
+		submit( document.querySelector( 'form' ) );
+		expect( ras.register ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'getMatchedForms resolves an over-broad selector to every form (why bare selectors are rejected server-side)', () => {
+		document.body.innerHTML = `<form id="a"></form><form id="b"></form>`;
+		expect( getMatchedForms( [ 'form' ] ).map( f => f.id ) ).toEqual( [ 'a', 'b' ] );
+	} );
+} );

--- a/plugins/newspack-plugin/src/reader-activation-form-capture/utils.js
+++ b/plugins/newspack-plugin/src/reader-activation-form-capture/utils.js
@@ -1,0 +1,90 @@
+const EMAIL_PATTERN = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
+
+const attrs = input => `${ input.name || '' } ${ input.id || '' } ${ input.getAttribute( 'autocomplete' ) || '' }`;
+
+/**
+ * Resolve the configured selectors to a unique list of form elements.
+ * Non-form matches resolve to their closest or first inner form; invalid
+ * selectors (publisher-supplied) are ignored.
+ *
+ * @param {string[]}         selectors CSS selectors.
+ * @param {Element|Document} root      Root to query. Defaults to document.
+ * @return {HTMLFormElement[]} Matched forms.
+ */
+export function getMatchedForms( selectors, root = document ) {
+	const forms = new Set();
+	selectors.forEach( selector => {
+		let matches = [];
+		try {
+			matches = root.querySelectorAll( selector );
+		} catch ( e ) {
+			return;
+		}
+		matches.forEach( el => {
+			const form = 'FORM' === el.tagName ? el : el.closest( 'form' ) || el.querySelector( 'form' );
+			if ( form ) {
+				forms.add( form );
+			}
+		} );
+	} );
+	return Array.from( forms );
+}
+
+/**
+ * Get a valid email value from a form, preferring input[type=email] and
+ * falling back to name/id/autocomplete heuristics on text inputs. Iterates
+ * all candidates in order and returns the first one with a valid value, so
+ * an empty honeypot or confirmation field ahead of the real one is skipped.
+ *
+ * @param {HTMLFormElement} form Form element.
+ * @return {string} The email value, or empty string.
+ */
+export function getEmailValue( form ) {
+	const candidates = [
+		...form.querySelectorAll( 'input[type="email"]' ),
+		...Array.from( form.querySelectorAll( 'input[type="text"], input:not([type])' ) ).filter( candidate =>
+			/e-?mail/i.test( attrs( candidate ) )
+		),
+	];
+	for ( const input of candidates ) {
+		const value = input?.value?.trim() || '';
+		if ( EMAIL_PATTERN.test( value ) ) {
+			// Lower-case at harvest so the client-side dedupe and current-reader
+			// checks agree with the server, which matches emails
+			// case-insensitively — Reader@example.com and reader@example.com
+			// from the same visitor are one capture, not two.
+			return value.toLowerCase();
+		}
+	}
+	return '';
+}
+
+/**
+ * Best-effort first/last name harvest from a form.
+ *
+ * @param {HTMLFormElement} form Form element.
+ * @return {Object} { first_name, last_name } or an empty object.
+ */
+export function getNameValues( form ) {
+	const inputs = Array.from( form.querySelectorAll( 'input[type="text"], input:not([type])' ) );
+	const valueMatching = ( pattern, reject = null ) =>
+		inputs
+			.find( input => {
+				const haystack = attrs( input );
+				return pattern.test( haystack ) && ! ( reject && reject.test( haystack ) );
+			} )
+			?.value?.trim() || '';
+	const firstName = valueMatching( /first[-_ ]?name|fname|given-name/i );
+	const lastName = valueMatching( /last[-_ ]?name|lname|family-name|surname/i );
+	if ( firstName || lastName ) {
+		return { first_name: firstName, last_name: lastName };
+	}
+	// A bare "name" field is only trusted when it isn't qualified as some
+	// other kind of name — organization_name, display-name, file name — which
+	// would set the reader's first name to a company or a handle.
+	const fullName = valueMatching(
+		/(^|[-_ [])name([-_ \]]|$)/i,
+		/(org|organi[sz]ation|business|company|user|display|file|nick|site|domain|host)[-_ ]?name/i
+	);
+	return fullName ? { first_name: fullName, last_name: '' } : {};
+}

--- a/plugins/newspack-plugin/src/reader-activation-form-capture/utils.test.js
+++ b/plugins/newspack-plugin/src/reader-activation-form-capture/utils.test.js
@@ -1,0 +1,104 @@
+import { getMatchedForms, getEmailValue, getNameValues } from './utils';
+
+describe( 'getMatchedForms', () => {
+	beforeEach( () => {
+		document.body.innerHTML = `
+			<form id="direct" class="newspack-form-capture"></form>
+			<div id="container"><form id="inner"></form></div>
+			<form id="other"></form>
+			<div id="formless"></div>
+		`;
+	} );
+	it( 'matches forms directly and resolves containers to their inner form', () => {
+		const forms = getMatchedForms( [ '.newspack-form-capture', '#container' ] );
+		expect( forms.map( f => f.id ) ).toEqual( [ 'direct', 'inner' ] );
+	} );
+	it( 'dedupes and ignores invalid selectors and formless matches', () => {
+		const forms = getMatchedForms( [ '.newspack-form-capture', '.newspack-form-capture', ':::garbage', '#formless' ] );
+		expect( forms.map( f => f.id ) ).toEqual( [ 'direct' ] );
+	} );
+	it( 'cannot use a selector list with a trailing comma', () => {
+		// Invalid CSS, so querySelectorAll() throws and the whole list is lost —
+		// which is why Form_Capture::get_selectors() rebuilds each configured
+		// line from its non-empty parts before it reaches the client.
+		document.body.innerHTML = `<form id="a"></form><form id="b"></form>`;
+		expect( getMatchedForms( [ '#a, #b' ] ).map( f => f.id ) ).toEqual( [ 'a', 'b' ] );
+		expect( getMatchedForms( [ '#a, #b,' ] ) ).toEqual( [] );
+	} );
+} );
+
+describe( 'getEmailValue', () => {
+	it( 'prefers input[type=email]', () => {
+		document.body.innerHTML = `<form><input type="text" name="whatever" value="x"><input type="email" value="reader@example.com"></form>`;
+		expect( getEmailValue( document.querySelector( 'form' ) ) ).toBe( 'reader@example.com' );
+	} );
+	it( 'falls back to name/id heuristics for text inputs (CF7 style)', () => {
+		document.body.innerHTML = `<form><input type="text" name="your-email" value="reader@example.com"></form>`;
+		expect( getEmailValue( document.querySelector( 'form' ) ) ).toBe( 'reader@example.com' );
+	} );
+	it( 'returns empty for invalid email values', () => {
+		document.body.innerHTML = `<form><input type="email" value="not-an-email"></form>`;
+		expect( getEmailValue( document.querySelector( 'form' ) ) ).toBe( '' );
+	} );
+	it( 'returns empty when there is no email field', () => {
+		document.body.innerHTML = `<form><input type="text" name="city" value="Lisbon"></form>`;
+		expect( getEmailValue( document.querySelector( 'form' ) ) ).toBe( '' );
+	} );
+	it( 'skips an empty honeypot text input and returns the first valid email value', () => {
+		document.body.innerHTML = `<form>
+			<input type="text" name="email" value="" style="display:none">
+			<input type="text" name="your-email" value="reader@example.com">
+		</form>`;
+		expect( getEmailValue( document.querySelector( 'form' ) ) ).toBe( 'reader@example.com' );
+	} );
+	it( 'skips an empty first email input (confirmation layouts) for a later valid one', () => {
+		document.body.innerHTML = `<form>
+			<input type="email" value="">
+			<input type="email" value="reader@example.com">
+		</form>`;
+		expect( getEmailValue( document.querySelector( 'form' ) ) ).toBe( 'reader@example.com' );
+	} );
+	it( 'lower-cases the harvested email so client dedupe agrees with the server', () => {
+		document.body.innerHTML = `<form><input type="email" value="Reader@Example.com"></form>`;
+		expect( getEmailValue( document.querySelector( 'form' ) ) ).toBe( 'reader@example.com' );
+	} );
+} );
+
+describe( 'getNameValues', () => {
+	it( 'finds first/last name by autocomplete attributes (GF advanced name field)', () => {
+		document.body.innerHTML = `<form>
+			<input type="text" name="input_1_3" autocomplete="given-name" value="Ada">
+			<input type="text" name="input_1_6" autocomplete="family-name" value="Lovelace">
+		</form>`;
+		expect( getNameValues( document.querySelector( 'form' ) ) ).toEqual( { first_name: 'Ada', last_name: 'Lovelace' } );
+	} );
+	it( 'finds first/last name by name attributes', () => {
+		document.body.innerHTML = `<form>
+			<input type="text" name="first_name" value="Ada">
+			<input type="text" name="last-name" value="Lovelace">
+		</form>`;
+		expect( getNameValues( document.querySelector( 'form' ) ) ).toEqual( { first_name: 'Ada', last_name: 'Lovelace' } );
+	} );
+	it( 'uses a single full-name field as first_name', () => {
+		document.body.innerHTML = `<form><input type="text" name="name" value="Ada Lovelace"></form>`;
+		expect( getNameValues( document.querySelector( 'form' ) ) ).toEqual( { first_name: 'Ada Lovelace', last_name: '' } );
+	} );
+	it( 'returns empty object when nothing matches', () => {
+		document.body.innerHTML = `<form><input type="text" name="username" value="ada"></form>`;
+		expect( getNameValues( document.querySelector( 'form' ) ) ).toEqual( {} );
+	} );
+	it( 'does not treat a non-person name field as the reader name', () => {
+		document.body.innerHTML = `<form>
+			<input type="text" name="organization_name" value="Acme Corp">
+			<input type="text" name="display-name" value="acme_handle">
+		</form>`;
+		expect( getNameValues( document.querySelector( 'form' ) ) ).toEqual( {} );
+	} );
+	it( 'still harvests a real full-name field alongside a non-person name field', () => {
+		document.body.innerHTML = `<form>
+			<input type="text" name="company_name" value="Acme Corp">
+			<input type="text" name="name" value="Ada Lovelace">
+		</form>`;
+		expect( getNameValues( document.querySelector( 'form' ) ) ).toEqual( { first_name: 'Ada Lovelace', last_name: '' } );
+	} );
+} );

--- a/plugins/newspack-plugin/src/reader-activation/index.js
+++ b/plugins/newspack-plugin/src/reader-activation/index.js
@@ -508,13 +508,16 @@ function acquireV2InvisibleToken( siteKey ) {
 /**
  * Register a reader via a frontend integration.
  *
- * @param {string} email                  Reader email address.
- * @param {string} integrationId          Registered integration ID.
- * @param {Object} profileFields          Optional profile fields: { first_name, last_name, metadata }.
- * @param {Object} profileFields.metadata Optional arbitrary key-value pairs to store as user meta.
+ * @param {string}  email                  Reader email address.
+ * @param {string}  integrationId          Registered integration ID.
+ * @param {Object}  profileFields          Optional profile fields: { first_name, last_name, metadata }.
+ * @param {Object}  profileFields.metadata Optional arbitrary key-value pairs to store as user meta.
+ * @param {Object}  options                Optional transport options.
+ * @param {boolean} options.keepalive      Keep the request alive through page navigation.
+ * @param {string}  options.captchaToken   Pre-acquired reCAPTCHA token, skips acquisition.
  * @return {Promise} Resolves with reader data on success, rejects with error on failure.
  */
-function register( email, integrationId, profileFields = {} ) {
+export function register( email, integrationId, profileFields = {}, options = {} ) {
 	const config = newspack_ras_config?.frontend_registration_integrations || {};
 	const integration = config[ integrationId ];
 
@@ -544,7 +547,10 @@ function register( email, integrationId, profileFields = {} ) {
 	const captchaVersion = newspack_ras_config?.captcha_version;
 	let captchaPromise;
 
-	if ( captchaSiteKey ) {
+	if ( options.captchaToken ) {
+		// Pre-acquired token (e.g. warmed before a page-navigating form submit).
+		captchaPromise = Promise.resolve( options.captchaToken );
+	} else if ( captchaSiteKey ) {
 		if ( ! window.grecaptcha ) {
 			return Promise.reject( new Error( 'reCAPTCHA is configured but not loaded.' ) );
 		}
@@ -582,10 +588,16 @@ function register( email, integrationId, profileFields = {} ) {
 			if ( nonce ) {
 				headers[ 'X-WP-Nonce' ] = nonce;
 			}
+			// keepalive: Firefox only supports it from version 133 (unknown init
+			// keys are silently ignored), so on older Firefox the request may
+			// still be cancelled at page unload. Accepted for v1: a
+			// navigator.sendBeacon fallback cannot carry the response callers
+			// consume here.
 			return fetch( newspack_ras_config.frontend_registration_url, {
 				method: 'POST',
 				headers,
 				credentials: 'same-origin',
+				keepalive: Boolean( options.keepalive ),
 				body: JSON.stringify( body ),
 			} );
 		} )
@@ -616,11 +628,27 @@ function register( email, integrationId, profileFields = {} ) {
 			return data;
 		} )
 		.catch( function ( error ) {
-			dispatchActivity( 'reader_registration_failed', {
-				email,
-				integration_id: integrationId,
-				error: error.code || 'network_error',
-			} );
+			if ( 'reader_already_exists' === error.code ) {
+				// A 409 is a successful outcome server-side: the reader exists and
+				// the auth intention is pinned to this email. Reflect the identity
+				// in the client store (which popups/segmentation read) and record
+				// a registration activity with the 'existing' status rather than a
+				// failure — on sites with returning readers this is the routine
+				// result. The promise still rejects so callers can distinguish
+				// created from existing.
+				setReaderEmail( email );
+				dispatchActivity( 'reader_registered', {
+					email,
+					integration_id: integrationId,
+					status: 'existing',
+				} );
+			} else {
+				dispatchActivity( 'reader_registration_failed', {
+					email,
+					integration_id: integrationId,
+					error: error.code || 'network_error',
+				} );
+			}
 			throw error;
 		} );
 }

--- a/plugins/newspack-plugin/src/reader-activation/index.test.js
+++ b/plugins/newspack-plugin/src/reader-activation/index.test.js
@@ -1,4 +1,4 @@
-import { store, dispatchActivity, getActivities, getUniqueActivitiesBy, setReaderEmail, setAuthenticated, getReader } from './index';
+import { store, dispatchActivity, getActivities, getUniqueActivitiesBy, setReaderEmail, setAuthenticated, getReader, register } from './index';
 import { on, off } from './events';
 
 describe( 'newspackReaderActivation', () => {
@@ -568,5 +568,80 @@ describe( 'shouldClearReaderData (NPPM-2899)', () => {
 				hasAuthReaderCookie: false,
 			} )
 		).toBe( false );
+	} );
+} );
+
+describe( 'register() transport options', () => {
+	beforeEach( () => {
+		// A prior describe block's afterEach deletes window.newspack_reader_data
+		// and doesn't restore it; re-seed it so dispatchActivity()'s store.add()
+		// (via assertNotReadOnly's bare newspack_reader_data reference) doesn't
+		// throw a ReferenceError on the register() success path.
+		global.newspack_reader_data = {};
+		global.newspack_ras_config = {
+			frontend_registration_url: 'https://test.test/wp-json/newspack/v1/reader-activation/register',
+			frontend_registration_integrations: {
+				'form-capture': { key: 'test-key', label: 'Form Capture' },
+			},
+		};
+		global.fetch = jest.fn( () =>
+			Promise.resolve( {
+				ok: true,
+				json: () => Promise.resolve( { success: true, status: 'created', email: 'a@b.co' } ),
+			} )
+		);
+	} );
+	afterEach( () => {
+		delete global.newspack_reader_data;
+		delete global.newspack_ras_config;
+		delete global.fetch;
+	} );
+	it( 'passes keepalive to fetch when requested', async () => {
+		await register( 'a@b.co', 'form-capture', {}, { keepalive: true } );
+		expect( global.fetch ).toHaveBeenCalledWith( expect.any( String ), expect.objectContaining( { keepalive: true } ) );
+	} );
+	it( 'does not set keepalive by default', async () => {
+		await register( 'a@b.co', 'form-capture' );
+		expect( global.fetch.mock.calls[ 0 ][ 1 ].keepalive ).toBe( false );
+	} );
+	it( 'uses a pre-acquired captcha token without invoking grecaptcha', async () => {
+		global.newspack_ras_config.captcha_site_key = 'site-key';
+		global.newspack_ras_config.captcha_version = 'v3';
+		// No window.grecaptcha stub: acquisition would reject if attempted.
+		await register( 'a@b.co', 'form-capture', {}, { captchaToken: 'warm-token' } );
+		const body = JSON.parse( global.fetch.mock.calls[ 0 ][ 1 ].body );
+		expect( body[ 'g-recaptcha-response' ] ).toBe( 'warm-token' );
+	} );
+	it( 'treats an existing-reader 409 as a successful capture client-side', async () => {
+		global.fetch = jest.fn( () =>
+			Promise.resolve( {
+				ok: false,
+				status: 409,
+				json: () => Promise.resolve( { code: 'reader_already_exists', message: 'Exists.' } ),
+			} )
+		);
+		// The promise still rejects — callers distinguish created from existing…
+		await expect( register( 'known@example.com', 'form-capture' ) ).rejects.toMatchObject( { code: 'reader_already_exists' } );
+		// …but the captured identity reaches the client store (read by targeting)…
+		expect( getReader().email ).toBe( 'known@example.com' );
+		// …and the activity stream records a registration with 'existing' status,
+		// not a failure — on sites with returning readers this is the routine outcome.
+		const registered = getActivities( 'reader_registered' ).filter( a => a.data.email === 'known@example.com' );
+		expect( registered ).toHaveLength( 1 );
+		expect( registered[ 0 ].data.status ).toBe( 'existing' );
+		expect( getActivities( 'reader_registration_failed' ).filter( a => a.data.email === 'known@example.com' ) ).toHaveLength( 0 );
+	} );
+	it( 'still records a failure activity for non-conflict errors', async () => {
+		global.fetch = jest.fn( () =>
+			Promise.resolve( {
+				ok: false,
+				status: 429,
+				json: () => Promise.resolve( { code: 'rate_limit_exceeded', message: 'Too many.' } ),
+			} )
+		);
+		await expect( register( 'limited@example.com', 'form-capture' ) ).rejects.toMatchObject( { code: 'rate_limit_exceeded' } );
+		expect( getReader().email ).not.toBe( 'limited@example.com' );
+		const failed = getActivities( 'reader_registration_failed' ).filter( a => a.data.email === 'limited@example.com' );
+		expect( failed ).toHaveLength( 1 );
 	} );
 } );

--- a/plugins/newspack-plugin/tests/unit-tests/integrations/class-inherited-validator-integration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/integrations/class-inherited-validator-integration.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ * Mock Integration with a custom key scheme that inherits the base validator.
+ *
+ * @package Newspack\Tests\Unit\Integrations
+ */
+
+use Newspack\Reader_Activation\Integration;
+
+/**
+ * Test integration that replaces get_registration_key() with a scheme of its
+ * own while inheriting validate_registration_request() — the shape the legacy
+ * registration key's transition allowance must not extend to.
+ *
+ * Distinct from Test_Custom_Key_Integration in reader-registration-endpoint.php,
+ * which overrides the validator too and so never reaches the base implementation.
+ */
+class Inherited_Validator_Integration extends Integration {
+	/**
+	 * Constructor.
+	 */
+	public function __construct() {
+		parent::__construct( 'custom-key-integration', 'Custom Key Integration' );
+	}
+
+	/**
+	 * Whether this integration supports frontend registration.
+	 *
+	 * @return bool
+	 */
+	public function supports_frontend_registration(): bool {
+		return true;
+	}
+
+	/**
+	 * A key scheme of the integration's own, replacing the framework's.
+	 *
+	 * @return string
+	 */
+	public function get_registration_key(): string {
+		return 'custom-scheme-key';
+	}
+
+	/**
+	 * Register settings fields.
+	 *
+	 * @return array
+	 */
+	public function register_settings_fields() {
+		return [];
+	}
+
+	/**
+	 * Whether this integration can sync.
+	 *
+	 * @param bool $return_errors Whether to return errors.
+	 * @return bool
+	 */
+	public function can_sync( $return_errors = false ) {
+		return false;
+	}
+
+	/**
+	 * Push contact data.
+	 *
+	 * @param array  $contact          Contact data.
+	 * @param string $context          Context.
+	 * @param array  $existing_contact Existing contact data.
+	 * @return bool
+	 */
+	public function push_contact_data( $contact, $context = '', $existing_contact = null ) {
+		return true;
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/reader-activation-form-capture.php
+++ b/plugins/newspack-plugin/tests/unit-tests/reader-activation-form-capture.php
@@ -1,0 +1,541 @@
+<?php
+/**
+ * Tests the Inbound Form Capture integration and its Reader Activation hooks.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Reader_Activation;
+use Newspack\Reader_Activation\Contact_Sync;
+use Newspack\Reader_Activation\Integrations;
+use Newspack\Reader_Activation\Integrations\Form_Capture;
+use Newspack\Reader_Registration;
+
+require_once __DIR__ . '/integrations/class-inherited-validator-integration.php';
+
+/**
+ * Test the Form Capture integration.
+ *
+ * @group form-capture
+ */
+class Test_Form_Capture extends WP_UnitTestCase {
+
+	/**
+	 * Set up.
+	 */
+	public function set_up() {
+		parent::set_up();
+		update_option( Reader_Activation::OPTIONS_PREFIX . 'enabled', true );
+	}
+
+	/**
+	 * Clean up.
+	 */
+	public function tear_down() {
+		delete_option( Reader_Activation::OPTIONS_PREFIX . 'enabled' );
+		delete_option( 'newspack_recaptcha_use_captcha' );
+		delete_option( 'newspack_recaptcha_version' );
+		delete_option( 'newspack_recaptcha_credentials' );
+		wp_set_current_user( 0 );
+		remove_all_filters( 'newspack_magic_link_rate_interval' );
+		remove_all_filters( 'newspack_reader_activation_send_magic_link_on_reregistration' );
+		remove_all_filters( 'newspack_reader_activation_is_syncing_allowed' );
+		parent::tear_down();
+	}
+
+	/**
+	 * Re-registering an existing password-less reader sends a magic link by
+	 * default, and the new filter can suppress it.
+	 */
+	public function test_magic_link_on_reregistration_is_filterable() {
+		// Neutralize the magic link rate limiter so back-to-back reregistrations
+		// within this test aren't rate-limited into a false "email suppressed"
+		// result (mirrors the pattern in tests/unit-tests/magic-link.php).
+		add_filter( 'newspack_magic_link_rate_interval', '__return_zero' );
+
+		// Not @example.com: that is the Guest Contributor placeholder domain,
+		// and the outbound-mail guard (#572) suppresses wp_mail() to it, which
+		// would fail the delivery assertion below. Mirrors magic-link.php's
+		// use of @test.com for mail-asserting tests.
+		$email = 'magic-link-filter@test.com';
+		Reader_Activation::register_reader( $email, '', false, [ 'registration_method' => 'test-first' ] );
+
+		// Default: second registration sends the magic link email.
+		reset_phpmailer_instance();
+		$result = Reader_Activation::register_reader( $email, '', false, [ 'registration_method' => 'test-second' ] );
+		$this->assertFalse( $result, 'Re-registration of an existing reader should return false.' );
+		$this->assertNotEmpty( tests_retrieve_phpmailer_instance()->mock_sent, 'Magic link email should be sent by default.' );
+
+		// Filter returning false suppresses the email.
+		$filter = function() {
+			return false;
+		};
+		add_filter( 'newspack_reader_activation_send_magic_link_on_reregistration', $filter );
+		reset_phpmailer_instance();
+		$result = Reader_Activation::register_reader( $email, '', false, [ 'registration_method' => 'test-third' ] );
+		$this->assertFalse( $result, 'Re-registration with suppression filter should still return false.' );
+		$this->assertEmpty( tests_retrieve_phpmailer_instance()->mock_sent, 'Filter should suppress the magic link email.' );
+	}
+
+	/**
+	 * The integration is registered but disabled by default, and enabling it
+	 * exposes it to the frontend registration endpoint.
+	 */
+	public function test_registered_disabled_by_default_and_enablement_gates_frontend_registration() {
+		$integration = Integrations::get_integration( Form_Capture::ID );
+		$this->assertInstanceOf( Form_Capture::class, $integration );
+		$this->assertFalse( Integrations::is_enabled( Form_Capture::ID ), 'Must be disabled by default.' );
+		$this->assertFalse( $integration->supports_frontend_registration() );
+		$this->assertArrayNotHasKey( Form_Capture::ID, Reader_Registration::get_frontend_registration_integrations() );
+
+		Integrations::enable( Form_Capture::ID );
+		$this->assertTrue( $integration->supports_frontend_registration() );
+		$this->assertArrayHasKey( Form_Capture::ID, Reader_Registration::get_frontend_registration_integrations() );
+		Integrations::disable( Form_Capture::ID );
+	}
+
+	/**
+	 * Selector and list settings parse into clean arrays, and bare
+	 * element/universal selectors — which would opt in every form on the
+	 * site — are rejected.
+	 */
+	public function test_settings_parsing() {
+		$integration = Integrations::get_integration( Form_Capture::ID );
+
+		$this->assertSame( [ '.newspack-form-capture' ], $integration->get_selectors(), 'Marker class is always present.' );
+		$integration->update_settings_field_value( 'selectors', "#signup-form\n .sidebar form \n#signup-form" );
+		$this->assertSame( [ '.newspack-form-capture', '#signup-form', '.sidebar form' ], $integration->get_selectors() );
+
+		$integration->update_settings_field_value( 'selectors', "form\n*\nbody\nDIV\n#signup-form\nform.signup" );
+		$this->assertSame(
+			[ '.newspack-form-capture', '#signup-form', 'form.signup' ],
+			$integration->get_selectors(),
+			'Bare element/universal selectors must be rejected; qualified ones kept.'
+		);
+
+		// An over-broad selector is over-broad wherever it sits: inside a
+		// comma-separated list, or behind ancestors that name only elements.
+		$integration->update_settings_field_value( 'selectors', "form, #signup\nbody , .thing\nbody form\ndiv > form\n#a, .b\nfooter form.signup" );
+		$this->assertSame(
+			[ '.newspack-form-capture', '#a, .b', 'footer form.signup' ],
+			$integration->get_selectors(),
+			'A line is dropped whole when any of its selectors matches every form.'
+		);
+
+		// A trailing comma is a plausible copy-paste from a CSS rule. The empty
+		// slot has to be removed, not merely tolerated: it makes the whole line
+		// invalid CSS, and querySelectorAll() would throw on it client-side.
+		$integration->update_settings_field_value( 'selectors', "#signup,\n#a, #b,\n ,#c" );
+		$this->assertSame(
+			[ '.newspack-form-capture', '#signup', '#a, #b', '#c' ],
+			$integration->get_selectors(),
+			'Lines are rebuilt from their non-empty parts, so what ships is valid CSS.'
+		);
+		$integration->update_settings_field_value( 'selectors', '' );
+	}
+
+	/**
+	 * The unsupported check must be consulted at runtime, not only when
+	 * enabling: a site that switches to reCAPTCHA v2 afterwards would
+	 * otherwise keep emitting a key capture can never use.
+	 */
+	public function test_switching_to_recaptcha_v2_after_enabling_stops_capture() {
+		Integrations::enable( Form_Capture::ID );
+		$integration = Integrations::get_integration( Form_Capture::ID );
+		$this->assertTrue( $integration->supports_frontend_registration(), 'Enabled with no captcha configured.' );
+
+		update_option( 'newspack_recaptcha_use_captcha', true );
+		update_option( 'newspack_recaptcha_version', 'v2_invisible' );
+		update_option(
+			'newspack_recaptcha_credentials',
+			[
+				'v2_invisible' => [
+					'site_key'    => 'test-key',
+					'site_secret' => 'test-secret',
+				],
+			]
+		);
+
+		$this->assertTrue( Integrations::is_enabled( Form_Capture::ID ), 'The integration stays enabled — only its support changes.' );
+		$this->assertFalse( $integration->supports_frontend_registration(), 'A v2 switch must withdraw frontend registration.' );
+		$this->assertArrayNotHasKey(
+			Form_Capture::ID,
+			Reader_Registration::get_frontend_registration_integrations(),
+			'No key may be emitted for a configuration capture cannot use.'
+		);
+
+		$integration->enqueue_scripts();
+		$this->assertFalse( wp_script_is( Form_Capture::SCRIPT_HANDLE, 'enqueued' ), 'The capture script must not load either.' );
+
+		Integrations::disable( Form_Capture::ID );
+	}
+
+	/**
+	 * The reCAPTCHA v2 flow renders an interactive widget capture cannot warm,
+	 * so the integration must report itself unsupported (the REST layer then
+	 * refuses to enable it) instead of silently capturing nothing.
+	 */
+	public function test_unsupported_on_recaptcha_v2() {
+		$integration = Integrations::get_integration( Form_Capture::ID );
+
+		$this->assertNull( $integration->get_unsupported_reason(), 'Supported when no captcha is configured.' );
+
+		update_option( 'newspack_recaptcha_use_captcha', true );
+		update_option( 'newspack_recaptcha_version', 'v2_invisible' );
+		update_option(
+			'newspack_recaptcha_credentials',
+			[
+				'v2_invisible' => [
+					'site_key'    => 'test-key',
+					'site_secret' => 'test-secret',
+				],
+				'v3'           => [
+					'site_key'    => 'test-key',
+					'site_secret' => 'test-secret',
+				],
+			]
+		);
+		$this->assertNotNull( $integration->get_unsupported_reason(), 'Unsupported while reCAPTCHA v2 is active.' );
+		$this->assertNotEmpty( $integration->get_setup_url(), 'Unsupported state must point at the reCAPTCHA settings.' );
+
+		update_option( 'newspack_recaptcha_version', 'v3' );
+		$this->assertNull( $integration->get_unsupported_reason(), 'Supported on reCAPTCHA v3.' );
+	}
+
+	/**
+	 * The registration method format is a public contract shared with the
+	 * frontend registration endpoint (and stored in user meta on live
+	 * sites) — pin the literal so accidental drift on either side of the
+	 * shared helper fails loudly.
+	 */
+	public function test_registration_method_format_is_pinned() {
+		$this->assertSame( 'integration-registration-form-capture', Form_Capture::get_registration_method() );
+		$this->assertSame(
+			Reader_Registration::get_registration_method_for( Form_Capture::ID ),
+			Form_Capture::get_registration_method(),
+			'Integration and endpoint must derive the method string from the same helper.'
+		);
+	}
+
+	/**
+	 * Verify can_sync() honors the base contract: WP_Error when $return_errors
+	 * is true — callers like health_check() invoke ->has_errors() on it unguarded.
+	 */
+	public function test_can_sync_honors_wp_error_contract() {
+		Integrations::enable( Form_Capture::ID );
+		$integration = Integrations::get_integration( Form_Capture::ID );
+
+		$this->assertTrue( $integration->can_sync() );
+		$errors = $integration->can_sync( true );
+		$this->assertInstanceOf( \WP_Error::class, $errors );
+		$this->assertFalse( $errors->has_errors(), 'Capture-only integration has no sync prerequisites to fail.' );
+
+		add_filter( 'newspack_reader_activation_is_syncing_allowed', '__return_true' );
+		// A push-less integration can never satisfy has_one_syncable_integration():
+		// its predicate is is_push_enabled() — capability AND toggle — and
+		// supports_push() declares the capability off, always-passing can_sync()
+		// notwithstanding.
+		$this->assertFalse( Contact_Sync::has_one_syncable_integration() );
+
+		Integrations::disable( Form_Capture::ID );
+	}
+
+	/**
+	 * The capability declarations are part of the sync framework contract:
+	 * capture-only means no push and no pull.
+	 */
+	public function test_declares_no_sync_capabilities() {
+		$integration = Integrations::get_integration( Form_Capture::ID );
+		$this->assertFalse( $integration->supports_push(), 'Capture-only integration must declare no push capability.' );
+		$this->assertFalse( $integration->supports_pull(), 'Capture-only integration must declare no pull capability.' );
+	}
+
+	/**
+	 * The magic link is suppressed for this integration's registrations only,
+	 * and only while the integration is enabled — the off switch must mean off
+	 * even if something else stamps the method string (a replayed job, a CLI
+	 * backfill).
+	 */
+	public function test_magic_link_suppressed_for_form_capture_method() {
+		$user   = self::factory()->user->create_and_get( [ 'role' => 'subscriber' ] );
+		$method = [ 'registration_method' => Form_Capture::get_registration_method() ];
+
+		$this->assertTrue(
+			apply_filters( 'newspack_reader_activation_send_magic_link_on_reregistration', true, $user, $method ),
+			'Suppression must not apply while the integration is disabled.'
+		);
+
+		Integrations::enable( Form_Capture::ID );
+		$this->assertFalse(
+			apply_filters( 'newspack_reader_activation_send_magic_link_on_reregistration', true, $user, $method )
+		);
+		$this->assertTrue(
+			apply_filters( 'newspack_reader_activation_send_magic_link_on_reregistration', true, $user, [ 'registration_method' => 'auth-form' ] )
+		);
+		Integrations::disable( Form_Capture::ID );
+	}
+
+	/**
+	 * Existing readers get an explicit contact sync — the reader_registered
+	 * data event covers new users only. The decision is gated on the enabled
+	 * state alongside the method check.
+	 */
+	public function test_should_sync_existing_reader_decision() {
+		$integration = Integrations::get_integration( Form_Capture::ID );
+		$user        = self::factory()->user->create_and_get( [ 'role' => 'subscriber' ] );
+		$method      = [ 'registration_method' => Form_Capture::get_registration_method() ];
+
+		$this->assertFalse( $integration->should_sync_existing_reader( $user, $method ), 'No sync decision while the integration is disabled.' );
+
+		Integrations::enable( Form_Capture::ID );
+		$this->assertTrue( $integration->should_sync_existing_reader( $user, $method ) );
+		$this->assertFalse( $integration->should_sync_existing_reader( false, $method ), 'New users are covered by the reader_registered data event.' );
+		$this->assertFalse( $integration->should_sync_existing_reader( $user, [ 'registration_method' => 'auth-form' ] ), 'Other methods are not ours to sync.' );
+		Integrations::disable( Form_Capture::ID );
+	}
+
+	/**
+	 * An existing-reader capture registration schedules the contact sync via
+	 * Action Scheduler in the integration's group — off the request thread,
+	 * retryable, inspectable — and repeat captures reuse the pending action
+	 * rather than stacking a second one.
+	 */
+	public function test_existing_reader_sync_is_scheduled_not_synchronous() {
+		if ( ! function_exists( 'as_schedule_single_action' ) ) {
+			$this->markTestSkipped( 'Action Scheduler is not available.' );
+		}
+
+		Integrations::enable( Form_Capture::ID );
+		$integration = Integrations::get_integration( Form_Capture::ID );
+		$user        = self::factory()->user->create_and_get( [ 'role' => 'subscriber' ] );
+		$method      = [ 'registration_method' => Form_Capture::get_registration_method() ];
+		$context     = 'Form Capture registration (existing reader)';
+		$hook        = 'newspack_scheduled_esp_sync';
+		$args        = [ $user->ID, $context ];
+		$group       = $integration->get_action_group();
+
+		$integration->handle_registered_reader( $user->user_email, true, false, $user, $method );
+		$this->assertNotFalse(
+			as_next_scheduled_action( $hook, $args, $group ),
+			'An async ESP sync must be scheduled for an existing reader capture.'
+		);
+
+		// A repeat capture before the sync runs must not stack a second action.
+		$integration->handle_registered_reader( $user->user_email, true, false, $user, $method );
+		$pending = as_get_scheduled_actions(
+			[
+				'hook'     => $hook,
+				'args'     => $args,
+				'group'    => $group,
+				'status'   => \ActionScheduler_Store::STATUS_PENDING,
+				'per_page' => 10,
+			],
+			'ids'
+		);
+		$this->assertCount( 1, $pending, 'Repeat captures must reuse the pending sync action.' );
+
+		as_unschedule_all_actions( $hook, $args, $group );
+		Integrations::disable( Form_Capture::ID );
+	}
+
+	/**
+	 * The scheduled-sync payload must carry the reader's name for readers
+	 * without a WooCommerce billing record — an empty name pushed to the ESP
+	 * clears the contact's stored name (the repeat-capture FNAME regression).
+	 */
+	public function test_scheduled_sync_payload_preserves_user_name() {
+		$user = self::factory()->user->create_and_get(
+			[
+				'role'       => 'subscriber',
+				'first_name' => 'Grace',
+				'last_name'  => 'Hopper',
+			]
+		);
+
+		$contact = \Newspack\Reader_Activation\Sync\Metadata::get_contact_with_metadata( $user->ID );
+		$this->assertSame( 'Grace Hopper', $contact['name'], 'The sync payload must fall back to the WP user name, not push an empty name.' );
+	}
+
+	/**
+	 * A capture with no name field registers a reader whose display name is
+	 * generated from the email. That is a placeholder, not a name: syncing it
+	 * would write the email's local part into the ESP's name field, overwriting
+	 * a name that may have arrived from a list import.
+	 */
+	public function test_scheduled_sync_payload_omits_generated_display_name() {
+		$user_id = Reader_Activation::register_reader( 'jane.doe@test.com' );
+		$this->assertIsInt( $user_id );
+		$user = get_userdata( $user_id );
+
+		// Precondition: this is the population the guard is for.
+		$this->assertSame( 'jane-doe', $user->display_name, 'register_reader() names the account after the email when none is given.' );
+		$this->assertSame( '', get_user_meta( $user_id, 'first_name', true ) );
+
+		// The key must be absent, not empty: connectors branch on isset(), so an
+		// empty string overwrites the name the contact already has at the provider.
+		$contact = \Newspack\Reader_Activation\Sync\Metadata::get_contact_with_metadata( $user_id );
+		$this->assertArrayNotHasKey( 'name', $contact, 'A nameless reader must sync no name at all, not an empty one.' );
+
+		// Same guarantee on the path that runs when WooCommerce is inactive.
+		$contact = Contact_Sync::get_contact_data( $user_id );
+		$this->assertArrayNotHasKey( 'name', $contact, 'The non-WooCommerce path must not send a name either.' );
+
+		// A display name the reader actually has still syncs.
+		wp_update_user(
+			[
+				'ID'           => $user_id,
+				'display_name' => 'Jane Doe',
+			]
+		);
+		$contact = \Newspack\Reader_Activation\Sync\Metadata::get_contact_with_metadata( $user_id );
+		$this->assertSame( 'Jane Doe', $contact['name'], 'A real display name is still worth syncing.' );
+	}
+
+	/**
+	 * A reader who deliberately saved a display name that looks generated has
+	 * chosen it — My Account records that in meta, and it is their name.
+	 */
+	public function test_deliberately_saved_generic_display_name_still_syncs() {
+		$user_id = Reader_Activation::register_reader( 'chosen.name@test.com' );
+		$this->assertIsInt( $user_id );
+
+		$contact = \Newspack\Reader_Activation\Sync\Metadata::get_contact_with_metadata( $user_id );
+		$this->assertArrayNotHasKey( 'name', $contact, 'Generated until the reader says otherwise.' );
+
+		update_user_meta( $user_id, Reader_Activation::READER_SAVED_GENERIC_DISPLAY_NAME, 1 );
+		$contact = \Newspack\Reader_Activation\Sync\Metadata::get_contact_with_metadata( $user_id );
+		$this->assertSame( 'chosen-name', $contact['name'], 'A name the reader saved deliberately must sync.' );
+	}
+
+	/**
+	 * Adding the seed to the HMAC input changes every integration's key once on
+	 * upgrade. Pages already in a CDN or page cache carry the old key, and the
+	 * capture client treats an invalid key as permanent — so the legacy key must
+	 * keep validating until those caches cycle.
+	 */
+	public function test_legacy_registration_key_is_accepted() {
+		$integration = Integrations::get_integration( Form_Capture::ID );
+		$legacy_key  = hash_hmac( 'sha256', Form_Capture::ID, wp_salt( 'auth' ) );
+		$request     = new WP_REST_Request( 'POST', '/newspack/v1/reader-activation/register' );
+
+		$this->assertNotSame( $legacy_key, $integration->get_registration_key(), 'The seeded key is a new value.' );
+		$this->assertTrue( $integration->validate_registration_request( $integration->get_registration_key(), $request ) );
+		$this->assertTrue( $integration->validate_registration_request( $legacy_key, $request ), 'A key from a cached page must still validate.' );
+		$this->assertFalse( $integration->validate_registration_request( 'not-a-key', $request ) );
+	}
+
+	/**
+	 * The transition allowance belongs to the framework's own key scheme. An
+	 * integration with a custom scheme that inherits this validator must not
+	 * find the framework's static HMAC accepted alongside its own — that would
+	 * permanently bypass whatever bound the custom scheme enforces.
+	 */
+	public function test_legacy_key_is_refused_for_custom_key_schemes() {
+		$integration = new Inherited_Validator_Integration();
+		$legacy_key  = hash_hmac( 'sha256', 'custom-key-integration', wp_salt( 'auth' ) );
+		$request     = new WP_REST_Request( 'POST', '/newspack/v1/reader-activation/register' );
+
+		$this->assertTrue( $integration->validate_registration_request( 'custom-scheme-key', $request ), 'The custom key still validates.' );
+		$this->assertFalse( $integration->validate_registration_request( $legacy_key, $request ), 'The framework legacy key must not bypass a custom scheme.' );
+	}
+
+	/**
+	 * End-to-end: the registration endpoint accepts this integration's key and
+	 * produces a reader stamped with this integration's registration method.
+	 *
+	 * Mirrors the logged-out precondition from
+	 * Newspack_Test_Frontend_Registration_Endpoint::set_up() in
+	 * reader-registration-endpoint.php (the frontend endpoint's step 2
+	 * short-circuits to a 200 "existing" response for a logged-in caller). That
+	 * suite always dispatches through a real WP_REST_Server; this test calls the
+	 * handler directly, which is equivalent here since the handler only reads
+	 * params via WP_REST_Request::get_param() and doesn't depend on the REST
+	 * server's schema-driven sanitization/defaults for the fields exercised below.
+	 */
+	public function test_endpoint_registers_reader() {
+		wp_set_current_user( 0 );
+
+		Integrations::enable( Form_Capture::ID );
+		$integration = Integrations::get_integration( Form_Capture::ID );
+
+		$captured_metadata = null;
+		$capture           = function( $email, $authenticate, $user_id, $existing_user, $metadata ) use ( &$captured_metadata ) {
+			$captured_metadata = $metadata;
+		};
+		add_action( 'newspack_registered_reader', $capture, 10, 5 );
+
+		$request = new WP_REST_Request( 'POST', '/newspack/v1/reader-activation/register' );
+		$request->set_param( 'npe', 'capture-endpoint@example.com' );
+		$request->set_param( 'integration_id', Form_Capture::ID );
+		$request->set_param( 'integration_key', $integration->get_registration_key() );
+		$response = Reader_Registration::api_frontend_register_reader( $request );
+
+		$this->assertSame( 201, $response->get_status() );
+		$this->assertSame( Form_Capture::get_registration_method(), $captured_metadata['registration_method'] );
+		$user = get_user_by( 'email', 'capture-endpoint@example.com' );
+		$this->assertNotFalse( $user );
+
+		remove_action( 'newspack_registered_reader', $capture );
+		Integrations::disable( Form_Capture::ID );
+	}
+
+	/**
+	 * The capture script is enqueued only when the integration is enabled.
+	 */
+	public function test_capture_script_enqueued_only_when_enabled() {
+		// A locally constructed instance, with register_handlers() run inside
+		// this test's hook-backup scope, pins the wiring order-independently
+		// (registry instances may have registered their hooks before this
+		// test's backup was taken).
+		$integration = new Form_Capture();
+		$integration->register_handlers();
+
+		$this->assertSame( 20, has_action( 'wp_enqueue_scripts', [ $integration, 'enqueue_scripts' ] ), 'Enqueue must be hooked at priority 20.' );
+
+		$integration->enqueue_scripts();
+		$this->assertFalse( wp_script_is( Form_Capture::SCRIPT_HANDLE, 'enqueued' ) );
+
+		Integrations::enable( Form_Capture::ID );
+		$integration->enqueue_scripts();
+		$this->assertTrue( wp_script_is( Form_Capture::SCRIPT_HANDLE, 'enqueued' ) );
+		Integrations::disable( Form_Capture::ID );
+	}
+
+	/**
+	 * Capture counts in its own per-IP rate-limit bucket, sized for form
+	 * traffic — it must neither starve nor be starved by the shared
+	 * registration bucket.
+	 */
+	public function test_rate_limit_bucket_and_sizing() {
+		$bucket = Reader_Registration::get_rate_limit_bucket_for( Form_Capture::ID );
+		$this->assertSame( 'registration_form-capture', $bucket );
+		// Separators are preserved, so ids differing only by one can't silently
+		// share a counter.
+		$this->assertNotSame( $bucket, Reader_Registration::get_rate_limit_bucket_for( 'form_capture' ) );
+
+		// The integration sizes its own bucket via the existing filter.
+		$this->assertSame(
+			Form_Capture::RATE_LIMIT_DEFAULT,
+			apply_filters( 'newspack_frontend_registration_rate_limit', 10, '203.0.113.9', $bucket )
+		);
+		// Every other bucket is left alone.
+		$this->assertSame( 10, apply_filters( 'newspack_frontend_registration_rate_limit', 10, '203.0.113.9', 'registration' ) );
+	}
+
+	/**
+	 * The registration key derives from a stored per-integration seed, so it
+	 * is stable across requests but revocable on its own — without rotating
+	 * AUTH_SALT and logging out every user.
+	 */
+	public function test_registration_key_is_stable_and_rotatable() {
+		$integration = Integrations::get_integration( Form_Capture::ID );
+
+		$key = $integration->get_registration_key();
+		$this->assertNotEmpty( $key );
+		$this->assertSame( $key, $integration->get_registration_key(), 'The key must be deterministic (pages are cached).' );
+
+		$new_key = $integration->rotate_registration_key();
+		$this->assertNotSame( $key, $new_key, 'Rotation must invalidate the previous key.' );
+		$this->assertSame( $new_key, $integration->get_registration_key(), 'The rotated key must be stable again.' );
+	}
+}

--- a/plugins/newspack-plugin/webpack.config.js
+++ b/plugins/newspack-plugin/webpack.config.js
@@ -40,6 +40,7 @@ const entry = {
 	'reader-activation': resolveSource( 'src', 'reader-activation', 'index' ),
 	'reader-auth': resolveSource( 'src', 'reader-activation-auth', 'index' ),
 	'newsletters-signup': resolveSource( 'src', 'reader-activation-newsletters', 'index' ),
+	'form-capture': resolveSource( 'src', 'reader-activation-form-capture', 'index' ),
 	'reader-registration-block': resolveSource( 'src', 'blocks', 'reader-registration', 'view' ),
 	'correction-box-block': resolveSource( 'src', 'blocks', 'correction-box', 'index' ),
 	'correction-item-block': resolveSource( 'src', 'blocks', 'correction-item', 'index' ),


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Cherry-picks the **Inbound Form Capture** Reader Activation integration onto `alpha`, ahead of a full `main` → `alpha` promotion. `alpha` is currently 30 commits behind `main`, so this brings across the one feature rather than everything queued.

`git cherry-pick -x 2e9fee86f` — a clean application, no conflicts. The commit body carries the upstream reference.

Publishers can opt specific frontend forms — built with any form tool — into reader capture. On submit, a small frontend script harvests the email (plus best-effort first/last name) and registers the visitor through the existing hardened `/reader-activation/register` endpoint, producing a session-known reader synced to the ESP. The integration ships disabled; enabling it is the single gate for the endpoint, the page-emitted key, and the script.

Full feature description, design context and consciously-accepted trade-offs are in the original PR: Automattic/newspack-workspace#684.

**Dependency check.** The feature builds on framework code that landed separately — the per-direction sync capabilities (`supports_push()` / `supports_pull()` / `is_push_enabled()`), `Integration::register_handlers()` and `get_action_group()`, `Reader_Registration::get_registration_method_for()`, and `Recaptcha::can_use_captcha( 'v3' )`. All are already present on `alpha`, so nothing else needs picking across.

### How to test the changes in this Pull Request:

1. Check out this branch and build the plugin so `dist/form-capture.js` exists, on a site with Reader Activation enabled.
2. Run the plugin's PHP suite. It passes on this base: 2721 tests, 7815 assertions, 9 skipped.
3. Run the JS suite. It passes on this base: 567 tests across 60 suites.
4. Enable the integration: `wp eval 'Newspack\Reader_Activation\Integrations::enable( "form-capture" );'`. Add the CSS class `newspack-form-capture` to a form with an email field.
5. Submit that form as a logged-out visitor with a new address. The form behaves exactly as before, and a reader account is created.
6. Full functional test steps, including the ESP and reCAPTCHA paths, are in Automattic/newspack-workspace#684.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? Tests came across with the cherry-pick — 20 form-capture PHPUnit tests and the capture client's own Jest suite.
* [x] Have you successfully run tests with your changes locally? Both suites pass on this base, and PHPCS and ESLint are clean.
