### PR TITLE
fix(listings): resolve event dates in the site timezone (NPPM-3125)

### DIFF
--- a/plugins/newspack-listings/src/blocks/event-dates/edit.js
+++ b/plugins/newspack-listings/src/blocks/event-dates/edit.js
@@ -59,7 +59,7 @@ export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 							) }
 						>
 							<DateTimePicker
-								currentDate={ startDate ? new Date( startDate ) : null }
+								currentDate={ startDate || null }
 								is12Hour={ true }
 								onChange={ value => {
 									if (
@@ -93,7 +93,7 @@ export const EventDatesEditor = ( { attributes, clientId, setAttributes } ) => {
 								) }
 							>
 								<DateTimePicker
-									currentDate={ endDate ? new Date( endDate ) : null }
+									currentDate={ endDate || null }
 									is12Hour={ true }
 									onChange={ value => {
 										if ( ! value || ! startDate || ( startDate && 0 <= new Date( value ) - new Date( startDate ) ) ) {


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Event Dates block now shows the time that was set, whatever timezone the editor works in.

An editor whose computer sits in a different timezone from the site saw event times come back changed. Set 6:00 PM on a UTC site from US Eastern, and the field redisplayed as 11:00 PM. Correcting it showed the shift again, so the field could not be trusted, and an editor who corrected what they saw would save a time that really was wrong.

The block stores times without an offset, and core's date picker resolves that form against the site timezone. It does so only when it receives the stored string. A value already parsed by `new Date()` skips the correction, because JavaScript reads an offset-less string as browser-local time. The picker then renders that instant in site time, off by the editor's offset. This change passes the stored value through untouched.

The stored format does not change, so existing events need no migration, and the front-end template is unaffected.

Found while testing WordPress 7.1, though it is not a regression from 7.1. The timezone handling in core's picker is identical in 7.0.4 and 7.1-RC3, and the behavior is the same on both. Proposed as a hotfix.

Addresses NPPM-3125.

### How to test the changes in this Pull Request:

1. In Settings > General, set Timezone to a zone several hours away from the machine you are testing from. UTC works from anywhere in the Americas. This offset is required; with matching timezones there is nothing to reproduce.
2. Create an Event listing and add the Event Dates block. Turn on **Show Times**.
3. Set the start time to 6:00 PM. The field keeps reading 6:00 PM. Before this change it redisplayed shifted by the offset, so 11:00 PM at UTC-5.
4. Reload the editor. The start time still reads 6:00 PM.
5. Turn on **Show End Time** and set an end time. It holds the same way.
6. Publish the event and view it on the front end. The time matches the editor.
7. Turn **Show Times** off, set a date only, and reload. The date stays on the same day. Before this change, a date-only event could show a day early or late for editors far from the site timezone.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? Tests n/a: `newspack-listings` has no JS test setup, so a unit test means adding that infrastructure first. Verified by the manual steps above.
* [x] Have you successfully run tests with your changes locally? Checked on WordPress 7.0.4 and 7.1-RC3, in separate environments running identical plugin code, with the editor at UTC+0, UTC-5, UTC+9, and UTC+11. ESLint clean.

<details>
<summary>Technical detail</summary>

`inputToDate()` in core's `@wordpress/components` branches on the type of its argument:

- an offset-less **string** goes through `getDate( input )`, which resolves it in the site timezone
- a **`Date`** goes through `input.getTime()`, the raw instant, with no correction

`edit.js` passed `new Date( startDate )`, which took the second branch. Confirmed in the editor console on a UTC site with the browser at `America/New_York`:

```js
wp.date.dateI18n( 'Y-m-d H:i', new Date( '2027-01-15T18:00:00' ) );        // 2027-01-15 23:00
wp.date.dateI18n( 'Y-m-d H:i', wp.date.getDate( '2027-01-15T18:00:00' ) ); // 2027-01-15 18:00
```

**The picker's behavior comes from core, not `node_modules`.** `@wordpress/components` is externalized at build time: `dist/editor.asset.php` lists `wp-components` and `wp-date` as dependencies, and `inputToDate` does not appear in the built `editor.js`. The copy under `node_modules` is a different implementation. Reading that copy suggests the opposite conclusion, that a string and a `Date` resolve identically, which would make this change a no-op. The behavior that applies is core's, in `wp-includes/js/dist/components.js`, and it is identical in 7.0.4 and 7.1-RC3.

The write path was already correct. `onChange` emits through `@wordpress/date`'s `date()` with `TIMEZONELESS_FORMAT`, which formats in site time, so the saved value was right even while the display was wrong.

The `new Date()` comparisons on lines 68 and 99 are left alone. Both operands are offset-less strings parsed the same way, so the ordering they produce holds.

**Related, not addressed here.** The same pattern appears in two other pickers in this plugin: `src/editor/sidebar/index.js` (listing expiration) and `src/editor/featured-listings/index.js` (featured-listing expiration). Both are date-only, so they are exposed to the day-boundary variant in test step 7, where an expiration lands a day early or late. Kept out of this hotfix to keep it reviewable; worth a follow-up ticket.

</details>
