### PR TITLE
fix(previews): keep prompt and gate previews alive under WP 7.1

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-content-gate.php
@@ -716,17 +716,45 @@ class Content_Gate {
 	}
 
 	/**
+	 * Whether the gate's front-end script should load on this request, and why.
+	 *
+	 * The decision lives here, not just its payload, so it can be asserted without
+	 * building assets: the script also has to load on a gate preview where no gate
+	 * renders — archives, home, search — so the previewed params survive a click
+	 * through one of those pages. Gate them out and the preview ends silently at
+	 * the first non-singular view, which is not what the pre-7.1 editor-side
+	 * handler did: it re-ran on every navigation inside the preview frame.
+	 * Returning both inputs alongside the verdict saves the caller recomputing them.
+	 *
+	 * @return array{enqueue: bool, renders_gate: bool, is_preview: bool}
+	 */
+	public static function get_frontend_script_conditions() {
+		// is_singular() first, matching enqueue_content_banner_assets(): during a
+		// preview on an archive, has_gate() would otherwise scan the gate list and have
+		// the result thrown away by the very next operand.
+		$renders_gate = is_singular() && self::has_gate() && self::is_post_restricted();
+		$is_preview   = Content_Gate\Gate_Preview::is_preview_request();
+		return [
+			'enqueue'      => $renders_gate || $is_preview,
+			'renders_gate' => $renders_gate,
+			'is_preview'   => $is_preview,
+		];
+	}
+
+	/**
 	 * Enqueue frontend scripts and styles for gated content.
 	 */
 	public static function enqueue_scripts() {
 		self::enqueue_content_banner_assets();
 
-		if ( ! self::has_gate() ) {
+		$context      = self::get_frontend_script_conditions();
+		$renders_gate = $context['renders_gate'];
+		$is_preview   = $context['is_preview'];
+
+		if ( ! $context['enqueue'] ) {
 			return;
 		}
-		if ( ! is_singular() || ! self::is_post_restricted() ) {
-			return;
-		}
+
 		$handle = 'newspack-content-gate';
 		\wp_enqueue_script(
 			$handle,
@@ -736,19 +764,55 @@ class Content_Gate {
 			true
 		);
 		\wp_script_add_data( $handle, 'async', true );
-		\wp_localize_script(
-			$handle,
-			'newspack_content_gate',
-			[
-				'metadata' => self::get_gate_metadata(),
-			]
-		);
+		\wp_localize_script( $handle, 'newspack_content_gate', self::get_frontend_script_data( $renders_gate, $is_preview ) );
+
+		// Only a rendering gate needs the styles.
+		if ( ! $renders_gate ) {
+			return;
+		}
 		\wp_enqueue_style(
 			$handle,
 			Newspack::plugin_url() . '/dist/content-gate.css',
 			[],
 			filemtime( dirname( NEWSPACK_PLUGIN_FILE ) . '/dist/content-gate.css' )
 		);
+	}
+
+	/**
+	 * Data localized to the front-end gate script.
+	 *
+	 * Split out from enqueue_scripts() so the payload is assertable without
+	 * touching the filesystem for asset versions. Whether the script loads at all
+	 * is decided in get_frontend_script_conditions().
+	 *
+	 * The two keys are independently optional: gate.js reads `metadata`, and
+	 * preview-links.js reads `preview_param_names`. A preview on a view where no
+	 * gate renders carries only the second.
+	 *
+	 * @param bool $renders_gate Whether a gate renders on this request.
+	 * @param bool $is_preview   Whether this is a gate preview request.
+	 * @return array{metadata?: array, preview_param_names?: string[]}
+	 */
+	public static function get_frontend_script_data( $renders_gate, $is_preview ) {
+		$script_data = [];
+
+		if ( $renders_gate ) {
+			$script_data['metadata'] = self::get_gate_metadata();
+		}
+
+		// On a gate preview the previewed document carries its own preview params
+		// onto same-origin links, so the preview survives navigation. It needs the
+		// param list to know which of its query params those are. Gate_Preview's
+		// own check already requires the preview capability, so this does not ship
+		// to ordinary readers.
+		if ( $is_preview ) {
+			$script_data['preview_param_names'] = array_merge(
+				[ Content_Gate\Gate_Preview::PREVIEW_QUERY_PARAM ],
+				array_values( Content_Gate\Gate_Preview::PREVIEW_QUERY_KEYS )
+			);
+		}
+
+		return $script_data;
 	}
 
 	/**

--- a/plugins/newspack-plugin/includes/content-gate/class-gate-preview.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-gate-preview.php
@@ -84,6 +84,35 @@ class Gate_Preview {
 		add_filter( 'newspack_gate_layout_content', [ __CLASS__, 'filter_gate_layout_content' ], PHP_INT_MAX, 2 );
 		add_filter( 'get_post_metadata', [ __CLASS__, 'filter_layout_meta' ], 10, 4 );
 		add_filter( 'show_admin_bar', [ __CLASS__, 'filter_show_admin_bar' ] ); // phpcs:ignore WordPressVIPMinimum.UserExperience.AdminBarRemoval.RemovalDetected
+		add_action( 'template_redirect', [ __CLASS__, 'prevent_preview_caching' ] );
+	}
+
+	/**
+	 * Keep preview responses out of caches.
+	 *
+	 * A preview response is capability-varying: the post is force-restricted, the
+	 * layout's autosaved content is substituted, and the front-end script carries
+	 * the preview param list. An edge cache keying on URL alone would serve all of
+	 * that to a reader, whose links would then be rewritten to carry `ngp_id` —
+	 * shareable and crawlable. The sibling per-user gate paths guard the same way.
+	 *
+	 * Returns whether it acted, so a test can assert that this consults the preview
+	 * gate rather than firing on every request. The action discards the value. Both
+	 * side effects are unobservable under PHPUnit: batcache_cancel() is not loaded,
+	 * and nocache_headers() bails on headers_sent(), which is true by the time any
+	 * test body runs because the WordPress test bootstrap has already printed.
+	 *
+	 * @return bool Whether cache prevention was applied.
+	 */
+	public static function prevent_preview_caching() {
+		if ( ! self::is_preview_request() ) {
+			return false;
+		}
+		if ( function_exists( 'batcache_cancel' ) ) {
+			batcache_cancel();
+		}
+		nocache_headers();
+		return true;
 	}
 
 	/**
@@ -344,12 +373,11 @@ class Gate_Preview {
 	/**
 	 * Data localized to the layout editor to power the Preview button.
 	 *
-	 * @return array{preview_post:string, frontend_url:string, query_param:string, preview_query_keys:array}
+	 * @return array{preview_post:string, query_param:string, preview_query_keys:array}
 	 */
 	public static function get_editor_preview_data() {
 		return [
 			'preview_post'       => self::preview_post_permalink(),
-			'frontend_url'       => get_site_url(),
 			'query_param'        => self::PREVIEW_QUERY_PARAM,
 			'preview_query_keys' => self::PREVIEW_QUERY_KEYS,
 		];
@@ -360,7 +388,8 @@ class Gate_Preview {
 	 *
 	 * Runs at PHP_INT_MAX so it wins over Content_Restriction_Control (which
 	 * returns false for users who can edit the post, and caches per
-	 * post/user). Only the queried post is forced; other post IDs pass through.
+	 * post/user). Only the queried post is forced; other post IDs pass through, and
+	 * nothing is forced on a view whose queried object is not a post.
 	 *
 	 * @param bool $restricted Whether the post is restricted.
 	 * @param int  $post_id    Post ID.
@@ -371,13 +400,43 @@ class Gate_Preview {
 		if ( ! self::is_preview_request() ) {
 			return $restricted;
 		}
-		// Force only the queried (previewed) post. An empty $post_id resolves to
-		// the queried object so in-loop calls still gate, but an explicit,
-		// unrelated post id is never force-restricted, and nothing is forced when
-		// there is no singular queried object.
-		$queried_id = (int) get_queried_object_id();
+		// Both halves are load-bearing. The type check is what makes the comparison
+		// below sound: a preview session now spans archive views, where
+		// get_queried_object_id() returns a term id (category, tag, taxonomy) or a
+		// user id (author) — numbering that shares nothing with post ids, so
+		// comparing them force-restricted whichever unrelated post carried the same
+		// number. is_singular() then confines the forcing to views that actually
+		// render one post: the blog posts index on a static-front-page site, and a
+		// 404 whose pagename matched an unpublished page, both hand back a WP_Post
+		// while not being singular. Every render path already guards on
+		// is_singular(), so those two are inert today — this keeps them that way
+		// without relying on callers to stay careful.
+		if ( ! is_singular() ) {
+			return $restricted;
+		}
+		$queried = get_queried_object();
+		if ( ! $queried instanceof \WP_Post ) {
+			return $restricted;
+		}
+
+		// Force only the queried (previewed) post. An empty $post_id means the call
+		// came from outside the loop — Content_Gate::is_post_restricted() substitutes
+		// get_the_ID() before applying this filter, so in-loop calls always arrive
+		// with an explicit id — and an explicit, unrelated post id is never forced.
+		//
+		// Deliberate consequence: because this forces restriction, a preview session
+		// can render a gate on singular pages the ordinary path skips.
+		// Content_Gate::restrict_post() bails on the privacy policy, account, terms,
+		// accessibility statement, cart and checkout pages, among others;
+		// Content_Gate::render_overlay_gate() has no such
+		// bails, so previewing an overlay layout and navigating to My Account shows
+		// the overlay there. That is wanted: the editor asked to see this layout, and
+		// a preview that silently declined to render on some pages would be a worse
+		// lie than one that renders everywhere. It is preview-only and limited to
+		// users who may preview, so no reader is affected.
+		$queried_id = (int) $queried->ID;
 		$target_id  = empty( $post_id ) ? $queried_id : (int) $post_id;
-		if ( $queried_id && $target_id === $queried_id ) {
+		if ( $target_id === $queried_id ) {
 			return true;
 		}
 		return $restricted;

--- a/plugins/newspack-plugin/src/content-gate/editor/preview.js
+++ b/plugins/newspack-plugin/src/content-gate/editor/preview.js
@@ -22,6 +22,15 @@ import WebPreview from '../../../packages/components/src/web-preview';
  * newspack-popups prompt preview: the reader's unsaved meta rides along in the
  * URL (autosaves don't persist meta), and in-iframe article links are rewritten
  * to keep the preview active as the reader navigates.
+ *
+ * That rewriting happens in the previewed document — see
+ * propagateGatePreviewParams() in src/content-gate/preview-links.js — not from
+ * out here. This component used to reach into the preview iframe, guarded by a
+ * try/catch for genuinely cross-origin setups. WordPress 7.1 turned that guard
+ * into a silent failure: it serves the block editor with
+ * `Document-Isolation-Policy`, which severs access to the frame even when it is
+ * same-origin, so the rewrite stopped happening and only a console warning
+ * marked it.
  */
 export default function GatePreview() {
 	const { postId, meta, isSavingPost } = useSelect( select => {
@@ -39,7 +48,7 @@ export default function GatePreview() {
 		return null;
 	}
 
-	const { preview_post: previewPost, frontend_url: frontendUrl, query_param: queryParam, preview_query_keys: previewQueryKeys } = preview;
+	const { preview_post: previewPost, query_param: queryParam, preview_query_keys: previewQueryKeys } = preview;
 
 	// Map edited meta onto the abbreviated query keys the server understands.
 	const abbreviatedKeys = {};
@@ -52,23 +61,6 @@ export default function GatePreview() {
 	const query = {
 		[ queryParam ]: postId,
 		...abbreviatedKeys,
-	};
-
-	const onWebPreviewLoad = iframeEl => {
-		if ( ! iframeEl ) {
-			return;
-		}
-		// Same-origin access can throw a DOMException on a cross-origin iframe
-		// (mapped domains, scheme mismatch). Link-rewriting is a nicety; never let
-		// it break opening the preview.
-		try {
-			[ ...iframeEl.contentWindow.document.querySelectorAll( 'a[href^="' + frontendUrl + '"]' ) ].forEach( anchor => {
-				anchor.setAttribute( 'href', addQueryArgs( anchor.getAttribute( 'href' ), query ) );
-			} );
-		} catch ( e ) {
-			// eslint-disable-next-line no-console
-			console.warn( 'Gate preview: could not rewrite in-iframe links (cross-origin).', e );
-		}
 	};
 
 	// Open the preview after the autosave settles. On a failed autosave, still
@@ -85,7 +77,6 @@ export default function GatePreview() {
 	return (
 		<WebPreview
 			url={ addQueryArgs( previewPost, query ) }
-			onLoad={ onWebPreviewLoad }
 			renderButton={ ( { showPreview } ) => (
 				<Button variant="primary" isBusy={ isSavingPost } disabled={ isSavingPost } onClick={ () => previewAfterAutosave( showPreview ) }>
 					{ __( 'Preview', 'newspack-plugin' ) }

--- a/plugins/newspack-plugin/src/content-gate/gate-preview-wiring.test.js
+++ b/plugins/newspack-plugin/src/content-gate/gate-preview-wiring.test.js
@@ -1,0 +1,63 @@
+/**
+ * The gate script wires preview-param propagation and gate rendering as two
+ * separate domReady registrations. This pins the property that comment claims:
+ * a throw in propagation must not stop the gate from initialising.
+ *
+ * gate.js is imported for its side effects, so the mocks below have to be in
+ * place before the import is evaluated.
+ */
+
+const mockPropagate = jest.fn();
+let warnSpy;
+
+jest.mock( './preview-links', () => ( {
+	propagateGatePreviewParams: ( ...args ) => mockPropagate( ...args ),
+} ) );
+
+jest.mock( '../reader-activation/analytics', () => ( { getEventPayload: jest.fn(), sendEvent: jest.fn() } ) );
+jest.mock( '../reader-activation/utils', () => ( { debugLog: jest.fn() } ) );
+jest.mock( '../shared/js/cta-attribution', () => ( { persistCtaAttribution: jest.fn() } ) );
+jest.mock( './gate.scss', () => ( {} ), { virtual: true } );
+
+describe( 'gate.js preview-param wiring', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		mockPropagate.mockReset();
+		global.newspack_content_gate = { metadata: {} };
+		window.newspackRAS = [];
+		// `interactive` makes gate.js's domReady() invoke synchronously, which is
+		// the path a footer/async script actually takes.
+		Object.defineProperty( document, 'readyState', { value: 'interactive', configurable: true } );
+		document.body.innerHTML = '<div class="newspack-content-gate__gate"></div>';
+		// Held in a variable rather than reached for as `console.warn`, which the
+		// no-console rule rejects.
+		warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		warnSpy.mockRestore();
+	} );
+
+	it( 'runs propagation on load', () => {
+		require( './gate' );
+
+		expect( mockPropagate ).toHaveBeenCalled();
+	} );
+
+	it( 'still initialises the gate when propagation throws', () => {
+		mockPropagate.mockImplementation( () => {
+			throw new Error( 'isolation' );
+		} );
+
+		expect( () => require( './gate' ) ).not.toThrow();
+		expect( warnSpy ).toHaveBeenCalled();
+		// Assert the gate actually initialised rather than inferring it from module
+		// evaluation completing. The assertion above already catches the try/catch
+		// being deleted outright, since that lets the throw escape require(). What
+		// only this line catches is the gate's own registration being folded *inside*
+		// the propagation try block: then require() still succeeds, the warning still
+		// fires, and nothing but an empty newspackRAS reveals that the gate never
+		// initialised.
+		expect( window.newspackRAS.length ).toBeGreaterThan( 0 );
+	} );
+} );

--- a/plugins/newspack-plugin/src/content-gate/gate.js
+++ b/plugins/newspack-plugin/src/content-gate/gate.js
@@ -6,6 +6,7 @@ import './gate.scss';
 import { getEventPayload, sendEvent } from '../reader-activation/analytics';
 import { debugLog } from '../reader-activation/utils';
 import { persistCtaAttribution } from '../shared/js/cta-attribution';
+import { propagateGatePreviewParams } from './preview-links';
 
 const EVENT_NAME = 'np_gate_interaction';
 
@@ -388,6 +389,21 @@ function handleFloatingElements() {
 		}
 	} );
 }
+
+// Registered on its own rather than inside the gate initialisation below, which
+// returns early when no gate element is present — propagation has to run on
+// those pages too, since the script now loads across a whole preview session.
+// Wrapped because domReady() runs synchronously once the document is ready, so
+// an unguarded throw here would abort module evaluation before the gate's own
+// registration below is even reached.
+domReady( () => {
+	try {
+		propagateGatePreviewParams();
+	} catch ( e ) {
+		// eslint-disable-next-line no-console
+		console.warn( 'Gate preview: could not propagate preview params.', e );
+	}
+} );
 
 domReady( function () {
 	const gate = document.querySelector( '.newspack-content-gate__gate' );

--- a/plugins/newspack-plugin/src/content-gate/preview-links.js
+++ b/plugins/newspack-plugin/src/content-gate/preview-links.js
@@ -1,0 +1,114 @@
+/**
+ * Carry the gate-preview parameters onto same-origin links.
+ *
+ * A gate preview renders the real front end inside an iframe in the layout
+ * editor, with the previewed layout's unsaved settings passed as query params.
+ * Those params have to survive navigation, or the first click inside the preview
+ * lands on the ordinary page and the editor loses what they were previewing.
+ *
+ * This runs in the previewed document rather than in the editor on purpose.
+ * WordPress 7.1 serves the block editor with `Document-Isolation-Policy`, which
+ * places it in its own agent cluster and severs synchronous access to the
+ * preview iframe even though the frame is same-origin — so the editor can no
+ * longer reach in and rewrite these links from outside. A document may always
+ * rewrite its own. Same fix as NEWS-2889, applied to the gate preview.
+ *
+ * Kept deliberately in step with newspack-popups/src/view/preview-links.js,
+ * which solves the same problem for prompt previews. The two are duplicated
+ * rather than shared because there is nowhere good to share them to: `packages/`
+ * is React components and build tooling, not view-layer utilities, and this is
+ * ~50 lines of dependency-free DOM code reading a differently-named global in
+ * each plugin. (Sharing would not create version coupling — workspace packages
+ * are bundled into each plugin's own dist/ at build time — so that is not the
+ * reason.) If you change one, change the other; there is a test file on each
+ * side to catch drift.
+ */
+export function propagateGatePreviewParams() {
+	// Previews only ever render inside the editor's preview iframe, so requiring a
+	// frame is what keeps preview mode from following an editor around the site.
+	// Someone who lands on a preview URL top-level — a new tab, a pasted link — is
+	// browsing, not previewing, and should get ordinary links. Comparing
+	// `window.top` is a reference check, which cross-origin isolation still
+	// permits.
+	if ( window.self === window.top ) {
+		return;
+	}
+
+	// Only localized on a gate preview, so its absence means there is nothing to
+	// propagate. Read through `window.` rather than as a bare identifier:
+	// optional chaining guards a null value, not an undeclared binding, and an
+	// undeclared one throws.
+	const params = window.newspack_content_gate?.preview_param_names;
+	if ( ! params?.length ) {
+		return;
+	}
+
+	const current = new URLSearchParams( window.location.search );
+	const present = params.filter( key => current.has( key ) ).map( key => [ key, current.get( key ) ] );
+	if ( ! present.length ) {
+		return;
+	}
+
+	// One eager pass at domReady. Anchors added later — "Load more", modal
+	// checkout, anything AJAX — keep their own hrefs and leave the preview on the
+	// first click. Neither does this reach the gate's own conversion CTAs, which
+	// are <form target="newspack_modal_checkout_iframe"> rather than links. A
+	// capture-phase click interceptor would close both gaps if it ever proves
+	// worth the extra surface.
+	document.querySelectorAll( 'a[href]' ).forEach( anchor => {
+		// Read the attribute rather than the `href` property: the selector also
+		// matches SVG <a>, whose property is an SVGAnimatedString, and resolving
+		// that yields a same-origin garbage path that would overwrite the link.
+		const href = anchor.getAttribute( 'href' );
+
+		// Leave in-page anchors alone; adding query params would reload the page
+		// instead of jumping within it.
+		if ( href.startsWith( '#' ) ) {
+			return;
+		}
+
+		let url;
+		try {
+			// Resolve against the document base so relative hrefs work and a <base>
+			// tag is respected.
+			url = new URL( href, document.baseURI );
+		} catch ( e ) {
+			return;
+		}
+
+		// Only http(s). An opaque-path URL like `blob:https://site/uuid` reports the
+		// inner origin, so it passes the origin test, but it has no meaningful path
+		// or query — the shape logic below would rewrite it into an ordinary page URL
+		// and destroy the link. Restricting the scheme keeps the rewrite to the two
+		// the shape logic was written for.
+		if ( 'http:' !== url.protocol && 'https:' !== url.protocol ) {
+			return;
+		}
+
+		// Off-site links are none of our business. Matching on origin rather than on
+		// the site URL means a subdirectory install also stamps links that sit outside
+		// WordPress; that is deliberate, because it is what makes multibranded
+		// sites work, where brands are same-origin paths. A stray `ngp_id` on such
+		// a page resolves to no layout and does nothing.
+		if ( url.origin !== window.location.origin ) {
+			return;
+		}
+
+		present.forEach( ( [ key, value ] ) => url.searchParams.set( key, value ) );
+
+		// Keep the href in the shape the page wrote it, because a preview exists to
+		// show what production does. Re-serializing through URL() turns a relative
+		// href absolute, which breaks exactly the theme code a preview should
+		// exercise: `a[href^="/"]` selectors, "current item" scripts comparing an
+		// href against location.pathname. Only the query is ours to change. Three
+		// residual differences we accept: a path-relative href comes back
+		// root-relative, since resolving it is what told us where it points, and
+		// URLSearchParams re-encodes an existing query (`%20` to `+`) — forms
+		// servers treat as equivalent, and unpicking it would mean editing the
+		// query string by hand. A same-origin protocol-relative href also comes back
+		// scheme-absolute — the one shape we do not preserve, because telling it
+		// apart needs a third branch and it is vanishingly rare in theme output.
+		const isAbsolute = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test( href );
+		anchor.setAttribute( 'href', isAbsolute ? url.toString() : url.pathname + url.search + url.hash );
+	} );
+}

--- a/plugins/newspack-plugin/src/content-gate/preview-links.test.js
+++ b/plugins/newspack-plugin/src/content-gate/preview-links.test.js
@@ -1,0 +1,181 @@
+import { propagateGatePreviewParams } from './preview-links';
+
+const setSearch = search => window.history.replaceState( {}, '', '/post/' + search );
+const setLinks = html => {
+	document.body.innerHTML = html;
+};
+const hrefs = () => [ ...document.querySelectorAll( 'a' ) ].map( anchor => anchor.getAttribute( 'href' ) );
+
+// Propagation only runs inside the preview iframe, so every positive case has to
+// look framed. jsdom's `top` points at the window itself.
+const setFramed = framed => {
+	Object.defineProperty( window, 'top', { value: framed ? {} : window, configurable: true } );
+};
+
+// Pins the contract that the early returns bail before touching the DOM at all,
+// which is what keeps this off the critical path of an ordinary page load. An
+// assertion on hrefs alone would still pass if the function walked every anchor
+// and happened to rewrite nothing.
+const expectNoTraversal = run => {
+	const spy = jest.spyOn( document, 'querySelectorAll' );
+	run();
+	expect( spy ).not.toHaveBeenCalled();
+	spy.mockRestore();
+};
+
+describe( 'propagateGatePreviewParams', () => {
+	beforeEach( () => {
+		global.newspack_content_gate = { preview_param_names: [ 'ngp_id', 'ngp_st' ] };
+		setFramed( true );
+		setSearch( '' );
+		setLinks( '' );
+	} );
+
+	it( 'does nothing top-level, so preview mode cannot follow an editor around the site', () => {
+		setFramed( false );
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		expectNoTraversal( propagateGatePreviewParams );
+
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'does nothing outside a preview, where the params are not localized', () => {
+		global.newspack_content_gate = { metadata: {} };
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		expectNoTraversal( propagateGatePreviewParams );
+
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'survives the global being absent entirely', () => {
+		delete global.newspack_content_gate;
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		expect( () => propagateGatePreviewParams() ).not.toThrow();
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'does nothing when no preview param is present in the URL', () => {
+		setLinks( '<a href="/other/">x</a>' );
+
+		expectNoTraversal( propagateGatePreviewParams );
+
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'carries the preview params onto a same-origin link', () => {
+		setSearch( '?ngp_id=7&ngp_st=locked' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagateGatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ '/other/?ngp_id=7&ngp_st=locked' ] );
+	} );
+
+	it( 'leaves off-site links, in-page anchors and non-http schemes alone', () => {
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="https://elsewhere.test/page/">a</a><a href="#section">b</a><a href="mailto:hi@example.com">c</a>' );
+
+		propagateGatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ 'https://elsewhere.test/page/', '#section', 'mailto:hi@example.com' ] );
+	} );
+
+	it( 'leaves an unparseable href alone rather than throwing', () => {
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="http://[">x</a><a href="/other/">y</a>' );
+
+		expect( () => propagateGatePreviewParams() ).not.toThrow();
+		// The bad href is skipped and the pass carries on to the next anchor.
+		expect( hrefs() ).toEqual( [ 'http://[', '/other/?ngp_id=7' ] );
+	} );
+
+	it( 'rewrites an SVG anchor correctly rather than corrupting it', () => {
+		setSearch( '?ngp_id=7' );
+		setLinks( '<svg xmlns="http://www.w3.org/2000/svg"><a href="/chart/"><text>x</text></a></svg>' );
+
+		propagateGatePreviewParams();
+
+		// An SVGAElement's href *property* is an SVGAnimatedString; resolving it
+		// yields a same-origin garbage path that silently replaces the link.
+		expect( document.querySelector( 'svg a' ).getAttribute( 'href' ) ).toBe( '/chart/?ngp_id=7' );
+	} );
+
+	describe( 'href shape', () => {
+		// A preview should differ from production in what it shows, not in the form
+		// of its markup: theme code keyed on href shape has to behave the same here.
+		it( 'keeps a root-relative href root-relative', () => {
+			setSearch( '?ngp_id=7' );
+			setLinks( '<a href="/other/">x</a>' );
+
+			propagateGatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ '/other/?ngp_id=7' ] );
+		} );
+
+		it( 'keeps an absolute href absolute', () => {
+			setSearch( '?ngp_id=7' );
+			setLinks( `<a href="${ window.location.origin }/other/">x</a>` );
+
+			propagateGatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ `${ window.location.origin }/other/?ngp_id=7` ] );
+		} );
+
+		it( 'leaves an opaque-path URL alone rather than flattening it to a page URL', () => {
+			setSearch( '?ngp_id=7' );
+			// A blob URL reports its inner origin, so it passes the origin test; the
+			// shape logic would turn it into an ordinary page URL and kill the link.
+			setLinks( `<a href="blob:${ window.location.origin }/abc-123">x</a>` );
+
+			propagateGatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ `blob:${ window.location.origin }/abc-123` ] );
+		} );
+
+		it( 'promotes a same-origin protocol-relative href, the one shape it cannot keep', () => {
+			setSearch( '?ngp_id=7' );
+			setLinks( `<a href="//${ window.location.host }/other/">x</a>` );
+
+			propagateGatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ `${ window.location.origin }/other/?ngp_id=7` ] );
+		} );
+
+		it( 'resolves a path-relative href against the document base', () => {
+			setSearch( '?ngp_id=7' );
+			setLinks( '<a href="sub/page/">x</a>' );
+
+			propagateGatePreviewParams();
+
+			// Root-relative rather than absolute: resolving it is what told us where
+			// it points, so this is as close to the original shape as we can get.
+			expect( hrefs() ).toEqual( [ '/post/sub/page/?ngp_id=7' ] );
+		} );
+	} );
+
+	it( 'keeps the fragment and unrelated params, and overwrites a stale one', () => {
+		setSearch( '?ngp_id=7' );
+		setLinks( '<a href="/other/?utm_source=nl&ngp_id=1#top">x</a>' );
+
+		propagateGatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ '/other/?utm_source=nl&ngp_id=7#top' ] );
+	} );
+
+	it( 'is idempotent, so a second pass does not duplicate params', () => {
+		setSearch( '?ngp_id=7&ngp_st=locked' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagateGatePreviewParams();
+		const first = hrefs();
+		propagateGatePreviewParams();
+
+		expect( hrefs() ).toEqual( first );
+	} );
+} );

--- a/plugins/newspack-plugin/src/wizards/audience/components/segmentation-preview/index.js
+++ b/plugins/newspack-plugin/src/wizards/audience/components/segmentation-preview/index.js
@@ -49,13 +49,45 @@ const SegmentationPreview = props => {
 	};
 
 	const onWebPreviewLoad = iframeEl => {
-		if ( iframeEl ) {
-			[ ...iframeEl.contentWindow.document.querySelectorAll( 'a' ) ].forEach( anchor => {
+		if ( ! iframeEl ) {
+			return;
+		}
+
+		// Reaching into the frame can throw — a genuinely cross-origin setup today,
+		// and cross-origin isolation if WordPress ever extends it past the
+		// post-editor screens it currently covers. The `finally` keeps the original
+		// ordering while guaranteeing the state update still runs: without it a
+		// throw left `isOpen` false, so the effect that recomputes the decorated URL
+		// never re-ran and every reopened preview reused the first session ID.
+		try {
+			const frameDoc = iframeEl.contentWindow.document;
+			// Loop-invariant: both operands are fixed for the whole pass, and a
+			// preview page can easily carry a few hundred anchors.
+			const referenceOrigin = new URL( frontendUrl, frameDoc.baseURI ).origin;
+			[ ...frameDoc.querySelectorAll( 'a[href]' ) ].forEach( anchor => {
 				const href = anchor.getAttribute( 'href' );
-				if ( href.indexOf( frontendUrl ) === 0 ) {
-					anchor.setAttribute( 'href', decorateUrl( href ) );
+				if ( href.startsWith( '#' ) ) {
+					return;
 				}
+				let target;
+				try {
+					target = new URL( href, frameDoc.baseURI );
+				} catch ( e ) {
+					return;
+				}
+				// Compare origins rather than prefix-matching `frontendUrl`, which
+				// falls back to '/' — under that fallback a protocol-relative
+				// off-site href like //example.com also "starts with" it, and would
+				// carry the segment and session IDs to a third party.
+				if ( target.origin !== referenceOrigin ) {
+					return;
+				}
+				anchor.setAttribute( 'href', decorateUrl( target.toString() ) );
 			} );
+		} catch ( e ) {
+			// eslint-disable-next-line no-console
+			console.warn( 'Segmentation preview: could not rewrite in-iframe links.', e );
+		} finally {
 			setIsOpen( true );
 			onLoad( iframeEl );
 		}

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-preview.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/gate-preview.php
@@ -500,4 +500,128 @@ class Test_Gate_Preview extends \WP_UnitTestCase {
 		unset( $_GET[ Gate_Preview::PREVIEW_QUERY_PARAM ] );
 		$this->assertTrue( Gate_Preview::filter_show_admin_bar( true ), 'Admin bar is shown when not previewing.' );
 	}
+
+	/**
+	 * The preview param list reaches the front-end script only on a preview
+	 * request, which by definition means a user who can preview.
+	 *
+	 * The list itself is not secret — it is constant param names — but shipping it
+	 * is what makes the previewed document rewrite every same-origin link. A
+	 * reader who received it would carry the preview params for the rest of their
+	 * session.
+	 */
+	public function test_preview_params_localized_only_for_a_previewing_user() {
+		wp_set_current_user( $this->admin_id );
+		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
+
+		$data = Content_Gate::get_frontend_script_data( false, Gate_Preview::is_preview_request() );
+		$this->assertArrayHasKey( 'preview_param_names', $data, 'An admin previewing gets the param list.' );
+		$this->assertContains( Gate_Preview::PREVIEW_QUERY_PARAM, $data['preview_param_names'], 'The list carries the preview param itself.' );
+		$this->assertArrayNotHasKey( 'metadata', $data, 'No gate metadata is sent where no gate renders.' );
+	}
+
+	/**
+	 * A subscriber on the same URL gets nothing, because is_preview_request()
+	 * requires the preview capability on every call.
+	 */
+	public function test_preview_params_absent_for_subscriber_on_preview_url() {
+		wp_set_current_user( $this->subscriber_id );
+		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
+
+		$data = Content_Gate::get_frontend_script_data( false, Gate_Preview::is_preview_request() );
+		$this->assertArrayNotHasKey( 'preview_param_names', $data, 'A subscriber on the preview URL gets no param list.' );
+	}
+
+	/**
+	 * Outside a preview the key is absent, so an ordinary page load carries no
+	 * extra payload.
+	 */
+	public function test_preview_params_absent_without_the_param() {
+		wp_set_current_user( $this->admin_id );
+
+		$data = Content_Gate::get_frontend_script_data( true, Gate_Preview::is_preview_request() );
+		$this->assertArrayNotHasKey( 'preview_param_names', $data, 'No param list without a preview request.' );
+		$this->assertArrayHasKey( 'metadata', $data, 'A rendering gate still gets its metadata.' );
+	}
+
+	/**
+	 * The enqueue decision itself — not just its payload — has to survive a
+	 * non-singular view, which is the whole point of the preview-session change.
+	 *
+	 * Asserts the context rather than driving enqueue_scripts(), because that would
+	 * need built assets for its filemtime() cache-busters and CI runs PHPUnit
+	 * without a build.
+	 */
+	public function test_script_loads_on_an_archive_during_a_preview() {
+		wp_set_current_user( $this->admin_id );
+		// After go_to(): it resets $_GET and repopulates it from the URL.
+		$this->go_to( get_category_link( self::factory()->category->create() ) );
+		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
+
+		$context = Content_Gate::get_frontend_script_conditions();
+
+		$this->assertFalse( $context['renders_gate'], 'No gate renders on an archive.' );
+		$this->assertTrue( $context['is_preview'], 'The request is still a preview.' );
+		$this->assertTrue( $context['enqueue'], 'The script has to load anyway, so a click through this page keeps the preview.' );
+	}
+
+	/**
+	 * The same view without a preview stays clean — the counterpart that would fail
+	 * if the decision were widened to "always enqueue".
+	 */
+	public function test_script_does_not_load_on_an_ordinary_archive() {
+		$this->go_to( get_category_link( self::factory()->category->create() ) );
+
+		$context = Content_Gate::get_frontend_script_conditions();
+
+		$this->assertFalse( $context['is_preview'], 'Not a preview request.' );
+		$this->assertFalse( $context['enqueue'], 'Nothing to enqueue on an ordinary archive.' );
+	}
+
+	/**
+	 * A term ID is not a post ID. On an archive the queried object is a term, and
+	 * comparing its ID against post IDs force-restricted whichever unrelated post
+	 * happened to share the number.
+	 */
+	public function test_archive_preview_does_not_force_restrict_an_unrelated_post() {
+		wp_set_current_user( $this->admin_id );
+		$term_id = self::factory()->category->create();
+		// After go_to(): it resets $_GET and repopulates it from the URL. Setting the
+		// param first would leave this not-a-preview, and the assertions below would
+		// pass trivially on filter_is_post_restricted()'s own early return.
+		$this->go_to( get_category_link( $term_id ) );
+		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
+
+		$this->assertTrue( Gate_Preview::is_preview_request(), 'Guard: the preview really is active here.' );
+
+		// An id equal to the queried term id is the case that bit: nothing is created
+		// at that id here, because the filter never loads the post — it only compares.
+		$this->assertFalse(
+			Gate_Preview::filter_is_post_restricted( false, $term_id ),
+			'A post sharing an ID with the queried term is not part of the preview.'
+		);
+		$this->assertFalse(
+			Gate_Preview::filter_is_post_restricted( false, 0 ),
+			'Out of the loop on an archive there is no previewed post to force.'
+		);
+	}
+
+	/**
+	 * Cache-cancelling is gated on the capability, like every other preview seam.
+	 */
+	public function test_preview_caching_only_prevented_for_a_previewing_user() {
+		$this->set_query_param( Gate_Preview::PREVIEW_QUERY_PARAM, $this->layout_id );
+
+		wp_set_current_user( $this->subscriber_id );
+		$this->assertFalse(
+			Gate_Preview::prevent_preview_caching(),
+			'A subscriber on the preview URL gets ordinary cache headers.'
+		);
+
+		wp_set_current_user( $this->admin_id );
+		$this->assertTrue(
+			Gate_Preview::prevent_preview_caching(),
+			'A previewing admin gets the page kept out of the cache.'
+		);
+	}
 }

--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -1009,6 +1009,52 @@ final class Newspack_Popups_Inserter {
 	}
 
 	/**
+	 * The preview slice of the view script's localized data.
+	 *
+	 * Separate from preview_param_names() so the localized *key* is assertable, not
+	 * just the list: the front end reads `newspack_popups_view.preview_param_names`,
+	 * and renaming either side alone would leave both suites green while previews
+	 * silently stopped surviving a click. Named for the shape it has — a flat list of
+	 * param names, where newspack_popups_data.preview_query_keys is a
+	 * meta-key => param map.
+	 *
+	 * @return array Empty when this is not a prompt preview.
+	 */
+	public static function get_view_script_preview_data() {
+		$names = self::preview_param_names();
+		return empty( $names ) ? [] : [ 'preview_param_names' => $names ];
+	}
+
+	/**
+	 * The preview query param names to hand the previewed document, so it can carry
+	 * them onto same-origin links and keep the preview alive across a click.
+	 *
+	 * Both checks earn their place, because previewed_popup_id() only reports that
+	 * the request carries a `pid` — not that anyone may preview, nor that the id is a
+	 * prompt. `pid` is a common campaign parameter, so without can_preview_popup() a
+	 * reader arriving on `?pid=…` would have it stamped onto every link for the rest
+	 * of their session while seeing no prompts at all, and an editor who follows an
+	 * ad or newsletter link carrying an unrelated `pid` would get the same.
+	 * is_preview_request() is the wrong test here — it also covers preset, view-as
+	 * and customizer previews, which pass their state differently.
+	 *
+	 * The JS half of this contract has its own guard: propagation only runs inside
+	 * the preview frame. See src/view/preview-links.js.
+	 *
+	 * @return array Param names, empty when this is not a prompt preview.
+	 */
+	public static function preview_param_names() {
+		$previewed_popup_id = Newspack_Popups::previewed_popup_id();
+		if ( ! $previewed_popup_id || ! Newspack_Popups::can_preview_popup( $previewed_popup_id ) ) {
+			return [];
+		}
+		return array_merge(
+			[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ],
+			array_values( Newspack_Popups::PREVIEW_QUERY_KEYS )
+		);
+	}
+
+	/**
 	 * Enqueue the assets needed to display the popups.
 	 */
 	public static function enqueue_scripts() {
@@ -1087,6 +1133,8 @@ final class Newspack_Popups_Inserter {
 			if ( ! empty( $donor_landing_page ) ) {
 				$script_data['donor_landing_page'] = $donor_landing_page;
 			}
+
+			$script_data = array_merge( $script_data, self::get_view_script_preview_data() );
 
 			\wp_localize_script( $script_handle, 'newspack_popups_view', $script_data );
 			\wp_enqueue_script( $script_handle );

--- a/plugins/newspack-popups/includes/class-newspack-popups-model.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-model.php
@@ -316,12 +316,7 @@ final class Newspack_Popups_Model {
 	 *                    the post is not a prompt, or the id does not resolve to a post.
 	 */
 	public static function retrieve_preview_popup( $post_id ) {
-		// Previews render unsaved prompt content, so restrict them to users who can manage
-		// prompts and to the prompts CPT, mirroring the plugin's other preview entry points.
-		if ( ! Newspack_Popups::is_user_admin() ) {
-			return null;
-		}
-		if ( Newspack_Popups::NEWSPACK_POPUPS_CPT !== get_post_type( $post_id ) ) {
+		if ( ! Newspack_Popups::can_preview_popup( $post_id ) ) {
 			return null;
 		}
 		// Up-to-date post data is stored in an autosave.

--- a/plugins/newspack-popups/includes/class-newspack-popups.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups.php
@@ -844,7 +844,6 @@ final class Newspack_Popups {
 			'newspack-popups',
 			'newspack_popups_data',
 			[
-				'frontend_url'                 => get_site_url(),
 				'preview_post'                 => self::preview_post_permalink(),
 				'preview_archive'              => self::preview_archive_permalink(),
 				'custom_placements'            => Newspack_Popups_Custom_Placements::get_custom_placements(),
@@ -923,6 +922,23 @@ final class Newspack_Popups {
 		// Used by the Newspack Plugin's Campaigns Wizard.
 		$is_view_as_preview = false != Newspack_Popups_View_As::viewing_as_spec();
 		return ! empty( self::previewed_popup_id() ) || ! empty( self::preset_popup_id() ) || $is_view_as_preview || $is_customizer_preview;
+	}
+
+	/**
+	 * Whether the current user may preview a given prompt.
+	 *
+	 * Previews render unsaved, request-supplied prompt content, so both halves
+	 * matter: the capability, and the id actually naming a prompt. Shared so the
+	 * renderer (Newspack_Popups_Model::retrieve_preview_popup) and the front-end
+	 * param list (Newspack_Popups_Inserter::preview_param_names) cannot drift apart
+	 * — a gate stricter than the renderer would produce a preview whose links go
+	 * nowhere, and one looser would leak preview state onto ordinary pages.
+	 *
+	 * @param int|string $post_id Prompt ID from the request.
+	 * @return bool
+	 */
+	public static function can_preview_popup( $post_id ) {
+		return self::is_user_admin() && self::NEWSPACK_POPUPS_CPT === get_post_type( $post_id );
 	}
 
 	/**

--- a/plugins/newspack-popups/src/editor/Preview.js
+++ b/plugins/newspack-popups/src/editor/Preview.js
@@ -18,7 +18,6 @@ const PreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields } ) =>
 	}
 
 	const previewQueryKeys = window.newspack_popups_data?.preview_query_keys || {};
-	const frontendUrl = window?.newspack_popups_data?.frontend_url || '/';
 	const abbreviatedKeys = {};
 	Object.keys( metaFields ).forEach( key => {
 		if ( previewQueryKeys.hasOwnProperty( key ) ) {
@@ -35,18 +34,16 @@ const PreviewSetting = ( { autosavePost, isSavingPost, postId, metaFields } ) =>
 	const isArchivePagesPrompt = metaFields.placement === 'archives';
 	const previewURL = window.newspack_popups_data[ isArchivePagesPrompt ? 'preview_archive' : 'preview_post' ] || '/';
 
-	const onWebPreviewLoad = iframeEl => {
-		if ( iframeEl ) {
-			[ ...iframeEl.contentWindow.document.querySelectorAll( 'a[href^="' + frontendUrl + '"]' ) ].forEach( anchor => {
-				anchor.setAttribute( 'href', addQueryArgs( anchor.getAttribute( 'href' ), query ) );
-			} );
-		}
-	};
-
+	// Links inside the preview keep their preview params, but the previewed
+	// document does that for itself — see propagatePreviewParams() in
+	// src/view/preview-links.js. The editor used to reach into the preview
+	// iframe and rewrite the links from out here, which WordPress 7.1 no longer
+	// permits: it serves the block editor with `Document-Isolation-Policy`,
+	// putting the editor in its own agent cluster and severing synchronous
+	// access to the frame even though it is same-origin.
 	return (
 		<WebPreview
 			url={ addQueryArgs( previewURL, query ) }
-			onLoad={ onWebPreviewLoad }
 			renderButton={ ( { showPreview } ) => (
 				<Button isPrimary isBusy={ isSavingPost } disabled={ isSavingPost } onClick={ () => autosavePost().then( showPreview ) }>
 					{ __( 'Preview', 'newspack-popups' ) }

--- a/plugins/newspack-popups/src/view/index.js
+++ b/plugins/newspack-popups/src/view/index.js
@@ -7,6 +7,7 @@ import './style.scss';
 import './patterns.scss';
 import { handleSegmentation } from './segmentation';
 import { handleAnalytics } from './analytics/ga4';
+import { propagatePreviewParams } from './preview-links';
 import { domReady, logPageview, getPrompts } from './utils';
 
 import './merge-tags';
@@ -14,6 +15,18 @@ import './merge-tags';
 domReady( () => {
 	window.newspackRAS = window.newspackRAS || [];
 	window.newspackRAS.push( logPageview ); // Pageviews should be logged whether or not prompts are enabled.
+
+	// Wrapped, and after the pageview push, on purpose. Everything below runs for
+	// every reader, while link rewriting is an admin-only preview nicety; a throw
+	// here would otherwise take prompt display and prompt analytics down with it.
+	// Nothing in it can throw today, so this keeps that a property of the structure
+	// rather than of the current implementation.
+	try {
+		propagatePreviewParams();
+	} catch ( e ) {
+		// eslint-disable-next-line no-console
+		console.warn( 'Prompt preview: could not propagate preview params.', e );
+	}
 
 	if ( ! newspack_popups_view?.has_disabled_prompts ) {
 		// Fetch all prompts on the page just once.

--- a/plugins/newspack-popups/src/view/index.test.js
+++ b/plugins/newspack-popups/src/view/index.test.js
@@ -1,0 +1,82 @@
+/**
+ * The view entry runs preview-link propagation and every reader-facing handler in
+ * one domReady callback, so a throw in the preview code would take prompt display
+ * and prompt analytics with it. That is what the try/catch there prevents, and
+ * this pins it: without the guard, reverting it leaves the suite green.
+ *
+ * index.js is imported for its side effects, so the mocks have to be in place
+ * before the import is evaluated.
+ */
+
+const mockPropagate = jest.fn();
+const mockHandleSegmentation = jest.fn();
+const mockHandleAnalytics = jest.fn();
+const mockGetPrompts = jest.fn( () => [] );
+const mockLogPageview = jest.fn();
+
+jest.mock( './preview-links', () => ( {
+	propagatePreviewParams: ( ...args ) => mockPropagate( ...args ),
+} ) );
+jest.mock( './segmentation', () => ( {
+	handleSegmentation: ( ...args ) => mockHandleSegmentation( ...args ),
+} ) );
+jest.mock( './analytics/ga4', () => ( {
+	handleAnalytics: ( ...args ) => mockHandleAnalytics( ...args ),
+} ) );
+jest.mock( './utils', () => ( {
+	// domReady runs the callback immediately, which is the path a footer script takes
+	// once the document is already parsed.
+	domReady: cb => cb(),
+	getPrompts: ( ...args ) => mockGetPrompts( ...args ),
+	logPageview: mockLogPageview,
+} ) );
+jest.mock( './style.scss', () => ( {} ), { virtual: true } );
+jest.mock( './patterns.scss', () => ( {} ), { virtual: true } );
+jest.mock( './merge-tags', () => ( {} ), { virtual: true } );
+
+let warnSpy;
+
+describe( 'view entry: preview propagation cannot break reader-facing prompt logic', () => {
+	beforeEach( () => {
+		jest.resetModules();
+		[ mockPropagate, mockHandleSegmentation, mockHandleAnalytics ].forEach( m => m.mockReset() );
+		global.newspack_popups_view = { has_disabled_prompts: false };
+		window.newspackRAS = [];
+		// Held in a variable rather than reached for as `console.warn`, which the
+		// no-console rule rejects.
+		warnSpy = jest.spyOn( console, 'warn' ).mockImplementation( () => {} );
+	} );
+
+	afterEach( () => {
+		warnSpy.mockRestore();
+	} );
+
+	it( 'runs propagation and the prompt handlers on load', () => {
+		require( './index' );
+
+		expect( mockPropagate ).toHaveBeenCalled();
+		expect( mockHandleSegmentation ).toHaveBeenCalled();
+		expect( mockHandleAnalytics ).toHaveBeenCalled();
+	} );
+
+	it( 'still runs the prompt handlers when propagation throws', () => {
+		mockPropagate.mockImplementation( () => {
+			throw new Error( 'isolation' );
+		} );
+
+		expect( () => require( './index' ) ).not.toThrow();
+		expect( warnSpy ).toHaveBeenCalled();
+		expect( mockHandleSegmentation ).toHaveBeenCalled();
+		expect( mockHandleAnalytics ).toHaveBeenCalled();
+	} );
+
+	it( 'pushes the pageview before propagation runs, so a reader never loses it', () => {
+		mockPropagate.mockImplementation( () => {
+			throw new Error( 'isolation' );
+		} );
+
+		require( './index' );
+
+		expect( window.newspackRAS ).toContain( mockLogPageview );
+	} );
+} );

--- a/plugins/newspack-popups/src/view/preview-links.js
+++ b/plugins/newspack-popups/src/view/preview-links.js
@@ -1,0 +1,132 @@
+/**
+ * Carry the prompt-preview parameters onto same-origin links.
+ *
+ * A prompt preview renders the real front end inside an iframe in the editor,
+ * with the previewed prompt's unsaved settings passed as query params. Those
+ * params have to survive navigation: without them the first click inside the
+ * preview lands on the ordinary published page, so the prompt stops following
+ * the editor and unsaved edits stop being reflected.
+ *
+ * This runs in the previewed document rather than in the editor on purpose.
+ * WordPress 7.1 serves the block editor with `Document-Isolation-Policy`, which
+ * places it in its own agent cluster and severs synchronous access to the
+ * preview iframe even though the frame is same-origin — so the editor can no
+ * longer reach in and rewrite these links from outside. A document may always
+ * rewrite its own. See NEWS-2889.
+ *
+ * AMP pages are not covered. The param list is localized alongside `view.js`,
+ * which the inserter only registers on non-AMP requests, so a site in AMP
+ * standard mode keeps the pre-7.1 behaviour. Closing that would mean rewriting
+ * the links server-side, since AMP forbids arbitrary inline script.
+ *
+ * Kept deliberately in step with
+ * newspack-plugin/src/content-gate/preview-links.js, which solves the same
+ * problem for gate previews. The two are duplicated rather than shared because
+ * there is nowhere good to share them to: `packages/` is React components and
+ * build tooling, not view-layer utilities, and this is ~50 lines of
+ * dependency-free DOM code reading a differently-named global in each plugin.
+ * (Sharing would not create version coupling — workspace packages are bundled
+ * into each plugin's own dist/ at build time — so that is not the reason.) If you
+ * change one, change the other; there is a test file on each side to catch drift.
+ */
+export function propagatePreviewParams() {
+	// Previews only ever render inside the editor's preview iframe, so requiring a
+	// frame is what keeps preview mode from following an admin around the site. An
+	// admin who lands on a preview URL top-level — a new tab, a pasted link — is
+	// browsing, not previewing, and should get ordinary links; preview mode also
+	// hides the admin bar, so sticky params there would leave no way out but
+	// editing the URL by hand.
+	//
+	// Belt and braces with the capability gate on the PHP side
+	// (Newspack_Popups_Inserter::preview_param_names): that one decides whether the
+	// param list is published at all, this one decides whether a published list is
+	// acted on. Neither makes the other redundant — dropping the PHP gate would hand
+	// the list to any framed reader, and dropping this one puts an editor's whole
+	// browsing session in preview mode.
+	//
+	// Verified against WordPress 7.1-RC3 in Chrome: inside the preview frame,
+	// `document` access from the editor throws but the frame still reports
+	// `self !== top`, so isolation does not defeat this check.
+	if ( window.self === window.top ) {
+		return;
+	}
+
+	// Only localized on a prompt preview, so its absence means there is nothing
+	// to propagate. Read through `window.` rather than as a bare identifier:
+	// optional chaining guards a null value, not an undeclared binding, and an
+	// undeclared one throws.
+	const params = window.newspack_popups_view?.preview_param_names;
+	if ( ! params?.length ) {
+		return;
+	}
+
+	const current = new URLSearchParams( window.location.search );
+	const present = params.filter( key => current.has( key ) ).map( key => [ key, current.get( key ) ] );
+	if ( ! present.length ) {
+		return;
+	}
+
+	// One eager pass at domReady. Overlays are already in the DOM (they print at
+	// wp_footer), but anchors added later — "Load more", modal checkout, anything
+	// AJAX — keep their own hrefs and leave the preview on the first click. Forms
+	// are untouched too, so a GET submission (theme site search is the common one)
+	// drops preview mode the same way. That matches the handler this replaced; a
+	// capture-phase interceptor would close both gaps if it ever proves worth the
+	// extra surface.
+	document.querySelectorAll( 'a[href]' ).forEach( anchor => {
+		// Read the attribute rather than the `href` property: the selector also
+		// matches SVG <a>, whose property is an SVGAnimatedString, and resolving
+		// that yields a same-origin garbage path that would overwrite the link.
+		const href = anchor.getAttribute( 'href' );
+
+		// Leave in-page anchors alone; adding query params would reload the page
+		// instead of jumping within it.
+		if ( href.startsWith( '#' ) ) {
+			return;
+		}
+
+		let url;
+		try {
+			// Resolve against the document base so relative hrefs work and a <base>
+			// tag is respected.
+			url = new URL( href, document.baseURI );
+		} catch ( e ) {
+			return;
+		}
+
+		// Only http(s). An opaque-path URL like `blob:https://site/uuid` reports the
+		// inner origin, so it passes the origin test, but it has no meaningful path
+		// or query — the shape logic below would rewrite it into an ordinary page URL
+		// and destroy the link. Restricting the scheme keeps the rewrite to the two
+		// the shape logic was written for.
+		if ( 'http:' !== url.protocol && 'https:' !== url.protocol ) {
+			return;
+		}
+
+		// Off-site links are none of our business. Matching on origin rather than on
+		// the site URL means a subdirectory install also stamps links that sit
+		// outside WordPress; that is deliberate, because it is what makes
+		// multibranded sites work, where brands are same-origin paths. A stray
+		// `pid` on such a page resolves to no prompt and does nothing.
+		if ( url.origin !== window.location.origin ) {
+			return;
+		}
+
+		present.forEach( ( [ key, value ] ) => url.searchParams.set( key, value ) );
+
+		// Keep the href in the shape the page wrote it, because a preview exists to
+		// show what production does. Re-serializing through URL() turns a relative
+		// href absolute, which breaks exactly the theme code a preview should
+		// exercise: `a[href^="/"]` selectors, "current item" scripts comparing an
+		// href against location.pathname. Only the query is ours to change. Three
+		// residual differences we accept: a path-relative href comes back
+		// root-relative, since resolving it is what told us where it points, and
+		// URLSearchParams re-encodes an existing query (`%20` to `+`) — forms
+		// servers treat as equivalent, and unpicking it would mean editing the
+		// query string by hand. A same-origin protocol-relative href also comes back
+		// scheme-absolute — the one shape we do not preserve, because telling it
+		// apart needs a third branch and it is vanishingly rare in theme output.
+		const isAbsolute = /^(?:[a-z][a-z0-9+.-]*:)?\/\//i.test( href );
+		anchor.setAttribute( 'href', isAbsolute ? url.toString() : url.pathname + url.search + url.hash );
+	} );
+}

--- a/plugins/newspack-popups/src/view/preview-links.test.js
+++ b/plugins/newspack-popups/src/view/preview-links.test.js
@@ -1,0 +1,221 @@
+import { propagatePreviewParams } from './preview-links';
+
+const setSearch = search => window.history.replaceState( {}, '', '/post/' + search );
+const setLinks = html => {
+	document.body.innerHTML = html;
+};
+const hrefs = () => [ ...document.querySelectorAll( 'a' ) ].map( anchor => anchor.getAttribute( 'href' ) );
+
+// Propagation only runs inside the preview iframe, so every positive case has to
+// look framed. jsdom's `top` points at the window itself.
+const setFramed = framed => {
+	Object.defineProperty( window, 'top', { value: framed ? {} : window, configurable: true } );
+};
+
+// Pins the contract that the early returns bail before touching the DOM at all,
+// which is what keeps this off the critical path of an ordinary page load. An
+// assertion on hrefs alone would still pass if the function walked every anchor
+// and happened to rewrite nothing.
+const expectNoTraversal = run => {
+	const spy = jest.spyOn( document, 'querySelectorAll' );
+	run();
+	expect( spy ).not.toHaveBeenCalled();
+	spy.mockRestore();
+};
+
+describe( 'propagatePreviewParams', () => {
+	beforeEach( () => {
+		global.newspack_popups_view = { preview_param_names: [ 'pid', 'n_bc' ] };
+		setFramed( true );
+		setSearch( '' );
+		setLinks( '' );
+	} );
+
+	it( 'does nothing top-level, so preview mode cannot follow an admin around the site', () => {
+		setFramed( false );
+		setSearch( '?pid=42' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		expectNoTraversal( propagatePreviewParams );
+
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'does nothing outside a preview, where the params are not localized', () => {
+		global.newspack_popups_view = {};
+		setSearch( '?pid=42' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		expectNoTraversal( propagatePreviewParams );
+
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'does nothing when no preview param is present in the URL', () => {
+		setLinks( '<a href="/other/">x</a>' );
+
+		expectNoTraversal( propagatePreviewParams );
+
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'carries the preview params onto a same-origin link', () => {
+		setSearch( '?pid=42&n_bc=blue' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ '/other/?pid=42&n_bc=blue' ] );
+	} );
+
+	it( 'only carries the preview params actually present in the URL', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ '/other/?pid=42' ] );
+	} );
+
+	it( 'leaves off-site links alone', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="https://elsewhere.test/page/">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ 'https://elsewhere.test/page/' ] );
+	} );
+
+	it( 'leaves in-page anchors alone, so they still jump rather than reload', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="#section">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ '#section' ] );
+	} );
+
+	it( 'leaves non-http schemes alone', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="mailto:hi@example.com">x</a><a href="tel:+15551234">y</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ 'mailto:hi@example.com', 'tel:+15551234' ] );
+	} );
+
+	it( 'leaves an unparseable href alone rather than throwing', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="http://[">x</a><a href="/other/">y</a>' );
+
+		expect( () => propagatePreviewParams() ).not.toThrow();
+		// The bad href is skipped and the pass carries on to the next anchor.
+		expect( hrefs() ).toEqual( [ 'http://[', '/other/?pid=42' ] );
+	} );
+
+	it( 'keeps unrelated query params and overwrites a stale preview param', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<a href="/other/?utm_source=nl&pid=7">x</a>' );
+
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( [ '/other/?utm_source=nl&pid=42' ] );
+	} );
+
+	it( 'survives the global being absent entirely', () => {
+		delete global.newspack_popups_view;
+		setSearch( '?pid=42' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		expect( () => propagatePreviewParams() ).not.toThrow();
+		expectNoTraversal( propagatePreviewParams );
+		expect( hrefs() ).toEqual( [ '/other/' ] );
+	} );
+
+	it( 'rewrites an SVG anchor correctly rather than corrupting it', () => {
+		setSearch( '?pid=42' );
+		setLinks( '<svg xmlns="http://www.w3.org/2000/svg"><a href="/chart/"><text>x</text></a></svg>' );
+
+		propagatePreviewParams();
+
+		// The selector matches SVG <a> too, and an SVGAElement's href *property* is
+		// an SVGAnimatedString — resolving it yields a same-origin garbage path that
+		// silently replaces the link. Reading the attribute keeps it intact.
+		expect( document.querySelector( 'svg a' ).getAttribute( 'href' ) ).toBe( '/chart/?pid=42' );
+	} );
+
+	describe( 'href shape', () => {
+		// A preview should differ from production in what it shows, not in the form
+		// of its markup: theme code keyed on href shape has to behave the same here.
+		it( 'keeps a root-relative href root-relative', () => {
+			setSearch( '?pid=42' );
+			setLinks( '<a href="/other/">x</a>' );
+
+			propagatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ '/other/?pid=42' ] );
+		} );
+
+		it( 'keeps an absolute href absolute', () => {
+			setSearch( '?pid=42' );
+			setLinks( `<a href="${ window.location.origin }/other/">x</a>` );
+
+			propagatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ `${ window.location.origin }/other/?pid=42` ] );
+		} );
+
+		it( 'leaves an opaque-path URL alone rather than flattening it to a page URL', () => {
+			setSearch( '?pid=42' );
+			// A blob URL reports its inner origin, so it passes the origin test; the
+			// shape logic would turn it into an ordinary page URL and kill the link.
+			setLinks( `<a href="blob:${ window.location.origin }/abc-123">x</a>` );
+
+			propagatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ `blob:${ window.location.origin }/abc-123` ] );
+		} );
+
+		it( 'promotes a same-origin protocol-relative href, the one shape it cannot keep', () => {
+			setSearch( '?pid=42' );
+			setLinks( `<a href="//${ window.location.host }/other/">x</a>` );
+
+			propagatePreviewParams();
+
+			// Documented in the module: telling this apart needs a third branch. Pinned
+			// so the behaviour is a decision rather than a surprise.
+			expect( hrefs() ).toEqual( [ `${ window.location.origin }/other/?pid=42` ] );
+		} );
+
+		it( 'resolves a path-relative href against the document base', () => {
+			setSearch( '?pid=42' );
+			setLinks( '<a href="sub/page/">x</a>' );
+
+			propagatePreviewParams();
+
+			// Root-relative rather than absolute: resolving it is what told us where
+			// it points, so this is as close to the original shape as we can get.
+			expect( hrefs() ).toEqual( [ '/post/sub/page/?pid=42' ] );
+		} );
+
+		it( 'keeps the fragment on a same-origin link', () => {
+			setSearch( '?pid=42' );
+			setLinks( '<a href="/other/#top">x</a>' );
+
+			propagatePreviewParams();
+
+			expect( hrefs() ).toEqual( [ '/other/?pid=42#top' ] );
+		} );
+	} );
+
+	it( 'is idempotent, so a second pass does not duplicate params', () => {
+		setSearch( '?pid=42&n_bc=blue' );
+		setLinks( '<a href="/other/">x</a>' );
+
+		propagatePreviewParams();
+		const first = hrefs();
+		propagatePreviewParams();
+
+		expect( hrefs() ).toEqual( first );
+	} );
+} );

