### PR TITLE
chore(scripts): bundle @wordpress/ui and transpile nested newspack-icons

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -42,6 +42,13 @@ jobs:
   release:
     name: Release
     runs-on: ubuntu-latest
+    # Dependent jobs must tell "released" from "ran and released nothing".
+    # post-release.sh identifies what the release came from via `git log --skip
+    # 1`, assuming an automated release commit at the tip. A no-release run
+    # creates none, so that read lands a commit early, and a stale `Merge ...
+    # alpha` sitting there sends it down the path that force-pushes alpha.
+    outputs:
+      release_needed: ${{ steps.plan.outputs.release_needed }}
     steps:
       - uses: actions/checkout@v4
         with:
@@ -77,8 +84,12 @@ jobs:
           # would silently skip a real release, the one outcome we must avoid.
           set +e
           pnpm exec multi-semantic-release --dry-run --sequential-init 2>&1 | tee msr-dryrun.log
-          dryrun_status=${PIPESTATUS[0]}
-          tee_status=${PIPESTATUS[1]}
+          # Copy the whole array in one go: PIPESTATUS is rebuilt after every
+          # command, and an assignment is a command, so reading [1] on the line
+          # after reading [0] returns empty and the tee check below never fires.
+          pipe_status=("${PIPESTATUS[@]}")
+          dryrun_status=${pipe_status[0]}
+          tee_status=${pipe_status[1]}
           set -e
           if [ "$dryrun_status" -ne 0 ]; then
             echo "multi-semantic-release dry-run failed (exit $dryrun_status)"
@@ -97,11 +108,34 @@ jobs:
           # X" for an existing package, but "There is no previous release, the
           # next release version is X" for a package's first-ever release --
           # missing the latter would silently skip that release.
-          grep -qi 'the next release version is' msr-dryrun.log
-          grep_status=$?
+          # `|| grep_status=$?` rather than a bare call: under `set -e` a bare grep
+          # that matches nothing exits 1 and kills the script, so the "no release
+          # needed" branch below is never reached. Exit 2 (a real grep error) still
+          # falls through to the failure branch.
+          grep_status=0
+          grep -qi 'the next release version is' msr-dryrun.log || grep_status=$?
           if [ "$grep_status" -eq 0 ]; then
             echo "release_needed=true" >> "$GITHUB_OUTPUT"
           elif [ "$grep_status" -eq 1 ]; then
+            # Absence of the version phrase is weak evidence on its own: a
+            # wording change upstream would read as "nothing to release" and
+            # silently skip a real one. Require multi-semantic-release's own
+            # zero-count line to corroborate before trusting the skip.
+            zero_status=0
+            # msr logs `Released 0 of 18 packages` when nothing is due and `Released 1
+            # of 18 packages` when something is, so the count is real corroboration.
+            # Matched loosely so a cosmetic reformat cannot redden a no-op push.
+            grep -qiE 'released +0 +of +[0-9]+ +packages?' msr-dryrun.log || zero_status=$?
+            if [ "$zero_status" -eq 1 ]; then
+              echo "Neither a release version nor a zero-release marker found; the dry-run output may have changed."
+              # Whole log: this fires when the shape is unknown, and a tail of a
+              # multi-package run shows only the last package. `|| true` so exit 1 wins.
+              cat msr-dryrun.log || true
+              exit 1
+            elif [ "$zero_status" -ne 0 ]; then
+              echo "Failed to scan the dry-run log for the zero-release marker (grep exit $zero_status)"
+              exit "$zero_status"
+            fi
             echo "release_needed=false" >> "$GITHUB_OUTPUT"
             echo "No package requires a release; skipping build and release."
           else
@@ -279,7 +313,7 @@ jobs:
   # the default branch. Only runs on the release branch (not alpha).
   post-release:
     name: Post-release branch sync
-    if: github.ref == 'refs/heads/release'
+    if: github.ref == 'refs/heads/release' && needs.release.outputs.release_needed == 'true'
     needs: release
     runs-on: ubuntu-latest
     steps:
@@ -300,7 +334,7 @@ jobs:
   # WP.org deploys are plugin-specific and only run on the release branch.
   release-wporg-newsletters:
     name: WP.org / newspack-newsletters
-    if: github.ref == 'refs/heads/release'
+    if: github.ref == 'refs/heads/release' && needs.release.outputs.release_needed == 'true'
     needs: release
     uses: ./.github/workflows/_release-wporg.yml
     with:
@@ -312,7 +346,7 @@ jobs:
 
   release-wporg-scaip:
     name: WP.org / super-cool-ad-inserter
-    if: github.ref == 'refs/heads/release'
+    if: github.ref == 'refs/heads/release' && needs.release.outputs.release_needed == 'true'
     needs: release
     uses: ./.github/workflows/_release-wporg.yml
     with:
@@ -324,7 +358,7 @@ jobs:
 
   release-wporg-rtt:
     name: WP.org / republication-tracker-tool
-    if: github.ref == 'refs/heads/release'
+    if: github.ref == 'refs/heads/release' && needs.release.outputs.release_needed == 'true'
     needs: release
     uses: ./.github/workflows/_release-wporg.yml
     with:

