### PR TITLE
fix(content-gate): keep gate preview links in preview mode under WP 7.1

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -772,8 +772,11 @@ class Content_Gate {
 	 *
 	 * @return array{enqueue: bool, renders_gate: bool, is_preview: bool}
 	 */
-	public static function get_frontend_script_context() {
-		$renders_gate = self::has_gate() && is_singular() && self::is_post_restricted();
+	public static function get_frontend_script_conditions() {
+		// is_singular() first, matching enqueue_content_banner_assets(): during a
+		// preview on an archive, has_gate() would otherwise scan the gate list and have
+		// the result thrown away by the very next operand.
+		$renders_gate = is_singular() && self::has_gate() && self::is_post_restricted();
 		$is_preview   = Content_Gate\Gate_Preview::is_preview_request();
 		return [
 			'enqueue'      => $renders_gate || $is_preview,
@@ -788,7 +791,7 @@ class Content_Gate {
 	public static function enqueue_scripts() {
 		self::enqueue_content_banner_assets();
 
-		$context      = self::get_frontend_script_context();
+		$context      = self::get_frontend_script_conditions();
 		$renders_gate = $context['renders_gate'];
 		$is_preview   = $context['is_preview'];
 
@@ -824,7 +827,7 @@ class Content_Gate {
 	 *
 	 * Split out from enqueue_scripts() so the payload is assertable without
 	 * touching the filesystem for asset versions. Whether the script loads at all
-	 * is decided in get_frontend_script_context().
+	 * is decided in get_frontend_script_conditions().
 	 *
 	 * The two keys are independently optional: gate.js reads `metadata`, and
 	 * preview-links.js reads `preview_param_names`. A preview on a view where no

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -824,7 +824,7 @@ class Content_Gate {
 		// own check already requires the preview capability, so this does not ship
 		// to ordinary readers.
 		if ( $is_preview ) {
-			$script_data['preview_query_params'] = array_merge(
+			$script_data['preview_param_names'] = array_merge(
 				[ Content_Gate\Gate_Preview::PREVIEW_QUERY_PARAM ],
 				array_values( Content_Gate\Gate_Preview::PREVIEW_QUERY_KEYS )
 			);

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -760,20 +760,39 @@ class Content_Gate {
 	}
 
 	/**
+	 * Whether the gate's front-end script should load on this request, and why.
+	 *
+	 * The decision lives here, not just its payload, so it can be asserted without
+	 * building assets: the script also has to load on a gate preview where no gate
+	 * renders — archives, home, search — so the previewed params survive a click
+	 * through one of those pages. Gate them out and the preview ends silently at
+	 * the first non-singular view, which is not what the pre-7.1 editor-side
+	 * handler did: it re-ran on every navigation inside the preview frame.
+	 * Returning both inputs alongside the verdict saves the caller recomputing them.
+	 *
+	 * @return array{enqueue: bool, renders_gate: bool, is_preview: bool}
+	 */
+	public static function get_frontend_script_context() {
+		$renders_gate = self::has_gate() && is_singular() && self::is_post_restricted();
+		$is_preview   = Content_Gate\Gate_Preview::is_preview_request();
+		return [
+			'enqueue'      => $renders_gate || $is_preview,
+			'renders_gate' => $renders_gate,
+			'is_preview'   => $is_preview,
+		];
+	}
+
+	/**
 	 * Enqueue frontend scripts and styles for gated content.
 	 */
 	public static function enqueue_scripts() {
 		self::enqueue_content_banner_assets();
 
-		$renders_gate = self::has_gate() && is_singular() && self::is_post_restricted();
-		$is_preview   = Content_Gate\Gate_Preview::is_preview_request();
+		$context      = self::get_frontend_script_context();
+		$renders_gate = $context['renders_gate'];
+		$is_preview   = $context['is_preview'];
 
-		// The script also loads on a gate preview where no gate renders — archives,
-		// home, search — so the previewed params survive a click through one of
-		// those pages. Gate them out and the preview ends silently at the first
-		// non-singular view, which is not something the pre-7.1 editor-side handler
-		// did: it re-ran on every navigation inside the preview frame.
-		if ( ! $renders_gate && ! $is_preview ) {
+		if ( ! $context['enqueue'] ) {
 			return;
 		}
 
@@ -803,13 +822,17 @@ class Content_Gate {
 	/**
 	 * Data localized to the front-end gate script.
 	 *
-	 * Split out from enqueue_scripts() so the preview branch — the one seam that
-	 * decides whether the preview params reach the page — is assertable without
-	 * touching the filesystem for asset versions.
+	 * Split out from enqueue_scripts() so the payload is assertable without
+	 * touching the filesystem for asset versions. Whether the script loads at all
+	 * is decided in get_frontend_script_context().
+	 *
+	 * The two keys are independently optional: gate.js reads `metadata`, and
+	 * preview-links.js reads `preview_param_names`. A preview on a view where no
+	 * gate renders carries only the second.
 	 *
 	 * @param bool $renders_gate Whether a gate renders on this request.
 	 * @param bool $is_preview   Whether this is a gate preview request.
-	 * @return array
+	 * @return array{metadata?: array, preview_param_names?: string[]}
 	 */
 	public static function get_frontend_script_data( $renders_gate, $is_preview ) {
 		$script_data = [];

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -780,13 +780,23 @@ class Content_Gate {
 			true
 		);
 		\wp_script_add_data( $handle, 'async', true );
-		\wp_localize_script(
-			$handle,
-			'newspack_content_gate',
-			[
-				'metadata' => self::get_gate_metadata(),
-			]
-		);
+		$script_data = [
+			'metadata' => self::get_gate_metadata(),
+		];
+
+		// On a gate preview the previewed document carries its own preview params
+		// onto same-origin links, so the preview survives navigation. It needs the
+		// param list to know which of its query params those are. Gate_Preview's
+		// own check already requires the preview capability, so this does not ship
+		// to ordinary readers.
+		if ( Content_Gate\Gate_Preview::is_preview_request() ) {
+			$script_data['preview_query_params'] = array_merge(
+				[ Content_Gate\Gate_Preview::PREVIEW_QUERY_PARAM ],
+				array_values( Content_Gate\Gate_Preview::PREVIEW_QUERY_KEYS )
+			);
+		}
+
+		\wp_localize_script( $handle, 'newspack_content_gate', $script_data );
 		\wp_enqueue_style(
 			$handle,
 			Newspack::plugin_url() . '/dist/content-gate.css',

--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -765,12 +765,18 @@ class Content_Gate {
 	public static function enqueue_scripts() {
 		self::enqueue_content_banner_assets();
 
-		if ( ! self::has_gate() ) {
+		$renders_gate = self::has_gate() && is_singular() && self::is_post_restricted();
+		$is_preview   = Content_Gate\Gate_Preview::is_preview_request();
+
+		// The script also loads on a gate preview where no gate renders — archives,
+		// home, search — so the previewed params survive a click through one of
+		// those pages. Gate them out and the preview ends silently at the first
+		// non-singular view, which is not something the pre-7.1 editor-side handler
+		// did: it re-ran on every navigation inside the preview frame.
+		if ( ! $renders_gate && ! $is_preview ) {
 			return;
 		}
-		if ( ! is_singular() || ! self::is_post_restricted() ) {
-			return;
-		}
+
 		$handle = 'newspack-content-gate';
 		\wp_enqueue_script(
 			$handle,
@@ -780,29 +786,51 @@ class Content_Gate {
 			true
 		);
 		\wp_script_add_data( $handle, 'async', true );
-		$script_data = [
-			'metadata' => self::get_gate_metadata(),
-		];
+		\wp_localize_script( $handle, 'newspack_content_gate', self::get_frontend_script_data( $renders_gate, $is_preview ) );
 
-		// On a gate preview the previewed document carries its own preview params
-		// onto same-origin links, so the preview survives navigation. It needs the
-		// param list to know which of its query params those are. Gate_Preview's
-		// own check already requires the preview capability, so this does not ship
-		// to ordinary readers.
-		if ( Content_Gate\Gate_Preview::is_preview_request() ) {
-			$script_data['preview_query_params'] = array_merge(
-				[ Content_Gate\Gate_Preview::PREVIEW_QUERY_PARAM ],
-				array_values( Content_Gate\Gate_Preview::PREVIEW_QUERY_KEYS )
-			);
+		// Only a rendering gate needs the styles.
+		if ( ! $renders_gate ) {
+			return;
 		}
-
-		\wp_localize_script( $handle, 'newspack_content_gate', $script_data );
 		\wp_enqueue_style(
 			$handle,
 			Newspack::plugin_url() . '/dist/content-gate.css',
 			[],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/content-gate.css' )
 		);
+	}
+
+	/**
+	 * Data localized to the front-end gate script.
+	 *
+	 * Split out from enqueue_scripts() so the preview branch — the one seam that
+	 * decides whether the preview params reach the page — is assertable without
+	 * touching the filesystem for asset versions.
+	 *
+	 * @param bool $renders_gate Whether a gate renders on this request.
+	 * @param bool $is_preview   Whether this is a gate preview request.
+	 * @return array
+	 */
+	public static function get_frontend_script_data( $renders_gate, $is_preview ) {
+		$script_data = [];
+
+		if ( $renders_gate ) {
+			$script_data['metadata'] = self::get_gate_metadata();
+		}
+
+		// On a gate preview the previewed document carries its own preview params
+		// onto same-origin links, so the preview survives navigation. It needs the
+		// param list to know which of its query params those are. Gate_Preview's
+		// own check already requires the preview capability, so this does not ship
+		// to ordinary readers.
+		if ( $is_preview ) {
+			$script_data['preview_query_params'] = array_merge(
+				[ Content_Gate\Gate_Preview::PREVIEW_QUERY_PARAM ],
+				array_values( Content_Gate\Gate_Preview::PREVIEW_QUERY_KEYS )
+			);
+		}
+
+		return $script_data;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-gate-preview.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-gate-preview.php
@@ -413,6 +413,16 @@ class Gate_Preview {
 		// Force only the queried (previewed) post. An empty $post_id resolves to
 		// the queried post so in-loop calls still gate, but an explicit, unrelated
 		// post id is never force-restricted.
+		//
+		// Deliberate consequence: because this forces restriction, a preview session
+		// can render a gate on singular pages the ordinary path skips.
+		// Content_Gate::restrict_post() bails on the privacy policy, account, terms,
+		// cart and checkout pages; Content_Gate::render_overlay_gate() has no such
+		// bails, so previewing an overlay layout and navigating to My Account shows
+		// the overlay there. That is wanted: the editor asked to see this layout, and
+		// a preview that silently declined to render on some pages would be a worse
+		// lie than one that renders everywhere. It is preview-only and limited to
+		// users who may preview, so no reader is affected.
 		$queried_id = (int) $queried->ID;
 		$target_id  = empty( $post_id ) ? $queried_id : (int) $post_id;
 		if ( $target_id === $queried_id ) {

--- a/plugins/newspack-plugin/includes/content-gate/class-gate-preview.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-gate-preview.php
@@ -84,6 +84,26 @@ class Gate_Preview {
 		add_filter( 'newspack_gate_layout_content', [ __CLASS__, 'filter_gate_layout_content' ], PHP_INT_MAX, 2 );
 		add_filter( 'get_post_metadata', [ __CLASS__, 'filter_layout_meta' ], 10, 4 );
 		add_filter( 'show_admin_bar', [ __CLASS__, 'filter_show_admin_bar' ] ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
+		add_action( 'template_redirect', [ __CLASS__, 'prevent_preview_caching' ] );
+	}
+
+	/**
+	 * Keep preview responses out of caches.
+	 *
+	 * A preview response is capability-varying: the post is force-restricted, the
+	 * layout's autosaved content is substituted, and the front-end script carries
+	 * the preview param list. An edge cache keying on URL alone would serve all of
+	 * that to a reader, whose links would then be rewritten to carry `ngp_id` —
+	 * shareable and crawlable. The sibling per-user gate paths guard the same way.
+	 */
+	public static function prevent_preview_caching() {
+		if ( ! self::is_preview_request() ) {
+			return;
+		}
+		if ( function_exists( 'batcache_cancel' ) ) {
+			batcache_cancel();
+		}
+		nocache_headers();
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-gate-preview.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-gate-preview.php
@@ -344,12 +344,11 @@ class Gate_Preview {
 	/**
 	 * Data localized to the layout editor to power the Preview button.
 	 *
-	 * @return array{preview_post:string, frontend_url:string, query_param:string, preview_query_keys:array}
+	 * @return array{preview_post:string, query_param:string, preview_query_keys:array}
 	 */
 	public static function get_editor_preview_data() {
 		return [
 			'preview_post'       => self::preview_post_permalink(),
-			'frontend_url'       => get_site_url(),
 			'query_param'        => self::PREVIEW_QUERY_PARAM,
 			'preview_query_keys' => self::PREVIEW_QUERY_KEYS,
 		];

--- a/plugins/newspack-plugin/includes/content-gate/class-gate-preview.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-gate-preview.php
@@ -96,10 +96,11 @@ class Gate_Preview {
 	 * that to a reader, whose links would then be rewritten to carry `ngp_id` —
 	 * shareable and crawlable. The sibling per-user gate paths guard the same way.
 	 *
-	 * Returns whether it acted. The action discards the value; it is there because
-	 * both side effects are unobservable under PHPUnit — nocache_headers() bails on
-	 * headers_sent() and batcache_cancel() is not loaded — which would otherwise
-	 * leave the capability gate untestable.
+	 * Returns whether it acted, so a test can assert that this consults the preview
+	 * gate rather than firing on every request. The action discards the value. Both
+	 * side effects are unobservable under PHPUnit: batcache_cancel() is not loaded,
+	 * and nocache_headers() bails on headers_sent(), which is true by the time any
+	 * test body runs because the WordPress test bootstrap has already printed.
 	 *
 	 * @return bool Whether cache prevention was applied.
 	 */
@@ -399,25 +400,35 @@ class Gate_Preview {
 		if ( ! self::is_preview_request() ) {
 			return $restricted;
 		}
-		// The queried object has to be an actual post. A preview session now spans
-		// archive, home and search views, where get_queried_object_id() returns a
-		// term or user id instead — and those ids share no numbering with post ids,
-		// so comparing them would force-restrict whichever unrelated post happened
-		// to carry the same number. Testing the type rather than is_singular() ties
-		// the guard to the thing being compared.
+		// Both halves are load-bearing. The type check is what makes the comparison
+		// below sound: a preview session now spans archive views, where
+		// get_queried_object_id() returns a term id (category, tag, taxonomy) or a
+		// user id (author) — numbering that shares nothing with post ids, so
+		// comparing them force-restricted whichever unrelated post carried the same
+		// number. is_singular() then confines the forcing to views that actually
+		// render one post: the blog posts index on a static-front-page site, and a
+		// 404 whose pagename matched an unpublished page, both hand back a WP_Post
+		// while not being singular. Every render path already guards on
+		// is_singular(), so those two are inert today — this keeps them that way
+		// without relying on callers to stay careful.
+		if ( ! is_singular() ) {
+			return $restricted;
+		}
 		$queried = get_queried_object();
 		if ( ! $queried instanceof \WP_Post ) {
 			return $restricted;
 		}
 
-		// Force only the queried (previewed) post. An empty $post_id resolves to
-		// the queried post so in-loop calls still gate, but an explicit, unrelated
-		// post id is never force-restricted.
+		// Force only the queried (previewed) post. An empty $post_id means the call
+		// came from outside the loop — Content_Gate::is_post_restricted() substitutes
+		// get_the_ID() before applying this filter, so in-loop calls always arrive
+		// with an explicit id — and an explicit, unrelated post id is never forced.
 		//
 		// Deliberate consequence: because this forces restriction, a preview session
 		// can render a gate on singular pages the ordinary path skips.
 		// Content_Gate::restrict_post() bails on the privacy policy, account, terms,
-		// cart and checkout pages; Content_Gate::render_overlay_gate() has no such
+		// accessibility statement, cart and checkout pages, among others;
+		// Content_Gate::render_overlay_gate() has no such
 		// bails, so previewing an overlay layout and navigating to My Account shows
 		// the overlay there. That is wanted: the editor asked to see this layout, and
 		// a preview that silently declined to render on some pages would be a worse

--- a/plugins/newspack-plugin/includes/content-gate/class-gate-preview.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-gate-preview.php
@@ -95,15 +95,23 @@ class Gate_Preview {
 	 * the preview param list. An edge cache keying on URL alone would serve all of
 	 * that to a reader, whose links would then be rewritten to carry `ngp_id` —
 	 * shareable and crawlable. The sibling per-user gate paths guard the same way.
+	 *
+	 * Returns whether it acted. The action discards the value; it is there because
+	 * both side effects are unobservable under PHPUnit — nocache_headers() bails on
+	 * headers_sent() and batcache_cancel() is not loaded — which would otherwise
+	 * leave the capability gate untestable.
+	 *
+	 * @return bool Whether cache prevention was applied.
 	 */
 	public static function prevent_preview_caching() {
 		if ( ! self::is_preview_request() ) {
-			return;
+			return false;
 		}
 		if ( function_exists( 'batcache_cancel' ) ) {
 			batcache_cancel();
 		}
 		nocache_headers();
+		return true;
 	}
 
 	/**
@@ -379,7 +387,8 @@ class Gate_Preview {
 	 *
 	 * Runs at PHP_INT_MAX so it wins over Content_Restriction_Control (which
 	 * returns false for users who can edit the post, and caches per
-	 * post/user). Only the queried post is forced; other post IDs pass through.
+	 * post/user). Only the queried post is forced; other post IDs pass through, and
+	 * nothing is forced on a view whose queried object is not a post.
 	 *
 	 * @param bool $restricted Whether the post is restricted.
 	 * @param int  $post_id    Post ID.
@@ -390,13 +399,23 @@ class Gate_Preview {
 		if ( ! self::is_preview_request() ) {
 			return $restricted;
 		}
+		// The queried object has to be an actual post. A preview session now spans
+		// archive, home and search views, where get_queried_object_id() returns a
+		// term or user id instead — and those ids share no numbering with post ids,
+		// so comparing them would force-restrict whichever unrelated post happened
+		// to carry the same number. Testing the type rather than is_singular() ties
+		// the guard to the thing being compared.
+		$queried = get_queried_object();
+		if ( ! $queried instanceof \WP_Post ) {
+			return $restricted;
+		}
+
 		// Force only the queried (previewed) post. An empty $post_id resolves to
-		// the queried object so in-loop calls still gate, but an explicit,
-		// unrelated post id is never force-restricted, and nothing is forced when
-		// there is no singular queried object.
-		$queried_id = (int) get_queried_object_id();
+		// the queried post so in-loop calls still gate, but an explicit, unrelated
+		// post id is never force-restricted.
+		$queried_id = (int) $queried->ID;
 		$target_id  = empty( $post_id ) ? $queried_id : (int) $post_id;
-		if ( $queried_id && $target_id === $queried_id ) {
+		if ( $target_id === $queried_id ) {
 			return true;
 		}
 		return $restricted;

--- a/plugins/newspack-plugin/src/content-gate/editor/preview.js
+++ b/plugins/newspack-plugin/src/content-gate/editor/preview.js
@@ -22,6 +22,15 @@ import WebPreview from '../../../packages/components/src/web-preview';
  * newspack-popups prompt preview: the reader's unsaved meta rides along in the
  * URL (autosaves don't persist meta), and in-iframe article links are rewritten
  * to keep the preview active as the reader navigates.
+ *
+ * That rewriting happens in the previewed document — see
+ * propagateGatePreviewParams() in src/content-gate/preview-links.js — not from
+ * out here. This component used to reach into the preview iframe, guarded by a
+ * try/catch for genuinely cross-origin setups. WordPress 7.1 turned that guard
+ * into a silent failure: it serves the block editor with
+ * `Document-Isolation-Policy`, which severs access to the frame even when it is
+ * same-origin, so the rewrite stopped happening and only a console warning
+ * marked it.
  */
 export default function GatePreview() {
 	const { postId, meta, isSavingPost } = useSelect( select => {
@@ -53,15 +62,6 @@ export default function GatePreview() {
 		[ queryParam ]: postId,
 		...abbreviatedKeys,
 	};
-
-	// Links inside the preview keep their preview params, but the previewed
-	// document does that for itself — see propagateGatePreviewParams() in
-	// src/content-gate/preview-links.js. This used to reach into the preview
-	// iframe from out here, guarded by a try/catch for genuinely cross-origin
-	// setups. WordPress 7.1 turned that guard into a silent failure: it serves the
-	// block editor with `Document-Isolation-Policy`, which severs access to the
-	// frame even when it is same-origin, so the rewrite stopped happening and only
-	// a console warning marked it.
 
 	// Open the preview after the autosave settles. On a failed autosave, still
 	// open it: the server falls back to the layout's saved content, so the reader

--- a/plugins/newspack-plugin/src/content-gate/editor/preview.js
+++ b/plugins/newspack-plugin/src/content-gate/editor/preview.js
@@ -39,7 +39,7 @@ export default function GatePreview() {
 		return null;
 	}
 
-	const { preview_post: previewPost, frontend_url: frontendUrl, query_param: queryParam, preview_query_keys: previewQueryKeys } = preview;
+	const { preview_post: previewPost, query_param: queryParam, preview_query_keys: previewQueryKeys } = preview;
 
 	// Map edited meta onto the abbreviated query keys the server understands.
 	const abbreviatedKeys = {};
@@ -54,22 +54,14 @@ export default function GatePreview() {
 		...abbreviatedKeys,
 	};
 
-	const onWebPreviewLoad = iframeEl => {
-		if ( ! iframeEl ) {
-			return;
-		}
-		// Same-origin access can throw a DOMException on a cross-origin iframe
-		// (mapped domains, scheme mismatch). Link-rewriting is a nicety; never let
-		// it break opening the preview.
-		try {
-			[ ...iframeEl.contentWindow.document.querySelectorAll( 'a[href^="' + frontendUrl + '"]' ) ].forEach( anchor => {
-				anchor.setAttribute( 'href', addQueryArgs( anchor.getAttribute( 'href' ), query ) );
-			} );
-		} catch ( e ) {
-			// eslint-disable-next-line no-console
-			console.warn( 'Gate preview: could not rewrite in-iframe links (cross-origin).', e );
-		}
-	};
+	// Links inside the preview keep their preview params, but the previewed
+	// document does that for itself — see propagateGatePreviewParams() in
+	// src/content-gate/preview-links.js. This used to reach into the preview
+	// iframe from out here, guarded by a try/catch for genuinely cross-origin
+	// setups. WordPress 7.1 turned that guard into a silent failure: it serves the
+	// block editor with `Document-Isolation-Policy`, which severs access to the
+	// frame even when it is same-origin, so the rewrite stopped happening and only
+	// a console warning marked it.
 
 	// Open the preview after the autosave settles. On a failed autosave, still
 	// open it: the server falls back to the layout's saved content, so the reader
@@ -85,7 +77,6 @@ export default function GatePreview() {
 	return (
 		<WebPreview
 			url={ addQueryArgs( previewPost, query ) }
-			onLoad={ onWebPreviewLoad }
 			renderButton={ ( { showPreview } ) => (
 				<Button variant="primary" isBusy={ isSavingPost } disabled={ isSavingPost } onClick={ () => previewAfterAutosave( showPreview ) }>
 					{ __( 'Preview', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/content-gate/gate-preview-wiring.test.js
+++ b/plugins/newspack-plugin/src/content-gate/gate-preview-wiring.test.js
@@ -8,6 +8,7 @@
  */
 
 const mockPropagate = jest.fn();
+let warnSpy;
 
 jest.mock( './preview-links', () => ( {
 	propagateGatePreviewParams: ( ...args ) => mockPropagate( ...args ),
@@ -27,11 +28,13 @@ describe( 'gate.js preview-param wiring', () => {
 		// the path a footer/async script actually takes.
 		Object.defineProperty( document, 'readyState', { value: 'interactive', configurable: true } );
 		document.body.innerHTML = '<div class="newspack-content-gate__gate"></div>';
-		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+		// Held in a variable rather than reached for as `console.warn`, which the
+		// no-console rule rejects.
+		warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
 	} );
 
 	afterEach( () => {
-		console.warn.mockRestore();
+		warnSpy.mockRestore();
 	} );
 
 	it( 'runs propagation on load', () => {
@@ -48,6 +51,6 @@ describe( 'gate.js preview-param wiring', () => {
 		// The throw is swallowed rather than aborting module evaluation, so the
 		// gate's own registration below it still runs.
 		expect( () => require( './gate' ) ).not.toThrow();
-		expect( console.warn ).toHaveBeenCalled();
+		expect( warnSpy ).toHaveBeenCalled();
 	} );
 } );

--- a/plugins/newspack-plugin/src/content-gate/gate-preview-wiring.test.js
+++ b/plugins/newspack-plugin/src/content-gate/gate-preview-wiring.test.js
@@ -24,6 +24,7 @@ describe( 'gate.js preview-param wiring', () => {
 		jest.resetModules();
 		mockPropagate.mockReset();
 		global.newspack_content_gate = { metadata: {} };
+		window.newspackRAS = [];
 		// `interactive` makes gate.js's domReady() invoke synchronously, which is
 		// the path a footer/async script actually takes.
 		Object.defineProperty( document, 'readyState', { value: 'interactive', configurable: true } );
@@ -48,9 +49,12 @@ describe( 'gate.js preview-param wiring', () => {
 			throw new Error( 'isolation' );
 		} );
 
-		// The throw is swallowed rather than aborting module evaluation, so the
-		// gate's own registration below it still runs.
 		expect( () => require( './gate' ) ).not.toThrow();
 		expect( warnSpy ).toHaveBeenCalled();
+		// Assert the gate actually initialised rather than inferring it from module
+		// evaluation completing: gate.js pushes onto newspackRAS on the gate path, so
+		// this fails if someone ever moves that registration above the propagation
+		// block — the arrangement this test exists to protect.
+		expect( window.newspackRAS.length ).toBeGreaterThan( 0 );
 	} );
 } );

--- a/plugins/newspack-plugin/src/content-gate/gate-preview-wiring.test.js
+++ b/plugins/newspack-plugin/src/content-gate/gate-preview-wiring.test.js
@@ -52,9 +52,12 @@ describe( 'gate.js preview-param wiring', () => {
 		expect( () => require( './gate' ) ).not.toThrow();
 		expect( warnSpy ).toHaveBeenCalled();
 		// Assert the gate actually initialised rather than inferring it from module
-		// evaluation completing: gate.js pushes onto newspackRAS on the gate path, so
-		// this fails if someone ever moves that registration above the propagation
-		// block — the arrangement this test exists to protect.
+		// evaluation completing. The assertion above already catches the try/catch
+		// being deleted outright, since that lets the throw escape require(). What
+		// only this line catches is the gate's own registration being folded *inside*
+		// the propagation try block: then require() still succeeds, the warning still
+		// fires, and nothing but an empty newspackRAS reveals that the gate never
+		// initialised.
 		expect( window.newspackRAS.length ).toBeGreaterThan( 0 );
 	} );
 } );

--- a/plugins/newspack-plugin/src/content-gate/gate-preview-wiring.test.js
+++ b/plugins/newspack-plugin/src/content-gate/gate-preview-wiring.test.js
@@ -1,0 +1,53 @@
+/**
+ * The gate script wires preview-param propagation and gate rendering as two
+ * separate domReady registrations. This pins the property that comment claims:
+ * a throw in propagation must not stop the gate from initialising.
+ *
+ * gate.js is imported for its side effects, so the mocks below have to be in
+ * place before the import is evaluated.
+ */
+
+const mockPropagate = jest.fn();
+
+jest.mock( './preview-links', () => ( {
+	propagateGatePreviewParams: ( ...args ) => mockPropagate( ...args ),
+} ) );
+
+jest.mock( '../reader-activation/analytics', () => ( { getEventPayload: jest.fn(), sendEvent: jest.fn() } ) );
+jest.mock( '../reader-activation/utils', () => ( { debugLog: jest.fn() } ) );
+jest.mock( '../shared/js/cta-attribution', () => ( { persistCtaAttribution: jest.fn() } ) );
+jest.mock( './gate.scss', () => ( {} ), { virtual: true } );
+
+describe( 'gate.js preview-param wiring', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		mockPropagate.mockReset();
+		global.newspack_content_gate = { metadata: {} };
+		// `interactive` makes gate.js's domReady() invoke synchronously, which is
+		// the path a footer/async script actually takes.
+		Object.defineProperty( document, 'readyState', { value: 'interactive', configurable: true } );
+		document.body.innerHTML = '<div class="newspack-content-gate__gate"></div>';
+		jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		console.warn.mockRestore();
+	} );
+
+	it( 'runs propagation on load', () => {
+		require( './gate' );
+
+		expect( mockPropagate ).toHaveBeenCalled();
+	} );
+
+	it( 'still initialises the gate when propagation throws', () => {
+		mockPropagate.mockImplementation( () => {
+			throw new Error( 'isolation' );
+		} );
+
+		// The throw is swallowed rather than aborting module evaluation, so the
+		// gate's own registration below it still runs.
+		expect( () => require( './gate' ) ).not.toThrow();
+		expect( console.warn ).toHaveBeenCalled();
+	} );
+} );

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -6,6 +6,7 @@ import './gate.scss';
 import { getEventPayload, sendEvent } from '../reader-activation/analytics';
 import { debugLog } from '../reader-activation/utils';
 import { persistCtaAttribution } from '../shared/js/cta-attribution';
+import { propagateGatePreviewParams } from './preview-links';
 
 const EVENT_NAME = 'np_gate_interaction';
 
@@ -388,6 +389,11 @@ function handleFloatingElements() {
 		}
 	} );
 }
+
+// Registered on its own rather than inside the gate initialisation below, so the
+// two cannot break each other: a preview nicety must never take down gate
+// rendering, and the gate's early return must never skip propagation.
+domReady( propagateGatePreviewParams );
 
 domReady( function () {
 	const gate = document.querySelector( '.newspack-content-gate__gate' );

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -390,10 +390,20 @@ function handleFloatingElements() {
 	} );
 }
 
-// Registered on its own rather than inside the gate initialisation below, so the
-// two cannot break each other: a preview nicety must never take down gate
-// rendering, and the gate's early return must never skip propagation.
-domReady( propagateGatePreviewParams );
+// Registered on its own rather than inside the gate initialisation below, which
+// returns early when no gate element is present — propagation has to run on
+// those pages too, since the script now loads across a whole preview session.
+// Wrapped because domReady() runs synchronously once the document is ready, so
+// an unguarded throw here would abort module evaluation before the gate's own
+// registration below is even reached.
+domReady( () => {
+	try {
+		propagateGatePreviewParams();
+	} catch ( e ) {
+		// eslint-disable-next-line no-console
+		console.warn( 'Gate preview: could not propagate preview params.', e );
+	}
+} );
 
 domReady( function () {
 	const gate = document.querySelector( '.newspack-content-gate__gate' );

--- a/plugins/newspack-plugin/src/content-gate/preview-links.js
+++ b/plugins/newspack-plugin/src/content-gate/preview-links.js
@@ -1,0 +1,67 @@
+/**
+ * Carry the gate-preview parameters onto same-origin links.
+ *
+ * A gate preview renders the real front end inside an iframe in the layout
+ * editor, with the previewed layout's unsaved settings passed as query params.
+ * Those params have to survive navigation, or the first click inside the preview
+ * lands on the ordinary page and the editor loses what they were previewing.
+ *
+ * This runs in the previewed document rather than in the editor on purpose.
+ * WordPress 7.1 serves the block editor with `Document-Isolation-Policy`, which
+ * places it in its own agent cluster and severs synchronous access to the
+ * preview iframe even though the frame is same-origin — so the editor can no
+ * longer reach in and rewrite these links from outside. A document may always
+ * rewrite its own. Same fix as NEWS-2889, applied to the gate preview.
+ *
+ * Scope note: the gate's front-end script only loads on restricted singular
+ * posts, so propagation reaches other restricted content and stops there. That
+ * is the surface a gate preview is about; an unrestricted page has no gate to
+ * preview.
+ */
+export function propagateGatePreviewParams() {
+	// Only localized on a gate preview, so its absence means there is nothing to
+	// propagate. Read through `window.` rather than as a bare identifier:
+	// optional chaining guards a null value, not an undeclared binding, and an
+	// undeclared one throws.
+	const params = window.newspack_content_gate?.preview_query_params;
+	if ( ! params?.length ) {
+		return;
+	}
+
+	const current = new URLSearchParams( window.location.search );
+	const present = params.filter( key => current.has( key ) ).map( key => [ key, current.get( key ) ] );
+	if ( ! present.length ) {
+		return;
+	}
+
+	document.querySelectorAll( 'a[href]' ).forEach( anchor => {
+		// Read the attribute rather than the `href` property: the selector also
+		// matches SVG <a>, whose property is an SVGAnimatedString, and resolving
+		// that yields a same-origin garbage path that would overwrite the link.
+		const href = anchor.getAttribute( 'href' );
+
+		// Leave in-page anchors alone; adding query params would reload the page
+		// instead of jumping within it.
+		if ( href.startsWith( '#' ) ) {
+			return;
+		}
+
+		let url;
+		try {
+			// Resolve against the document base so relative hrefs work and a <base>
+			// tag is respected.
+			url = new URL( href, document.baseURI );
+		} catch ( e ) {
+			return;
+		}
+
+		// Off-site links, and schemes like mailto: and tel: that resolve to a null
+		// origin, are none of our business.
+		if ( url.origin !== window.location.origin ) {
+			return;
+		}
+
+		present.forEach( ( [ key, value ] ) => url.searchParams.set( key, value ) );
+		anchor.setAttribute( 'href', url.toString() );
+	} );
+}

--- a/plugins/newspack-plugin/src/content-gate/preview-links.js
+++ b/plugins/newspack-plugin/src/content-gate/preview-links.js
@@ -13,10 +13,11 @@
  * longer reach in and rewrite these links from outside. A document may always
  * rewrite its own. Same fix as NEWS-2889, applied to the gate preview.
  *
- * Scope note: the gate's front-end script only loads on restricted singular
- * posts, so propagation reaches other restricted content and stops there. That
- * is the surface a gate preview is about; an unrestricted page has no gate to
- * preview.
+ * Kept deliberately in step with newspack-popups/src/view/preview-links.js,
+ * which solves the same problem for prompt previews. The two are duplicated
+ * rather than shared: a shared package would tie two independently released
+ * plugins to one version, which is the wrong trade for a fix this small. If you
+ * change one, change the other.
  */
 export function propagateGatePreviewParams() {
 	// Only localized on a gate preview, so its absence means there is nothing to
@@ -34,6 +35,12 @@ export function propagateGatePreviewParams() {
 		return;
 	}
 
+	// One eager pass at domReady. Anchors added later — "Load more", modal
+	// checkout, anything AJAX — keep their own hrefs and leave the preview on the
+	// first click. Neither does this reach the gate's own conversion CTAs, which
+	// are <form target="newspack_modal_checkout_iframe"> rather than links. A
+	// capture-phase click interceptor would close both gaps if it ever proves
+	// worth the extra surface.
 	document.querySelectorAll( 'a[href]' ).forEach( anchor => {
 		// Read the attribute rather than the `href` property: the selector also
 		// matches SVG <a>, whose property is an SVGAnimatedString, and resolving

--- a/plugins/newspack-plugin/src/content-gate/preview-links.js
+++ b/plugins/newspack-plugin/src/content-gate/preview-links.js
@@ -15,9 +15,13 @@
  *
  * Kept deliberately in step with newspack-popups/src/view/preview-links.js,
  * which solves the same problem for prompt previews. The two are duplicated
- * rather than shared: a shared package would tie two independently released
- * plugins to one version, which is the wrong trade for a fix this small. If you
- * change one, change the other.
+ * rather than shared because there is nowhere good to share them to: `packages/`
+ * is React components and build tooling, not view-layer utilities, and this is
+ * ~50 lines of dependency-free DOM code reading a differently-named global in
+ * each plugin. (Sharing would not create version coupling — workspace packages
+ * are bundled into each plugin's own dist/ at build time — so that is not the
+ * reason.) If you change one, change the other; there is a test file on each
+ * side to catch drift.
  */
 export function propagateGatePreviewParams() {
 	// Previews only ever render inside the editor's preview iframe, so requiring a

--- a/plugins/newspack-plugin/src/content-gate/preview-links.js
+++ b/plugins/newspack-plugin/src/content-gate/preview-links.js
@@ -20,11 +20,21 @@
  * change one, change the other.
  */
 export function propagateGatePreviewParams() {
+	// Previews only ever render inside the editor's preview iframe, so requiring a
+	// frame is what keeps preview mode from following an editor around the site.
+	// Someone who lands on a preview URL top-level — a new tab, a pasted link — is
+	// browsing, not previewing, and should get ordinary links. Comparing
+	// `window.top` is a reference check, which cross-origin isolation still
+	// permits.
+	if ( window.self === window.top ) {
+		return;
+	}
+
 	// Only localized on a gate preview, so its absence means there is nothing to
 	// propagate. Read through `window.` rather than as a bare identifier:
 	// optional chaining guards a null value, not an undeclared binding, and an
 	// undeclared one throws.
-	const params = window.newspack_content_gate?.preview_query_params;
+	const params = window.newspack_content_gate?.preview_param_names;
 	if ( ! params?.length ) {
 		return;
 	}
@@ -63,12 +73,28 @@ export function propagateGatePreviewParams() {
 		}
 
 		// Off-site links, and schemes like mailto: and tel: that resolve to a null
-		// origin, are none of our business.
+		// origin, are none of our business. Matching on origin rather than on the
+		// site URL means a subdirectory install also stamps links that sit outside
+		// WordPress; that is deliberate, because it is what makes multibranded
+		// sites work, where brands are same-origin paths. A stray `ngp_id` on such
+		// a page resolves to no layout and does nothing.
 		if ( url.origin !== window.location.origin ) {
 			return;
 		}
 
 		present.forEach( ( [ key, value ] ) => url.searchParams.set( key, value ) );
-		anchor.setAttribute( 'href', url.toString() );
+
+		// Keep the href in the shape the page wrote it, because a preview exists to
+		// show what production does. Re-serializing through URL() turns a relative
+		// href absolute, which breaks exactly the theme code a preview should
+		// exercise: `a[href^="/"]` selectors, "current item" scripts comparing an
+		// href against location.pathname. Only the query is ours to change. Two
+		// residual differences we accept: a path-relative href comes back
+		// root-relative, since resolving it is what told us where it points, and
+		// URLSearchParams re-encodes an existing query (`%20` to `+`) — forms
+		// servers treat as equivalent, and unpicking it would mean editing the
+		// query string by hand.
+		const isAbsolute = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test( href );
+		anchor.setAttribute( 'href', isAbsolute ? url.toString() : url.pathname + url.search + url.hash );
 	} );
 }

--- a/plugins/newspack-plugin/src/content-gate/preview-links.js
+++ b/plugins/newspack-plugin/src/content-gate/preview-links.js
@@ -76,9 +76,17 @@ export function propagateGatePreviewParams() {
 			return;
 		}
 
-		// Off-site links, and schemes like mailto: and tel: that resolve to a null
-		// origin, are none of our business. Matching on origin rather than on the
-		// site URL means a subdirectory install also stamps links that sit outside
+		// Only http(s). An opaque-path URL like `blob:https://site/uuid` reports the
+		// inner origin, so it passes the origin test, but it has no meaningful path
+		// or query — the shape logic below would rewrite it into an ordinary page URL
+		// and destroy the link. Restricting the scheme keeps the rewrite to the two
+		// the shape logic was written for.
+		if ( 'http:' !== url.protocol && 'https:' !== url.protocol ) {
+			return;
+		}
+
+		// Off-site links are none of our business. Matching on origin rather than on
+		// the site URL means a subdirectory install also stamps links that sit outside
 		// WordPress; that is deliberate, because it is what makes multibranded
 		// sites work, where brands are same-origin paths. A stray `ngp_id` on such
 		// a page resolves to no layout and does nothing.
@@ -92,12 +100,14 @@ export function propagateGatePreviewParams() {
 		// show what production does. Re-serializing through URL() turns a relative
 		// href absolute, which breaks exactly the theme code a preview should
 		// exercise: `a[href^="/"]` selectors, "current item" scripts comparing an
-		// href against location.pathname. Only the query is ours to change. Two
+		// href against location.pathname. Only the query is ours to change. Three
 		// residual differences we accept: a path-relative href comes back
 		// root-relative, since resolving it is what told us where it points, and
 		// URLSearchParams re-encodes an existing query (`%20` to `+`) — forms
 		// servers treat as equivalent, and unpicking it would mean editing the
-		// query string by hand.
+		// query string by hand. A same-origin protocol-relative href also comes back
+		// scheme-absolute — the one shape we do not preserve, because telling it
+		// apart needs a third branch and it is vanishingly rare in theme output.
 		const isAbsolute = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test( href );
 		anchor.setAttribute( 'href', isAbsolute ? url.toString() : url.pathname + url.search + url.hash );
 	} );

--- a/plugins/newspack-plugin/src/content-gate/preview-links.test.js
+++ b/plugins/newspack-plugin/src/content-gate/preview-links.test.js
@@ -1,20 +1,44 @@
 import { propagateGatePreviewParams } from './preview-links';
 
-// The jsdom origin, whatever the runner sets it to. Expectations are built from
-// it independently of the code under test.
-const abs = path => new URL( path, window.location.origin ).toString();
-
 const setSearch = search => window.history.replaceState( {}, '', '/post/' + search );
 const setLinks = html => {
 	document.body.innerHTML = html;
 };
 const hrefs = () => [ ...document.querySelectorAll( 'a' ) ].map( anchor => anchor.getAttribute( 'href' ) );
 
+// Propagation only runs inside the preview iframe, so every positive case has to
+// look framed. jsdom's `top` points at the window itself.
+const setFramed = framed => {
+	Object.defineProperty( window, 'top', { value: framed ? {} : window, configurable: true } );
+};
+
+// Pins the contract that the early returns bail before touching the DOM at all,
+// which is what keeps this off the critical path of an ordinary page load. An
+// assertion on hrefs alone would still pass if the function walked every anchor
+// and happened to rewrite nothing.
+const expectNoTraversal = run => {
+	const spy = jest.spyOn( document, 'querySelectorAll' );
+	run();
+	expect( spy ).not.toHaveBeenCalled();
+	spy.mockRestore();
+};
+
 describe( 'propagateGatePreviewParams', () => {
 	beforeEach( () => {
-		global.newspack_content_gate = { preview_query_params: [ 'ngp_id', 'ngp_st' ] };
+		global.newspack_content_gate = { preview_param_names: [ 'ngp_id', 'ngp_st' ] };
+		setFramed( true );
 		setSearch( '' );
 		setLinks( '' );
+	} );
+
+	it( 'does nothing top-level, so preview mode cannot follow an editor around the site', () => {
+		setFramed( false );
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		expectNoTraversal( propagateGatePreviewParams );
+
+		expect( hrefs() ).toEqual( [ '/other/' ] );
 	} );
 
 	it( 'does nothing outside a preview, where the params are not localized', () => {
@@ -22,7 +46,7 @@ describe( 'propagateGatePreviewParams', () => {
 		setSearch( '?ngp_id=7' );
 		setLinks( '<a href="/other/">x</a>' );
 
-		propagateGatePreviewParams();
+		expectNoTraversal( propagateGatePreviewParams );
 
 		expect( hrefs() ).toEqual( [ '/other/' ] );
 	} );
@@ -39,7 +63,7 @@ describe( 'propagateGatePreviewParams', () => {
 	it( 'does nothing when no preview param is present in the URL', () => {
 		setLinks( '<a href="/other/">x</a>' );
 
-		propagateGatePreviewParams();
+		expectNoTraversal( propagateGatePreviewParams );
 
 		expect( hrefs() ).toEqual( [ '/other/' ] );
 	} );
@@ -50,7 +74,7 @@ describe( 'propagateGatePreviewParams', () => {
 
 		propagateGatePreviewParams();
 
-		expect( hrefs() ).toEqual( [ abs( '/other/?ngp_id=7&ngp_st=locked' ) ] );
+		expect( hrefs() ).toEqual( [ '/other/?ngp_id=7&ngp_st=locked' ] );
 	} );
 
 	it( 'leaves off-site links, in-page anchors and non-http schemes alone', () => {
@@ -62,6 +86,15 @@ describe( 'propagateGatePreviewParams', () => {
 		expect( hrefs() ).toEqual( [ 'https://elsewhere.test/page/', '#section', 'mailto:hi@example.com' ] );
 	} );
 
+	it( 'leaves an unparseable href alone rather than throwing', () => {
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="http://[">x</a><a href="/other/">y</a>' );
+
+		expect( () => propagateGatePreviewParams() ).not.toThrow();
+		// The bad href is skipped and the pass carries on to the next anchor.
+		expect( hrefs() ).toEqual( [ 'http://[', '/other/?ngp_id=7' ] );
+	} );
+
 	it( 'rewrites an SVG anchor correctly rather than corrupting it', () => {
 		setSearch( '?ngp_id=7' );
 		setLinks( '<svg xmlns="http://www.w3.org/2000/svg"><a href="/chart/"><text>x</text></a></svg>' );
@@ -70,16 +103,40 @@ describe( 'propagateGatePreviewParams', () => {
 
 		// An SVGAElement's href *property* is an SVGAnimatedString; resolving it
 		// yields a same-origin garbage path that silently replaces the link.
-		expect( document.querySelector( 'svg a' ).getAttribute( 'href' ) ).toBe( abs( '/chart/?ngp_id=7' ) );
+		expect( document.querySelector( 'svg a' ).getAttribute( 'href' ) ).toBe( '/chart/?ngp_id=7' );
 	} );
 
-	it( 'resolves a relative href against the document base', () => {
-		setSearch( '?ngp_id=7' );
-		setLinks( '<a href="sub/page/">x</a>' );
+	describe( 'href shape', () => {
+		// A preview should differ from production in what it shows, not in the form
+		// of its markup: theme code keyed on href shape has to behave the same here.
+		it( 'keeps a root-relative href root-relative', () => {
+			setSearch( '?ngp_id=7' );
+			setLinks( '<a href="/other/">x</a>' );
 
-		propagateGatePreviewParams();
+			propagateGatePreviewParams();
 
-		expect( hrefs() ).toEqual( [ abs( '/post/sub/page/?ngp_id=7' ) ] );
+			expect( hrefs() ).toEqual( [ '/other/?ngp_id=7' ] );
+		} );
+
+		it( 'keeps an absolute href absolute', () => {
+			setSearch( '?ngp_id=7' );
+			setLinks( `<a href="${ window.location.origin }/other/">x</a>` );
+
+			propagateGatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ `${ window.location.origin }/other/?ngp_id=7` ] );
+		} );
+
+		it( 'resolves a path-relative href against the document base', () => {
+			setSearch( '?ngp_id=7' );
+			setLinks( '<a href="sub/page/">x</a>' );
+
+			propagateGatePreviewParams();
+
+			// Root-relative rather than absolute: resolving it is what told us where
+			// it points, so this is as close to the original shape as we can get.
+			expect( hrefs() ).toEqual( [ '/post/sub/page/?ngp_id=7' ] );
+		} );
 	} );
 
 	it( 'keeps the fragment and unrelated params, and overwrites a stale one', () => {
@@ -88,7 +145,7 @@ describe( 'propagateGatePreviewParams', () => {
 
 		propagateGatePreviewParams();
 
-		expect( hrefs() ).toEqual( [ abs( '/other/?utm_source=nl&ngp_id=7#top' ) ] );
+		expect( hrefs() ).toEqual( [ '/other/?utm_source=nl&ngp_id=7#top' ] );
 	} );
 
 	it( 'is idempotent, so a second pass does not duplicate params', () => {

--- a/plugins/newspack-plugin/src/content-gate/preview-links.test.js
+++ b/plugins/newspack-plugin/src/content-gate/preview-links.test.js
@@ -127,6 +127,26 @@ describe( 'propagateGatePreviewParams', () => {
 			expect( hrefs() ).toEqual( [ `${ window.location.origin }/other/?ngp_id=7` ] );
 		} );
 
+		it( 'leaves an opaque-path URL alone rather than flattening it to a page URL', () => {
+			setSearch( '?ngp_id=7' );
+			// A blob URL reports its inner origin, so it passes the origin test; the
+			// shape logic would turn it into an ordinary page URL and kill the link.
+			setLinks( `<a href="blob:${ window.location.origin }/abc-123">x</a>` );
+
+			propagateGatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ `blob:${ window.location.origin }/abc-123` ] );
+		} );
+
+		it( 'promotes a same-origin protocol-relative href, the one shape it cannot keep', () => {
+			setSearch( '?ngp_id=7' );
+			setLinks( `<a href="//${ window.location.host }/other/">x</a>` );
+
+			propagateGatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ `${ window.location.origin }/other/?ngp_id=7` ] );
+		} );
+
 		it( 'resolves a path-relative href against the document base', () => {
 			setSearch( '?ngp_id=7' );
 			setLinks( '<a href="sub/page/">x</a>' );

--- a/plugins/newspack-plugin/src/content-gate/preview-links.test.js
+++ b/plugins/newspack-plugin/src/content-gate/preview-links.test.js
@@ -1,0 +1,104 @@
+import { propagateGatePreviewParams } from './preview-links';
+
+// The jsdom origin, whatever the runner sets it to. Expectations are built from
+// it independently of the code under test.
+const abs = path => new URL( path, window.location.origin ).toString();
+
+const setSearch = search => window.history.replaceState( {}, '', '/post/' + search );
+const setLinks = html => {
+	document.body.innerHTML = html;
+};
+const hrefs = () => [ ...document.querySelectorAll( 'a' ) ].map( anchor => anchor.getAttribute( 'href' ) );
+
+describe( 'propagateGatePreviewParams', () => {
+	beforeEach( () => {
+		global.newspack_content_gate = { preview_query_params: [ 'ngp_id', 'ngp_st' ] };
+		setSearch( '' );
+		setLinks( '' );
+	} );
+
+	it( 'does nothing outside a preview, where the params are not localized', () => {
+		global.newspack_content_gate = { metadata: {} };
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagateGatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'survives the global being absent entirely', () => {
+		delete global.newspack_content_gate;
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		expect( () => propagateGatePreviewParams() ).not.toThrow();
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'does nothing when no preview param is present in the URL', () => {
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagateGatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'carries the preview params onto a same-origin link', () => {
+		setSearch( '?ngp_id=7&ngp_st=locked' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagateGatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ abs( '/other/?ngp_id=7&ngp_st=locked' ) ] );
+	} );
+
+	it( 'leaves off-site links, in-page anchors and non-http schemes alone', () => {
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="https://elsewhere.test/page/">a</a><a href="#section">b</a><a href="mailto:hi@example.com">c</a>' );
+
+		propagateGatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ 'https://elsewhere.test/page/', '#section', 'mailto:hi@example.com' ] );
+	} );
+
+	it( 'rewrites an SVG anchor correctly rather than corrupting it', () => {
+		setSearch( '?ngp_id=7' );
+		setLinks( '<svg xmlns="http://www.w3.org/2000/svg"><a href="/chart/"><text>x</text></a></svg>' );
+
+		propagateGatePreviewParams();
+
+		// An SVGAElement's href *property* is an SVGAnimatedString; resolving it
+		// yields a same-origin garbage path that silently replaces the link.
+		expect( document.querySelector( 'svg a' ).getAttribute( 'href' ) ).toBe( abs( '/chart/?ngp_id=7' ) );
+	} );
+
+	it( 'resolves a relative href against the document base', () => {
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="sub/page/">x</a>' );
+
+		propagateGatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ abs( '/post/sub/page/?ngp_id=7' ) ] );
+	} );
+
+	it( 'keeps the fragment and unrelated params, and overwrites a stale one', () => {
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="/other/?utm_source=nl&ngp_id=1#top">x</a>' );
+
+		propagateGatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ abs( '/other/?utm_source=nl&ngp_id=7#top' ) ] );
+	} );
+
+	it( 'is idempotent, so a second pass does not duplicate params', () => {
+		setSearch( '?ngp_id=7&ngp_st=locked' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagateGatePreviewParams();
+		const first = hrefs();
+		propagateGatePreviewParams();
+
+		expect( hrefs() ).toEqual( first );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/components/segmentation-preview/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/components/segmentation-preview/index.js
@@ -53,24 +53,40 @@ const SegmentationPreview = props => {
 			return;
 		}
 
-		// Open the preview first. Reaching into the frame below can throw — a
-		// genuinely cross-origin setup today, and cross-origin isolation if
-		// WordPress ever extends it past the post-editor screens it currently
-		// covers. Rewriting links is a nicety; leaving the modal stuck on
-		// "Loading…" because a nicety threw is not.
-		setIsOpen( true );
-		onLoad( iframeEl );
-
+		// Reaching into the frame can throw — a genuinely cross-origin setup today,
+		// and cross-origin isolation if WordPress ever extends it past the
+		// post-editor screens it currently covers. The `finally` keeps the original
+		// ordering while guaranteeing the state update still runs: without it a
+		// throw left `isOpen` false, so the effect that recomputes the decorated URL
+		// never re-ran and every reopened preview reused the first session ID.
 		try {
-			[ ...iframeEl.contentWindow.document.querySelectorAll( 'a' ) ].forEach( anchor => {
+			const frameDoc = iframeEl.contentWindow.document;
+			[ ...frameDoc.querySelectorAll( 'a[href]' ) ].forEach( anchor => {
 				const href = anchor.getAttribute( 'href' );
-				if ( href.indexOf( frontendUrl ) === 0 ) {
-					anchor.setAttribute( 'href', decorateUrl( href ) );
+				if ( href.startsWith( '#' ) ) {
+					return;
 				}
+				let target;
+				try {
+					target = new URL( href, frameDoc.baseURI );
+				} catch ( e ) {
+					return;
+				}
+				// Compare origins rather than prefix-matching `frontendUrl`, which
+				// falls back to '/' — under that fallback a protocol-relative
+				// off-site href like //example.com also "starts with" it, and would
+				// carry the segment and session IDs to a third party.
+				if ( target.origin !== new URL( frontendUrl, frameDoc.baseURI ).origin ) {
+					return;
+				}
+				anchor.setAttribute( 'href', decorateUrl( target.toString() ) );
 			} );
 		} catch ( e ) {
 			// eslint-disable-next-line no-console
 			console.warn( 'Segmentation preview: could not rewrite in-iframe links.', e );
+		} finally {
+			setIsOpen( true );
+			onLoad( iframeEl );
 		}
 	};
 

--- a/plugins/newspack-plugin/src/wizards/audience/components/segmentation-preview/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/components/segmentation-preview/index.js
@@ -49,15 +49,28 @@ const SegmentationPreview = props => {
 	};
 
 	const onWebPreviewLoad = iframeEl => {
-		if ( iframeEl ) {
+		if ( ! iframeEl ) {
+			return;
+		}
+
+		// Open the preview first. Reaching into the frame below can throw — a
+		// genuinely cross-origin setup today, and cross-origin isolation if
+		// WordPress ever extends it past the post-editor screens it currently
+		// covers. Rewriting links is a nicety; leaving the modal stuck on
+		// "Loading…" because a nicety threw is not.
+		setIsOpen( true );
+		onLoad( iframeEl );
+
+		try {
 			[ ...iframeEl.contentWindow.document.querySelectorAll( 'a' ) ].forEach( anchor => {
 				const href = anchor.getAttribute( 'href' );
 				if ( href.indexOf( frontendUrl ) === 0 ) {
 					anchor.setAttribute( 'href', decorateUrl( href ) );
 				}
 			} );
-			setIsOpen( true );
-			onLoad( iframeEl );
+		} catch ( e ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'Segmentation preview: could not rewrite in-iframe links.', e );
 		}
 	};
 

--- a/plugins/newspack-plugin/src/wizards/audience/components/segmentation-preview/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/components/segmentation-preview/index.js
@@ -61,6 +61,9 @@ const SegmentationPreview = props => {
 		// never re-ran and every reopened preview reused the first session ID.
 		try {
 			const frameDoc = iframeEl.contentWindow.document;
+			// Loop-invariant: both operands are fixed for the whole pass, and a
+			// preview page can easily carry a few hundred anchors.
+			const referenceOrigin = new URL( frontendUrl, frameDoc.baseURI ).origin;
 			[ ...frameDoc.querySelectorAll( 'a[href]' ) ].forEach( anchor => {
 				const href = anchor.getAttribute( 'href' );
 				if ( href.startsWith( '#' ) ) {
@@ -76,7 +79,7 @@ const SegmentationPreview = props => {
 				// falls back to '/' — under that fallback a protocol-relative
 				// off-site href like //example.com also "starts with" it, and would
 				// carry the segment and session IDs to a third party.
-				if ( target.origin !== new URL( frontendUrl, frameDoc.baseURI ).origin ) {
+				if ( target.origin !== referenceOrigin ) {
 					return;
 				}
 				anchor.setAttribute( 'href', decorateUrl( target.toString() ) );

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-preview.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-preview.php
@@ -500,4 +500,47 @@ class Test_Gate_Preview extends \WP_UnitTestCase {
 		unset( $_GET[ Gate_Preview::PREVIEW_QUERY_PARAM ] );
 		$this->assertTrue( Gate_Preview::filter_show_admin_bar( true ), 'Admin bar is shown when not previewing.' );
 	}
+
+	/**
+	 * The preview param list reaches the front-end script only on a preview
+	 * request, which by definition means a user who can preview.
+	 *
+	 * The list itself is not secret — it is constant param names — but shipping it
+	 * is what makes the previewed document rewrite every same-origin link. A
+	 * reader who received it would carry the preview params for the rest of their
+	 * session.
+	 */
+	public function test_preview_params_localized_only_for_a_previewing_user() {
+		wp_set_current_user( $this->admin_id );
+		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
+
+		$data = Content_Gate::get_frontend_script_data( false, Gate_Preview::is_preview_request() );
+		$this->assertArrayHasKey( 'preview_query_params', $data, 'An admin previewing gets the param list.' );
+		$this->assertContains( Gate_Preview::PREVIEW_QUERY_PARAM, $data['preview_query_params'], 'The list carries the preview param itself.' );
+		$this->assertArrayNotHasKey( 'metadata', $data, 'No gate metadata is sent where no gate renders.' );
+	}
+
+	/**
+	 * A subscriber on the same URL gets nothing, because is_preview_request()
+	 * requires the preview capability on every call.
+	 */
+	public function test_preview_params_absent_for_subscriber_on_preview_url() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
+
+		$data = Content_Gate::get_frontend_script_data( false, Gate_Preview::is_preview_request() );
+		$this->assertArrayNotHasKey( 'preview_query_params', $data, 'A subscriber on the preview URL gets no param list.' );
+	}
+
+	/**
+	 * Outside a preview the key is absent, so an ordinary page load carries no
+	 * extra payload.
+	 */
+	public function test_preview_params_absent_without_the_param() {
+		wp_set_current_user( $this->admin_id );
+
+		$data = Content_Gate::get_frontend_script_data( true, Gate_Preview::is_preview_request() );
+		$this->assertArrayNotHasKey( 'preview_query_params', $data, 'No param list without a preview request.' );
+		$this->assertArrayHasKey( 'metadata', $data, 'A rendering gate still gets its metadata.' );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-preview.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-preview.php
@@ -543,4 +543,85 @@ class Test_Gate_Preview extends \WP_UnitTestCase {
 		$this->assertArrayNotHasKey( 'preview_param_names', $data, 'No param list without a preview request.' );
 		$this->assertArrayHasKey( 'metadata', $data, 'A rendering gate still gets its metadata.' );
 	}
+
+	/**
+	 * The enqueue decision itself — not just its payload — has to survive a
+	 * non-singular view, which is the whole point of the preview-session change.
+	 *
+	 * Asserts the context rather than driving enqueue_scripts(), because that would
+	 * need built assets for its filemtime() cache-busters and CI runs PHPUnit
+	 * without a build.
+	 */
+	public function test_script_loads_on_an_archive_during_a_preview() {
+		wp_set_current_user( $this->admin_id );
+		// After go_to(): it resets $_GET and repopulates it from the URL.
+		$this->go_to( get_category_link( self::factory()->category->create() ) );
+		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
+
+		$context = Content_Gate::get_frontend_script_context();
+
+		$this->assertFalse( $context['renders_gate'], 'No gate renders on an archive.' );
+		$this->assertTrue( $context['is_preview'], 'The request is still a preview.' );
+		$this->assertTrue( $context['enqueue'], 'The script has to load anyway, so a click through this page keeps the preview.' );
+	}
+
+	/**
+	 * The same view without a preview stays clean — the counterpart that would fail
+	 * if the decision were widened to "always enqueue".
+	 */
+	public function test_script_does_not_load_on_an_ordinary_archive() {
+		$this->go_to( get_category_link( self::factory()->category->create() ) );
+
+		$context = Content_Gate::get_frontend_script_context();
+
+		$this->assertFalse( $context['is_preview'], 'Not a preview request.' );
+		$this->assertFalse( $context['enqueue'], 'Nothing to enqueue on an ordinary archive.' );
+	}
+
+	/**
+	 * A term ID is not a post ID. On an archive the queried object is a term, and
+	 * comparing its ID against post IDs force-restricted whichever unrelated post
+	 * happened to share the number.
+	 */
+	public function test_archive_preview_does_not_force_restrict_an_unrelated_post() {
+		wp_set_current_user( $this->admin_id );
+		$term_id = self::factory()->category->create();
+		// After go_to(): it resets $_GET and repopulates it from the URL. Setting the
+		// param first would leave this not-a-preview, and the assertions below would
+		// pass trivially on filter_is_post_restricted()'s own early return.
+		$this->go_to( get_category_link( $term_id ) );
+		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
+
+		$this->assertTrue( Gate_Preview::is_preview_request(), 'Guard: the preview really is active here.' );
+
+		// A post whose ID collides with the queried term ID is the case that bit:
+		// it has nothing to do with the preview.
+		$this->assertFalse(
+			Gate_Preview::filter_is_post_restricted( false, $term_id ),
+			'A post sharing an ID with the queried term is not part of the preview.'
+		);
+		$this->assertFalse(
+			Gate_Preview::filter_is_post_restricted( false, 0 ),
+			'Out of the loop on an archive there is no previewed post to force.'
+		);
+	}
+
+	/**
+	 * Cache-cancelling is gated on the capability, like every other preview seam.
+	 */
+	public function test_preview_caching_only_prevented_for_a_previewing_user() {
+		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
+
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse(
+			Gate_Preview::prevent_preview_caching(),
+			'A subscriber on the preview URL gets ordinary cache headers.'
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue(
+			Gate_Preview::prevent_preview_caching(),
+			'A previewing admin gets the page kept out of the cache.'
+		);
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-preview.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-preview.php
@@ -515,8 +515,8 @@ class Test_Gate_Preview extends \WP_UnitTestCase {
 		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
 
 		$data = Content_Gate::get_frontend_script_data( false, Gate_Preview::is_preview_request() );
-		$this->assertArrayHasKey( 'preview_query_params', $data, 'An admin previewing gets the param list.' );
-		$this->assertContains( Gate_Preview::PREVIEW_QUERY_PARAM, $data['preview_query_params'], 'The list carries the preview param itself.' );
+		$this->assertArrayHasKey( 'preview_param_names', $data, 'An admin previewing gets the param list.' );
+		$this->assertContains( Gate_Preview::PREVIEW_QUERY_PARAM, $data['preview_param_names'], 'The list carries the preview param itself.' );
 		$this->assertArrayNotHasKey( 'metadata', $data, 'No gate metadata is sent where no gate renders.' );
 	}
 
@@ -529,7 +529,7 @@ class Test_Gate_Preview extends \WP_UnitTestCase {
 		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
 
 		$data = Content_Gate::get_frontend_script_data( false, Gate_Preview::is_preview_request() );
-		$this->assertArrayNotHasKey( 'preview_query_params', $data, 'A subscriber on the preview URL gets no param list.' );
+		$this->assertArrayNotHasKey( 'preview_param_names', $data, 'A subscriber on the preview URL gets no param list.' );
 	}
 
 	/**
@@ -540,7 +540,7 @@ class Test_Gate_Preview extends \WP_UnitTestCase {
 		wp_set_current_user( $this->admin_id );
 
 		$data = Content_Gate::get_frontend_script_data( true, Gate_Preview::is_preview_request() );
-		$this->assertArrayNotHasKey( 'preview_query_params', $data, 'No param list without a preview request.' );
+		$this->assertArrayNotHasKey( 'preview_param_names', $data, 'No param list without a preview request.' );
 		$this->assertArrayHasKey( 'metadata', $data, 'A rendering gate still gets its metadata.' );
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-preview.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-preview.php
@@ -558,7 +558,7 @@ class Test_Gate_Preview extends \WP_UnitTestCase {
 		$this->go_to( get_category_link( self::factory()->category->create() ) );
 		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
 
-		$context = Content_Gate::get_frontend_script_context();
+		$context = Content_Gate::get_frontend_script_conditions();
 
 		$this->assertFalse( $context['renders_gate'], 'No gate renders on an archive.' );
 		$this->assertTrue( $context['is_preview'], 'The request is still a preview.' );
@@ -572,7 +572,7 @@ class Test_Gate_Preview extends \WP_UnitTestCase {
 	public function test_script_does_not_load_on_an_ordinary_archive() {
 		$this->go_to( get_category_link( self::factory()->category->create() ) );
 
-		$context = Content_Gate::get_frontend_script_context();
+		$context = Content_Gate::get_frontend_script_conditions();
 
 		$this->assertFalse( $context['is_preview'], 'Not a preview request.' );
 		$this->assertFalse( $context['enqueue'], 'Nothing to enqueue on an ordinary archive.' );
@@ -594,8 +594,8 @@ class Test_Gate_Preview extends \WP_UnitTestCase {
 
 		$this->assertTrue( Gate_Preview::is_preview_request(), 'Guard: the preview really is active here.' );
 
-		// A post whose ID collides with the queried term ID is the case that bit:
-		// it has nothing to do with the preview.
+		// An id equal to the queried term id is the case that bit: nothing is created
+		// at that id here, because the filter never loads the post — it only compares.
 		$this->assertFalse(
 			Gate_Preview::filter_is_post_restricted( false, $term_id ),
 			'A post sharing an ID with the queried term is not part of the preview.'


### PR DESCRIPTION
> **Stacked on #875.** Base is `hotfix/prompt-preview-cross-origin-isolation`, so this diff shows only the follow-up. Merge #875 first, or retarget this to `main` once it lands.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

#875 fixed prompt previews under WordPress 7.1. Reviewing it turned up the same cross-frame pattern in two other places, so this applies the same fix where it is needed and hardens the one place where it is not.

**Content-gate preview — the real one.** The gate's layout editor reached into the preview iframe to append preview params to links, exactly as the prompt editor did. WordPress 7.1's `Document-Isolation-Policy` severs that access. This one failed *quietly*: the call sat inside a `try`/`catch` written for genuinely cross-origin setups, so under 7.1 link rewriting simply stopped and left only a console warning. A gate preview still opened, but the first click inside it landed on the ordinary page.

The fix mirrors #875. `propagateGatePreviewParams()` runs in the previewed document, which may always rewrite its own links, and the editor no longer touches the frame. The gate's front-end script now also loads on a preview request where no gate renders — an archive, the home page, a search — because a click through one of those pages has to keep the previewed params too. Its stylesheet still loads only where a gate actually renders.

A gate preview no longer gets served from the page cache, matching what the two sibling classes already do.

**Opaque-path hrefs survive a preview.** `blob:` and friends report their *inner* origin, so they passed the origin test, failed the "is this absolute" test, and were rewritten into ordinary page URLs — destroying the link. The rewrite is now confined to `http(s)`, matching the sibling module in newspack-popups. The two files' rewriting logic is byte-identical again; only their comments and the exported names differ.

**Archive previews no longer misreport unrelated posts.** `filter_is_post_restricted()` compared `get_queried_object_id()` against post IDs. On the archive, home and search views this PR newly supports, that value is a *term* or *user* ID, so any post whose ID happened to match the queried term was force-restricted — and consumers act on that, `exclude_restricted_posts_from_feed()` among them. It now requires both `is_singular()` and the queried object being a `WP_Post`. The type check is what makes the ID comparison sound; `is_singular()` confines the forcing to views that render one post, since the blog posts index on a static-front-page site and a 404 whose `pagename` matched an unpublished page both hand back a `WP_Post` without being singular. Those two are inert today — every render path already guards on `is_singular()` — so that half is hardening that keeps them inert without relying on callers staying careful. Preview-only and privileged-only, so not a security matter; it made the preview lie about posts it was never previewing.

**Segmentation preview — hardening, and one real fix.** The Audience wizard's "view as" preview uses the same construct, but wizards run on `admin.php`, and cross-origin isolation is hooked only to the post-editor, site-editor and widgets screens. The cross-frame access is not broken today. Two things were worth changing anyway:

- It was unguarded, and `setIsOpen( true )` came after the rewrite, so any throw left the modal stuck on "Loading…" — and, because the effect that recomputes the URL never re-ran, every reopened preview reused the first session ID. The state update now runs in a `finally`.
- It matched links by prefixing the site URL, which falls back to `/`. Under that fallback a protocol-relative off-site href such as `//example.com/page` also "starts with" the prefix, so it was decorated with the segment and session IDs and carried them to a third party. It now compares origins.

**Newsletters preview — deliberately not changed.** It also reads `contentDocument`, but for a different purpose (scoping a CSS class and awaiting stylesheet load) and against Gutenberg's own editor-canvas iframe, which stays reachable under isolation. Verified in a live 7.1-RC3 editor: `contentDocument` returns a live document with cross-origin isolation active. Nothing to fix.

Also removed `frontend_url` from the gate's editor preview payload, which the deleted handler was the only consumer of.

### How to test the changes in this Pull Request:

Requires **Chrome 137 or later over HTTPS** on WordPress 7.1, signed in as a user who can edit others' pages. Cross-origin isolation is only sent to Chromium, so this will not reproduce in curl, Firefox, or Safari.

1. Enable content gating and create a gate layout, with at least two restricted posts.
2. Open the gate layout in the editor and open the browser console.
3. Click **Preview**. No `Gate preview: could not rewrite in-iframe links` warning appears.
4. Inside the preview, click a link to another restricted post.
5. The preview stays in preview mode — the gate still reflects the layout's unsaved settings.
6. Click through to an archive or the home page, then on to another restricted post. Preview mode survives the trip.

On the base branch, step 3 logs the warning and step 4 drops out of preview.

For the segmentation preview, open **Audience → Segments**, use "view as" on any segment, and confirm the preview modal still opens and links are still decorated.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Thirteen unit tests cover `propagateGatePreviewParams`, matching the coverage added in #875: same-origin rewriting, the top-level and no-preview and no-matching-param cases, an absent global, off-site links, in-page anchors, `mailto:`, an unparseable href, SVG anchors, href shape, fragment and unrelated-param preservation, and idempotency. Two more pin the wiring itself — that a throw in propagation cannot stop the gate from initialising, which is the property the comment there claims.

Seven PHP tests cover the seams this PR introduces. Three pin the localized payload: an admin previewing gets the param names and no gate metadata, a subscriber on the same URL gets neither, and a request without the param gets neither. Four more pin the behaviour, and each was mutation-tested to confirm it fails when the fix is reverted:

- the script still loads on an archive during a preview, and does **not** on an ordinary archive — reverting the enqueue decision to `renders_gate` alone fails this;
- an archive preview does not force-restrict a post sharing the queried term's ID — dropping the `WP_Post` guard fails this, reproducing the reported behaviour as a unit test;
- cache prevention applies only to a user who may preview.

The enqueue decision is asserted through `get_frontend_script_context()` rather than by driving `enqueue_scripts()`, because that path needs built assets for its `filemtime()` cache-busters and CI runs PHPUnit without a build — a test that called it directly would pass locally and error in CI.

Locally: the full newspack-plugin JS suite passes (627 tests, 67 suites), the full PHP suite passes (3028 tests, 8922 assertions, 10 pre-existing environmental skips), and ESLint and PHPCS are clean on every changed file.

**Not verified at runtime:** the gate preview itself. The available environment has no content gating configured, so the gate path was verified by unit tests, build inspection, and PHP class resolution rather than by clicking through a real preview. Worth one manual pass before merge, since that is the half of this PR that actually changes behaviour.