--- a/plugins/newspack-popups/tests/test-preview-param-names.php
+++ b/plugins/newspack-popups/tests/test-preview-param-names.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * Class Preview Param Names Test
+ *
+ * @package Newspack_Popups
+ */
+
+/**
+ * Tests the gate on the preview param list handed to the previewed document.
+ *
+ * The list is what lets a prompt preview survive a click, so it must reach a
+ * genuine prompt preview and nothing else: `pid` is a common campaign parameter,
+ * and anyone can put one in a URL.
+ */
+class PreviewParamNamesTest extends WP_UnitTestCase {
+	/**
+	 * Log in as a user holding the prompt-management capability.
+	 *
+	 * Deliberately an editor, not an administrator, matching test-presets.php: the
+	 * gate is `edit_others_pages` via a filterable capability, and an administrator
+	 * would satisfy any capability this were later tightened to, hiding the
+	 * regression from this suite.
+	 */
+	private function login_as_prompt_manager() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'editor' ] ) );
+	}
+
+	/**
+	 * A user who may manage prompts, previewing a prompt, gets the list.
+	 */
+	public function test_param_names_for_a_prompt_manager_previewing_a_prompt() {
+		$this->login_as_prompt_manager();
+		$prompt_id = self::factory()->post->create( [ 'post_type' => Newspack_Popups::NEWSPACK_POPUPS_CPT ] );
+		$_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] = $prompt_id;
+
+		$names = Newspack_Popups_Inserter::preview_param_names();
+
+		$this->assertContains(
+			Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM,
+			$names,
+			'The list carries the preview param itself.'
+		);
+		foreach ( Newspack_Popups::PREVIEW_QUERY_KEYS as $param ) {
+			$this->assertContains( $param, $names, 'The list carries every abbreviated meta param.' );
+		}
+	}
+
+	/**
+	 * A `pid` that is not a prompt is somebody else's parameter.
+	 */
+	public function test_no_param_names_when_pid_is_not_a_prompt() {
+		$this->login_as_prompt_manager();
+		$_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] = self::factory()->post->create();
+
+		$this->assertSame(
+			[],
+			Newspack_Popups_Inserter::preview_param_names(),
+			'An editor following a link that carries an unrelated `pid` gets ordinary links.'
+		);
+	}
+
+	/**
+	 * Readers never get preview params, however well-formed the URL.
+	 */
+	public function test_no_param_names_for_a_reader() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'subscriber' ] ) );
+		$_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] = self::factory()->post->create(
+			[ 'post_type' => Newspack_Popups::NEWSPACK_POPUPS_CPT ]
+		);
+
+		$this->assertSame(
+			[],
+			Newspack_Popups_Inserter::preview_param_names(),
+			'A reader arriving on a prompt preview URL gets ordinary links.'
+		);
+	}
+
+	/**
+	 * No `pid`, nothing to propagate — the ordinary front-end request.
+	 */
+	public function test_no_param_names_without_the_param() {
+		$this->login_as_prompt_manager();
+
+		$this->assertSame(
+			[],
+			Newspack_Popups_Inserter::preview_param_names(),
+			'An admin browsing the site normally gets ordinary links.'
+		);
+	}
+
+	/**
+	 * An author holds edit_posts but not edit_others_pages, which pins the boundary
+	 * from below — the subscriber case only pins it from far outside.
+	 */
+	public function test_no_param_names_for_an_author() {
+		wp_set_current_user( self::factory()->user->create( [ 'role' => 'author' ] ) );
+		$_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] = self::factory()->post->create(
+			[ 'post_type' => Newspack_Popups::NEWSPACK_POPUPS_CPT ]
+		);
+
+		$this->assertSame( [], Newspack_Popups_Inserter::preview_param_names() );
+	}
+
+	/**
+	 * Pins the PHP-to-JS contract: the param names are useless unless they arrive
+	 * under the key src/view/preview-links.js reads.
+	 */
+	public function test_param_names_are_localized_under_the_key_the_view_script_reads() {
+		$this->login_as_prompt_manager();
+		$_GET[ Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM ] = self::factory()->post->create(
+			[ 'post_type' => Newspack_Popups::NEWSPACK_POPUPS_CPT ]
+		);
+
+		$data = Newspack_Popups_Inserter::get_view_script_preview_data();
+
+		$this->assertArrayHasKey(
+			'preview_param_names',
+			$data,
+			'The front end reads newspack_popups_view.preview_param_names; renaming either side alone breaks the preview silently.'
+		);
+		$this->assertContains( Newspack_Popups::NEWSPACK_POPUP_PREVIEW_QUERY_PARAM, $data['preview_param_names'] );
+
+		wp_set_current_user( 0 );
+		$this->assertSame(
+			[],
+			Newspack_Popups_Inserter::get_view_script_preview_data(),
+			'Nothing is merged into the localized data outside a preview.'
+		);
+	}
+}