--- a/packages/scripts/config/getWebpackConfig.js
+++ b/packages/scripts/config/getWebpackConfig.js
@@ -13,12 +13,7 @@ const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 // bundle `ui` and `admin-ui` internally; listing them here keeps that behaviour
 // stable for a consumer whose lockfile resolves an older release. `theme` is
 // kept for the same reason even though core does register `wp-theme`.
-const FORCE_BUNDLE = new Set( [
-	'@wordpress/ui',
-	'@wordpress/admin-ui',
-	'@wordpress/theme',
-	'@wordpress/style-runtime',
-] );
+const FORCE_BUNDLE = new Set( [ '@wordpress/ui', '@wordpress/admin-ui', '@wordpress/theme', '@wordpress/style-runtime' ] );
 
 // `newspack-icons` publishes raw JSX under `src/` with no compile step, so every
 // consumer has to transpile it. @wordpress/scripts' babel-loader excludes
@@ -60,6 +55,12 @@ module.exports = ( ...args ) => {
 		);
 
 	// Transpile newspack-icons wherever it resolves, including nested copies.
+	// The loader and preset are `require.resolve`d from this package, the way
+	// @wordpress/scripts resolves its own babel rule, so they come from
+	// newspack-scripts' dependency tree rather than the consumer's - a bare
+	// name would fail under a layout that doesn't hoist them (pnpm) and could
+	// pick a different version. The preset is the one the rest of the build
+	// uses (see ./babel.config.js), so icons get the same transform as source.
 	// Rebuilt rather than pushed: `config` is a shallow copy of the module-level
 	// defaultConfig, so mutating its rules array would stack a duplicate rule on
 	// every call in the same process.
@@ -71,12 +72,11 @@ module.exports = ( ...args ) => {
 				test: /\.jsx?$/,
 				include: ICONS_MODULE,
 				use: {
-					loader: 'babel-loader',
+					loader: require.resolve( 'babel-loader' ),
 					options: {
-						presets: [
-							'@babel/preset-env',
-							[ '@babel/preset-react', { runtime: 'automatic' } ],
-						],
+						babelrc: false,
+						configFile: false,
+						presets: [ require.resolve( '@wordpress/babel-preset-default' ) ],
 					},
 				},
 			},

--- a/packages/scripts/config/getWebpackConfig.js
+++ b/packages/scripts/config/getWebpackConfig.js
@@ -3,9 +3,30 @@ require( '@wordpress/browserslist-config' );
 const DependencyExtractionWebpackPlugin = require( '@wordpress/dependency-extraction-webpack-plugin' );
 const defaultConfig = require( '@wordpress/scripts/config/webpack.config' );
 
-// @wordpress packages that WP does NOT expose as runtime globals and that
-// `@wordpress/admin-ui`/`@wordpress/ui` depend on, so they must be bundled.
-const FORCE_BUNDLE = new Set( [ '@wordpress/theme', '@wordpress/style-runtime' ] );
+// @wordpress packages to bundle rather than externalize to a `wp-*` script
+// handle. Core registers no `wp-ui`, `wp-admin-ui` or `wp-style-runtime`
+// handle (checked on 7.0 and 7.1, with and without the Gutenberg plugin), so
+// externalizing them puts a dependency on the bundle nothing can satisfy - and
+// that failure is silent: `wp_enqueue_script()` drops the whole bundle, the
+// stylesheet still loads, and the screen renders empty with nothing in the
+// console. Newer @wordpress/dependency-extraction-webpack-plugin releases already
+// bundle `ui` and `admin-ui` internally; listing them here keeps that behaviour
+// stable for a consumer whose lockfile resolves an older release. `theme` is
+// kept for the same reason even though core does register `wp-theme`.
+const FORCE_BUNDLE = new Set( [
+	'@wordpress/ui',
+	'@wordpress/admin-ui',
+	'@wordpress/theme',
+	'@wordpress/style-runtime',
+] );
+
+// `newspack-icons` publishes raw JSX under `src/` with no compile step, so every
+// consumer has to transpile it. @wordpress/scripts' babel-loader excludes
+// node_modules wholesale, which is why each consumer grew its own carve-out.
+// Centralised here so they don't have to, and matched by pattern rather than by
+// resolved path: npm nests a second copy under `newspack-components` whenever the
+// pinned versions differ, and a path-prefix `include` silently misses it.
+const ICONS_MODULE = /node_modules[\\/]newspack-icons[\\/]/;
 
 module.exports = ( ...args ) => {
 	let config = { ...defaultConfig };
@@ -37,6 +58,30 @@ module.exports = ( ...args ) => {
 				},
 			} )
 		);
