### PR TITLE
ci(release): document the re-run trap after a partial release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -176,6 +176,11 @@ jobs:
       # packages were published.
       - name: Snapshot existing tags
         run: git tag > "$RUNNER_TEMP/tags-before.txt"
+      # A failed run here is not recoverable by re-running it: after a partial
+      # multi-semantic-release the re-run checks out the original trigger SHA
+      # while msr's own pushed commits have advanced the branch, so
+      # semantic-release refuses with "The local branch release is behind the
+      # remote one". Recovery is a new push to the branch, not a re-run.
       - name: Release
         if: steps.plan.outputs.release_needed == 'true'
         run: pnpm exec multi-semantic-release --sequential-init


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)? — n/a: comment-only change to a GitHub Actions workflow, no PHP or JS.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Documents an operational trap on the Release step, hit in [run 32050353517, attempt 2](https://github.com/Automattic/newspack-workspace/actions/runs/32050353517/attempts/2): once multi-semantic-release fails partway with some commits already pushed, "Re-run failed jobs" can never succeed. The re-run checks out the original trigger SHA while the pushed commits have advanced the branch, so semantic-release refuses with "The local branch release is behind the remote one". Recovery is a new push to the branch. The comment records that at the step, so the next person debugging a failed release run reaches for a push instead of the re-run button.

The plan-step bash bugs from the same incident are already fixed by #833, so this PR deliberately adds only the documentation, on lines #833 does not touch.

### How to test the changes in this Pull Request:

1. Confirm the diff adds only comment lines. Workflow behavior is unchanged.
2. Check the claim against [run 32050353517, attempt 2](https://github.com/Automattic/newspack-workspace/actions/runs/32050353517/attempts/2). The Release step fails there with "The local branch release is behind the remote one".

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — n/a for a comment.
* [x] Have you successfully run tests with your changes locally? — YAML parse check; there is no behavior to test.