### PR DESCRIPTION
> **Hotfix against `release`, for WP 7.1 shipping this week.** Replaces the #875 → #877 stack, which was built on `main` and so cannot be retargeted here (merging it would carry 47 unrelated `main` commits into `release`). Same net change as that stack, minus two lines that don't apply to `release` — see *Differences from the stack* below.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Prompt previews and content-gate layout previews keep working under WordPress 7.1. Before this, the first click on any link inside either preview dropped out to the ordinary page: the prompt or gate stopped following the editor, and unsaved settings stopped being reflected.

WordPress 7.1 serves the block editor with `Document-Isolation-Policy`, which puts it in its own agent cluster and severs synchronous access to the preview iframe — even though the frame is same-origin. Both editors used to reach into the frame and rewrite its links from outside. Under 7.1 the prompt editor threw on every preview open:

```
SecurityError: Failed to read a named property 'document' from 'Window':
Blocked a frame with origin "https://<site>" from accessing a cross-origin frame.
```

The gate editor failed *silently*, because its equivalent call sat inside a `try`/`catch` written for genuinely cross-origin setups: link rewriting simply stopped, leaving only a console warning.

The fix moves the work into the previewed document, which may always rewrite its own links. No cross-document access remains, so the error is gone at its source rather than caught and swallowed.