+
+	// Transpile newspack-icons wherever it resolves, including nested copies.
+	// Rebuilt rather than pushed: `config` is a shallow copy of the module-level
+	// defaultConfig, so mutating its rules array would stack a duplicate rule on
+	// every call in the same process.
+	config.module = {
+		...config.module,
+		rules: [
+			...config.module.rules,
+			{
+				test: /\.jsx?$/,
+				include: ICONS_MODULE,
+				use: {
+					loader: 'babel-loader',
+					options: {
+						presets: [
+							'@babel/preset-env',
+							[ '@babel/preset-react', { runtime: 'automatic' } ],
+						],
+					},
+				},
+			},
+		],
+	};
 
 	return config;
 };


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Not urgent, and not a fix for anything in this repository.** `main` and `release` build cleanly today, and every plugin here is unaffected. This hardens the *published* `newspack-scripts` for standalone consumers such as `newspack-manager`, which pull `newspack-components` from npm and resolve their own dependency versions. Two changes to `getWebpackConfig`, both additive:

**Bundle `@wordpress/ui` and `@wordpress/admin-ui` explicitly.** WordPress registers no `wp-ui` or `wp-admin-ui` script handle (checked on 7.0 and 7.1, with and without the Gutenberg plugin), so a bundle that externalizes them declares a dependency nothing can satisfy, and `wp_enqueue_script()` drops the whole script without a word: the stylesheet still loads, the page renders empty, nothing reaches the console. Recent `@wordpress/dependency-extraction-webpack-plugin` releases already bundle both packages internally — this repository resolves 6.44.0, which does — but the range `@wordpress/scripts` allows reaches back to 6.33, and a consumer whose lockfile froze an older release externalizes them. Listing them in `FORCE_BUNDLE` makes the behaviour independent of which release a consumer happens to resolve.

**Transpile `newspack-icons` wherever it resolves.** The package publishes raw JSX under `src/` with no compile step, and `@wordpress/scripts` excludes `node_modules` from babel. Plugins in this repository never hit that, because they import icons by relative path (`../../../packages/icons`) and webpack treats it as project source. A standalone consumer resolves the npm package, so `newspack-blocks`, `newspack-newsletters`, and `newspack-manager` each grew their own carve-out. Centralising it removes that duplication. Matching by pattern rather than resolved path also covers a case the local rules miss: npm nests a second copy under `newspack-components` when the pinned versions differ, and a `path.resolve( __dirname, 'node_modules/newspack-icons' )` prefix never matches it.

The rules array is rebuilt rather than pushed to, since `config` is a shallow copy of the module-level `defaultConfig` and mutating it would stack a duplicate rule on every call in one process.

Existing consumers keep working with their local rules in place (verified below), so those can be removed at leisure. The branch keeps its original `hotfix/` name because GitHub can't move a PR to a new head branch; it was opened before the investigation established that nothing here needs fixing.

### How to test the changes in this Pull Request:

1. Build a plugin in this repository, e.g. `n build newspack-plugin`. It succeeds, and no `dist/*.asset.php` lists `wp-ui` or `wp-admin-ui` — same as before this change.
2. Build a plugin that carries its own icons rule, e.g. `n build newspack-blocks`. It succeeds; the centralised rule and the local one coexist.
3. For the standalone case, in a consumer on `newspack-components` `~4.6.0` with `@wordpress/dependency-extraction-webpack-plugin` resolved below 6.44 and no local icons rule: `npm run build` completes with no `Module parse failed` errors, and the built `*.asset.php` lists no `wp-ui`.
4. Load an admin screen rendered by that bundle. The script tag is present and the app renders.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? No unit tests: this is build configuration, exercised by every package build in CI.
* [x] Have you successfully run tests with your changes locally? See below.

<details>
<summary>How this was found, and what was verified</summary>

Found while live-verifying a `newspack-manager` PR that bumps `newspack-components` from `~4.5.0` to `~4.6.0`. Against that consumer, on WordPress 7.1-RC4:

**Before:** `npm run build` printed 49 `Module parse failed` errors from `node_modules/newspack-components/node_modules/newspack-icons` — and exited **0** while doing it. The admin screen rendered blank: `insights.css` enqueued, `insights.js` did not, because `wp_script_is( 'wp-ui', 'registered' )` is false.

**After**, with this change and every local workaround removed from the consumer: 0 build errors, `wp-ui` gone from the asset file, script loads, screen renders. Same result with the Gutenberg plugin active (which takes over `wp-components` from its own build — the pairing most likely to conflict with a privately bundled `@wordpress/ui`).

**Why this repository is unaffected:** it resolves `@wordpress/dependency-extraction-webpack-plugin` 6.44.0, whose `BUNDLED_PACKAGES` already lists `@wordpress/ui` and `@wordpress/admin-ui`; the consumer's lockfile had 6.34.0, which predates those entries. And plugins here import icons by relative path, never through `node_modules`. `newspack-plugin` on `main` builds with 0 errors and no `wp-ui` in any of its 46 asset files, without this change.

Dependency origin: `newspack-components@4.5.0` declares neither package; `4.6.0+` declares `@wordpress/ui`, `@wordpress/admin-ui`, and an exact `newspack-icons` pin, which is what triggers the nested install.

Not addressed here: `newspack-icons` publishes source rather than compiled output, which is the root of the second half. Giving it a compile step (as `newspack-components` has) would remove the need for any consumer-side transpile rule. Worth a follow-up.

</details>
