### PR TITLE
fix(guest-contributors): restore empty-email creation on WP 7.0.3+

### DIFF
--- a/plugins/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/plugins/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -629,11 +629,13 @@ class Guest_Contributor_Role {
 
 		// Since WordPress 7.0.3, edit_user() validates the submitted email at
 		// assignment, so an empty field adds invalid_email before this action
-		// fires. Clear it only when the submission is empty — a malformed,
-		// non-empty address must keep failing validation.
-		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification happens in wp-admin/user-new.php before this hook.
-		$submitted_email = isset( $_POST['email'] ) ? trim( sanitize_text_field( wp_unslash( $_POST['email'] ) ) ) : '';
-		if ( '' === $submitted_email && ! empty( $errors->errors['invalid_email'] ) ) {
+		// fires. Clear it only when the submission is genuinely empty, judged
+		// on the raw value: input that only sanitization would empty (stray
+		// markup, an address pasted with angle brackets, a non-string
+		// payload) keeps failing validation like any other malformed entry.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing,WordPress.Security.ValidatedSanitizedInput.InputNotSanitized -- Every edit_user() caller verifies a nonce first (user-new.php, user-edit.php, profile.php, wp_ajax_add_user()); the value is only compared with the empty string, never stored or output.
+		$is_empty_email = isset( $_POST['email'] ) && is_string( $_POST['email'] ) && '' === trim( wp_unslash( $_POST['email'] ) );
+		if ( $is_empty_email && ! empty( $errors->errors['invalid_email'] ) ) {
 			$errors->remove( 'invalid_email' );
 		}
 

--- a/plugins/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php
+++ b/plugins/newspack-plugin/includes/plugins/co-authors-plus/class-guest-contributor-role.php
@@ -627,6 +627,16 @@ class Guest_Contributor_Role {
 			$errors->remove( 'user_login' );
 		}
 
+		// Since WordPress 7.0.3, edit_user() validates the submitted email at
+		// assignment, so an empty field adds invalid_email before this action
+		// fires. Clear it only when the submission is empty — a malformed,
+		// non-empty address must keep failing validation.
+		// phpcs:ignore WordPress.Security.NonceVerification.Missing -- Nonce verification happens in wp-admin/user-new.php before this hook.
+		$submitted_email = isset( $_POST['email'] ) ? trim( sanitize_text_field( wp_unslash( $_POST['email'] ) ) ) : '';
+		if ( '' === $submitted_email && ! empty( $errors->errors['invalid_email'] ) ) {
+			$errors->remove( 'invalid_email' );
+		}
+
 		// We still don't want users with duplicate emails.
 		if ( ! empty( $errors->errors['email_exists'] ) ) {
 			return $errors;

--- a/plugins/newspack-plugin/tests/unit-tests/guest-contributor-role.php
+++ b/plugins/newspack-plugin/tests/unit-tests/guest-contributor-role.php
@@ -788,20 +788,20 @@ class Newspack_Test_Guest_Contributor_Role extends WP_UnitTestCase {
 		wp_set_current_user( $admin_id );
 		require_once ABSPATH . 'wp-admin/includes/user.php';
 
-		$_POST = array_merge(
-			$_POST,
-			[
-				'action'     => 'createuser',
-				'user_login' => 'Integration GC',
-				'email'      => '',
-				'first_name' => '',
-				'last_name'  => '',
-				'url'        => '',
-				'pass1'      => 'S0me-Str0ng-Pass!',
-				'pass2'      => 'S0me-Str0ng-Pass!',
-				'role'       => Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME,
-			]
-		);
+		// The test framework clears $_POST in set_up(), so assign directly —
+		// reading the superglobal (e.g. via array_merge) trips the
+		// nonce-verification sniff, and there is nothing to merge with.
+		$_POST = [
+			'action'     => 'createuser',
+			'user_login' => 'Integration GC',
+			'email'      => '',
+			'first_name' => '',
+			'last_name'  => '',
+			'url'        => '',
+			'pass1'      => 'S0me-Str0ng-Pass!',
+			'pass2'      => 'S0me-Str0ng-Pass!',
+			'role'       => Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME,
+		];
 
 		$result = edit_user();
 		$this->assertIsInt( $result, 'edit_user() must create a Guest Contributor with an empty email on the running core version.' );

--- a/plugins/newspack-plugin/tests/unit-tests/guest-contributor-role.php
+++ b/plugins/newspack-plugin/tests/unit-tests/guest-contributor-role.php
@@ -652,8 +652,12 @@ class Newspack_Test_Guest_Contributor_Role extends WP_UnitTestCase {
 		$_POST['user_login'] = 'Malformed Email GC';
 		$_POST['email']      = 'not-an-address';
 
+		// WordPress 7.0.3+ adds both errors for a malformed submission too:
+		// the assignment fails, so user_email stays unset and the later
+		// empty-check also fires. Seed both to mirror the production state.
 		$errors = new WP_Error();
 		$errors->add( 'invalid_email', 'The email address is not correct.', [ 'form-field' => 'email' ] );
+		$errors->add( 'empty_email', 'Please enter an email address.', [ 'form-field' => 'email' ] );
 
 		$user             = new stdClass();
 		$user->role       = Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME;
@@ -705,5 +709,109 @@ class Newspack_Test_Guest_Contributor_Role extends WP_UnitTestCase {
 		$this->assertEmpty( $errors->get_error_messages( 'invalid_email' ), 'The invalid_email error must be cleared when blanking an existing Guest Contributor email.' );
 		$this->assertSame( 'existing-contributor', $user->user_login, 'The update path must not regenerate the login.' );
 		$this->assertSame( 'existing-contributor@' . Guest_Contributor_Role::get_dummy_email_domain(), $user->user_email );
+	}
+
+	/**
+	 * A submission that only sanitization would empty — stray markup like
+	 * <b></b>, or an address pasted with angle brackets — is not an empty
+	 * submission. Emptiness is judged on the raw value, so these keep
+	 * failing validation instead of silently becoming a placeholder.
+	 */
+	public function test_user_profile_update_errors_keeps_invalid_email_for_markup_only_email() {
+		$_POST['user_login'] = 'Markup Email GC';
+		$_POST['email']      = '<b></b>';
+
+		$errors = new WP_Error();
+		$errors->add( 'invalid_email', 'The email address is not correct.', [ 'form-field' => 'email' ] );
+		$errors->add( 'empty_email', 'Please enter an email address.', [ 'form-field' => 'email' ] );
+
+		$user             = new stdClass();
+		$user->role       = Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME;
+		$user->user_login = 'Markup Email GC';
+
+		Guest_Contributor_Role::user_profile_update_errors( $errors, false, $user );
+
+		$this->assertNotEmpty( $errors->get_error_messages( 'invalid_email' ), 'A submission that only sanitization empties must still fail validation.' );
+	}
+
+	/**
+	 * A non-string email payload (e.g. email[]=… from a mis-built form) is
+	 * rejected by WordPress 7.0.3+ with invalid_email; it must not be
+	 * treated as an empty submission.
+	 */
+	public function test_user_profile_update_errors_keeps_invalid_email_for_array_email() {
+		$_POST['user_login'] = 'Array Email GC';
+		$_POST['email']      = [ 'jane@paper.com' ];
+
+		$errors = new WP_Error();
+		$errors->add( 'invalid_email', 'The email address is not correct.', [ 'form-field' => 'email' ] );
+
+		$user             = new stdClass();
+		$user->role       = Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME;
+		$user->user_login = 'Array Email GC';
+
+		Guest_Contributor_Role::user_profile_update_errors( $errors, false, $user );
+
+		$this->assertNotEmpty( $errors->get_error_messages( 'invalid_email' ), 'A non-string email payload must still fail validation.' );
+	}
+
+	/**
+	 * A Guest Contributor submitted with a valid email keeps it: no errors
+	 * are added and the address is not replaced by a placeholder.
+	 */
+	public function test_user_profile_update_errors_leaves_valid_email_untouched() {
+		$_POST['user_login'] = 'Valid Email GC';
+		$_POST['email']      = 'jane@paper.com';
+
+		$errors = new WP_Error();
+
+		$user             = new stdClass();
+		$user->role       = Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME;
+		$user->user_login = 'Valid Email GC';
+		$user->user_email = 'jane@paper.com';
+
+		Guest_Contributor_Role::user_profile_update_errors( $errors, false, $user );
+
+		$this->assertEmpty( $errors->get_error_codes(), 'No errors may be introduced for a valid submission.' );
+		$this->assertSame( 'jane@paper.com', $user->user_email, 'A valid email must not be replaced by a placeholder.' );
+	}
+
+	/**
+	 * End-to-end through core: edit_user() on the running WordPress version
+	 * creates a Guest Contributor with an empty email and assigns the
+	 * placeholder, while a control role still fails. Guards against core
+	 * changing this validation surface again (the NPPM-3124 class of change).
+	 */
+	public function test_edit_user_creates_guest_contributor_with_empty_email() {
+		Guest_Contributor_Role::setup_custom_role_and_capability();
+		$admin_id = $this->factory()->user->create( [ 'role' => 'administrator' ] );
+		wp_set_current_user( $admin_id );
+		require_once ABSPATH . 'wp-admin/includes/user.php';
+
+		$_POST = array_merge(
+			$_POST,
+			[
+				'action'     => 'createuser',
+				'user_login' => 'Integration GC',
+				'email'      => '',
+				'first_name' => '',
+				'last_name'  => '',
+				'url'        => '',
+				'pass1'      => 'S0me-Str0ng-Pass!',
+				'pass2'      => 'S0me-Str0ng-Pass!',
+				'role'       => Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME,
+			]
+		);
+
+		$result = edit_user();
+		$this->assertIsInt( $result, 'edit_user() must create a Guest Contributor with an empty email on the running core version.' );
+		$user = get_user_by( 'id', $result );
+		$this->assertSame( 'integration-gc@' . Guest_Contributor_Role::get_dummy_email_domain(), $user->user_email );
+
+		// Control: a non-Guest-Contributor role with an empty email must still fail.
+		$_POST['user_login'] = 'Integration Control';
+		$_POST['role']       = 'subscriber';
+		$control             = edit_user();
+		$this->assertWPError( $control, 'A subscriber with an empty email must still fail core validation.' );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/guest-contributor-role.php
+++ b/plugins/newspack-plugin/tests/unit-tests/guest-contributor-role.php
@@ -641,6 +641,7 @@ class Newspack_Test_Guest_Contributor_Role extends WP_UnitTestCase {
 		Guest_Contributor_Role::user_profile_update_errors( $errors, false, $user );
 
 		$this->assertEmpty( $errors->get_error_messages( 'invalid_email' ), 'The invalid_email error must be cleared for a whitespace-only submission.' );
+		$this->assertEmpty( $errors->get_error_messages( 'empty_email' ), 'The empty_email error must be cleared for a whitespace-only submission.' );
 		$this->assertSame( 'whitespace-email-gc@' . Guest_Contributor_Role::get_dummy_email_domain(), $user->user_email );
 	}
 

--- a/plugins/newspack-plugin/tests/unit-tests/guest-contributor-role.php
+++ b/plugins/newspack-plugin/tests/unit-tests/guest-contributor-role.php
@@ -595,4 +595,115 @@ class Newspack_Test_Guest_Contributor_Role extends WP_UnitTestCase {
 			remove_filter( 'newspack_guest_author_email_domain', $set_domain );
 		}
 	}
+
+	/**
+	 * Creating a Guest Contributor with an empty email must clear the
+	 * invalid_email error WordPress 7.0.3+ adds before the
+	 * user_profile_update_errors action fires, and assign the placeholder.
+	 */
+	public function test_user_profile_update_errors_clears_invalid_email_for_empty_email() {
+		$_POST['user_login'] = 'Empty Email GC';
+		$_POST['email']      = '';
+
+		// WordPress 7.0.3+ adds both errors for an empty submission: invalid_email
+		// at assignment, empty_email later because user_email is never set.
+		$errors = new WP_Error();
+		$errors->add( 'invalid_email', 'The email address is not correct.', [ 'form-field' => 'email' ] );
+		$errors->add( 'empty_email', 'Please enter an email address.', [ 'form-field' => 'email' ] );
+
+		$user             = new stdClass();
+		$user->role       = Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME;
+		$user->user_login = 'Empty Email GC';
+
+		Guest_Contributor_Role::user_profile_update_errors( $errors, false, $user );
+
+		$this->assertEmpty( $errors->get_error_messages( 'invalid_email' ), 'The invalid_email error must be cleared for an empty submission.' );
+		$this->assertEmpty( $errors->get_error_messages( 'empty_email' ), 'The empty_email error must be cleared for an empty submission.' );
+		$this->assertSame( 'empty-email-gc@' . Guest_Contributor_Role::get_dummy_email_domain(), $user->user_email );
+	}
+
+	/**
+	 * A whitespace-only email submission is an empty submission: the
+	 * invalid_email error must be cleared and the placeholder assigned.
+	 */
+	public function test_user_profile_update_errors_clears_invalid_email_for_whitespace_email() {
+		$_POST['user_login'] = 'Whitespace Email GC';
+		$_POST['email']      = '   ';
+
+		$errors = new WP_Error();
+		$errors->add( 'invalid_email', 'The email address is not correct.', [ 'form-field' => 'email' ] );
+		$errors->add( 'empty_email', 'Please enter an email address.', [ 'form-field' => 'email' ] );
+
+		$user             = new stdClass();
+		$user->role       = Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME;
+		$user->user_login = 'Whitespace Email GC';
+
+		Guest_Contributor_Role::user_profile_update_errors( $errors, false, $user );
+
+		$this->assertEmpty( $errors->get_error_messages( 'invalid_email' ), 'The invalid_email error must be cleared for a whitespace-only submission.' );
+		$this->assertSame( 'whitespace-email-gc@' . Guest_Contributor_Role::get_dummy_email_domain(), $user->user_email );
+	}
+
+	/**
+	 * A malformed, non-empty email submission must keep the invalid_email
+	 * error: the clearing is scoped to empty submissions only.
+	 */
+	public function test_user_profile_update_errors_keeps_invalid_email_for_malformed_email() {
+		$_POST['user_login'] = 'Malformed Email GC';
+		$_POST['email']      = 'not-an-address';
+
+		$errors = new WP_Error();
+		$errors->add( 'invalid_email', 'The email address is not correct.', [ 'form-field' => 'email' ] );
+
+		$user             = new stdClass();
+		$user->role       = Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME;
+		$user->user_login = 'Malformed Email GC';
+
+		Guest_Contributor_Role::user_profile_update_errors( $errors, false, $user );
+
+		$this->assertNotEmpty( $errors->get_error_messages( 'invalid_email' ), 'A malformed, non-empty submission must still fail validation.' );
+	}
+
+	/**
+	 * The invalid_email clearing is scoped to the Guest Contributor role:
+	 * other roles keep core validation untouched.
+	 */
+	public function test_user_profile_update_errors_keeps_invalid_email_for_other_roles() {
+		$_POST['user_login'] = 'Regular Author';
+		$_POST['email']      = '';
+
+		$errors = new WP_Error();
+		$errors->add( 'invalid_email', 'The email address is not correct.', [ 'form-field' => 'email' ] );
+
+		$user             = new stdClass();
+		$user->role       = 'author';
+		$user->user_login = 'Regular Author';
+
+		Guest_Contributor_Role::user_profile_update_errors( $errors, false, $user );
+
+		$this->assertNotEmpty( $errors->get_error_messages( 'invalid_email' ), 'Non-Guest-Contributor roles must keep core email validation.' );
+	}
+
+	/**
+	 * Blanking the email on an existing Guest Contributor (the update path)
+	 * must clear the invalid_email error and assign the placeholder from the
+	 * existing login, without regenerating the login.
+	 */
+	public function test_user_profile_update_errors_clears_invalid_email_on_update() {
+		$_POST['email'] = '';
+
+		$errors = new WP_Error();
+		$errors->add( 'invalid_email', 'The email address is not correct.', [ 'form-field' => 'email' ] );
+		$errors->add( 'empty_email', 'Please enter an email address.', [ 'form-field' => 'email' ] );
+
+		$user             = new stdClass();
+		$user->role       = Guest_Contributor_Role::CONTRIBUTOR_NO_EDIT_ROLE_NAME;
+		$user->user_login = 'existing-contributor';
+
+		Guest_Contributor_Role::user_profile_update_errors( $errors, true, $user );
+
+		$this->assertEmpty( $errors->get_error_messages( 'invalid_email' ), 'The invalid_email error must be cleared when blanking an existing Guest Contributor email.' );
+		$this->assertSame( 'existing-contributor', $user->user_login, 'The update path must not regenerate the login.' );
+		$this->assertSame( 'existing-contributor@' . Guest_Contributor_Role::get_dummy_email_domain(), $user->user_email );
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Creating a Guest Contributor with the Email field left empty stopped working on WordPress 7.0.3 and later: the form shows "**Error:** The email address is not correct." and no account is created. Removing the email from an existing Guest Contributor fails the same way. Newspack is designed to allow the empty field — it assigns a placeholder `@example.com` address and suppresses mail to placeholder addresses.

WordPress now validates the submitted email earlier, adding an `invalid_email` error before Newspack's hook runs. The hook cleared only the `empty_email` error, so the new error survived and blocked the account.

This change clears the new error only when the submission is genuinely empty, judged on the raw value: whitespace-only counts as empty, while malformed addresses, stray markup, and non-string payloads keep failing validation. The same handling restores removing an existing Guest Contributor's email.

Reference: NPPM-3124.

### How to test the changes in this Pull Request:

1. Use a site on WordPress 7.0.3 or later (a fresh isolated env installs 7.0.4) with newspack-plugin at `release`.
2. Go to Users → Add User and set Role to Guest Contributor.
3. Enter a display name, leave Email empty, and click Add User. The page shows "Error: The email address is not correct." and no account is created.
4. Switch newspack-plugin to this branch and repeat steps 2–3. The page shows "New user created." and the account carries an `@example.com` placeholder address.
5. Repeat with Email `not-an-address`. The error still appears and no account is created.
6. Repeat with Email `<b></b>`. The error still appears.
7. Open an existing Guest Contributor on the profile screen, clear the Email field, and click Update User. The placeholder address is assigned.
8. Optional: run `n test-php` in `plugins/newspack-plugin`. The suite passes (2,379 tests).

### Release risk: ELEVATED

| Signal | Reading |
|---|---|
| Contract surface | Shared class consumed by newspack-blocks and newspack-manager; both verified to reference only symbols this change does not touch |
| Change shape | Ten production lines, additive inside an existing hook callback; no signature, hook, or constant changes; no-op on WordPress before 7.0.3 |
| Consequences | None identified — over-clearing is fenced by the role gate, raw-value emptiness check, and a valid-email regression test |
| Verification | Live on WP 7.0.4 (create, malformed, markup, and update paths) and reproduced on 7.1-RC3; 2,379-test suite green locally and in CI |

Driven by the contract-surface touch alone; review came back with no blockers and all findings were addressed before this PR opened.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

The WordPress check was confirmed against the core source tags: absent through 7.0.2, present from 7.0.3, and still present in 7.1-RC3 — so this fix is needed unchanged on WordPress 7.1. One test drives core's real `edit_user()` end to end, so a future core-side change to this validation surface fails CI instead of reaching publishers. The changed class is a shared surface consumed by newspack-blocks and newspack-manager; both reference only symbols this change does not touch.