**newspack-popups (prompt previews)**
- `src/view/preview-links.js` (new) — the previewed page carries its own preview params onto same-origin links. Runs only inside the preview iframe; confined to `http(s)` so an opaque-path href like `blob:` is left alone rather than flattened into a page URL; skips in-page anchors and off-site links; uses `searchParams.set` so a second pass cannot duplicate params; and leaves each href in the shape the page wrote it, so a relative link stays relative.
- `src/view/index.js` — runs it on `domReady`, wrapped and ordered after the pageview push, so an admin-only nicety cannot cost a reader their pageview or their prompts.
- `src/editor/Preview.js` — drops the cross-frame rewrite.
- `includes/` — the param list is localized only for a genuine prompt preview: a `pid` that names a prompt, held by a user who may preview one. That predicate now lives once, in `Newspack_Popups::can_preview_popup()`, shared with the renderer.

**newspack-plugin (gate previews)**
- `src/content-gate/preview-links.js` (new) — the same module for gate previews, deliberately kept in step with the popups one.
- The gate's front-end script now also loads on a preview request where no gate renders — archives, home, search — so the previewed params survive a click through one of those views. Its stylesheet still loads only where a gate actually renders.
- `filter_is_post_restricted()` now requires both `is_singular()` and a `WP_Post` queried object. It previously compared `get_queried_object_id()` against post IDs; on the archive views this PR newly supports that value is a *term* or *user* ID, so any post whose ID collided was force-restricted — and consumers act on that, `exclude_restricted_posts_from_feed()` among them.
- Gate previews are no longer served from the page cache.
- The Audience segmentation preview is hardened, and two live bugs there are fixed: a protocol-relative off-site href was matching a `'/'` prefix fallback and carrying segment and session IDs to a third party, and a throw left the modal's `isOpen` false so every reopened preview reused the first session ID.

