### PR TITLE
fix(popups): preview links keep preview mode under WP 7.1 (NEWS-2889)

### DIFF
--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -1009,30 +1009,43 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
+	 * The preview slice of the view script's localized data.
+	 *
+	 * Separate from preview_param_names() so the localized *key* is assertable, not
+	 * just the list: the front end reads `newspack_popups_view.preview_param_names`,
+	 * and renaming either side alone would leave both suites green while previews
+	 * silently stopped surviving a click. Named for the shape it has — a flat list of
+	 * param names, where newspack_popups_data.preview_query_keys is a
+	 * meta-key => param map.
+	 *
+	 * @return array Empty when this is not a prompt preview.
+	 */
+	public static function get_view_script_preview_data() {
+		$names = self::preview_param_names();
+		return empty( $names ) ? [] : [ 'preview_param_names' => $names ];
+	}
+
+	/**
 	 * The preview query param names to hand the previewed document, so it can carry
 	 * them onto same-origin links and keep the preview alive across a click.
 	 *
-	 * All three checks earn their place, because previewed_popup_id() only reports
-	 * that the request carries a `pid` — not that anyone may preview, nor that the
-	 * id is a prompt. `pid` is a common campaign parameter, so without
-	 * is_user_admin() a reader arriving on `?pid=…` would have it stamped onto every
-	 * link for the rest of their session while seeing no prompts at all; without the
-	 * post-type check an editor who follows an ad or newsletter link carrying an
-	 * unrelated `pid` would get the same. Together they make this mean "an actual
-	 * prompt preview", matching the gate on
-	 * Newspack_Popups_Model::retrieve_preview_popup(), which is what renders one.
+	 * Both checks earn their place, because previewed_popup_id() only reports that
+	 * the request carries a `pid` — not that anyone may preview, nor that the id is a
+	 * prompt. `pid` is a common campaign parameter, so without can_preview_popup() a
+	 * reader arriving on `?pid=…` would have it stamped onto every link for the rest
+	 * of their session while seeing no prompts at all, and an editor who follows an
+	 * ad or newsletter link carrying an unrelated `pid` would get the same.
 	 * is_preview_request() is the wrong test here — it also covers preset, view-as
 	 * and customizer previews, which pass their state differently.
+	 *
+	 * The JS half of this contract has its own guard: propagation only runs inside
+	 * the preview frame. See src/view/preview-links.js.
 	 *
 	 * @return array Param names, empty when this is not a prompt preview.
 	 */
 	public static function preview_param_names() {
 		$previewed_popup_id = Newspack_Popups::previewed_popup_id();
-		if (
-			! $previewed_popup_id
-			|| ! Newspack_Popups::is_user_admin()
-			|| Newspack_Popups::NEWSPACK_POPUPS_CPT !== get_post_type( $previewed_popup_id )
-		) {
+		if ( ! $previewed_popup_id || ! Newspack_Popups::can_preview_popup( $previewed_popup_id ) ) {
 			return [];
 		}
 		return array_merge(
@@ -1121,12 +1134,7 @@ final class Newspack_Popups_Inserter {
 				$script_data['donor_landing_page'] = $donor_landing_page;
 			}
 
-			// Named for the shape it has: a flat list of param names, where
-			// newspack_popups_data.preview_query_keys is a meta-key => param map.
-			$preview_param_names = self::preview_param_names();
-			if ( ! empty( $preview_param_names ) ) {
-				$script_data['preview_param_names'] = $preview_param_names;
-			}
+			$script_data = array_merge( $script_data, self::get_view_script_preview_data() );
 
 			\wp_localize_script( $script_handle, 'newspack_popups_view', $script_data );
 			\wp_enqueue_script( $script_handle );

--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -1009,6 +1009,39 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
+	 * The preview query param names to hand the previewed document, so it can carry
+	 * them onto same-origin links and keep the preview alive across a click.
+	 *
+	 * All three checks earn their place, because previewed_popup_id() only reports
+	 * that the request carries a `pid` — not that anyone may preview, nor that the
+	 * id is a prompt. `pid` is a common campaign parameter, so without
+	 * is_user_admin() a reader arriving on `?pid=…` would have it stamped onto every
+	 * link for the rest of their session while seeing no prompts at all; without the
+	 * post-type check an editor who follows an ad or newsletter link carrying an
+	 * unrelated `pid` would get the same. Together they make this mean "an actual
+	 * prompt preview", matching the gate on
+	 * Newspack_Popups_Model::retrieve_preview_popup(), which is what renders one.
+	 * is_preview_request() is the wrong test here — it also covers preset, view-as
+	 * and customizer previews, which pass their state differently.
+	 *
+	 * @return array Param names, empty when this is not a prompt preview.
+	 */
+	public static function preview_param_names() {
+		$previewed_popup_id = Newspack_Popups::previewed_popup_id();
+		if (
+			! $previewed_popup_id
+			|| ! Newspack_Popups::is_user_admin()
+			|| Newspack_Popups::NEWSPACK_POPUPS_CPT !== get_post_type( $previewed_popup_id )
+		) {
+			return [];
+		}
+		return array_merge(
+			[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ],
+			array_values( Newspack_Popups::PREVIEW_QUERY_KEYS )
+		);
+	}
+
+	/**
 	 * Enqueue the assets needed to display the popups.
 	 */
 	public static function enqueue_scripts() {
@@ -1088,22 +1121,11 @@ final class Newspack_Popups_Inserter {
 				$script_data['donor_landing_page'] = $donor_landing_page;
 			}
 
-			// In a prompt preview the previewed document carries its own preview
-			// params onto same-origin links, so the preview survives navigation.
-			// It needs the param list to know which of its query params those are.
-			//
-			// Gated on the prompt preview specifically, not on is_preview_request():
-			// that covers preset, view-as and customizer previews too, and it is not
-			// a capability check — previewed_popup_id() reads `pid` from any request,
-			// signed in or not. `pid` is also a common campaign parameter, so without
-			// is_user_admin() an ordinary reader arriving on `?pid=…` would have it
-			// stamped onto every link for the rest of their session while seeing no
-			// prompts at all. preset_popup_id() guards itself the same way.
-			if ( Newspack_Popups::previewed_popup_id() && Newspack_Popups::is_user_admin() ) {
-				$script_data['preview_query_params'] = array_merge(
-					[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ],
-					array_values( Newspack_Popups::PREVIEW_QUERY_KEYS )
-				);
+			// Named for the shape it has: a flat list of param names, where
+			// newspack_popups_data.preview_query_keys is a meta-key => param map.
+			$preview_param_names = self::preview_param_names();
+			if ( ! empty( $preview_param_names ) ) {
+				$script_data['preview_param_names'] = $preview_param_names;
 			}
 
 			\wp_localize_script( $script_handle, 'newspack_popups_view', $script_data );

--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -1088,6 +1088,18 @@ final class Newspack_Popups_Inserter {
 				$script_data['donor_landing_page'] = $donor_landing_page;
 			}
 
+			// In a prompt preview the previewed document carries its own preview
+			// params onto same-origin links, so the preview survives navigation.
+			// It needs the key list to know which of its query params those are.
+			// Sent only on a preview request: outside one there is nothing to
+			// propagate, and the keys would be dead weight on every page.
+			if ( Newspack_Popups::is_preview_request() ) {
+				$script_data['preview_query_keys'] = array_merge(
+					[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ],
+					array_values( Newspack_Popups::PREVIEW_QUERY_KEYS )
+				);
+			}
+
 			\wp_localize_script( $script_handle, 'newspack_popups_view', $script_data );
 			\wp_enqueue_script( $script_handle );
 		}

--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -1090,11 +1090,17 @@ final class Newspack_Popups_Inserter {
 
 			// In a prompt preview the previewed document carries its own preview
 			// params onto same-origin links, so the preview survives navigation.
-			// It needs the key list to know which of its query params those are.
-			// Sent only on a preview request: outside one there is nothing to
-			// propagate, and the keys would be dead weight on every page.
-			if ( Newspack_Popups::is_preview_request() ) {
-				$script_data['preview_query_keys'] = array_merge(
+			// It needs the param list to know which of its query params those are.
+			//
+			// Gated on the prompt preview specifically, not on is_preview_request():
+			// that covers preset, view-as and customizer previews too, and it is not
+			// a capability check — previewed_popup_id() reads `pid` from any request,
+			// signed in or not. `pid` is also a common campaign parameter, so without
+			// is_user_admin() an ordinary reader arriving on `?pid=…` would have it
+			// stamped onto every link for the rest of their session while seeing no
+			// prompts at all. preset_popup_id() guards itself the same way.
+			if ( Newspack_Popups::previewed_popup_id() && Newspack_Popups::is_user_admin() ) {
+				$script_data['preview_query_params'] = array_merge(
 					[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ],
 					array_values( Newspack_Popups::PREVIEW_QUERY_KEYS )
 				);

--- a/plugins/newspack-popups/includes/class-newspack-popups-model.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-model.php
@@ -316,12 +316,7 @@ final class Newspack_Popups_Model {
 	 *                    the post is not a prompt, or the id does not resolve to a post.
 	 */
 	public static function retrieve_preview_popup( $post_id ) {
-		// Previews render unsaved prompt content, so restrict them to users who can manage
-		// prompts and to the prompts CPT, mirroring the plugin's other preview entry points.
-		if ( ! Newspack_Popups::is_user_admin() ) {
-			return null;
-		}
-		if ( Newspack_Popups::NEWSPACK_POPUPS_CPT !== get_post_type( $post_id ) ) {
+		if ( ! Newspack_Popups::can_preview_popup( $post_id ) ) {
 			return null;
 		}
 		// The editor's autosave only holds the freshest content while there are

--- a/plugins/newspack-popups/includes/class-newspack-popups.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups.php
@@ -968,7 +968,6 @@ final class Newspack_Popups {
 			'newspack-popups',
 			'newspack_popups_data',
 			[
-				'frontend_url'                 => get_site_url(),
 				'preview_post'                 => self::preview_post_permalink(),
 				'preview_archive'              => self::preview_archive_permalink(),
 				'custom_placements'            => Newspack_Popups_Custom_Placements::get_custom_placements(),

--- a/plugins/newspack-popups/includes/class-newspack-popups.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups.php
@@ -1049,6 +1049,23 @@ final class Newspack_Popups {
 	}
 
 	/**
+	 * Whether the current user may preview a given prompt.
+	 *
+	 * Previews render unsaved, request-supplied prompt content, so both halves
+	 * matter: the capability, and the id actually naming a prompt. Shared so the
+	 * renderer (Newspack_Popups_Model::retrieve_preview_popup) and the front-end
+	 * param list (Newspack_Popups_Inserter::preview_param_names) cannot drift apart
+	 * — a gate stricter than the renderer would produce a preview whose links go
+	 * nowhere, and one looser would leak preview state onto ordinary pages.
+	 *
+	 * @param int|string $post_id Prompt ID from the request.
+	 * @return bool
+	 */
+	public static function can_preview_popup( $post_id ) {
+		return self::is_user_admin() && self::NEWSPACK_POPUPS_CPT === get_post_type( $post_id );
+	}
+
+	/**
 	 * Get previewed popup id from the URL.
 	 *
 	 * @return number|null Popup id, if found in the URL

--- a/plugins/newspack-popups/src/editor/Preview.js
+++ b/plugins/newspack-popups/src/editor/Preview.js
@@ -18,7 +18,6 @@ const PreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields } ) =>
 	}
 
 	const previewQueryKeys = window.newspack_popups_data?.preview_query_keys || {};
-	const frontendUrl = window?.newspack_popups_data?.frontend_url || '/';
 	const abbreviatedKeys = {};
 	Object.keys( metaFields ).forEach( key => {
 		if ( previewQueryKeys.hasOwnProperty( key ) ) {
@@ -35,18 +34,16 @@ const PreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields } ) =>
 	const isArchivePagesPrompt = metaFields.placement === 'archives';
 	const previewURL = window.newspack_popups_data[ isArchivePagesPrompt ? 'preview_archive' : 'preview_post' ] || '/';
 
-	const onWebPreviewLoad = iframeEl => {
-		if ( iframeEl ) {
-			[ ...iframeEl.contentWindow.document.querySelectorAll( 'a[href^="' + frontendUrl + '"]' ) ].forEach( anchor => {
-				anchor.setAttribute( 'href', addQueryArgs( anchor.getAttribute( 'href' ), query ) );
-			} );
-		}
-	};
-
+	// Links inside the preview keep their preview params, but the previewed
+	// document does that for itself — see propagatePreviewParams() in
+	// src/view/preview-links.js. The editor used to reach into the preview
+	// iframe and rewrite the links from out here, which WordPress 7.1 no longer
+	// permits: it serves the block editor with `Document-Isolation-Policy`,
+	// putting the editor in its own agent cluster and severing synchronous
+	// access to the frame even though it is same-origin.
 	return (
 		<WebPreview
 			url={ addQueryArgs( previewURL, query ) }
-			onLoad={ onWebPreviewLoad }
 			renderButton={ ( { showPreview } ) => (
 				<Button isPrimary isBusy={ isSavingPost } disabled={ isSavingPost } onClick={ () => autosavePost().then( showPreview ) }>
 					{ __( 'Preview', 'newspack-popups' ) }

--- a/plugins/newspack-popups/src/view/index.js
+++ b/plugins/newspack-popups/src/view/index.js
@@ -14,12 +14,12 @@ import { domReady, logPageview, getPrompts } from './utils';
 import './merge-tags';
 
 domReady( () => {
-	// Runs regardless of the prompt-disabled flag: a preview has to survive
-	// navigation even on a page where prompts are switched off.
-	propagatePreviewParams();
-
 	window.newspackRAS = window.newspackRAS || [];
 	window.newspackRAS.push( logPageview ); // Pageviews should be logged whether or not prompts are enabled.
+
+	// After the pageview push on purpose: link rewriting is a preview nicety, and
+	// nothing about it should be able to cost a real reader their pageview.
+	propagatePreviewParams();
 
 	if ( ! newspack_popups_view?.has_disabled_prompts ) {
 		// Fetch all prompts on the page just once.

--- a/plugins/newspack-popups/src/view/index.js
+++ b/plugins/newspack-popups/src/view/index.js
@@ -8,11 +8,16 @@ import './patterns.scss';
 import { handleSegmentation } from './segmentation';
 import { handleAnalytics } from './analytics/ga4';
 import { handleContextualPromptAnalytics } from './analytics/contextual-prompt';
+import { propagatePreviewParams } from './preview-links';
 import { domReady, logPageview, getPrompts } from './utils';
 
 import './merge-tags';
 
 domReady( () => {
+	// Runs regardless of the prompt-disabled flag: a preview has to survive
+	// navigation even on a page where prompts are switched off.
+	propagatePreviewParams();
+
 	window.newspackRAS = window.newspackRAS || [];
 	window.newspackRAS.push( logPageview ); // Pageviews should be logged whether or not prompts are enabled.
 

--- a/plugins/newspack-popups/src/view/index.js
+++ b/plugins/newspack-popups/src/view/index.js
@@ -17,9 +17,17 @@ domReady( () => {
 	window.newspackRAS = window.newspackRAS || [];
 	window.newspackRAS.push( logPageview ); // Pageviews should be logged whether or not prompts are enabled.
 
-	// After the pageview push on purpose: link rewriting is a preview nicety, and
-	// nothing about it should be able to cost a real reader their pageview.
-	propagatePreviewParams();
+	// Wrapped, and after the pageview push, on purpose. Everything below runs for
+	// every reader, while link rewriting is an admin-only preview nicety; a throw
+	// here would otherwise take prompt display and prompt analytics down with it.
+	// Nothing in it can throw today, so this keeps that a property of the structure
+	// rather than of the current implementation.
+	try {
+		propagatePreviewParams();
+	} catch ( e ) {
+		// eslint-disable-next-line no-console
+		console.warn( 'Prompt preview: could not propagate preview params.', e );
+	}
 
 	if ( ! newspack_popups_view?.has_disabled_prompts ) {
 		// Fetch all prompts on the page just once.

--- a/plugins/newspack-popups/src/view/index.test.js
+++ b/plugins/newspack-popups/src/view/index.test.js
@@ -1,0 +1,87 @@
+/**
+ * The view entry runs preview-link propagation and every reader-facing handler in
+ * one domReady callback, so a throw in the preview code would take prompt display
+ * and prompt analytics with it. That is what the try/catch there prevents, and
+ * this pins it: without the guard, reverting it leaves the suite green.
+ *
+ * index.js is imported for its side effects, so the mocks have to be in place
+ * before the import is evaluated.
+ */
+
+const mockPropagate = jest.fn();
+const mockHandleSegmentation = jest.fn();
+const mockHandleAnalytics = jest.fn();
+const mockHandleContextual = jest.fn();
+const mockGetPrompts = jest.fn( () => [] );
+const mockLogPageview = jest.fn();
+
+jest.mock( './preview-links', () => ( {
+	propagatePreviewParams: ( ...args ) => mockPropagate( ...args ),
+} ) );
+jest.mock( './segmentation', () => ( {
+	handleSegmentation: ( ...args ) => mockHandleSegmentation( ...args ),
+} ) );
+jest.mock( './analytics/ga4', () => ( {
+	handleAnalytics: ( ...args ) => mockHandleAnalytics( ...args ),
+} ) );
+jest.mock( './analytics/contextual-prompt', () => ( {
+	handleContextualPromptAnalytics: ( ...args ) => mockHandleContextual( ...args ),
+} ) );
+jest.mock( './utils', () => ( {
+	// domReady runs the callback immediately, which is the path a footer script takes
+	// once the document is already parsed.
+	domReady: cb => cb(),
+	getPrompts: ( ...args ) => mockGetPrompts( ...args ),
+	logPageview: mockLogPageview,
+} ) );
+jest.mock( './style.scss', () => ( {} ), { virtual: true } );
+jest.mock( './patterns.scss', () => ( {} ), { virtual: true } );
+jest.mock( './merge-tags', () => ( {} ), { virtual: true } );
+
+let warnSpy;
+
+describe( 'view entry: preview propagation cannot break reader-facing prompt logic', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		[ mockPropagate, mockHandleSegmentation, mockHandleAnalytics, mockHandleContextual ].forEach( m => m.mockReset() );
+		global.newspack_popups_view = { has_disabled_prompts: false };
+		window.newspackRAS = [];
+		// Held in a variable rather than reached for as `console.warn`, which the
+		// no-console rule rejects.
+		warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		warnSpy.mockRestore();
+	} );
+
+	it( 'runs propagation and the prompt handlers on load', () => {
+		require( './index' );
+
+		expect( mockPropagate ).toHaveBeenCalled();
+		expect( mockHandleSegmentation ).toHaveBeenCalled();
+		expect( mockHandleAnalytics ).toHaveBeenCalled();
+	} );
+
+	it( 'still runs the prompt handlers when propagation throws', () => {
+		mockPropagate.mockImplementation( () => {
+			throw new Error( 'isolation' );
+		} );
+
+		expect( () => require( './index' ) ).not.toThrow();
+		expect( warnSpy ).toHaveBeenCalled();
+		expect( mockHandleSegmentation ).toHaveBeenCalled();
+		expect( mockHandleAnalytics ).toHaveBeenCalled();
+		expect( mockHandleContextual ).toHaveBeenCalled();
+	} );
+
+	it( 'pushes the pageview before propagation runs, so a reader never loses it', () => {
+		mockPropagate.mockImplementation( () => {
+			throw new Error( 'isolation' );
+		} );
+
+		require( './index' );
+
+		expect( window.newspackRAS ).toContain( mockLogPageview );
+	} );
+} );

--- a/plugins/newspack-popups/src/view/preview-links.js
+++ b/plugins/newspack-popups/src/view/preview-links.js
@@ -13,13 +13,35 @@
  * preview iframe even though the frame is same-origin — so the editor can no
  * longer reach in and rewrite these links from outside. A document may always
  * rewrite its own. See NEWS-2889.
+ *
+ * AMP pages are not covered. The param list is localized alongside `view.js`,
+ * which the inserter only registers on non-AMP requests, so a site in AMP
+ * standard mode keeps the pre-7.1 behaviour. Closing that would mean rewriting
+ * the links server-side, since AMP forbids arbitrary inline script.
+ *
+ * Kept deliberately in step with
+ * newspack-plugin/src/content-gate/preview-links.js, which solves the same
+ * problem for gate previews. The two are duplicated rather than shared: a shared
+ * package would tie two independently released plugins to one version, which is
+ * the wrong trade for a fix this small. If you change one, change the other.
  */
 export function propagatePreviewParams() {
+	// Previews only ever render inside the editor's preview iframe, so requiring a
+	// frame is what keeps preview mode from following an admin around the site. An
+	// admin who lands on a preview URL top-level — a new tab, a pasted link — is
+	// browsing, not previewing, and should get ordinary links; preview mode also
+	// hides the admin bar, so sticky params there would leave no way out but
+	// editing the URL by hand. Comparing `window.top` is a reference check, which
+	// cross-origin isolation still permits.
+	if ( window.self === window.top ) {
+		return;
+	}
+
 	// Only localized on a prompt preview, so its absence means there is nothing
 	// to propagate. Read through `window.` rather than as a bare identifier:
 	// optional chaining guards a null value, not an undeclared binding, and an
 	// undeclared one throws.
-	const params = window.newspack_popups_view?.preview_query_params;
+	const params = window.newspack_popups_view?.preview_param_names;
 	if ( ! params?.length ) {
 		return;
 	}
@@ -57,12 +79,28 @@ export function propagatePreviewParams() {
 		}
 
 		// Off-site links, and schemes like mailto: and tel: that resolve to a
-		// null origin, are none of our business.
+		// null origin, are none of our business. Matching on origin rather than on
+		// the site URL means a subdirectory install also stamps links that sit
+		// outside WordPress; that is deliberate, because it is what makes
+		// multibranded sites work, where brands are same-origin paths. A stray
+		// `pid` on such a page resolves to no prompt and does nothing.
 		if ( url.origin !== window.location.origin ) {
 			return;
 		}
 
 		present.forEach( ( [ key, value ] ) => url.searchParams.set( key, value ) );
-		anchor.setAttribute( 'href', url.toString() );
+
+		// Keep the href in the shape the page wrote it, because a preview exists to
+		// show what production does. Re-serializing through URL() turns a relative
+		// href absolute, which breaks exactly the theme code a preview should
+		// exercise: `a[href^="/"]` selectors, "current item" scripts comparing an
+		// href against location.pathname. Only the query is ours to change. Two
+		// residual differences we accept: a path-relative href comes back
+		// root-relative, since resolving it is what told us where it points, and
+		// URLSearchParams re-encodes an existing query (`%20` to `+`) — forms
+		// servers treat as equivalent, and unpicking it would mean editing the
+		// query string by hand.
+		const isAbsolute = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test( href );
+		anchor.setAttribute( 'href', isAbsolute ? url.toString() : url.pathname + url.search + url.hash );
 	} );
 }

--- a/plugins/newspack-popups/src/view/preview-links.js
+++ b/plugins/newspack-popups/src/view/preview-links.js
@@ -21,9 +21,13 @@
  *
  * Kept deliberately in step with
  * newspack-plugin/src/content-gate/preview-links.js, which solves the same
- * problem for gate previews. The two are duplicated rather than shared: a shared
- * package would tie two independently released plugins to one version, which is
- * the wrong trade for a fix this small. If you change one, change the other.
+ * problem for gate previews. The two are duplicated rather than shared because
+ * there is nowhere good to share them to: `packages/` is React components and
+ * build tooling, not view-layer utilities, and this is ~50 lines of
+ * dependency-free DOM code reading a differently-named global in each plugin.
+ * (Sharing would not create version coupling — workspace packages are bundled
+ * into each plugin's own dist/ at build time — so that is not the reason.) If you
+ * change one, change the other; there is a test file on each side to catch drift.
  */
 export function propagatePreviewParams() {
 	// Previews only ever render inside the editor's preview iframe, so requiring a
@@ -31,8 +35,18 @@ export function propagatePreviewParams() {
 	// admin who lands on a preview URL top-level — a new tab, a pasted link — is
 	// browsing, not previewing, and should get ordinary links; preview mode also
 	// hides the admin bar, so sticky params there would leave no way out but
-	// editing the URL by hand. Comparing `window.top` is a reference check, which
-	// cross-origin isolation still permits.
+	// editing the URL by hand.
+	//
+	// Belt and braces with the capability gate on the PHP side
+	// (Newspack_Popups_Inserter::preview_param_names): that one decides whether the
+	// param list is published at all, this one decides whether a published list is
+	// acted on. Neither makes the other redundant — dropping the PHP gate would hand
+	// the list to any framed reader, and dropping this one puts an editor's whole
+	// browsing session in preview mode.
+	//
+	// Verified against WordPress 7.1-RC3 in Chrome: inside the preview frame,
+	// `document` access from the editor throws but the frame still reports
+	// `self !== top`, so isolation does not defeat this check.
 	if ( window.self === window.top ) {
 		return;
 	}
@@ -54,9 +68,11 @@ export function propagatePreviewParams() {
 
 	// One eager pass at domReady. Overlays are already in the DOM (they print at
 	// wp_footer), but anchors added later — "Load more", modal checkout, anything
-	// AJAX — keep their own hrefs and leave the preview on the first click. That
-	// matches the handler this replaced; a capture-phase click interceptor would
-	// close the gap if it ever proves worth the extra surface.
+	// AJAX — keep their own hrefs and leave the preview on the first click. Forms
+	// are untouched too, so a GET submission (theme site search is the common one)
+	// drops preview mode the same way. That matches the handler this replaced; a
+	// capture-phase interceptor would close both gaps if it ever proves worth the
+	// extra surface.
 	document.querySelectorAll( 'a[href]' ).forEach( anchor => {
 		// Read the attribute rather than the `href` property: the selector also
 		// matches SVG <a>, whose property is an SVGAnimatedString, and resolving
@@ -78,8 +94,16 @@ export function propagatePreviewParams() {
 			return;
 		}
 
-		// Off-site links, and schemes like mailto: and tel: that resolve to a
-		// null origin, are none of our business. Matching on origin rather than on
+		// Only http(s). An opaque-path URL like `blob:https://site/uuid` reports the
+		// inner origin, so it passes the origin test, but it has no meaningful path
+		// or query — the shape logic below would rewrite it into an ordinary page URL
+		// and destroy the link. Restricting the scheme keeps the rewrite to the two
+		// the shape logic was written for.
+		if ( 'http:' !== url.protocol && 'https:' !== url.protocol ) {
+			return;
+		}
+
+		// Off-site links are none of our business. Matching on origin rather than on
 		// the site URL means a subdirectory install also stamps links that sit
 		// outside WordPress; that is deliberate, because it is what makes
 		// multibranded sites work, where brands are same-origin paths. A stray
@@ -94,12 +118,14 @@ export function propagatePreviewParams() {
 		// show what production does. Re-serializing through URL() turns a relative
 		// href absolute, which breaks exactly the theme code a preview should
 		// exercise: `a[href^="/"]` selectors, "current item" scripts comparing an
-		// href against location.pathname. Only the query is ours to change. Two
+		// href against location.pathname. Only the query is ours to change. Three
 		// residual differences we accept: a path-relative href comes back
 		// root-relative, since resolving it is what told us where it points, and
 		// URLSearchParams re-encodes an existing query (`%20` to `+`) — forms
 		// servers treat as equivalent, and unpicking it would mean editing the
-		// query string by hand.
+		// query string by hand. A same-origin protocol-relative href also comes back
+		// scheme-absolute — the one shape we do not preserve, because telling it
+		// apart needs a third branch and it is vanishingly rare in theme output.
 		const isAbsolute = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test( href );
 		anchor.setAttribute( 'href', isAbsolute ? url.toString() : url.pathname + url.search + url.hash );
 	} );

--- a/plugins/newspack-popups/src/view/preview-links.js
+++ b/plugins/newspack-popups/src/view/preview-links.js
@@ -1,5 +1,3 @@
-/* globals newspack_popups_view */
-
 /**
  * Carry the prompt-preview parameters onto same-origin links.
  *
@@ -17,31 +15,43 @@
  * rewrite its own. See NEWS-2889.
  */
 export function propagatePreviewParams() {
-	// Only localized on a preview request, so its absence means there is
-	// nothing to propagate.
-	const keys = newspack_popups_view?.preview_query_keys;
-	if ( ! keys?.length ) {
+	// Only localized on a prompt preview, so its absence means there is nothing
+	// to propagate. Read through `window.` rather than as a bare identifier:
+	// optional chaining guards a null value, not an undeclared binding, and an
+	// undeclared one throws.
+	const params = window.newspack_popups_view?.preview_query_params;
+	if ( ! params?.length ) {
 		return;
 	}
 
 	const current = new URLSearchParams( window.location.search );
-	const params = keys.filter( key => current.has( key ) ).map( key => [ key, current.get( key ) ] );
-	if ( ! params.length ) {
+	const present = params.filter( key => current.has( key ) ).map( key => [ key, current.get( key ) ] );
+	if ( ! present.length ) {
 		return;
 	}
 
+	// One eager pass at domReady. Overlays are already in the DOM (they print at
+	// wp_footer), but anchors added later — "Load more", modal checkout, anything
+	// AJAX — keep their own hrefs and leave the preview on the first click. That
+	// matches the handler this replaced; a capture-phase click interceptor would
+	// close the gap if it ever proves worth the extra surface.
 	document.querySelectorAll( 'a[href]' ).forEach( anchor => {
+		// Read the attribute rather than the `href` property: the selector also
+		// matches SVG <a>, whose property is an SVGAnimatedString, and resolving
+		// that yields a same-origin garbage path that would overwrite the link.
 		const href = anchor.getAttribute( 'href' );
 
 		// Leave in-page anchors alone; adding query params would reload the page
 		// instead of jumping within it.
-		if ( ! href || href.startsWith( '#' ) ) {
+		if ( href.startsWith( '#' ) ) {
 			return;
 		}
 
 		let url;
 		try {
-			url = new URL( anchor.href, window.location.origin );
+			// Resolve against the document base so relative hrefs work and a <base>
+			// tag is respected.
+			url = new URL( href, document.baseURI );
 		} catch ( e ) {
 			return;
 		}
@@ -52,7 +62,7 @@ export function propagatePreviewParams() {
 			return;
 		}
 
-		params.forEach( ( [ key, value ] ) => url.searchParams.set( key, value ) );
+		present.forEach( ( [ key, value ] ) => url.searchParams.set( key, value ) );
 		anchor.setAttribute( 'href', url.toString() );
 	} );
 }

--- a/plugins/newspack-popups/src/view/preview-links.js
+++ b/plugins/newspack-popups/src/view/preview-links.js
@@ -1,0 +1,58 @@
+/* globals newspack_popups_view */
+
+/**
+ * Carry the prompt-preview parameters onto same-origin links.
+ *
+ * A prompt preview renders the real front end inside an iframe in the editor,
+ * with the previewed prompt's unsaved settings passed as query params. Those
+ * params have to survive navigation: without them the first click inside the
+ * preview lands on the ordinary published page, so the prompt stops following
+ * the editor and unsaved edits stop being reflected.
+ *
+ * This runs in the previewed document rather than in the editor on purpose.
+ * WordPress 7.1 serves the block editor with `Document-Isolation-Policy`, which
+ * places it in its own agent cluster and severs synchronous access to the
+ * preview iframe even though the frame is same-origin — so the editor can no
+ * longer reach in and rewrite these links from outside. A document may always
+ * rewrite its own. See NEWS-2889.
+ */
+export function propagatePreviewParams() {
+	// Only localized on a preview request, so its absence means there is
+	// nothing to propagate.
+	const keys = newspack_popups_view?.preview_query_keys;
+	if ( ! keys?.length ) {
+		return;
+	}
+
+	const current = new URLSearchParams( window.location.search );
+	const params = keys.filter( key => current.has( key ) ).map( key => [ key, current.get( key ) ] );
+	if ( ! params.length ) {
+		return;
+	}
+
+	document.querySelectorAll( 'a[href]' ).forEach( anchor => {
+		const href = anchor.getAttribute( 'href' );
+
+		// Leave in-page anchors alone; adding query params would reload the page
+		// instead of jumping within it.
+		if ( ! href || href.startsWith( '#' ) ) {
+			return;
+		}
+
+		let url;
+		try {
+			url = new URL( anchor.href, window.location.origin );
+		} catch ( e ) {
+			return;
+		}
+
+		// Off-site links, and schemes like mailto: and tel: that resolve to a
+		// null origin, are none of our business.
+		if ( url.origin !== window.location.origin ) {
+			return;
+		}
+
+		params.forEach( ( [ key, value ] ) => url.searchParams.set( key, value ) );
+		anchor.setAttribute( 'href', url.toString() );
+	} );
+}

--- a/plugins/newspack-popups/src/view/preview-links.test.js
+++ b/plugins/newspack-popups/src/view/preview-links.test.js
@@ -13,12 +13,12 @@ const hrefs = () => [ ...document.querySelectorAll( 'a' ) ].map( anchor => ancho
 
 describe( 'propagatePreviewParams', () => {
 	beforeEach( () => {
-		global.newspack_popups_view = { preview_query_keys: [ 'pid', 'n_bc' ] };
+		global.newspack_popups_view = { preview_query_params: [ 'pid', 'n_bc' ] };
 		setSearch( '' );
 		setLinks( '' );
 	} );
 
-	it( 'does nothing outside a preview, where the keys are not localized', () => {
+	it( 'does nothing outside a preview, where the params are not localized', () => {
 		global.newspack_popups_view = {};
 		setSearch( '?pid=42' );
 		setLinks( '<a href="/other/">x</a>' );
@@ -88,6 +88,45 @@ describe( 'propagatePreviewParams', () => {
 		propagatePreviewParams();
 
 		expect( hrefs() ).toEqual( [ abs( '/other/?utm_source=nl&pid=42' ) ] );
+	} );
+
+	it( 'survives the global being absent entirely', () => {
+		delete global.newspack_popups_view;
+		setSearch( '?pid=42' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		expect( () => propagatePreviewParams() ).not.toThrow();
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'rewrites an SVG anchor correctly rather than corrupting it', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<svg xmlns="http://www.w3.org/2000/svg"><a href="/chart/"><text>x</text></a></svg>' );
+
+		propagatePreviewParams();
+
+		// The selector matches SVG <a> too, and an SVGAElement's href *property* is
+		// an SVGAnimatedString — resolving it yields a same-origin garbage path that
+		// silently replaces the link. Reading the attribute keeps it intact.
+		expect( document.querySelector( 'svg a' ).getAttribute( 'href' ) ).toBe( abs( '/chart/?pid=42' ) );
+	} );
+
+	it( 'resolves a relative href against the document base', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="sub/page/">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ abs( '/post/sub/page/?pid=42' ) ] );
+	} );
+
+	it( 'keeps the fragment on a same-origin link', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="/other/#top">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ abs( '/other/?pid=42#top' ) ] );
 	} );
 
 	it( 'is idempotent, so a second pass does not duplicate params', () => {

--- a/plugins/newspack-popups/src/view/preview-links.test.js
+++ b/plugins/newspack-popups/src/view/preview-links.test.js
@@ -128,6 +128,7 @@ describe( 'propagatePreviewParams', () => {
 		setLinks( '<a href="/other/">x</a>' );
 
 		expect( () => propagatePreviewParams() ).not.toThrow();
+		expectNoTraversal( propagatePreviewParams );
 		expect( hrefs() ).toEqual( [ '/other/' ] );
 	} );
 
@@ -161,6 +162,28 @@ describe( 'propagatePreviewParams', () => {
 
 			propagatePreviewParams();
 
+			expect( hrefs() ).toEqual( [ `${ window.location.origin }/other/?pid=42` ] );
+		} );
+
+		it( 'leaves an opaque-path URL alone rather than flattening it to a page URL', () => {
+			setSearch( '?pid=42' );
+			// A blob URL reports its inner origin, so it passes the origin test; the
+			// shape logic would turn it into an ordinary page URL and kill the link.
+			setLinks( `<a href="blob:${ window.location.origin }/abc-123">x</a>` );
+
+			propagatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ `blob:${ window.location.origin }/abc-123` ] );
+		} );
+
+		it( 'promotes a same-origin protocol-relative href, the one shape it cannot keep', () => {
+			setSearch( '?pid=42' );
+			setLinks( `<a href="//${ window.location.host }/other/">x</a>` );
+
+			propagatePreviewParams();
+
+			// Documented in the module: telling this apart needs a third branch. Pinned
+			// so the behaviour is a decision rather than a surprise.
 			expect( hrefs() ).toEqual( [ `${ window.location.origin }/other/?pid=42` ] );
 		} );
 

--- a/plugins/newspack-popups/src/view/preview-links.test.js
+++ b/plugins/newspack-popups/src/view/preview-links.test.js
@@ -1,21 +1,44 @@
 import { propagatePreviewParams } from './preview-links';
 
-// The jsdom origin, whatever the runner sets it to. Expectations are built from
-// it independently of the code under test.
-const origin = () => window.location.origin;
-const abs = path => new URL( path, origin() ).toString();
-
 const setSearch = search => window.history.replaceState( {}, '', '/post/' + search );
 const setLinks = html => {
 	document.body.innerHTML = html;
 };
 const hrefs = () => [ ...document.querySelectorAll( 'a' ) ].map( anchor => anchor.getAttribute( 'href' ) );
 
+// Propagation only runs inside the preview iframe, so every positive case has to
+// look framed. jsdom's `top` points at the window itself.
+const setFramed = framed => {
+	Object.defineProperty( window, 'top', { value: framed ? {} : window, configurable: true } );
+};
+
+// Pins the contract that the early returns bail before touching the DOM at all,
+// which is what keeps this off the critical path of an ordinary page load. An
+// assertion on hrefs alone would still pass if the function walked every anchor
+// and happened to rewrite nothing.
+const expectNoTraversal = run => {
+	const spy = jest.spyOn( document, 'querySelectorAll' );
+	run();
+	expect( spy ).not.toHaveBeenCalled();
+	spy.mockRestore();
+};
+
 describe( 'propagatePreviewParams', () => {
 	beforeEach( () => {
-		global.newspack_popups_view = { preview_query_params: [ 'pid', 'n_bc' ] };
+		global.newspack_popups_view = { preview_param_names: [ 'pid', 'n_bc' ] };
+		setFramed( true );
 		setSearch( '' );
 		setLinks( '' );
+	} );
+
+	it( 'does nothing top-level, so preview mode cannot follow an admin around the site', () => {
+		setFramed( false );
+		setSearch( '?pid=42' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		expectNoTraversal( propagatePreviewParams );
+
+		expect( hrefs() ).toEqual( [ '/other/' ] );
 	} );
 
 	it( 'does nothing outside a preview, where the params are not localized', () => {
@@ -23,7 +46,7 @@ describe( 'propagatePreviewParams', () => {
 		setSearch( '?pid=42' );
 		setLinks( '<a href="/other/">x</a>' );
 
-		propagatePreviewParams();
+		expectNoTraversal( propagatePreviewParams );
 
 		expect( hrefs() ).toEqual( [ '/other/' ] );
 	} );
@@ -31,7 +54,7 @@ describe( 'propagatePreviewParams', () => {
 	it( 'does nothing when no preview param is present in the URL', () => {
 		setLinks( '<a href="/other/">x</a>' );
 
-		propagatePreviewParams();
+		expectNoTraversal( propagatePreviewParams );
 
 		expect( hrefs() ).toEqual( [ '/other/' ] );
 	} );
@@ -42,7 +65,7 @@ describe( 'propagatePreviewParams', () => {
 
 		propagatePreviewParams();
 
-		expect( hrefs() ).toEqual( [ abs( '/other/?pid=42&n_bc=blue' ) ] );
+		expect( hrefs() ).toEqual( [ '/other/?pid=42&n_bc=blue' ] );
 	} );
 
 	it( 'only carries the preview params actually present in the URL', () => {
@@ -51,7 +74,7 @@ describe( 'propagatePreviewParams', () => {
 
 		propagatePreviewParams();
 
-		expect( hrefs() ).toEqual( [ abs( '/other/?pid=42' ) ] );
+		expect( hrefs() ).toEqual( [ '/other/?pid=42' ] );
 	} );
 
 	it( 'leaves off-site links alone', () => {
@@ -81,13 +104,22 @@ describe( 'propagatePreviewParams', () => {
 		expect( hrefs() ).toEqual( [ 'mailto:hi@example.com', 'tel:+15551234' ] );
 	} );
 
+	it( 'leaves an unparseable href alone rather than throwing', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="http://[">x</a><a href="/other/">y</a>' );
+
+		expect( () => propagatePreviewParams() ).not.toThrow();
+		// The bad href is skipped and the pass carries on to the next anchor.
+		expect( hrefs() ).toEqual( [ 'http://[', '/other/?pid=42' ] );
+	} );
+
 	it( 'keeps unrelated query params and overwrites a stale preview param', () => {
 		setSearch( '?pid=42' );
 		setLinks( '<a href="/other/?utm_source=nl&pid=7">x</a>' );
 
 		propagatePreviewParams();
 
-		expect( hrefs() ).toEqual( [ abs( '/other/?utm_source=nl&pid=42' ) ] );
+		expect( hrefs() ).toEqual( [ '/other/?utm_source=nl&pid=42' ] );
 	} );
 
 	it( 'survives the global being absent entirely', () => {
@@ -108,25 +140,49 @@ describe( 'propagatePreviewParams', () => {
 		// The selector matches SVG <a> too, and an SVGAElement's href *property* is
 		// an SVGAnimatedString — resolving it yields a same-origin garbage path that
 		// silently replaces the link. Reading the attribute keeps it intact.
-		expect( document.querySelector( 'svg a' ).getAttribute( 'href' ) ).toBe( abs( '/chart/?pid=42' ) );
+		expect( document.querySelector( 'svg a' ).getAttribute( 'href' ) ).toBe( '/chart/?pid=42' );
 	} );
 
-	it( 'resolves a relative href against the document base', () => {
-		setSearch( '?pid=42' );
-		setLinks( '<a href="sub/page/">x</a>' );
+	describe( 'href shape', () => {
+		// A preview should differ from production in what it shows, not in the form
+		// of its markup: theme code keyed on href shape has to behave the same here.
+		it( 'keeps a root-relative href root-relative', () => {
+			setSearch( '?pid=42' );
+			setLinks( '<a href="/other/">x</a>' );
 
-		propagatePreviewParams();
+			propagatePreviewParams();
 
-		expect( hrefs() ).toEqual( [ abs( '/post/sub/page/?pid=42' ) ] );
-	} );
+			expect( hrefs() ).toEqual( [ '/other/?pid=42' ] );
+		} );
 
-	it( 'keeps the fragment on a same-origin link', () => {
-		setSearch( '?pid=42' );
-		setLinks( '<a href="/other/#top">x</a>' );
+		it( 'keeps an absolute href absolute', () => {
+			setSearch( '?pid=42' );
+			setLinks( `<a href="${ window.location.origin }/other/">x</a>` );
 
-		propagatePreviewParams();
+			propagatePreviewParams();
 
-		expect( hrefs() ).toEqual( [ abs( '/other/?pid=42#top' ) ] );
+			expect( hrefs() ).toEqual( [ `${ window.location.origin }/other/?pid=42` ] );
+		} );
+
+		it( 'resolves a path-relative href against the document base', () => {
+			setSearch( '?pid=42' );
+			setLinks( '<a href="sub/page/">x</a>' );
+
+			propagatePreviewParams();
+
+			// Root-relative rather than absolute: resolving it is what told us where
+			// it points, so this is as close to the original shape as we can get.
+			expect( hrefs() ).toEqual( [ '/post/sub/page/?pid=42' ] );
+		} );
+
+		it( 'keeps the fragment on a same-origin link', () => {
+			setSearch( '?pid=42' );
+			setLinks( '<a href="/other/#top">x</a>' );
+
+			propagatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ '/other/?pid=42#top' ] );
+		} );
 	} );
 
 	it( 'is idempotent, so a second pass does not duplicate params', () => {

--- a/plugins/newspack-popups/src/view/preview-links.test.js
+++ b/plugins/newspack-popups/src/view/preview-links.test.js
@@ -1,0 +1,103 @@
+import { propagatePreviewParams } from './preview-links';
+
+// The jsdom origin, whatever the runner sets it to. Expectations are built from
+// it independently of the code under test.
+const origin = () => window.location.origin;
+const abs = path => new URL( path, origin() ).toString();
+
+const setSearch = search => window.history.replaceState( {}, '', '/post/' + search );
+const setLinks = html => {
+	document.body.innerHTML = html;
+};
+const hrefs = () => [ ...document.querySelectorAll( 'a' ) ].map( anchor => anchor.getAttribute( 'href' ) );
+
+describe( 'propagatePreviewParams', () => {
+	beforeEach( () => {
+		global.newspack_popups_view = { preview_query_keys: [ 'pid', 'n_bc' ] };
+		setSearch( '' );
+		setLinks( '' );
+	} );
+
+	it( 'does nothing outside a preview, where the keys are not localized', () => {
+		global.newspack_popups_view = {};
+		setSearch( '?pid=42' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'does nothing when no preview param is present in the URL', () => {
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'carries the preview params onto a same-origin link', () => {
+		setSearch( '?pid=42&n_bc=blue' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ abs( '/other/?pid=42&n_bc=blue' ) ] );
+	} );
+
+	it( 'only carries the preview params actually present in the URL', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ abs( '/other/?pid=42' ) ] );
+	} );
+
+	it( 'leaves off-site links alone', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="https://elsewhere.test/page/">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ 'https://elsewhere.test/page/' ] );
+	} );
+
+	it( 'leaves in-page anchors alone, so they still jump rather than reload', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="#section">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ '#section' ] );
+	} );
+
+	it( 'leaves non-http schemes alone', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="mailto:hi@example.com">x</a><a href="tel:+15551234">y</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ 'mailto:hi@example.com', 'tel:+15551234' ] );
+	} );
+
+	it( 'keeps unrelated query params and overwrites a stale preview param', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="/other/?utm_source=nl&pid=7">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ abs( '/other/?utm_source=nl&pid=42' ) ] );
+	} );
+
+	it( 'is idempotent, so a second pass does not duplicate params', () => {
+		setSearch( '?pid=42&n_bc=blue' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagatePreviewParams();
+		const first = hrefs();
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( first );
+	} );
+} );

--- a/plugins/newspack-popups/tests/test-preview-param-names.php
+++ b/plugins/newspack-popups/tests/test-preview-param-names.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Class Preview Param Names Test
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Tests the gate on the preview param list handed to the previewed document.
+ *
+ * The list is what lets a prompt preview survive a click, so it must reach a
+ * genuine prompt preview and nothing else: `pid` is a common campaign parameter,
+ * and anyone can put one in a URL.
+ */
+class PreviewParamNamesTest extends WP_UnitTestCase {
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		unset( $_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] );
+		parent::tear_down();
+	}
+
+	/**
+	 * An admin previewing a prompt gets the list.
+	 */
+	public function test_param_names_for_an_admin_previewing_a_prompt() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$prompt_id = self::factory()->post->create( [ 'post_type' => Newspack_Popups::NEWSPACK_POPUPS_CPT ] );
+		$_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] = $prompt_id;
+
+		$names = Newspack_Popups_Inserter::preview_param_names();
+
+		$this->assertContains(
+			Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM,
+			$names,
+			'The list carries the preview param itself.'
+		);
+		foreach ( Newspack_Popups::PREVIEW_QUERY_KEYS as $param ) {
+			$this->assertContains( $param, $names, 'The list carries every abbreviated meta param.' );
+		}
+	}
+
+	/**
+	 * A `pid` that is not a prompt is somebody else's parameter.
+	 */
+	public function test_no_param_names_when_pid_is_not_a_prompt() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] = self::factory()->post->create();
+
+		$this->assertSame(
+			[],
+			Newspack_Popups_Inserter::preview_param_names(),
+			'An editor following a link that carries an unrelated `pid` gets ordinary links.'
+		);
+	}
+
+	/**
+	 * Readers never get preview params, however well-formed the URL.
+	 */
+	public function test_no_param_names_for_a_reader() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] = self::factory()->post->create(
+			[ 'post_type' => Newspack_Popups::NEWSPACK_POPUPS_CPT ]
+		);
+
+		$this->assertSame(
+			[],
+			Newspack_Popups_Inserter::preview_param_names(),
+			'A reader arriving on a prompt preview URL gets ordinary links.'
+		);
+	}
+
+	/**
+	 * No `pid`, nothing to propagate — the ordinary front-end request.
+	 */
+	public function test_no_param_names_without_the_param() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+
+		$this->assertSame(
+			[],
+			Newspack_Popups_Inserter::preview_param_names(),
+			'An admin browsing the site normally gets ordinary links.'
+		);
+	}
+}

--- a/plugins/newspack-popups/tests/test-preview-param-names.php
+++ b/plugins/newspack-popups/tests/test-preview-param-names.php
@@ -14,18 +14,22 @@
  */
 class PreviewParamNamesTest extends WP_UnitTestCase {
 	/**
-	 * Tear down.
+	 * Log in as a user holding the prompt-management capability.
+	 *
+	 * Deliberately an editor, not an administrator, matching test-presets.php: the
+	 * gate is `edit_others_pages` via a filterable capability, and an administrator
+	 * would satisfy any capability this were later tightened to, hiding the
+	 * regression from this suite.
 	 */
-	public function tear_down() {
-		unset( $_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] );
-		parent::tear_down();
+	private function login_as_prompt_manager() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
 	}
 
 	/**
-	 * An admin previewing a prompt gets the list.
+	 * A user who may manage prompts, previewing a prompt, gets the list.
 	 */
-	public function test_param_names_for_an_admin_previewing_a_prompt() {
-		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+	public function test_param_names_for_a_prompt_manager_previewing_a_prompt() {
+		$this->login_as_prompt_manager();
 		$prompt_id = self::factory()->post->create( [ 'post_type' => Newspack_Popups::NEWSPACK_POPUPS_CPT ] );
 		$_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] = $prompt_id;
 
@@ -45,7 +49,7 @@ class PreviewParamNamesTest extends WP_UnitTestCase {
 	 * A `pid` that is not a prompt is somebody else's parameter.
 	 */
 	public function test_no_param_names_when_pid_is_not_a_prompt() {
-		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->login_as_prompt_manager();
 		$_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] = self::factory()->post->create();
 
 		$this->assertSame(
@@ -75,12 +79,52 @@ class PreviewParamNamesTest extends WP_UnitTestCase {
 	 * No `pid`, nothing to propagate — the ordinary front-end request.
 	 */
 	public function test_no_param_names_without_the_param() {
-		wp_set_current_user( self::factory()->user->create( [ 'role' => 'administrator' ] ) );
+		$this->login_as_prompt_manager();
 
 		$this->assertSame(
 			[],
 			Newspack_Popups_Inserter::preview_param_names(),
 			'An admin browsing the site normally gets ordinary links.'
+		);
+	}
+
+	/**
+	 * An author holds edit_posts but not edit_others_pages, which pins the boundary
+	 * from below — the subscriber case only pins it from far outside.
+	 */
+	public function test_no_param_names_for_an_author() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'author' ] ) );
+		$_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] = self::factory()->post->create(
+			[ 'post_type' => Newspack_Popups::NEWSPACK_POPUPS_CPT ]
+		);
+
+		$this->assertSame( [], Newspack_Popups_Inserter::preview_param_names() );
+	}
+
+	/**
+	 * Pins the PHP-to-JS contract: the param names are useless unless they arrive
+	 * under the key src/view/preview-links.js reads.
+	 */
+	public function test_param_names_are_localized_under_the_key_the_view_script_reads() {
+		$this->login_as_prompt_manager();
+		$_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] = self::factory()->post->create(
+			[ 'post_type' => Newspack_Popups::NEWSPACK_POPUPS_CPT ]
+		);
+
+		$data = Newspack_Popups_Inserter::get_view_script_preview_data();
+
+		$this->assertArrayHasKey(
+			'preview_param_names',
+			$data,
+			'The front end reads newspack_popups_view.preview_param_names; renaming either side alone breaks the preview silently.'
+		);
+		$this->assertContains( Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM, $data['preview_param_names'] );
+
+		wp_set_current_user( 0 );
+		$this->assertSame(
+			[],
+			Newspack_Popups_Inserter::get_view_script_preview_data(),
+			'Nothing is merged into the localized data outside a preview.'
 		);
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Links inside a prompt preview keep the preview going. Before this, the first click on any link inside the preview landed on the ordinary published page: the prompt stopped following the editor and unsaved settings stopped being reflected.

WordPress 7.1 serves the block editor with `Document-Isolation-Policy`, which places it in its own agent cluster and severs synchronous access to the preview iframe — even though that frame is same-origin. The editor used to reach into the frame and rewrite the links from outside, so under 7.1 it threw before rewriting anything, uncaught, on every preview open:

```
SecurityError: Failed to read a named property 'document' from 'Window':
Blocked a frame with origin "https://<site>" from accessing a cross-origin frame.
    at onLoad (…/newspack-popups/dist/editor.js)
```

The fix moves the work into the previewed document, which may always rewrite its own links. No cross-document access remains, so the error is gone at its source rather than caught and swallowed.

- `src/view/preview-links.js` (new) — the previewed page carries its own preview params onto same-origin links. It runs only inside the preview iframe, confines itself to `http(s)` (so an opaque-path href like `blob:` is left alone rather than flattened into a page URL), skips in-page anchors and off-site links, uses `searchParams.set` so a second pass cannot duplicate params, and leaves each href in the shape the page wrote it so a relative link stays relative.
- `src/view/index.js` — runs it on `domReady`, regardless of the prompt-disabled flag, since a preview has to survive navigation even where prompts are switched off. Wrapped, and ordered after the pageview push, so an admin-only nicety cannot cost a reader their pageview or their prompts.
- `src/editor/Preview.js` — drops the cross-frame rewrite.
- `includes/class-newspack-popups-inserter.php` — localizes the preview param names to the view script only where the request is an actual prompt preview: a `pid` that names a prompt, held by a user who may preview one. `pid` is a common campaign parameter, so the check matters.
- `includes/class-newspack-popups.php` — that predicate now lives in one place, `Newspack_Popups::can_preview_popup()`, shared with the renderer (`Newspack_Popups_Model::retrieve_preview_popup()`). Two copies of a security-relevant check is how they drift: a gate stricter than the renderer yields a preview whose links go nowhere, and a looser one leaks preview state onto ordinary pages.

Closes NEWS-2889.

### How to test the changes in this Pull Request:

Requires **Chrome 137 or later over HTTPS**, signed in as a user who can upload files. Cross-origin isolation is only sent to Chromium, so this will not reproduce in curl, Firefox, or Safari.

1. On WordPress 7.1, open any prompt in the editor.
2. Open the browser console. Click **Preview** in the sidebar. No `SecurityError` appears.
3. Dismiss the overlay shown inside the preview.
4. Click any link in the preview, such as a category or a post title.
5. The preview stays in preview mode: the prompt still carries its PREVIEW badge, and the front-end admin bar stays suppressed.
6. Copy the preview's own URL into a new top-level tab and click a link there. Preview mode does **not** follow you: the links on that page are ordinary ones. Preview stickiness belongs to the preview frame.

On `main` the same steps throw a `SecurityError` at step 2, and at step 5 the preview drops out to the ordinary page.

Step 5 with this branch applied — the preview has followed a category link and is still in preview mode, prompt and PREVIEW badge intact, front-end admin bar still suppressed. On `main` the badge is gone by this point and the front-end admin bar is back.

![Prompt preview still in preview mode after following a link](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/14/cirlmn5p-news-2889-preview-after.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Eighteen unit tests cover `propagatePreviewParams`: same-origin rewriting, the top-level and no-preview and no-matching-param cases, an absent global, off-site links, in-page anchors, `mailto:`/`tel:`, an unparseable href, SVG anchors, href shape (root-relative, absolute, path-relative, opaque-path and protocol-relative), fragment and unrelated-param preservation, and idempotency. All four negative cases assert that nothing is traversed at all, so reordering the early returns fails loudly rather than quietly walking every anchor on every page load.

Three more cover the entry point, because the propagation call shares a `domReady` callback with every reader-facing prompt handler: they pin that a throw in propagation still leaves prompt display, prompt analytics and the pageview push intact.

Six PHP tests cover the localization gate — a prompt manager previewing a prompt, a `pid` that is not a prompt, a reader and an author on a well-formed preview URL, no `pid` at all, and the localized key itself. The capability cases use an *editor*, not an administrator, matching the convention in `test-presets.php`: an administrator satisfies any capability the gate might later be tightened to, which would hide the regression.

The two behavioural fixes in the latest round were mutation-tested: removing the `http(s)` guard fails the opaque-path test, and removing the `try`/`catch` fails the entry-point tests.

Verified by hand in Chrome 151 against WordPress 7.1-RC3 with `crossOriginIsolated: true`.

The frame check the fix now depends on was measured rather than reasoned about, since the whole fix would silently no-op if `Document-Isolation-Policy` collapsed the frame tree. In a 7.1-RC3 editor, reading only cross-origin-allowlisted properties:

| frame | `document` readable from the editor | frame's own `self === top` |
| --- | --- | --- |
| `editor-canvas` (Gutenberg) | yes | false |
| `web-preview` (prompt preview) | **throws `SecurityError`** | false |

So isolation is genuinely in effect on the preview frame — that `SecurityError` is the original bug — while the frame still reports `self !== top`, with `top` and `parent` both resolving to the editor window. The guard does not fire inside a preview. As a side effect this also confirms Gutenberg's own editor canvas stays reachable under isolation.

Locally: the full JS suite passes (245 tests, 13 suites), the full PHP suite passes (417 tests, 1103 assertions), and PHPCS and ESLint are clean on every changed file.

**Not covered:** AMP. The param names are localized alongside `view.js`, which the inserter only registers on non-AMP requests, so a site in AMP standard mode keeps the pre-7.1 behaviour. Restoring it there would mean rewriting the links server-side, since AMP forbids arbitrary inline script. The module's docblock says so.

