### PR TITLE
fix: three WordPress 7.1 regressions in Newsletters

### DIFF
--- a/packages/components/src/grid/style.scss
+++ b/packages/components/src/grid/style.scss
@@ -83,11 +83,13 @@
 		&__columns-4 {
 			grid-template-columns: repeat(2, 1fr);
 
-			> [start] {
+			> [start],
+			> [data-start] {
 				grid-column-start: 1;
 			}
 
-			> [end] {
+			> [end],
+			> [data-end] {
 				grid-column-end: -1;
 			}
 		}
@@ -108,11 +110,26 @@
 		&__columns-4 {
 			grid-template-columns: repeat(4, 1fr);
 
-			> [start="2"] {
+			// Positioning is keyed off `data-` attributes because the emotion-styled
+			// components in newer `@wordpress/components` filter props through
+			// `@emotion/is-prop-valid` before they reach the DOM. Its allowlist
+			// carries `start` (a real attribute, on `<ol>`) but not `end`, so a
+			// `VStack` asking for `end` silently lost its `grid-column-end` and
+			// collapsed to one column (NEWS-2866). `data-` attributes are never
+			// filtered, so they hold whatever component renders them.
+			//
+			// This is a component-level filter, not a WordPress-wide one: a plain
+			// `<div start="2" end="4">` still emits both attributes. The bare
+			// selectors below are kept for those plain children — they do NOT
+			// rescue an emotion-styled consumer still passing `end`, which never
+			// reaches the DOM to be matched.
+			> [start="2"],
+			> [data-start="2"] {
 				grid-column-start: 2;
 			}
 
-			> [end="4"] {
+			> [end="4"],
+			> [data-end="4"] {
 				grid-column-end: 4;
 			}
 		}

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-renderer.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-renderer.php
@@ -898,6 +898,123 @@ final class Newspack_Newsletters_Renderer {
 	}
 
 	/**
+	 * Get a button's width as a column percentage, or null when it sets none.
+	 *
+	 * Buttons carry their width in one of two shapes. Newsletters authored before
+	 * WordPress 7.1 store a bare `width` attribute; WordPress 7.1 moved
+	 * `core/button` to the `dimensions` block support, so the editor rewrites the
+	 * markup under `style.dimensions.width` the first time a newsletter is
+	 * re-saved. Both forms can coexist in the same newsletter, so every width read
+	 * goes through here (NEWS-2852).
+	 *
+	 * The legacy attribute is preferred when it yields a usable width, but an
+	 * unusable one falls through to the `dimensions` value rather than discarding
+	 * it — partially-migrated content is exactly what this helper exists to
+	 * survive.
+	 *
+	 * A width is usable only if it resolves to a percentage above 0 and at most
+	 * 100. Absolute
+	 * units have no meaning as an MJML column share, and a column outside that
+	 * range disturbs the rest of its row; either way the button falls back to the
+	 * default share, which is what a width-less button gets.
+	 *
+	 * Safe to call with either raw parsed-block attributes or the output of
+	 * `process_attributes()`, which touches neither width key.
+	 *
+	 * @param array $attrs A core/button block's attributes.
+	 * @return float|null Width as a percentage, or null when unset or unusable.
+	 */
+	private static function get_button_width( array $attrs ): ?float {
+		$candidates = [];
+
+		if ( isset( $attrs['width'] ) && is_scalar( $attrs['width'] ) ) {
+			$candidates[] = (string) $attrs['width'];
+		}
+		if ( isset( $attrs['style']['dimensions']['width'] ) && is_scalar( $attrs['style']['dimensions']['width'] ) ) {
+			$candidates[] = self::resolve_dimension_preset( (string) $attrs['style']['dimensions']['width'] );
+		}
+
+		foreach ( $candidates as $candidate ) {
+			if ( ! preg_match( '/^\s*(\d+(?:\.\d+)?)\s*%?\s*$/', $candidate, $matches ) ) {
+				continue;
+			}
+			$percentage = (float) $matches[1];
+			if ( $percentage > 0 && $percentage <= 100 ) {
+				return $percentage;
+			}
+		}
+
+		return null;
+	}
+
+	/**
+	 * Resolve a `dimensions.width` preset reference to its literal size.
+	 *
+	 * WordPress stores a chosen preset as `var:preset|dimension|<slug>` rather than
+	 * a size. On the web an unresolved reference still renders, because the style
+	 * engine falls back to the `--wp--preset--dimension--<slug>` custom property
+	 * that theme.json emits. Email clients do not support custom properties, so the
+	 * reference has to be resolved here or the width is simply lost — which is why
+	 * this looks harder for the preset than core does.
+	 *
+	 * Core's own lookup (`render_block_core_button()`) reads only the
+	 * `blocks.core/button` node. That is enough for core because of the
+	 * custom-property fallback; it isn't enough for us, so this also reads the
+	 * root `dimensions.dimensionSizes` group and includes the `blocks` origin.
+	 * Slugs are compared exactly, as core compares them: the editor writes the
+	 * slug verbatim into the reference, and `_wp_to_kebab_case()` is applied only
+	 * when core builds the CSS custom-property name, never to the stored value.
+	 *
+	 * @param string $width The raw `style.dimensions.width` value.
+	 * @return string The resolved width, or the input unchanged when it isn't a
+	 *                preset reference or names an unknown preset.
+	 */
+	private static function resolve_dimension_preset( string $width ): string {
+		$prefix = 'var:preset|dimension|';
+		if ( ! str_starts_with( $width, $prefix ) ) {
+			return $width;
+		}
+		$slug = substr( $width, strlen( $prefix ) );
+
+		// Read the settings once and index into them. `wp_get_global_settings()`
+		// returns the *whole* settings array when the requested path is absent, so
+		// asking it for a path and testing `is_array()` on the result never fails —
+		// it just hands back a different array to walk.
+		$settings = wp_get_global_settings();
+		$groups   = [];
+		if ( isset( $settings['blocks']['core/button']['dimensions']['dimensionSizes'] ) ) {
+			$groups[] = $settings['blocks']['core/button']['dimensions']['dimensionSizes'];
+		}
+		if ( isset( $settings['dimensions']['dimensionSizes'] ) ) {
+			$groups[] = $settings['dimensions']['dimensionSizes'];
+		}
+
+		foreach ( $groups as $presets ) {
+			if ( ! is_array( $presets ) ) {
+				continue;
+			}
+			// Origin priority, most specific first.
+			foreach ( [ 'custom', 'theme', 'blocks', 'default' ] as $origin ) {
+				if ( empty( $presets[ $origin ] ) || ! is_array( $presets[ $origin ] ) ) {
+					continue;
+				}
+				foreach ( $presets[ $origin ] as $preset ) {
+					if ( ! is_array( $preset ) || ! isset( $preset['slug'] ) || ! is_scalar( $preset['slug'] ) ) {
+						continue;
+					}
+					if ( (string) $preset['slug'] !== $slug ) {
+						continue;
+					}
+					$size = $preset['size'] ?? null;
+					return is_scalar( $size ) ? (string) $size : $width;
+				}
+			}
+		}
+
+		return $width;
+	}
+
+	/**
 	 * Convert a Gutenberg block to an MJML component.
 	 * MJML component will be put in an mj-column in an mj-section for consistent layout,
 	 * unless it's a group or a columns block.
@@ -1212,8 +1329,9 @@ final class Newspack_Newsletters_Renderer {
 				$total_defined_width = array_reduce(
 					$inner_blocks,
 					function ( $acc, $block ) {
-						if ( isset( $block['attrs']['width'] ) ) {
-							$acc += intval( $block['attrs']['width'] );
+						$width = self::get_button_width( $block['attrs'] ?? [] );
+						if ( null !== $width ) {
+							$acc += $width;
 						}
 						return $acc;
 					},
@@ -1225,7 +1343,7 @@ final class Newspack_Newsletters_Renderer {
 					array_filter(
 						$inner_blocks,
 						function ( $block ) {
-							return empty( $block['attrs']['width'] );
+							return null === self::get_button_width( $block['attrs'] ?? [] );
 						}
 					)
 				);
@@ -1320,10 +1438,16 @@ final class Newspack_Newsletters_Renderer {
 						$button_attrs['css-class'] = $attrs['className'];
 					}
 
+					// NOTE: the width below goes on $default_button_attrs, which is what
+					// the emit at the end of this case actually serializes. The
+					// $button_attrs built just above is dead (pre-existing) — if that
+					// is ever cleaned up, move this width with it or buttons silently
+					// lose their width again.
 					$column_attrs['css-class'] = 'mj-column-has-width';
 					$column_width              = $default_width;
-					if ( ! empty( $attrs['width'] ) ) {
-						$column_width                  = $attrs['width'];
+					$button_width              = self::get_button_width( $attrs );
+					if ( null !== $button_width ) {
+						$column_width                  = $button_width;
 						$default_button_attrs['width'] = '100%'; // Buttons with defined width should fill their column.
 					}
 					$column_attrs['width'] = $column_width . '%';

--- a/plugins/newspack-newsletters/src/admin-shell/components/empty-state/index.js
+++ b/plugins/newspack-newsletters/src/admin-shell/components/empty-state/index.js
@@ -48,7 +48,7 @@ export default function EmptyState( { icon, title, description, ctaTitle, ctaHre
 
 	return (
 		<Grid className="newspack-newsletters-admin__empty-state" columns={ 4 } noMargin>
-			<VStack start={ 2 } end={ 4 } spacing={ 8 }>
+			<VStack data-start="2" data-end="4" spacing={ 8 }>
 				<SectionHeader icon={ icon } title={ title } description={ description } pageHeader noMargin />
 				<HStack justify="center">
 					<Button { ...buttonProps }>{ ctaTitle }</Button>

--- a/plugins/newspack-newsletters/src/newsletter-editor/editor/index.js
+++ b/plugins/newspack-newsletters/src/newsletter-editor/editor/index.js
@@ -20,7 +20,6 @@ import { registerPlugin } from '@wordpress/plugins';
 import withApiHandler from '../../components/with-api-handler';
 import SendButton from '../../components/send-button';
 import './style.scss';
-import { validateNewsletter } from '../utils';
 import { CAMPAIGN_SENT_NOTICE_ID } from '../../utils/consts';
 
 const Editor = compose( [
@@ -38,21 +37,18 @@ const Editor = compose( [
 		return {
 			html: meta[ newspack_email_editor_data.email_html_meta ],
 			colorPalette: colors.reduce( ( _colors, { slug, color } ) => ( { ..._colors, [ slug ]: color } ), {} ),
-			meta,
 			sent,
 			newsletterSendErrors: meta.newsletter_send_errors,
 			isCustomFieldsMetaBoxActive: getAllMetaBoxes().some( box => box.id === 'postcustom' ),
 		};
 	} ),
 	withDispatch( dispatch => {
-		const { lockPostAutosaving, lockPostSaving, unlockPostAutosaving, unlockPostSaving, editPost } = dispatch( 'core/editor' );
+		const { lockPostAutosaving, unlockPostAutosaving, editPost } = dispatch( 'core/editor' );
 		const { createNotice, removeNotice } = dispatch( 'core/notices' );
 		const { openModal } = dispatch( 'core/interface' );
 		return {
 			lockPostAutosaving,
-			lockPostSaving,
 			unlockPostAutosaving,
-			unlockPostSaving,
 			editPost,
 			createNotice,
 			removeNotice,
@@ -66,18 +62,24 @@ const Editor = compose( [
 	html,
 	isCustomFieldsMetaBoxActive,
 	lockPostAutosaving,
-	lockPostSaving,
-	meta,
 	newsletterSendErrors,
 	openModal,
 	removeNotice,
-	unlockPostSaving,
 	sent,
 	successNote,
 } ) => {
+	// This component holds no validation-based saving lock, by design. Sending is
+	// gated by the Send button itself (see components/send-button), which is the
+	// control that dispatches to the ESP; an incomplete newsletter is still a
+	// perfectly good draft. WordPress 7.1 added the post-saving lock to core's
+	// "Save draft" disabled condition, so holding one here left authors unable to
+	// save work in progress until they had filled in sender and list (NEWS-2888).
+	//
+	// Note this is only about the *validation* lock: `editor/mjml` still takes a
+	// short-lived `newspack-newsletters-refresh-html` saving lock around the
+	// post-save HTML refresh, so a greyed-out "Save draft" is not automatically
+	// this file's doing.
 	const [ publishEl ] = useState( document.createElement( 'div' ) );
-	const newsletterValidationErrors = validateNewsletter( meta );
-	const isReady = newsletterValidationErrors.length === 0;
 
 	useEffect( () => {
 		// Create alternate publish button.
@@ -96,15 +98,6 @@ const Editor = compose( [
 			method: 'POST',
 		} );
 	}, [ JSON.stringify( colorPalette ) ] );
-
-	// Lock or unlock post publishing.
-	useEffect( () => {
-		if ( isReady ) {
-			unlockPostSaving( 'newspack-newsletters-post-lock' );
-		} else {
-			lockPostSaving( 'newspack-newsletters-post-lock' );
-		}
-	}, [ isReady ] );
 
 	useEffect( () => {
 		if ( sent ) {

--- a/plugins/newspack-newsletters/tests/test-renderer.php
+++ b/plugins/newspack-newsletters/tests/test-renderer.php
@@ -11,9 +11,22 @@
 class Newsletters_Renderer_Test extends WP_UnitTestCase {
 
 	/**
+	 * Filter registered by register_dimension_presets(), removed on tear down.
+	 *
+	 * @var callable|null
+	 */
+	private $dimension_preset_filter = null;
+
+
+	/**
 	 * Clean up after each test.
 	 */
 	public function tear_down() {
+		if ( null !== $this->dimension_preset_filter ) {
+			remove_filter( 'wp_theme_json_data_theme', $this->dimension_preset_filter );
+			$this->dimension_preset_filter = null;
+			wp_clean_theme_json_cache();
+		}
 		parent::tear_down();
 		// Reset stub RDB to prevent test pollution.
 		\RemoteDataBlocks\Editor\DataBinding\BlockBindings::reset();
@@ -301,6 +314,315 @@ class Newsletters_Renderer_Test extends WP_UnitTestCase {
 			),
 			'<mj-section url="https://www.amazon.com/Learning-PHP-MySQL-JavaScript-Javascript/dp/1491978910" padding="0"><mj-column padding="12px" width="100%"><mj-text padding="0" line-height="1.5" font-size="16px" >Embed</mj-text></mj-column></mj-section>',
 			'Renders invalid rich HTML as link'
+		);
+	}
+
+	/**
+	 * Registers dimension presets at the theme layer, for the current test only.
+	 *
+	 * The preset tests must not depend on what the installed WordPress ships: core
+	 * only gained `dimensionSizes` for `core/button` in 7.1, so asserting against
+	 * its built-in 25/50/75/100 passes locally on an RC and fails on CI, which
+	 * installs the latest stable release. Declaring our own preset keeps the test
+	 * hermetic, and puts it at the theme layer's root — the natural place for a
+	 * theme to declare one, and a node core's own lookup does not read.
+	 *
+	 * @return void
+	 */
+	private function register_dimension_presets() {
+		$this->dimension_preset_filter = function ( $theme_json ) {
+			return $theme_json->update_with(
+				[
+					'version'  => 3,
+					'settings' => [
+						'dimensions' => [
+							'dimensionSizes' => [
+								[
+									'name' => 'QA Half',
+									'slug' => 'qa-half',
+									'size' => '50%',
+								],
+								[
+									'name' => 'QA Camel',
+									'slug' => 'qaCamelQuarter',
+									'size' => '25%',
+								],
+							],
+						],
+					],
+				]
+			);
+		};
+		add_filter( 'wp_theme_json_data_theme', $this->dimension_preset_filter );
+		wp_clean_theme_json_cache();
+	}
+
+	/**
+	 * Build a `core/buttons` block wrapping one `core/button` per set of attributes.
+	 *
+	 * @param array ...$button_attrs One attributes array per button, in order.
+	 * @return array Parsed-block array suitable for render_mjml_component().
+	 */
+	private function buttons_block( ...$button_attrs ) {
+		$inner_html = '<button><a>Test Button</a></button>';
+		$buttons    = [];
+		foreach ( $button_attrs as $attrs ) {
+			$buttons[] = [
+				'blockName'    => 'core/button',
+				'attrs'        => $attrs,
+				'innerBlocks'  => [],
+				'innerContent' => [ $inner_html ],
+				'innerHTML'    => $inner_html,
+			];
+		}
+		return [
+			'blockName'    => 'core/buttons',
+			'attrs'        => [],
+			'innerBlocks'  => $buttons,
+			'innerContent' => [ '<div>', null, '</div>' ],
+			'innerHTML'    => '<div></div>',
+		];
+	}
+
+	/**
+	 * Render a buttons block and return its `mj-column` widths, in order.
+	 *
+	 * @param array ...$button_attrs One attributes array per button.
+	 * @return array Width strings, e.g. `[ '50%', '25%' ]`.
+	 */
+	private function button_column_widths( ...$button_attrs ) {
+		$mjml = Newspack_Newsletters_Renderer::render_mjml_component( $this->buttons_block( ...$button_attrs ) );
+		preg_match_all( '/<mj-column[^>]*width="([^"]*)"/', $mjml, $matches );
+		return $matches[1];
+	}
+
+	/**
+	 * A button width set the pre-WP-7.1 way renders as its own column percentage.
+	 *
+	 * Guards the legacy `{"width":50}` attribute, which is what every newsletter
+	 * authored before WP 7.1 still carries on disk.
+	 */
+	public function test_button_width_legacy_attribute() {
+		$this->assertSame(
+			[ '50%' ],
+			$this->button_column_widths( [ 'width' => 50 ] ),
+			'Expected a button with the legacy width attribute to render a 50% column.'
+		);
+	}
+
+	/**
+	 * A button width set the WP 7.1 way renders the same column percentage.
+	 *
+	 * WP 7.1 moved core/button width from a top-level `width` attribute to the
+	 * `dimensions` block support, so the editor rewrites stored markup the first
+	 * time a newsletter is re-saved. Without this the column silently falls back
+	 * to the shared default and the sent email loses the author's layout
+	 * (NEWS-2852).
+	 */
+	public function test_button_width_dimensions_support() {
+		$this->assertSame(
+			[ '50%' ],
+			$this->button_column_widths( [ 'style' => [ 'dimensions' => [ 'width' => '50%' ] ] ] ),
+			'Expected a button using the WP 7.1 dimensions support to render a 50% column.'
+		);
+	}
+
+	/**
+	 * A `dimensions` width naming a preset resolves to that preset's size.
+	 *
+	 * WordPress stores a chosen preset as `var:preset|dimension|<slug>` rather than
+	 * a size, and on the web an unresolved reference still renders via the
+	 * `--wp--preset--dimension--*` custom property. Email has no custom properties,
+	 * so failing to resolve here loses the width outright.
+	 *
+	 * The preset is declared at the theme layer's root, which is where a theme
+	 * would naturally put one — and which core's own button lookup does not read.
+	 */
+	public function test_button_width_dimensions_preset() {
+		$this->register_dimension_presets();
+		$this->assertSame(
+			[ '50%' ],
+			$this->button_column_widths( [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|qa-half' ] ] ] ),
+			'Expected a theme-declared preset reference to resolve to the preset size.'
+		);
+	}
+
+	/**
+	 * A camelCase preset slug resolves from its verbatim reference.
+	 *
+	 * The editor writes the slug into the reference unchanged, so a camelCase slug
+	 * arrives camelCased. Core kebab-cases slugs only when building the CSS
+	 * custom-property name, never the stored value - so an exact comparison is
+	 * both what core does and all that real content needs.
+	 */
+	public function test_button_width_dimensions_preset_camel_case_slug() {
+		$this->register_dimension_presets();
+		$this->assertSame(
+			[ '25%' ],
+			$this->button_column_widths( [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|qaCamelQuarter' ] ] ] ),
+			'Expected a camelCase slug to resolve from its verbatim reference.'
+		);
+	}
+
+	/**
+	 * Widths MJML columns can't express fall back to the shared default.
+	 *
+	 * An absolute unit, an unresolvable preset, a kebab-cased reference to a
+	 * camelCase slug, a missing `width` key, or a value outside the usable range
+	 * all mean "no usable column percentage". The button then takes
+	 * the default share, which is what a lone width-less button gets: 100%.
+	 * Emitting the raw value instead would produce columns like `200%` or `-50%`
+	 * and break the whole row, not just that button.
+	 *
+	 * @dataProvider unusable_button_width_provider
+	 *
+	 * @param array  $attrs A core/button block's attributes.
+	 * @param string $case  Human-readable label for the failure message.
+	 */
+	public function test_button_width_unusable_values_fall_back( $attrs, $case ) {
+		// Registered so the kebab-cased row is a real miss against an existing
+		// camelCase preset, rather than passing because nothing was declared.
+		$this->register_dimension_presets();
+		$this->assertSame(
+			[ '100%' ],
+			$this->button_column_widths( $attrs ),
+			sprintf( 'Expected %s to fall back to the default column width.', $case )
+		);
+	}
+
+	/**
+	 * Width values that cannot become an MJML column percentage.
+	 *
+	 * @return array[]
+	 */
+	public function unusable_button_width_provider() {
+		return [
+			'absolute unit'       => [ [ 'style' => [ 'dimensions' => [ 'width' => '200px' ] ] ], 'an absolute unit' ],
+			'unknown preset'      => [ [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|nope' ] ] ], 'an unresolvable preset' ],
+			'kebab-cased slug'    => [ [ 'style' => [ 'dimensions' => [ 'width' => 'var:preset|dimension|qa-camel-quarter' ] ] ], 'a kebab-cased reference to a camelCase slug' ],
+			'dimensions no width' => [ [ 'style' => [ 'dimensions' => [] ] ], 'dimensions without a width' ],
+			'legacy zero'         => [ [ 'width' => 0 ], 'a zero legacy width' ],
+			'legacy negative'     => [ [ 'width' => -50 ], 'a negative legacy width' ],
+			'legacy over 100'     => [ [ 'width' => 150 ], 'a legacy width above 100' ],
+		];
+	}
+
+	/**
+	 * An unusable legacy width falls through to the `dimensions` value.
+	 *
+	 * The legacy attribute is preferred, but only when it yields a usable width.
+	 * Choosing the branch on the legacy key's mere presence - and validating only
+	 * afterwards - would discard a perfectly good `dimensions` width and drop the
+	 * button to the default share. Partially-migrated content is exactly where
+	 * both keys coexist, so this is the case the preference order exists to get
+	 * right.
+	 *
+	 * @dataProvider unusable_legacy_falls_through_provider
+	 *
+	 * @param mixed  $legacy The unusable legacy `width` attribute.
+	 * @param string $case   Human-readable label for the failure message.
+	 */
+	public function test_button_width_unusable_legacy_falls_through( $legacy, $case ) {
+		$this->assertSame(
+			[ '40%' ],
+			$this->button_column_widths(
+				[
+					'width' => $legacy,
+					'style' => [ 'dimensions' => [ 'width' => '40%' ] ],
+				]
+			),
+			sprintf( 'Expected %s to fall through to the dimensions width.', $case )
+		);
+	}
+
+	/**
+	 * Unusable legacy widths that should not mask a usable `dimensions` width.
+	 *
+	 * @return array[]
+	 */
+	public function unusable_legacy_falls_through_provider() {
+		return [
+			'zero'        => [ 0, 'a zero legacy width' ],
+			'negative'    => [ -50, 'a negative legacy width' ],
+			'over 100'    => [ 150, 'a legacy width above 100' ],
+			'empty'       => [ '', 'an empty legacy width' ],
+			'non-numeric' => [ 'abc', 'a non-numeric legacy width' ],
+		];
+	}
+
+	/**
+	 * The legacy attribute wins when a block carries both shapes.
+	 *
+	 * WP 7.1's migration deletes the old key as it writes the new one, so the two
+	 * should never coexist — but hand-edited or partially-migrated content can
+	 * carry both, and the read order needs to be deterministic either way.
+	 */
+	public function test_button_width_legacy_wins_over_dimensions() {
+		$this->assertSame(
+			[ '50%' ],
+			$this->button_column_widths(
+				[
+					'width' => 50,
+					'style' => [ 'dimensions' => [ 'width' => '25%' ] ],
+				]
+			),
+			'Expected the legacy width attribute to take precedence.'
+		);
+	}
+
+	/**
+	 * A fractional width keeps its precision.
+	 *
+	 * MJML accepts fractional column widths, so rounding to an integer would make
+	 * three equal thirds sum to 99% and leave the row visibly short.
+	 */
+	public function test_button_width_keeps_fraction() {
+		$this->assertSame(
+			[ '33.9%' ],
+			$this->button_column_widths( [ 'style' => [ 'dimensions' => [ 'width' => '33.9%' ] ] ] ),
+			'Expected a fractional width to survive rather than being truncated.'
+		);
+	}
+
+	/**
+	 * Sibling buttons keep their own widths, whichever form each one uses.
+	 *
+	 * A newsletter can hold both forms at once: re-saving rewrites the buttons the
+	 * editor parsed, while untouched ones keep the legacy attribute. Widths are
+	 * chosen so the two cases can't coincide - if `dimensions` were ignored, the
+	 * 30% button would fall back to the default share.
+	 *
+	 * Note the width-less button here lands on the 25% floor rather than the 20%
+	 * actually left over; see test_button_width_shares_remainder() for a fixture
+	 * that pins the remainder arithmetic itself.
+	 */
+	public function test_button_width_mixed_forms() {
+		$this->assertSame(
+			[ '50%', '30%', '25%' ],
+			$this->button_column_widths(
+				[ 'width' => 50 ],
+				[ 'style' => [ 'dimensions' => [ 'width' => '30%' ] ] ],
+				[]
+			),
+			'Expected each button to keep its own width, with the width-less button taking the remaining share.'
+		);
+	}
+
+	/**
+	 * A width-less button takes what's actually left, not a fixed share.
+	 *
+	 * This is the fixture that pins the accumulation itself: 60% leaves 40%, which
+	 * is above the 25% floor, so the floor can't mask a wrong total. Reading the
+	 * defined width as anything other than 60 gives the width-less button 50%.
+	 */
+	public function test_button_width_shares_remainder() {
+		$this->assertSame(
+			[ '60%', '40%' ],
+			$this->button_column_widths(
+				[ 'style' => [ 'dimensions' => [ 'width' => '60%' ] ] ],
+				[]
+			),
+			'Expected the width-less button to take the exact remainder.'
 		);
 	}
 

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates-onboarding.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/content-gates-onboarding.tsx
@@ -18,7 +18,7 @@ import { contentLocked, emailPremium } from '../../../../../packages/icons';
 const ContentGatesOnboarding = ( { isNewsletter = false }: { isNewsletter?: boolean } ) => {
 	return (
 		<Grid columns={ 4 } noMargin>
-			<VStack start={ 2 } end={ 4 } spacing={ 8 }>
+			<VStack data-start="2" data-end="4" spacing={ 8 }>
 				<SectionHeader
 					icon={ isNewsletter ? emailPremium : contentLocked }
 					title={ sprintf(

--- a/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/onboarding.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/content-gates/institutions/onboarding.tsx
@@ -24,7 +24,7 @@ const InstitutionsOnboarding = () => {
 			} }
 		>
 			<Grid columns={ 4 } noMargin>
-				<VStack start={ 2 } end={ 4 } spacing={ 8 }>
+				<VStack data-start="2" data-end="4" spacing={ 8 }>
 					<SectionHeader
 						icon={ institution }
 						title={ __( 'Get started with institutions', 'newspack-plugin' ) }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

WordPress 7.1 ships this week. This brings the three Newsletters regression fixes from #876 onto `release` so publishers have them before they take the update, rather than waiting for the next promotion from `main`.

Cherry-pick of `2cbc6877394b03eb1fff4694753414ef37d03406`, unchanged except as noted below.

The three fixes:

- **Button widths render again.** WordPress 7.1 moved `core/button` width from `attributes.width` to the `dimensions` block support, so a newsletter re-saved under 7.1 lost its button widths in the email. The MJML renderer now reads both shapes, and resolves `var:preset|dimension|<slug>` references against theme.json presets. Email clients have no CSS custom properties, so an unresolved reference loses the width outright rather than degrading the way it does on the web. (NEWS-2852)
- **Admin grid layouts position correctly.** `@wordpress/components` filters unrecognized props through `@emotion/is-prop-valid`, whose HTML allowlist contains `start` but not `end`, so grid children stopped reaching their `[end]` selectors. The grid styles now match `data-start` / `data-end` alongside the original attributes, and the call sites pass the `data-` form. (NEWS-2866)
- **Newsletters save again.** WordPress 7.1 added `isSavingLocked` to core's save-state condition, which surfaced a pre-existing save lock the editor never released. (NEWS-2888)

**Two files from #876 are deliberately not included.** `contextual-prompts-settings.js` and `audience-management-required.tsx` belong to features that haven't reached `release` yet, so the cherry-pick reported them as modify/delete. Adding them would pull unreleased work onto this branch. Both are grid call-site migrations with nothing to migrate here, and a scan of this branch found no remaining `start=` / `end=` grid consumers.

The grid styles keep the original `[start]` / `[end]` selectors alongside the new ones, so any consumer not yet migrated behaves exactly as it does today.

### How to test the changes in this Pull Request:

1. Check out this branch and build `newspack-newsletters`, `newspack-plugin`, and `newspack-components`.
2. On a site running WordPress 7.1, create a newsletter with a buttons block. Set one button to 50% width and leave a second at no width. Save.
3. Send a test email. The first button spans half the row and the second takes the remainder.
4. Open a newsletter and edit it. The Save button is enabled, and the newsletter saves.
5. Open the Audience Management wizard's content gates screens at a viewport above 1054px. Grid items sit in their intended columns rather than collapsing to the first.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? Ten renderer tests cover the width shapes, preset resolution, and the fallback cases.
* [x] Have you successfully run tests with your changes locally? The suite passed on #876 against both WordPress 7.0.4 and 7.1-RC3; CI runs it here.