Closes NEWS-2889.

### How to test the changes in this Pull Request:

Requires **Chrome 137 or later over HTTPS** on WordPress 7.1, signed in as a user who can edit others' pages. Cross-origin isolation is only sent to Chromium, so this will not reproduce in curl, Firefox, or Safari.

**Prompt preview**
1. Open any prompt in the editor, with the browser console open. Click **Preview** — no `SecurityError` appears.
2. Dismiss the overlay, then click a link in the preview, such as a category or a post title.
3. The preview stays in preview mode: the prompt still carries its PREVIEW badge and the front-end admin bar stays suppressed.
4. Copy the preview's own URL into a new top-level tab and click a link. Preview mode does **not** follow you — stickiness belongs to the preview frame.

**Gate preview** — note this needs **WooCommerce Memberships deactivated**; see *Known limitation*.
1. Create a published gate layout. Open it in the editor and click **Preview**. No `Gate preview: could not rewrite in-iframe links` warning appears.
2. The previewed post renders with the gate.
3. Click a category link, then from that archive click through to a different post. The gate is still rendering — the preview survived a non-singular view.

On `release` today, step 1 of the prompt flow throws and step 2 of the gate flow drops out of preview.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

**Verified against this branch's tree, not inherited from the stack.** `release` is 47 commits behind `main`, so everything was re-run here:

| check | result |
| --- | --- |
| newspack-popups JS | 90 tests, 7 suites — pass |
| newspack-plugin JS | 584 tests, 62 suites — pass |
| newspack-popups PHP | 271 tests, 703 assertions — pass |
| newspack-plugin PHP | 2751 tests, 7867 assertions — pass (10 pre-existing environmental skips) |
| PHPCS / ESLint | clean on every changed file |
| Builds | both plugins compile; propagation present in both bundles |

**Runtime verification.** The frame check the fix depends on was measured rather than reasoned about, since the whole thing would silently no-op if `Document-Isolation-Policy` collapsed the frame tree. In a 7.1-RC3 editor with `crossOriginIsolated: true`, reading only cross-origin-allowlisted properties: the `web-preview` frame throws `SecurityError` on `document` access — that throw *is* the original bug — while still reporting `self !== top`, with `top` and `parent` resolving to the editor window. Gutenberg's own `editor-canvas` frame stays readable, which is why the newsletters preview needed no change.

The gate preview was also exercised by hand end to end on 7.1-RC3: opened a layout preview, clicked through to a category archive, then on to a different post, with the gate still rendering at each step.

Both behavioural guards were mutation-tested rather than assumed load-bearing: removing the `http(s)` guard fails the opaque-path test in each plugin; removing the `try`/`catch` fails the entry-point tests; reverting the enqueue decision fails the archive test; dropping the `WP_Post` guard fails the unrelated-post test.

**Known limitation.** The gate preview is not offered while WooCommerce Memberships is active — `newspack_content_gate.preview` localizes as `null` and no Preview button renders. That is deliberate and pre-existing, but it means publishers on Memberships cannot use this preview, and QA has to deactivate it to exercise the gate path.

**Expected back-merge conflict.** The post-release sync of `release` into `main` will conflict in `plugins/newspack-popups/includes/class-newspack-popups-inserter.php`, because #656 added an A/B config block on `main` immediately adjacent to this PR's `$script_data` line. The resolution is to keep both additions. Everything else auto-merges, verified by simulating the merge.

**Differences from the #875 → #877 stack.** Two lines, both because `release` predates Contextual Prompts: `src/view/index.js` does not import `handleContextualPromptAnalytics`, and `src/view/index.test.js` does not mock that module. Nothing else differs.

**Review history.** #875 and #877 carry two full reviews from @chickenn00dle with nineteen comment threads, all answered; nine were resolved and one — a declined suggestion to add PHP type declarations — was deliberately left open. Worth reading there rather than re-deriving here.
