### PR TITLE
feat(campaigns): segment logged-out readers from newsletter links

### DIFF
--- a/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -106,19 +106,10 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * Per-request memo of get_field_merge_tag_name() results, keyed by field
 	 * name, sitting in front of that method's transient cache.
 	 *
-	 * Static rather than an instance property: Newspack_Newsletters_Service_Provider::instance()
-	 * hands back a brand-new object on every call in a test environment (see
-	 * its IS_TEST_ENV escape hatch), so an instance property would not survive
-	 * from one instance() call to the next even within a single request/render.
-	 *
-	 * This is the memo half of the design; get_field_merge_tag_name()'s
-	 * transient is the other half. Link decoration runs once per link per
-	 * newsletter render, and the underlying fetch (get_all_contact_fields())
-	 * is a recursive, paginated API call, so whenever the transient layer
-	 * cannot return — a dead object-cache drop-in is a recurring failure mode
-	 * on this platform, and it makes get_transient() silently always miss —
-	 * this memo is what stops a 40-link newsletter from repeating that fetch
-	 * up to 40 times inside one render.
+	 * Static because instance() returns a new object per call in test
+	 * environments. Sits in front of the transient so a failing object cache
+	 * (get_transient() always missing) can't repeat the paginated field fetch
+	 * once per link within a render.
 	 *
 	 * @var array<string, string>
 	 */
@@ -2322,12 +2313,9 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * value AC substitutes. A row with an empty perstag can never match: it
 	 * supplies no usable tag.
 	 *
-	 * Cached because the field list is an uncached, paginated fetch and link
-	 * decoration runs once per link per newsletter render. Misses are cached
-	 * briefly so a field created after the first lookup is picked up soon.
-	 * A static per-request memo sits in front of the transient — see
-	 * $field_merge_tag_name_memo — for when the transient layer itself can't
-	 * return.
+	 * Memoized per request and cached in a transient: the field list is an
+	 * uncached, paginated fetch and link decoration runs once per link per
+	 * render. Misses are cached briefly so a new field is picked up soon.
 	 *
 	 * @param string      $field_name Field title as synced (e.g. 'NP_Account').
 	 * @param string|null $list_id    Unused; ActiveCampaign fields are account-wide.
@@ -2353,11 +2341,8 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 
 		$fields = $this->get_all_contact_fields();
 		if ( is_wp_error( $fields ) || ! is_array( $fields ) ) {
-			// Deliberately not memoized: a transport failure or missing
-			// credentials can be transient within the same render (e.g. a
-			// slow upstream that succeeds on a later link's retry), so the
-			// next link for the same field should try again rather than be
-			// locked into '' for the rest of the request.
+			// Not memoized: a transport failure can clear up within the same
+			// render, so later links should retry rather than lock into ''.
 			return '';
 		}
 

--- a/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -103,6 +103,28 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	private $contact_data = [];
 
 	/**
+	 * Per-request memo of get_field_merge_tag_name() results, keyed by field
+	 * name, sitting in front of that method's transient cache.
+	 *
+	 * Static rather than an instance property: Newspack_Newsletters_Service_Provider::instance()
+	 * hands back a brand-new object on every call in a test environment (see
+	 * its IS_TEST_ENV escape hatch), so an instance property would not survive
+	 * from one instance() call to the next even within a single request/render.
+	 *
+	 * This is the memo half of the design; get_field_merge_tag_name()'s
+	 * transient is the other half. Link decoration runs once per link per
+	 * newsletter render, and the underlying fetch (get_all_contact_fields())
+	 * is a recursive, paginated API call, so whenever the transient layer
+	 * cannot return — a dead object-cache drop-in is a recurring failure mode
+	 * on this platform, and it makes get_transient() silently always miss —
+	 * this memo is what stops a 40-link newsletter from repeating that fetch
+	 * up to 40 times inside one render.
+	 *
+	 * @var array<string, string>
+	 */
+	private static $field_merge_tag_name_memo = [];
+
+	/**
 	 * Whether the provider has support to tags and tags based Subscription Lists.
 	 *
 	 * @var boolean
@@ -2293,6 +2315,9 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	 * Cached because the field list is an uncached, paginated fetch and link
 	 * decoration runs once per link per newsletter render. Misses are cached
 	 * briefly so a field created after the first lookup is picked up soon.
+	 * A static per-request memo sits in front of the transient — see
+	 * $field_merge_tag_name_memo — for when the transient layer itself can't
+	 * return.
 	 *
 	 * @param string      $field_name Field title as synced (e.g. 'NP_Account').
 	 * @param string|null $list_id    Unused; ActiveCampaign fields are account-wide.
@@ -2305,14 +2330,24 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 			return '';
 		}
 
+		if ( array_key_exists( $field_name, self::$field_merge_tag_name_memo ) ) {
+			return self::$field_merge_tag_name_memo[ $field_name ];
+		}
+
 		$cache_key = 'np_nl_field_tag_' . md5( $field_name );
 		$cached    = get_transient( $cache_key );
 		if ( false !== $cached ) {
+			self::$field_merge_tag_name_memo[ $field_name ] = (string) $cached;
 			return (string) $cached;
 		}
 
 		$fields = $this->get_all_contact_fields();
 		if ( is_wp_error( $fields ) || ! is_array( $fields ) ) {
+			// Deliberately not memoized: a transport failure or missing
+			// credentials can be transient within the same render (e.g. a
+			// slow upstream that succeeds on a later link's retry), so the
+			// next link for the same field should try again rather than be
+			// locked into '' for the rest of the request.
 			return '';
 		}
 
@@ -2337,6 +2372,7 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 		}
 
 		set_transient( $cache_key, $perstag, '' === $perstag ? 15 * MINUTE_IN_SECONDS : 12 * HOUR_IN_SECONDS );
+		self::$field_merge_tag_name_memo[ $field_name ] = $perstag;
 		return $perstag;
 	}
 

--- a/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
+++ b/plugins/newspack-newsletters/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php
@@ -2282,6 +2282,65 @@ final class Newspack_Newsletters_Active_Campaign extends \Newspack_Newsletters_S
 	}
 
 	/**
+	 * Get the perstag for a synced ActiveCampaign custom field.
+	 *
+	 * Matches by generated perstag first, then by title — the same order
+	 * add_contact() uses, because an ActiveCampaign admin may have renamed a
+	 * field's perstag, in which case the account's actual perstag is the only
+	 * value AC substitutes. A row with an empty perstag can never match: it
+	 * supplies no usable tag.
+	 *
+	 * Cached because the field list is an uncached, paginated fetch and link
+	 * decoration runs once per link per newsletter render. Misses are cached
+	 * briefly so a field created after the first lookup is picked up soon.
+	 *
+	 * @param string      $field_name Field title as synced (e.g. 'NP_Account').
+	 * @param string|null $list_id    Unused; ActiveCampaign fields are account-wide.
+	 *
+	 * @return string Perstag, or '' when unknown.
+	 */
+	public function get_field_merge_tag_name( $field_name, $list_id = null ) {
+		$field_name = trim( (string) $field_name );
+		if ( '' === $field_name ) {
+			return '';
+		}
+
+		$cache_key = 'np_nl_field_tag_' . md5( $field_name );
+		$cached    = get_transient( $cache_key );
+		if ( false !== $cached ) {
+			return (string) $cached;
+		}
+
+		$fields = $this->get_all_contact_fields();
+		if ( is_wp_error( $fields ) || ! is_array( $fields ) ) {
+			return '';
+		}
+
+		$generated = strtoupper( str_replace( '-', '_', sanitize_title( $field_name ) ) );
+		$perstag   = '';
+		foreach ( $fields as $field ) {
+			if ( ! empty( $field['perstag'] ) && $field['perstag'] === $generated ) {
+				$perstag = (string) $field['perstag'];
+				break;
+			}
+		}
+		if ( '' === $perstag ) {
+			foreach ( $fields as $field ) {
+				if (
+					! empty( $field['title'] ) && ! empty( $field['perstag'] ) &&
+					0 === strcasecmp( trim( $field['title'] ), $field_name )
+				) {
+					$perstag = (string) $field['perstag'];
+					break;
+				}
+			}
+		}
+
+		set_transient( $cache_key, $perstag, '' === $perstag ? 15 * MINUTE_IN_SECONDS : 12 * HOUR_IN_SECONDS );
+		return $perstag;
+	}
+
+	/**
 	 * Get contact data by email.
 	 *
 	 * @param string $email Email address.

--- a/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -593,15 +593,11 @@ Error message(s) received:
 	}
 
 	/**
-	 * Get the ESP's merge-tag name for a synced contact field.
-	 *
-	 * Callers embed the returned name in a merge tag — see
-	 * Newspack_Newsletters\Tracking\Utils::get_merge_tag() — so the ESP
-	 * substitutes the recipient's value at send time. The tag name is NOT
-	 * derivable from the field name: ActiveCampaign generates a perstag and an
-	 * admin can rename it, and Mailchimp assigns its own tag per audience.
-	 * Providers that can resolve it override this; the rest return '' and their
-	 * callers emit nothing.
+	 * Get the ESP's merge-tag name for a synced contact field, for embedding in
+	 * a merge tag (see Tracking\Utils::get_merge_tag()). Not derivable from the
+	 * field name: ActiveCampaign perstags can be renamed, and Mailchimp assigns
+	 * tags per audience. Providers that can resolve it override this; the rest
+	 * return '' and callers emit nothing.
 	 *
 	 * @param string      $field_name Field name as synced (e.g. 'NP_Account').
 	 * @param string|null $list_id    Audience/list ID, for providers whose

--- a/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
+++ b/plugins/newspack-newsletters/includes/service-providers/class-newspack-newsletters-service-provider.php
@@ -593,6 +593,27 @@ Error message(s) received:
 	}
 
 	/**
+	 * Get the ESP's merge-tag name for a synced contact field.
+	 *
+	 * Callers embed the returned name in a merge tag — see
+	 * Newspack_Newsletters\Tracking\Utils::get_merge_tag() — so the ESP
+	 * substitutes the recipient's value at send time. The tag name is NOT
+	 * derivable from the field name: ActiveCampaign generates a perstag and an
+	 * admin can rename it, and Mailchimp assigns its own tag per audience.
+	 * Providers that can resolve it override this; the rest return '' and their
+	 * callers emit nothing.
+	 *
+	 * @param string      $field_name Field name as synced (e.g. 'NP_Account').
+	 * @param string|null $list_id    Audience/list ID, for providers whose
+	 *                                fields are per-list. Null when not applicable.
+	 *
+	 * @return string The ESP's bare tag name, or '' when it can't be resolved.
+	 */
+	public function get_field_merge_tag_name( $field_name, $list_id = null ) {
+		return '';
+	}
+
+	/**
 	 * Get the merge-tag dictionary for this ESP.
 	 *
 	 * Override on each concrete provider to expose its merge-tag autocomplete

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp.php
@@ -1358,6 +1358,48 @@ final class Newspack_Newsletters_Mailchimp extends \Newspack_Newsletters_Service
 	}
 
 	/**
+	 * Get the Mailchimp merge-field tag for a synced field on an audience.
+	 *
+	 * Mailchimp assigns tags itself and they are per-audience, so the tag is
+	 * read from the audience's merge-field list rather than derived from the
+	 * field name — it can be anything, including `MMERGE7`.
+	 *
+	 * @param string      $field_name Field name as synced (e.g. 'NP_Account').
+	 * @param string|null $list_id    Audience ID. Required: tags are per-audience.
+	 *
+	 * @return string Merge-field tag, or '' when unknown.
+	 */
+	public function get_field_merge_tag_name( $field_name, $list_id = null ) {
+		$field_name = trim( (string) $field_name );
+		if ( '' === $field_name || empty( $list_id ) ) {
+			return '';
+		}
+
+		try {
+			$merge_fields = Newspack_Newsletters_Mailchimp_Cached_Data::get_merge_fields( $list_id );
+		} catch ( \Throwable $e ) {
+			// A cache miss that needs the API can fail; emitting no param is the
+			// safe outcome, so swallow it rather than break newsletter rendering.
+			return '';
+		}
+
+		if ( ! is_array( $merge_fields ) ) {
+			return '';
+		}
+
+		foreach ( $merge_fields as $field ) {
+			if (
+				! empty( $field['name'] ) && ! empty( $field['tag'] ) &&
+				0 === strcasecmp( trim( $field['name'] ), $field_name )
+			) {
+				return (string) $field['tag'];
+			}
+		}
+
+		return '';
+	}
+
+	/**
 	 * Filter newsletter content prior to converting to MJML.
 	 *
 	 * @param string $content The post content.

--- a/plugins/newspack-newsletters/tests/test-active-campaign-field-tag-name.php
+++ b/plugins/newspack-newsletters/tests/test-active-campaign-field-tag-name.php
@@ -1,11 +1,8 @@
 <?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
 /**
  * Tests for resolving an ActiveCampaign custom field's perstag by field name.
- *
- * Newsletter links carry a merge tag for a synced field, and AC substitutes it
- * per recipient. The tag is the field's perstag, which AC generates from the
- * title and an AC admin may rename — so it has to be read back from the
- * account, never derived from the field name.
+ * The perstag is generated from the title and can be renamed by an AC admin,
+ * so it must be read back from the account, never derived.
  *
  * @package Newspack_Newsletters
  */
@@ -192,24 +189,11 @@ class ActiveCampaignFieldTagNameTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A dead object-cache drop-in makes get_transient() silently miss every
-	 * time, whether or not set_transient() actually persisted anything — a
-	 * recurring failure mode on this platform. Without a per-request memo in
-	 * front of the transient, link decoration (which resolves the same field
-	 * once per link) would repeat the whole paginated fetch for every link in
-	 * the newsletter.
-	 *
-	 * Forces that failure mode directly via the `transient_{$transient}`
-	 * filter, which WordPress applies unconditionally to get_transient()'s
-	 * return value — unlike `pre_transient_{$transient}`, whose own default
-	 * is `false`, so a filter merely returning `false` there is a no-op and
-	 * would not actually force a miss against a value that was successfully
-	 * set.
-	 *
-	 * instance() hands back a brand-new object on every call in this test
-	 * environment (see its IS_TEST_ENV escape hatch), so resolving twice via
-	 * two separate instance() calls also proves the memo is static — an
-	 * instance property would not have survived between them.
+	 * With get_transient() forced to always miss (a dead object cache), the
+	 * per-request memo must still stop repeat fetches. Forced via the
+	 * `transient_{$transient}` filter, which applies unconditionally —
+	 * `pre_transient_` returning false is a no-op. Resolving through two
+	 * instance() calls also proves the memo is static.
 	 */
 	public function test_memoizes_within_a_request_when_transient_cannot_return() {
 		$this->remote_fields = [

--- a/plugins/newspack-newsletters/tests/test-active-campaign-field-tag-name.php
+++ b/plugins/newspack-newsletters/tests/test-active-campaign-field-tag-name.php
@@ -1,0 +1,186 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Tests for resolving an ActiveCampaign custom field's perstag by field name.
+ *
+ * Newsletter links carry a merge tag for a synced field, and AC substitutes it
+ * per recipient. The tag is the field's perstag, which AC generates from the
+ * title and an AC admin may rename — so it has to be read back from the
+ * account, never derived from the field name.
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Test Newspack_Newsletters_Active_Campaign::get_field_merge_tag_name().
+ */
+class ActiveCampaignFieldTagNameTest extends WP_UnitTestCase {
+
+	/**
+	 * Fields the mocked ActiveCampaign account reports via GET /api/3/fields.
+	 *
+	 * @var array
+	 */
+	private $remote_fields = [];
+
+	/**
+	 * Number of field-list requests the mocked HTTP layer served.
+	 *
+	 * @var int
+	 */
+	private $list_calls = 0;
+
+	/**
+	 * Set up: credentials, intercepted HTTP, and a clean tag cache.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->remote_fields = [];
+		$this->list_calls    = 0;
+		delete_transient( 'np_nl_field_tag_' . md5( 'NP_Account' ) );
+		delete_transient( 'np_nl_field_tag_' . md5( 'NP_Missing' ) );
+		Newspack_Newsletters_Active_Campaign::instance()->set_api_credentials(
+			[
+				'url' => 'https://example.api-us1.com',
+				'key' => 'test-key',
+			]
+		);
+		add_filter( 'pre_http_request', [ $this, 'mock_http' ], 10, 3 );
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		remove_filter( 'pre_http_request', [ $this, 'mock_http' ], 10 );
+		parent::tear_down();
+	}
+
+	/**
+	 * Play an ActiveCampaign account holding $remote_fields.
+	 *
+	 * @param mixed  $preempt Short-circuit value.
+	 * @param array  $args    HTTP request arguments.
+	 * @param string $url     Request URL.
+	 *
+	 * @return array
+	 */
+	public function mock_http( $preempt, $args, $url ) {
+		if ( false !== strpos( $url, '/api/3/fields' ) && 'GET' === $args['method'] ) {
+			$this->list_calls++;
+			return [
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'body'     => wp_json_encode(
+					[
+						'fields' => $this->remote_fields,
+						'meta'   => [ 'total' => count( $this->remote_fields ) ],
+					]
+				),
+			];
+		}
+		return [
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+			'body'     => wp_json_encode( [] ),
+		];
+	}
+
+	/**
+	 * The common case: the perstag AC generated from the field title.
+	 */
+	public function test_resolves_generated_perstag() {
+		$this->remote_fields = [
+			[
+				'title'   => 'NP_Account',
+				'perstag' => 'NP_ACCOUNT',
+			],
+		];
+		$this->assertSame(
+			'NP_ACCOUNT',
+			Newspack_Newsletters_Active_Campaign::instance()->get_field_merge_tag_name( 'NP_Account' )
+		);
+	}
+
+	/**
+	 * An AC admin renamed the perstag. The title still matches, and the
+	 * account's actual perstag is the only value AC will substitute.
+	 */
+	public function test_resolves_renamed_perstag_by_title() {
+		$this->remote_fields = [
+			[
+				'title'   => 'NP_Account',
+				'perstag' => 'READER_ID',
+			],
+		];
+		$this->assertSame(
+			'READER_ID',
+			Newspack_Newsletters_Active_Campaign::instance()->get_field_merge_tag_name( 'NP_Account' )
+		);
+	}
+
+	/**
+	 * A field that isn't on the account yields no tag, so the caller emits no
+	 * param rather than a tag AC would leave unsubstituted.
+	 */
+	public function test_returns_empty_for_unknown_field() {
+		$this->remote_fields = [
+			[
+				'title'   => 'Something Else',
+				'perstag' => 'SOMETHING_ELSE',
+			],
+		];
+		$this->assertSame(
+			'',
+			Newspack_Newsletters_Active_Campaign::instance()->get_field_merge_tag_name( 'NP_Missing' )
+		);
+	}
+
+	/**
+	 * A row with an empty perstag can't supply a usable merge tag, so it must
+	 * never match — mirroring the guard in add_contact().
+	 */
+	public function test_ignores_field_with_empty_perstag() {
+		$this->remote_fields = [
+			[
+				'title'   => 'NP_Account',
+				'perstag' => '',
+			],
+		];
+		$this->assertSame(
+			'',
+			Newspack_Newsletters_Active_Campaign::instance()->get_field_merge_tag_name( 'NP_Account' )
+		);
+	}
+
+	/**
+	 * Link decoration runs once per link per newsletter render, and the AC
+	 * field list is an uncached paginated fetch — so the result must be cached.
+	 */
+	public function test_caches_resolved_tag() {
+		$this->remote_fields = [
+			[
+				'title'   => 'NP_Account',
+				'perstag' => 'NP_ACCOUNT',
+			],
+		];
+		$provider = Newspack_Newsletters_Active_Campaign::instance();
+		$provider->get_field_merge_tag_name( 'NP_Account' );
+		$provider->get_field_merge_tag_name( 'NP_Account' );
+		$this->assertSame( 1, $this->list_calls );
+	}
+
+	/**
+	 * An empty field name never reaches the API.
+	 */
+	public function test_empty_field_name_makes_no_request() {
+		$this->assertSame(
+			'',
+			Newspack_Newsletters_Active_Campaign::instance()->get_field_merge_tag_name( '' )
+		);
+		$this->assertSame( 0, $this->list_calls );
+	}
+}

--- a/plugins/newspack-newsletters/tests/test-active-campaign-field-tag-name.php
+++ b/plugins/newspack-newsletters/tests/test-active-campaign-field-tag-name.php
@@ -38,6 +38,13 @@ class ActiveCampaignFieldTagNameTest extends WP_UnitTestCase {
 		$this->list_calls    = 0;
 		delete_transient( 'np_nl_field_tag_' . md5( 'NP_Account' ) );
 		delete_transient( 'np_nl_field_tag_' . md5( 'NP_Missing' ) );
+		// The per-request memo is a static property (see
+		// $field_merge_tag_name_memo's docblock), so it otherwise survives
+		// across every test in this process, not just within one. Reset it
+		// directly via reflection; there's no public API for it.
+		$memo = new ReflectionProperty( 'Newspack_Newsletters_Active_Campaign', 'field_merge_tag_name_memo' );
+		$memo->setAccessible( true );
+		$memo->setValue( null, [] );
 		Newspack_Newsletters_Active_Campaign::instance()->set_api_credentials(
 			[
 				'url' => 'https://example.api-us1.com',
@@ -182,5 +189,45 @@ class ActiveCampaignFieldTagNameTest extends WP_UnitTestCase {
 			Newspack_Newsletters_Active_Campaign::instance()->get_field_merge_tag_name( '' )
 		);
 		$this->assertSame( 0, $this->list_calls );
+	}
+
+	/**
+	 * A dead object-cache drop-in makes get_transient() silently miss every
+	 * time, whether or not set_transient() actually persisted anything — a
+	 * recurring failure mode on this platform. Without a per-request memo in
+	 * front of the transient, link decoration (which resolves the same field
+	 * once per link) would repeat the whole paginated fetch for every link in
+	 * the newsletter.
+	 *
+	 * Forces that failure mode directly via the `transient_{$transient}`
+	 * filter, which WordPress applies unconditionally to get_transient()'s
+	 * return value — unlike `pre_transient_{$transient}`, whose own default
+	 * is `false`, so a filter merely returning `false` there is a no-op and
+	 * would not actually force a miss against a value that was successfully
+	 * set.
+	 *
+	 * instance() hands back a brand-new object on every call in this test
+	 * environment (see its IS_TEST_ENV escape hatch), so resolving twice via
+	 * two separate instance() calls also proves the memo is static — an
+	 * instance property would not have survived between them.
+	 */
+	public function test_memoizes_within_a_request_when_transient_cannot_return() {
+		$this->remote_fields = [
+			[
+				'title'   => 'NP_Account',
+				'perstag' => 'NP_ACCOUNT',
+			],
+		];
+		$cache_key = 'np_nl_field_tag_' . md5( 'NP_Account' );
+		add_filter( "transient_{$cache_key}", '__return_false' );
+
+		try {
+			$this->assertSame( 'NP_ACCOUNT', Newspack_Newsletters_Active_Campaign::instance()->get_field_merge_tag_name( 'NP_Account' ) );
+			$this->assertSame( 'NP_ACCOUNT', Newspack_Newsletters_Active_Campaign::instance()->get_field_merge_tag_name( 'NP_Account' ) );
+		} finally {
+			remove_filter( "transient_{$cache_key}", '__return_false' );
+		}
+
+		$this->assertSame( 1, $this->list_calls, 'A per-request memo must prevent a second fetch when the transient layer cannot return a cached value.' );
 	}
 }

--- a/plugins/newspack-newsletters/tests/test-mailchimp-field-tag-name.php
+++ b/plugins/newspack-newsletters/tests/test-mailchimp-field-tag-name.php
@@ -1,0 +1,120 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Tests for resolving a Mailchimp merge field's tag by field name.
+ *
+ * Mailchimp assigns merge-field tags itself, per audience, so the tag for a
+ * synced field has to be read back from the audience rather than derived from
+ * the field name.
+ *
+ * @package Newspack_Newsletters
+ */
+
+/**
+ * Test Newspack_Newsletters_Mailchimp::get_field_merge_tag_name().
+ */
+class MailchimpFieldTagNameTest extends WP_UnitTestCase {
+
+	/**
+	 * Seed the cached-data store for an audience's merge fields.
+	 *
+	 * The cached-data class serves from the option `newspack_nl_mailchimp_cache_<list_id>`
+	 * when it exists, so seeding it keeps the test off the network. The companion
+	 * `_date_` option is deliberately NOT seeded: is_cache_expired() returns false
+	 * for a missing date, so no background refresh is dispatched.
+	 *
+	 * Each test uses its own list ID because the cached-data class memoizes per
+	 * list ID in a static that outlives a single test — reusing one ID would serve
+	 * the first test's fields to every later test.
+	 *
+	 * @param string $list_id      Audience ID, unique per test.
+	 * @param array  $merge_fields Merge fields as the Mailchimp API reports them.
+	 */
+	private function seed_merge_fields( $list_id, $merge_fields ) {
+		update_option(
+			'newspack_nl_mailchimp_cache_' . $list_id,
+			[
+				'merge_fields' => $merge_fields,
+				'interests'    => [],
+				'tags'         => [],
+			],
+			false
+		);
+	}
+
+	/**
+	 * The common case: the audience reports a tag for the synced field.
+	 */
+	public function test_resolves_tag_for_field_name() {
+		$this->seed_merge_fields(
+			'list-resolves',
+			[
+				[
+					'name' => 'NP_Account',
+					'tag'  => 'NP_ACCOUNT',
+				],
+			]
+		);
+		$this->assertSame(
+			'NP_ACCOUNT',
+			Newspack_Newsletters_Mailchimp::instance()->get_field_merge_tag_name( 'NP_Account', 'list-resolves' )
+		);
+	}
+
+	/**
+	 * Mailchimp often assigns an opaque tag. It is still the only value
+	 * Mailchimp substitutes, so it must be used verbatim.
+	 */
+	public function test_resolves_opaque_generated_tag() {
+		$this->seed_merge_fields(
+			'list-opaque',
+			[
+				[
+					'name' => 'NP_Account',
+					'tag'  => 'MMERGE7',
+				],
+			]
+		);
+		$this->assertSame(
+			'MMERGE7',
+			Newspack_Newsletters_Mailchimp::instance()->get_field_merge_tag_name( 'NP_Account', 'list-opaque' )
+		);
+	}
+
+	/**
+	 * A field the audience doesn't have yields no tag.
+	 */
+	public function test_returns_empty_for_unknown_field() {
+		$this->seed_merge_fields(
+			'list-unknown',
+			[
+				[
+					'name' => 'Something Else',
+					'tag'  => 'SOMETHING',
+				],
+			]
+		);
+		$this->assertSame(
+			'',
+			Newspack_Newsletters_Mailchimp::instance()->get_field_merge_tag_name( 'NP_Account', 'list-unknown' )
+		);
+	}
+
+	/**
+	 * Tags are per-audience, so without an audience there is nothing to resolve.
+	 */
+	public function test_returns_empty_without_a_list_id() {
+		$this->seed_merge_fields(
+			'list-nolist',
+			[
+				[
+					'name' => 'NP_Account',
+					'tag'  => 'NP_ACCOUNT',
+				],
+			]
+		);
+		$this->assertSame(
+			'',
+			Newspack_Newsletters_Mailchimp::instance()->get_field_merge_tag_name( 'NP_Account', null )
+		);
+	}
+}

--- a/plugins/newspack-newsletters/tests/test-mailchimp-field-tag-name.php
+++ b/plugins/newspack-newsletters/tests/test-mailchimp-field-tag-name.php
@@ -15,16 +15,10 @@
 class MailchimpFieldTagNameTest extends WP_UnitTestCase {
 
 	/**
-	 * Seed the cached-data store for an audience's merge fields.
-	 *
-	 * The cached-data class serves from the option `newspack_nl_mailchimp_cache_<list_id>`
-	 * when it exists, so seeding it keeps the test off the network. The companion
-	 * `_date_` option is deliberately NOT seeded: is_cache_expired() returns false
-	 * for a missing date, so no background refresh is dispatched.
-	 *
-	 * Each test uses its own list ID because the cached-data class memoizes per
-	 * list ID in a static that outlives a single test — reusing one ID would serve
-	 * the first test's fields to every later test.
+	 * Seed the cached-data option for an audience's merge fields, keeping the
+	 * test off the network. The `_date_` option stays unseeded so no refresh is
+	 * dispatched, and each test uses its own list ID because the cached-data
+	 * class memoizes per list ID in a static that outlives a test.
 	 *
 	 * @param string $list_id      Audience ID, unique per test.
 	 * @param array  $merge_fields Merge fields as the Mailchimp API reports them.

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -659,21 +659,24 @@ final class Newspack_Popups_Segmentation {
 	 * set_carried_segments_cookie()'s own `setcookie()` call only runs when
 	 * `! headers_sent()`, which is never true under PHPUnit, so without this
 	 * extraction none of these option values would be exercised by any test in
-	 * the suite — e.g. an `expires => 0` typo in the clearing branch, which
-	 * would stop the cookie ever clearing, would pass every test.
+	 * the suite — e.g. an `expires` other than 0 would pass every test while
+	 * silently stopping a real browser from ever delivering an empty
+	 * resolution as anything but a deletion.
 	 *
-	 * @param bool $clearing Whether this is the clearing (empty-resolution)
-	 *                       form rather than the setting form.
+	 * Always a session cookie, including when the value being written is
+	 * empty: an empty value is itself the "matches nothing" assertion, not a
+	 * request to delete the cookie. A past-expiry `Set-Cookie` (the pattern
+	 * used elsewhere for actual deletion — see class-magic-link.php and
+	 * class-reader-activation.php) is exactly that to a real browser: it
+	 * removes the cookie and never sends it again, so the view script would
+	 * never observe the empty value at all. See
+	 * set_carried_segments_cookie()'s docblock.
 	 *
 	 * @return array `setcookie()`'s `$options` argument.
 	 */
-	private static function get_carried_segments_cookie_options( bool $clearing ): array {
+	private static function get_carried_segments_cookie_options(): array {
 		return [
-			// An empty resolved set clears the cookie by expiring it in the past,
-			// mirroring the unset( $_COOKIE ) below — see class-magic-link.php and
-			// class-reader-activation.php for the same expire-in-the-past pattern.
-			// A non-empty set is a session cookie: expires at 0.
-			'expires'  => $clearing ? time() - YEAR_IN_SECONDS : 0,
+			'expires'  => 0,
 			'path'     => '/',
 			'secure'   => is_ssl(),
 			// Must stay readable by the view script; this is a segmentation
@@ -684,8 +687,9 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
-	 * Hand the resolved segment IDs to the view script, or clear a previous
-	 * arrival's handoff when a valid account ID resolves nothing.
+	 * Hand the resolved segment IDs to the view script. An empty array is a
+	 * real assertion — "this account matches no segments" — and must reach
+	 * the browser as such, not as a deleted cookie.
 	 *
 	 * A session cookie, readable by JavaScript (the view script moves it into
 	 * sessionStorage and deletes it on first read) and named so Batcache does not
@@ -693,19 +697,26 @@ final class Newspack_Popups_Segmentation {
 	 *
 	 * Called for every arrival whose np_account value passes the
 	 * positive-integer gate (see handle_account_param()), so each such arrival
-	 * is authoritative — including clearing when a valid ID resolves no
-	 * segments. The view script deletes the cookie on first read, but on an
-	 * arrival where that script never runs (a page with no prompts, JS
+	 * is authoritative — including overriding a previous arrival's segments
+	 * when this one resolves none. The cookie is always written with the same
+	 * session-lifetime options (see get_carried_segments_cookie_options()),
+	 * whether or not the value is empty: expiring it in the past instead would
+	 * make a real browser delete it rather than deliver it, so the view
+	 * script would never see the empty value and would fall through to
+	 * whatever a previous arrival already left in sessionStorage — silently
+	 * keeping a stale, previously-matched segment set alive for the rest of
+	 * the session. The view script deletes the cookie on first read, but on
+	 * an arrival where that script never runs (a page with no prompts, JS
 	 * disabled), a previous arrival's segments would otherwise carry into the
 	 * next click.
 	 *
 	 * Not called at all for a value that never passed the gate: such a value
 	 * makes no assertion about the reader — e.g. an unsubstituted merge tag
 	 * from an already-delivered newsletter — so an existing carried set is left
-	 * alone rather than wiped.
+	 * alone rather than overwritten.
 	 *
-	 * @param string[] $segment_ids Active segment IDs; an empty array clears
-	 *                              the cookie instead of setting it.
+	 * @param string[] $segment_ids Active segment IDs; an empty array asserts
+	 *                              that the account matches no segments.
 	 */
 	private static function set_carried_segments_cookie( $segment_ids ) {
 		$value = implode( ',', $segment_ids );
@@ -714,16 +725,14 @@ final class Newspack_Popups_Segmentation {
 			setcookie(
 				self::CARRIED_SEGMENTS_COOKIE,
 				$value,
-				self::get_carried_segments_cookie_options( empty( $segment_ids ) )
+				self::get_carried_segments_cookie_options()
 			);
 		}
 		// Unconditionally update $_COOKIE so same-request readers (and tests, where
-		// headers are already sent) can see the handoff, or its absence.
-		if ( empty( $segment_ids ) ) {
-			unset( $_COOKIE[ self::CARRIED_SEGMENTS_COOKIE ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
-		} else {
-			$_COOKIE[ self::CARRIED_SEGMENTS_COOKIE ] = $value; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
-		}
+		// headers are already sent) see the same assertion a real browser would
+		// receive — including an empty string when nothing resolved, rather than
+		// unsetting it, which would be indistinguishable from no handoff at all.
+		$_COOKIE[ self::CARRIED_SEGMENTS_COOKIE ] = $value; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -72,6 +72,26 @@ final class Newspack_Popups_Segmentation {
 	const CARRIED_SEGMENTS_COOKIE = 'np_carried_segments';
 
 	/**
+	 * Sentinel cookie value asserting that an account matched no segments —
+	 * distinct from an absent cookie, which means no handoff happened at all.
+	 *
+	 * Never a valid segment ID: segment IDs are always positive-integer term
+	 * IDs (see get_carried_segments_for_account()), so this string can never
+	 * collide with a real one. This can never be an empty string instead:
+	 * PHP's `setcookie()` sends a deletion whenever the *value* is empty,
+	 * ignoring whatever `expires` is passed — confirmed against Apache in
+	 * this project's container. A real browser then deletes the cookie and
+	 * never sends it again, indistinguishable from no handoff ever having
+	 * happened, so the "matches nothing" assertion would silently never
+	 * reach the view script. See get_carried_segments_cookie_value() and
+	 * set_carried_segments_cookie()'s docblocks.
+	 *
+	 * Mirrored in carried-segments.js as CARRIED_SEGMENTS_NONE — keep the two
+	 * in sync.
+	 */
+	const CARRIED_SEGMENTS_NONE = 'none';
+
+	/**
 	 * Installed version number of the custom table.
 	 */
 	const TABLE_VERSION = '1.0';
@@ -397,10 +417,20 @@ final class Newspack_Popups_Segmentation {
 	 * after, so `/post/#section` becomes `/post/?np_account=TAG#section`
 	 * instead of the unparseable `/post/#section?np_account=TAG`.
 	 *
+	 * Because $value is concatenated in raw, with no urlencode(), the caller
+	 * must guarantee it contains none of `&`, `=`, or `#`: unlike
+	 * add_query_arg(), nothing here escapes them. A `&` would start a bogus
+	 * extra param, truncating this one; a `#` would start a bogus fragment,
+	 * truncating the query string; and a bare `=` is not spec-safe inside a
+	 * query value even where a particular parser happens to tolerate it. Every
+	 * current caller passes an ESP merge tag (e.g. `*|TAG|*`, `%TAG%`), whose
+	 * delimiter syntaxes don't use any of the three.
+	 *
 	 * @param string $url   URL to append to; may already carry a query string
 	 *                      and/or a fragment.
 	 * @param string $param Parameter name.
-	 * @param string $value Raw (unencoded) parameter value.
+	 * @param string $value Raw (unencoded) parameter value. Must not contain
+	 *                      `&`, `=`, or `#` — see above.
 	 *
 	 * @return string
 	 */
@@ -659,18 +689,17 @@ final class Newspack_Popups_Segmentation {
 	 * set_carried_segments_cookie()'s own `setcookie()` call only runs when
 	 * `! headers_sent()`, which is never true under PHPUnit, so without this
 	 * extraction none of these option values would be exercised by any test in
-	 * the suite — e.g. an `expires` other than 0 would pass every test while
-	 * silently stopping a real browser from ever delivering an empty
-	 * resolution as anything but a deletion.
+	 * the suite — e.g. an `httponly => true` typo would silently break the
+	 * view script's document.cookie read, and every other test would still
+	 * pass.
 	 *
-	 * Always a session cookie, including when the value being written is
-	 * empty: an empty value is itself the "matches nothing" assertion, not a
-	 * request to delete the cookie. A past-expiry `Set-Cookie` (the pattern
-	 * used elsewhere for actual deletion — see class-magic-link.php and
-	 * class-reader-activation.php) is exactly that to a real browser: it
-	 * removes the cookie and never sends it again, so the view script would
-	 * never observe the empty value at all. See
-	 * set_carried_segments_cookie()'s docblock.
+	 * Always a session cookie (`expires => 0`). That alone does not guarantee
+	 * a "matches nothing" resolution is ever delivered, though: PHP's
+	 * `setcookie()` sends a deletion whenever the cookie's *value* is empty,
+	 * regardless of the `expires` passed here — confirmed against Apache in
+	 * this project's container. Keeping the value non-empty is
+	 * get_carried_segments_cookie_value()'s job, not this method's; the two
+	 * only work together. See set_carried_segments_cookie()'s docblock.
 	 *
 	 * @return array `setcookie()`'s `$options` argument.
 	 */
@@ -687,6 +716,34 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
+	 * The carried-segments cookie *value* for a resolved set of segment IDs.
+	 *
+	 * Extracted into its own seam so it's reachable directly from a test:
+	 * set_carried_segments_cookie()'s own `setcookie()` call never runs under
+	 * PHPUnit (`headers_sent()` is always true there), so a test that only
+	 * exercises that method and inspects the $_COOKIE mirror can prove what
+	 * ends up in PHP's superglobal, but not what a real browser's Set-Cookie
+	 * header would actually carry — the exact gap that let this cookie ship
+	 * as a real-browser deletion twice under review.
+	 *
+	 * Never empty: PHP's `setcookie()` treats an empty string value as a
+	 * request to delete the cookie, no matter what `expires` is passed (see
+	 * get_carried_segments_cookie_options()'s docblock) — a real browser then
+	 * never delivers the "matches nothing" assertion at all. CARRIED_SEGMENTS_NONE
+	 * is the non-empty sentinel used instead; it can never collide with a real
+	 * segment ID, which is always a positive integer term ID.
+	 *
+	 * @param string[] $segment_ids Active segment IDs; an empty array asserts
+	 *                               that the account matches no segments.
+	 *
+	 * @return string Comma-joined segment IDs, or CARRIED_SEGMENTS_NONE when
+	 *                $segment_ids is empty.
+	 */
+	private static function get_carried_segments_cookie_value( array $segment_ids ): string {
+		return empty( $segment_ids ) ? self::CARRIED_SEGMENTS_NONE : implode( ',', $segment_ids );
+	}
+
+	/**
 	 * Hand the resolved segment IDs to the view script. An empty array is a
 	 * real assertion — "this account matches no segments" — and must reach
 	 * the browser as such, not as a deleted cookie.
@@ -700,10 +757,12 @@ final class Newspack_Popups_Segmentation {
 	 * is authoritative — including overriding a previous arrival's segments
 	 * when this one resolves none. The cookie is always written with the same
 	 * session-lifetime options (see get_carried_segments_cookie_options()),
-	 * whether or not the value is empty: expiring it in the past instead would
-	 * make a real browser delete it rather than deliver it, so the view
-	 * script would never see the empty value and would fall through to
-	 * whatever a previous arrival already left in sessionStorage — silently
+	 * and the value written is never an empty string (see
+	 * get_carried_segments_cookie_value()): PHP's `setcookie()` sends a
+	 * deletion whenever the value is empty, no matter what `expires` is
+	 * passed, so a real browser would then never deliver the "matches
+	 * nothing" assertion at all — the view script would fall through to
+	 * whatever a previous arrival already left in sessionStorage, silently
 	 * keeping a stale, previously-matched segment set alive for the rest of
 	 * the session. The view script deletes the cookie on first read, but on
 	 * an arrival where that script never runs (a page with no prompts, JS
@@ -719,7 +778,7 @@ final class Newspack_Popups_Segmentation {
 	 *                              that the account matches no segments.
 	 */
 	private static function set_carried_segments_cookie( $segment_ids ) {
-		$value = implode( ',', $segment_ids );
+		$value = self::get_carried_segments_cookie_value( $segment_ids );
 		if ( ! headers_sent() ) {
 			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
 			setcookie(
@@ -730,8 +789,10 @@ final class Newspack_Popups_Segmentation {
 		}
 		// Unconditionally update $_COOKIE so same-request readers (and tests, where
 		// headers are already sent) see the same assertion a real browser would
-		// receive — including an empty string when nothing resolved, rather than
-		// unsetting it, which would be indistinguishable from no handoff at all.
+		// receive — including the CARRIED_SEGMENTS_NONE sentinel when nothing
+		// resolved, rather than an empty string (which setcookie() above would
+		// have sent as a deletion) or unsetting it (indistinguishable from no
+		// handoff at all).
 		$_COOKIE[ self::CARRIED_SEGMENTS_COOKIE ] = $value; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 	}
 

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -304,6 +304,18 @@ final class Newspack_Popups_Segmentation {
 		if ( ! self::is_newsletter_post( $post ) ) {
 			return $url;
 		}
+		// Mailchimp's own process_link() filter (priority 10) hands the whole URL
+		// back as a bare merge-tag placeholder for links like *|UNSUB|* and
+		// *|UPDATE_PROFILE|*, and is_first_party_url() reads a host-less string as
+		// first-party. Appending to one produces `*|UNSUB|*?np_seg_donor=...`, which the ESP
+		// expands into an unsubscribe URL that already carries its own query string
+		// — two `?`, a link that no longer works, and unsubscribe is required by law
+		// and by Mailchimp's terms. The anchored match only fires when the entire
+		// URL is a placeholder, so a real URL carrying a merge tag in a query value
+		// is still decorated.
+		if ( self::is_unsubstituted_merge_tag( $url ) ) {
+			return $url;
+		}
 		if ( ! self::is_first_party_url( $url ) ) {
 			return $url;
 		}
@@ -369,6 +381,18 @@ final class Newspack_Popups_Segmentation {
 			return $url;
 		}
 		if ( ! self::is_newsletter_post( $post ) ) {
+			return $url;
+		}
+		// Mailchimp's own process_link() filter (priority 10) hands the whole URL
+		// back as a bare merge-tag placeholder for links like *|UNSUB|* and
+		// *|UPDATE_PROFILE|*, and is_first_party_url() reads a host-less string as
+		// first-party. Appending to one produces `*|UNSUB|*?np_account=...`, which the ESP
+		// expands into an unsubscribe URL that already carries its own query string
+		// — two `?`, a link that no longer works, and unsubscribe is required by law
+		// and by Mailchimp's terms. The anchored match only fires when the entire
+		// URL is a placeholder, so a real URL carrying a merge tag in a query value
+		// is still decorated.
+		if ( self::is_unsubstituted_merge_tag( $url ) ) {
 			return $url;
 		}
 		if ( ! self::is_first_party_url( $url ) ) {

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -605,8 +605,11 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
-	 * A reader's last-known matching segment IDs, filtered to segments this site
-	 * still ships to the browser.
+	 * A reader's last-known matching segment IDs, filtered to the site's active
+	 * segments — not the narrower set the inserter actually ships to the
+	 * browser (see class-newspack-popups-inserter.php), which also requires
+	 * non-empty criteria. A surplus ID here just matches nothing, so the
+	 * difference is harmless.
 	 *
 	 * The snapshot is client-asserted and only as fresh as the reader's last
 	 * visit — deliberately uncapped, so a dormant reader can be matched on old
@@ -627,6 +630,19 @@ final class Newspack_Popups_Segmentation {
 			return [];
 		}
 
+		// The snapshot is client-asserted (see docblock above), so guard against
+		// shapes strval() would mishandle below: a nested array raises "Array to
+		// string conversion", and strval( true ) is '1', which could alias
+		// segment ID 1. A real segment ID is only ever an int or a numeric
+		// string. Unreachable through the real Reader_Data::get_matched_segments(),
+		// which already filters non-scalars — this is defence in depth.
+		$snapshot = array_filter(
+			$snapshot,
+			function ( $value ) {
+				return is_int( $value ) || is_string( $value );
+			}
+		);
+
 		$active = [];
 		foreach ( self::get_segments( false ) as $segment ) {
 			if ( ! empty( $segment['id'] ) ) {
@@ -638,13 +654,20 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
-	 * Hand the resolved segment IDs to the view script.
+	 * Hand the resolved segment IDs to the view script, or clear a previous
+	 * arrival's handoff when this one resolves nothing.
 	 *
 	 * A session cookie, readable by JavaScript (the view script moves it into
 	 * sessionStorage and deletes it on first read) and named so Batcache does not
 	 * treat it as a cache-bypass signal — see CARRIED_SEGMENTS_COOKIE.
 	 *
-	 * @param string[] $segment_ids Active segment IDs.
+	 * Called unconditionally on every arrival so each one is authoritative. The
+	 * view script deletes the cookie on first read, but on an arrival where that
+	 * script never runs (a page with no prompts, JS disabled), a previous
+	 * arrival's segments would otherwise carry into the next click.
+	 *
+	 * @param string[] $segment_ids Active segment IDs; an empty array clears
+	 *                              the cookie instead of setting it.
 	 */
 	private static function set_carried_segments_cookie( $segment_ids ) {
 		$value = implode( ',', $segment_ids );
@@ -654,7 +677,10 @@ final class Newspack_Popups_Segmentation {
 				self::CARRIED_SEGMENTS_COOKIE,
 				$value,
 				[
-					'expires'  => 0,
+					// An empty resolved set clears the cookie by expiring it in the past,
+					// mirroring the unset( $_COOKIE ) below — see class-magic-link.php and
+					// class-reader-activation.php for the same expire-in-the-past pattern.
+					'expires'  => empty( $segment_ids ) ? time() - YEAR_IN_SECONDS : 0,
 					'path'     => '/',
 					'secure'   => is_ssl(),
 					// Must stay readable by the view script; this is a segmentation
@@ -665,8 +691,12 @@ final class Newspack_Popups_Segmentation {
 			);
 		}
 		// Unconditionally update $_COOKIE so same-request readers (and tests, where
-		// headers are already sent) can see the handoff.
-		$_COOKIE[ self::CARRIED_SEGMENTS_COOKIE ] = $value; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		// headers are already sent) can see the handoff, or its absence.
+		if ( empty( $segment_ids ) ) {
+			unset( $_COOKIE[ self::CARRIED_SEGMENTS_COOKIE ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		} else {
+			$_COOKIE[ self::CARRIED_SEGMENTS_COOKIE ] = $value; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		}
 	}
 
 	/**
@@ -701,13 +731,14 @@ final class Newspack_Popups_Segmentation {
 			return;
 		}
 
-		$raw = sanitize_text_field( wp_unslash( $_GET[ self::ACCOUNT_QUERY_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$raw         = sanitize_text_field( wp_unslash( $_GET[ self::ACCOUNT_QUERY_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$segment_ids = [];
 		if ( 1 === preg_match( '/^[1-9][0-9]*$/', $raw ) ) {
 			$segment_ids = self::get_carried_segments_for_account( (int) $raw );
-			if ( ! empty( $segment_ids ) ) {
-				self::set_carried_segments_cookie( $segment_ids );
-			}
 		}
+		// Unconditional so each arrival is authoritative — see
+		// set_carried_segments_cookie()'s docblock.
+		self::set_carried_segments_cookie( $segment_ids );
 
 		// This response carries a per-reader Set-Cookie and must never be stored.
 		if ( function_exists( 'batcache_cancel' ) ) {

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -354,10 +354,49 @@ final class Newspack_Popups_Segmentation {
 			return $url;
 		}
 
-		$url = add_query_arg( self::ACCOUNT_QUERY_PARAM, $merge_tag, $url );
-		// add_query_arg() URL-encodes the value, but ESPs substitute only the raw
-		// merge-tag syntax. Restore the raw tag so the ESP resolves it.
-		return str_replace( urlencode( $merge_tag ), $merge_tag, $url );
+		// Deliberately no is_url_safe_merge_tag() guard here, unlike the donor
+		// handler above: an unsubstituted np_account never reaches a consumer
+		// because it's always redirected away before output. Full reasoning is
+		// in the ACCOUNT_QUERY_PARAM docblock.
+		return self::append_raw_query_param( $url, self::ACCOUNT_QUERY_PARAM, $merge_tag );
+	}
+
+	/**
+	 * Append a query parameter to a URL with its value left completely raw,
+	 * bypassing add_query_arg().
+	 *
+	 * Calling add_query_arg() here would reparse the URL's entire existing
+	 * query string and run urlencode_deep() over every value already in it —
+	 * see the "This re-URL-encodes things that were already in the query
+	 * string" comment at wp-includes/functions.php:1183. On a URL that already
+	 * carries another handler's raw merge tag (e.g.
+	 * append_donor_segment_param()'s np_seg_donor, appended earlier in the same
+	 * newspack_newsletters_process_link chain), that reparse re-encodes it
+	 * right back into a form no ESP substitutes — exactly the corruption this
+	 * helper exists to avoid. Do NOT replace this with add_query_arg(): plain
+	 * string concatenation never looks at the existing query string, so it
+	 * cannot corrupt it.
+	 *
+	 * Fragment-aware: the param is inserted before a `#fragment` rather than
+	 * after, so `/post/#section` becomes `/post/?np_account=TAG#section`
+	 * instead of the unparseable `/post/#section?np_account=TAG`.
+	 *
+	 * @param string $url   URL to append to; may already carry a query string
+	 *                      and/or a fragment.
+	 * @param string $param Parameter name.
+	 * @param string $value Raw (unencoded) parameter value.
+	 *
+	 * @return string
+	 */
+	private static function append_raw_query_param( $url, $param, $value ) {
+		$fragment = '';
+		$hash_pos = strpos( $url, '#' );
+		if ( false !== $hash_pos ) {
+			$fragment = substr( $url, $hash_pos );
+			$url      = substr( $url, 0, $hash_pos );
+		}
+		$separator = false === strpos( $url, '?' ) ? '?' : '&';
+		return $url . $separator . $param . '=' . $value . $fragment;
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -630,10 +630,9 @@ final class Newspack_Popups_Segmentation {
 			return [];
 		}
 
-		// The snapshot is client-asserted (see docblock above), so guard against
-		// shapes strval() would mishandle below: a nested array raises "Array to
-		// string conversion", and strval( true ) is '1', which could alias
-		// segment ID 1. A real segment ID is only ever an int or a numeric
+		// The snapshot is client-asserted (see docblock above), so guard against a
+		// shape strval() would mishandle below: a nested array raises "Array to
+		// string conversion". A real segment ID is only ever an int or a numeric
 		// string. Unreachable through the real Reader_Data::get_matched_segments(),
 		// which already filters non-scalars — this is defence in depth.
 		$snapshot = array_filter(
@@ -654,17 +653,56 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
+	 * The `setcookie()` options for the carried-segments cookie.
+	 *
+	 * Extracted purely so these values are reachable from a test:
+	 * set_carried_segments_cookie()'s own `setcookie()` call only runs when
+	 * `! headers_sent()`, which is never true under PHPUnit, so without this
+	 * extraction none of these option values would be exercised by any test in
+	 * the suite — e.g. an `expires => 0` typo in the clearing branch, which
+	 * would stop the cookie ever clearing, would pass every test.
+	 *
+	 * @param bool $clearing Whether this is the clearing (empty-resolution)
+	 *                       form rather than the setting form.
+	 *
+	 * @return array `setcookie()`'s `$options` argument.
+	 */
+	private static function get_carried_segments_cookie_options( bool $clearing ): array {
+		return [
+			// An empty resolved set clears the cookie by expiring it in the past,
+			// mirroring the unset( $_COOKIE ) below — see class-magic-link.php and
+			// class-reader-activation.php for the same expire-in-the-past pattern.
+			// A non-empty set is a session cookie: expires at 0.
+			'expires'  => $clearing ? time() - YEAR_IN_SECONDS : 0,
+			'path'     => '/',
+			'secure'   => is_ssl(),
+			// Must stay readable by the view script; this is a segmentation
+			// hint, never a credential.
+			'httponly' => false,
+			'samesite' => 'Lax',
+		];
+	}
+
+	/**
 	 * Hand the resolved segment IDs to the view script, or clear a previous
-	 * arrival's handoff when this one resolves nothing.
+	 * arrival's handoff when a valid account ID resolves nothing.
 	 *
 	 * A session cookie, readable by JavaScript (the view script moves it into
 	 * sessionStorage and deletes it on first read) and named so Batcache does not
 	 * treat it as a cache-bypass signal — see CARRIED_SEGMENTS_COOKIE.
 	 *
-	 * Called unconditionally on every arrival so each one is authoritative. The
-	 * view script deletes the cookie on first read, but on an arrival where that
-	 * script never runs (a page with no prompts, JS disabled), a previous
-	 * arrival's segments would otherwise carry into the next click.
+	 * Called for every arrival whose np_account value passes the
+	 * positive-integer gate (see handle_account_param()), so each such arrival
+	 * is authoritative — including clearing when a valid ID resolves no
+	 * segments. The view script deletes the cookie on first read, but on an
+	 * arrival where that script never runs (a page with no prompts, JS
+	 * disabled), a previous arrival's segments would otherwise carry into the
+	 * next click.
+	 *
+	 * Not called at all for a value that never passed the gate: such a value
+	 * makes no assertion about the reader — e.g. an unsubstituted merge tag
+	 * from an already-delivered newsletter — so an existing carried set is left
+	 * alone rather than wiped.
 	 *
 	 * @param string[] $segment_ids Active segment IDs; an empty array clears
 	 *                              the cookie instead of setting it.
@@ -676,18 +714,7 @@ final class Newspack_Popups_Segmentation {
 			setcookie(
 				self::CARRIED_SEGMENTS_COOKIE,
 				$value,
-				[
-					// An empty resolved set clears the cookie by expiring it in the past,
-					// mirroring the unset( $_COOKIE ) below — see class-magic-link.php and
-					// class-reader-activation.php for the same expire-in-the-past pattern.
-					'expires'  => empty( $segment_ids ) ? time() - YEAR_IN_SECONDS : 0,
-					'path'     => '/',
-					'secure'   => is_ssl(),
-					// Must stay readable by the view script; this is a segmentation
-					// hint, never a credential.
-					'httponly' => false,
-					'samesite' => 'Lax',
-				]
+				self::get_carried_segments_cookie_options( empty( $segment_ids ) )
 			);
 		}
 		// Unconditionally update $_COOKIE so same-request readers (and tests, where
@@ -714,7 +741,10 @@ final class Newspack_Popups_Segmentation {
 	 * Only a plain positive integer is accepted. That single rule rejects every
 	 * unsubstituted merge-tag shape at once, so unlike
 	 * scrub_unsubstituted_donor_param() there is no need to inspect the raw,
-	 * still-encoded query string.
+	 * still-encoded query string. Unlike the redirect, the cookie handoff below
+	 * is conditional on this gate: a value that fails it makes no assertion
+	 * about the reader, so it must not overwrite an existing carried set — see
+	 * set_carried_segments_cookie()'s docblock.
 	 */
 	public static function handle_account_param() {
 		// Redirecting a POST would discard its body, and a redirect is only
@@ -731,16 +761,16 @@ final class Newspack_Popups_Segmentation {
 			return;
 		}
 
-		$raw         = sanitize_text_field( wp_unslash( $_GET[ self::ACCOUNT_QUERY_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
-		$segment_ids = [];
+		$raw = sanitize_text_field( wp_unslash( $_GET[ self::ACCOUNT_QUERY_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( 1 === preg_match( '/^[1-9][0-9]*$/', $raw ) ) {
-			$segment_ids = self::get_carried_segments_for_account( (int) $raw );
+			// A value reaching here passed the positive-integer gate, so it makes
+			// a real assertion about the reader — including "no segments match"
+			// when the resolved set is empty. Handing that off keeps every valid
+			// arrival authoritative; see set_carried_segments_cookie().
+			self::set_carried_segments_cookie( self::get_carried_segments_for_account( (int) $raw ) );
 		}
-		// Unconditional so each arrival is authoritative — see
-		// set_carried_segments_cookie()'s docblock.
-		self::set_carried_segments_cookie( $segment_ids );
 
-		// This response carries a per-reader Set-Cookie and must never be stored.
+		// This redirect may carry a per-reader Set-Cookie and must never be stored.
 		if ( function_exists( 'batcache_cancel' ) ) {
 			batcache_cancel();
 		}

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -41,53 +41,33 @@ final class Newspack_Popups_Segmentation {
 
 	/**
 	 * Query param appended to newsletter links carrying the reader's account ID.
-	 * Its value is the ESP merge tag for the synced Account field, which the ESP
-	 * substitutes with the recipient's WordPress user ID at send time. On arrival
-	 * the ID is resolved to that reader's last-known matching segments, which
-	 * count as matched for the browsing session — no login required.
+	 * Its value is the ESP merge tag for the synced Account field, substituted
+	 * per recipient at send time. On arrival the ID resolves to the reader's
+	 * last-known matched segments for the browsing session.
 	 *
-	 * This is an unsigned, reader-visible, forgeable signal, and the ID space is
-	 * enumerable: it must only ever drive prompt segmentation, never content
-	 * access, never analytics identity, and never a write to the reader profile.
-	 * Restricted content stays behind the HMAC-signed newsletter pass (see
-	 * Newspack\Newsletters_Access).
+	 * Unsigned, forgeable, and enumerable: drives prompt segmentation only —
+	 * never content access, analytics identity, or reader-profile writes.
 	 *
-	 * Unlike DONOR_SEGMENT_QUERY_PARAM, this param is emitted for every supported
-	 * ESP including ActiveCampaign, whose `%FIELD%` syntax is not URL-safe when
-	 * unsubstituted (NPPM-3032). It is safe here because handle_account_param()
-	 * always redirects the param away before any output, so no consumer that
-	 * percent-decodes query params ever sees it.
+	 * Emitted for every supported ESP, including ActiveCampaign's `%FIELD%`
+	 * syntax (unsafe when unsubstituted, NPPM-3032), because
+	 * handle_account_param() always redirects the param away before any output.
 	 */
 	const ACCOUNT_QUERY_PARAM = 'np_account';
 
 	/**
-	 * Cookie used to hand the resolved segment IDs from the inbound redirect to
-	 * the view script, which moves them into sessionStorage and deletes the
-	 * cookie on first read.
-	 *
-	 * The name must NOT begin with `wp`, `wordpress`, or `comment_author`:
-	 * Batcache skips page cache for any request carrying such a cookie, which
-	 * would defeat the point of redirecting to a shared cacheable URL.
+	 * Cookie handing the resolved segment IDs to the view script, which moves
+	 * them into sessionStorage and deletes the cookie on first read. The name
+	 * must not start with `wp`, `wordpress`, or `comment_author` — Batcache
+	 * skips page cache for requests carrying such cookies.
 	 */
 	const CARRIED_SEGMENTS_COOKIE = 'np_carried_segments';
 
 	/**
-	 * Sentinel cookie value asserting that an account matched no segments —
-	 * distinct from an absent cookie, which means no handoff happened at all.
-	 *
-	 * Never a valid segment ID: segment IDs are always positive-integer term
-	 * IDs (see get_carried_segments_for_account()), so this string can never
-	 * collide with a real one. This can never be an empty string instead:
-	 * PHP's `setcookie()` sends a deletion whenever the *value* is empty,
-	 * ignoring whatever `expires` is passed — confirmed against Apache in
-	 * this project's container. A real browser then deletes the cookie and
-	 * never sends it again, indistinguishable from no handoff ever having
-	 * happened, so the "matches nothing" assertion would silently never
-	 * reach the view script. See get_carried_segments_cookie_value() and
-	 * set_carried_segments_cookie()'s docblocks.
-	 *
-	 * Mirrored in carried-segments.js as CARRIED_SEGMENTS_NONE — keep the two
-	 * in sync.
+	 * Cookie value asserting the account matched no segments, distinct from an
+	 * absent cookie (no handoff). Cannot be an empty string: setcookie() sends a
+	 * deletion for an empty value regardless of `expires`, so the assertion
+	 * would never reach the browser. Never collides with a real segment ID
+	 * (positive-integer term IDs). Mirrored in carried-segments.js — keep in sync.
 	 */
 	const CARRIED_SEGMENTS_NONE = 'none';
 
@@ -139,8 +119,7 @@ final class Newspack_Popups_Segmentation {
 		// the ESP being supported, so it's cheap to register unconditionally.
 		add_filter( 'newspack_newsletters_process_link', [ __CLASS__, 'append_donor_segment_param' ], 30, 3 );
 
-		// Append the reader's account ID to newsletter links so a logged-out click
-		// can be resolved to that reader's last-known segments. Self-guards on the
+		// Append the reader's account ID to newsletter links. Self-guards on the
 		// Account field being synced, so it's cheap to register unconditionally.
 		add_filter( 'newspack_newsletters_process_link', [ __CLASS__, 'append_account_param' ], 30, 3 );
 
@@ -151,9 +130,8 @@ final class Newspack_Popups_Segmentation {
 		// so it runs before redirect_canonical() and before any HTML is generated.
 		add_action( 'template_redirect', [ __CLASS__, 'scrub_unsubstituted_donor_param' ], 1 );
 
-		// Resolve an inbound account ID to the reader's last-known segments and
-		// redirect the param away before any output. Priority 1 so it runs before
-		// redirect_canonical() and before any HTML is generated.
+		// Resolve an inbound account ID to carried segments and redirect the param
+		// away. Priority 1: before redirect_canonical() and any HTML output.
 		add_action( 'template_redirect', [ __CLASS__, 'handle_account_param' ], 1 );
 	}
 
@@ -304,15 +282,10 @@ final class Newspack_Popups_Segmentation {
 		if ( ! self::is_newsletter_post( $post ) ) {
 			return $url;
 		}
-		// Mailchimp's own process_link() filter (priority 10) hands the whole URL
-		// back as a bare merge-tag placeholder for links like *|UNSUB|* and
-		// *|UPDATE_PROFILE|*, and is_first_party_url() reads a host-less string as
-		// first-party. Appending to one produces `*|UNSUB|*?np_seg_donor=...`, which the ESP
-		// expands into an unsubscribe URL that already carries its own query string
-		// — two `?`, a link that no longer works, and unsubscribe is required by law
-		// and by Mailchimp's terms. The anchored match only fires when the entire
-		// URL is a placeholder, so a real URL carrying a merge tag in a query value
-		// is still decorated.
+		// Mailchimp's process_link() (priority 10) can hand back a bare merge-tag
+		// placeholder as the whole URL (e.g. *|UNSUB|*), which is host-less and so
+		// reads as first-party. Decorating it breaks the expanded link. Anchored
+		// match: a real URL carrying a merge tag in a query value still passes.
 		if ( self::is_unsubstituted_merge_tag( $url ) ) {
 			return $url;
 		}
@@ -355,13 +328,9 @@ final class Newspack_Popups_Segmentation {
 
 	/**
 	 * Filter callback: append the reader's account-ID merge tag to first-party
-	 * newsletter links.
-	 *
-	 * Skips when the Newsletters helpers are unavailable, the post isn't a
-	 * newsletter (ad links are proxied separately and wouldn't forward the
-	 * param), the link is third-party, the Account field can't be resolved, or
-	 * the ESP reports no tag for it — which also means the field isn't synced
-	 * there, so there would be nothing to substitute.
+	 * newsletter links. Skips when the required helpers are unavailable, the
+	 * post isn't a newsletter, the link is third-party, or the Account field
+	 * has no resolvable ESP tag (i.e. it isn't synced there).
 	 *
 	 * @param string        $url          Processed URL (may already carry other params).
 	 * @param string        $original_url Original URL before processing.
@@ -370,10 +339,8 @@ final class Newspack_Popups_Segmentation {
 	 * @return string
 	 */
 	public static function append_account_param( $url, $original_url, $post ) {
-		// Guard on methods, not classes: these helpers postdate their classes, so
-		// an older newspack-newsletters or newspack-plugin can satisfy a
-		// class_exists() check while lacking them — calling one would fatal
-		// mid-render and break every newsletter on the site.
+		// method_exists() covers both a missing plugin and version skew; a fatal
+		// here would break newsletter rendering.
 		if ( ! method_exists( '\Newspack_Newsletters\Tracking\Utils', 'get_merge_tag' ) ) {
 			return $url;
 		}
@@ -383,15 +350,10 @@ final class Newspack_Popups_Segmentation {
 		if ( ! self::is_newsletter_post( $post ) ) {
 			return $url;
 		}
-		// Mailchimp's own process_link() filter (priority 10) hands the whole URL
-		// back as a bare merge-tag placeholder for links like *|UNSUB|* and
-		// *|UPDATE_PROFILE|*, and is_first_party_url() reads a host-less string as
-		// first-party. Appending to one produces `*|UNSUB|*?np_account=...`, which the ESP
-		// expands into an unsubscribe URL that already carries its own query string
-		// — two `?`, a link that no longer works, and unsubscribe is required by law
-		// and by Mailchimp's terms. The anchored match only fires when the entire
-		// URL is a placeholder, so a real URL carrying a merge tag in a query value
-		// is still decorated.
+		// Mailchimp's process_link() (priority 10) can hand back a bare merge-tag
+		// placeholder as the whole URL (e.g. *|UNSUB|*), which is host-less and so
+		// reads as first-party. Decorating it breaks the expanded link. Anchored
+		// match: a real URL carrying a merge tag in a query value still passes.
 		if ( self::is_unsubstituted_merge_tag( $url ) ) {
 			return $url;
 		}
@@ -414,47 +376,23 @@ final class Newspack_Popups_Segmentation {
 			return $url;
 		}
 
-		// Deliberately no is_url_safe_merge_tag() guard here, unlike the donor
-		// handler above: an unsubstituted np_account never reaches a consumer
-		// because it's always redirected away before output. Full reasoning is
-		// in the ACCOUNT_QUERY_PARAM docblock.
+		// No is_url_safe_merge_tag() guard, unlike the donor handler: an
+		// unsubstituted np_account is always redirected away before output.
 		return self::append_raw_query_param( $url, self::ACCOUNT_QUERY_PARAM, $merge_tag );
 	}
 
 	/**
-	 * Append a query parameter to a URL with its value left completely raw,
-	 * bypassing add_query_arg().
+	 * Append a query parameter with its value left raw. Not add_query_arg():
+	 * that reparses the URL and urlencode_deep()s values already in it,
+	 * re-encoding another handler's raw merge tag into a form no ESP
+	 * substitutes. The param is inserted before any `#fragment`.
 	 *
-	 * Calling add_query_arg() here would reparse the URL's entire existing
-	 * query string and run urlencode_deep() over every value already in it —
-	 * see the "This re-URL-encodes things that were already in the query
-	 * string" comment at wp-includes/functions.php:1183. On a URL that already
-	 * carries another handler's raw merge tag (e.g.
-	 * append_donor_segment_param()'s np_seg_donor, appended earlier in the same
-	 * newspack_newsletters_process_link chain), that reparse re-encodes it
-	 * right back into a form no ESP substitutes — exactly the corruption this
-	 * helper exists to avoid. Do NOT replace this with add_query_arg(): plain
-	 * string concatenation never looks at the existing query string, so it
-	 * cannot corrupt it.
+	 * The value is not escaped, so it must not contain `&`, `=`, or `#`. ESP
+	 * merge-tag syntaxes use none of them.
 	 *
-	 * Fragment-aware: the param is inserted before a `#fragment` rather than
-	 * after, so `/post/#section` becomes `/post/?np_account=TAG#section`
-	 * instead of the unparseable `/post/#section?np_account=TAG`.
-	 *
-	 * Because $value is concatenated in raw, with no urlencode(), the caller
-	 * must guarantee it contains none of `&`, `=`, or `#`: unlike
-	 * add_query_arg(), nothing here escapes them. A `&` would start a bogus
-	 * extra param, truncating this one; a `#` would start a bogus fragment,
-	 * truncating the query string; and a bare `=` is not spec-safe inside a
-	 * query value even where a particular parser happens to tolerate it. Every
-	 * current caller passes an ESP merge tag (e.g. `*|TAG|*`, `%TAG%`), whose
-	 * delimiter syntaxes don't use any of the three.
-	 *
-	 * @param string $url   URL to append to; may already carry a query string
-	 *                      and/or a fragment.
+	 * @param string $url   URL, possibly with a query string and/or fragment.
 	 * @param string $param Parameter name.
-	 * @param string $value Raw (unencoded) parameter value. Must not contain
-	 *                      `&`, `=`, or `#` — see above.
+	 * @param string $value Raw parameter value; must not contain `&`, `=`, or `#`.
 	 *
 	 * @return string
 	 */
@@ -470,11 +408,9 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
-	 * The prefixed ESP field name carrying the reader's account ID.
-	 *
-	 * The raw metadata key differs by schema version — 'Account' in v1, 'account'
-	 * in legacy — and the prefix is configurable per integration, so resolve
-	 * through Metadata::get_key() rather than hardcoding 'NP_Account'.
+	 * The prefixed ESP field name carrying the reader's account ID. The raw key
+	 * is 'Account' in the v1 metadata schema and 'account' in legacy, and the
+	 * prefix is configurable, so resolve through Metadata::get_key().
 	 *
 	 * @return string Prefixed field name, or '' when unresolvable.
 	 */
@@ -489,11 +425,9 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
-	 * Ask the connected ESP for its merge-tag name for a synced field.
-	 *
-	 * The tag is not derivable from the field name: ActiveCampaign generates a
-	 * perstag an admin can rename, and Mailchimp assigns its own tag per
-	 * audience — hence the newsletter's send list.
+	 * The connected ESP's merge-tag name for a synced field. Not derivable from
+	 * the field name: ActiveCampaign perstags can be renamed, and Mailchimp
+	 * assigns tags per audience — hence the newsletter's send list.
 	 *
 	 * @param string   $field_name Prefixed ESP field name.
 	 * @param \WP_Post $post       Newsletter post.
@@ -660,15 +594,8 @@ final class Newspack_Popups_Segmentation {
 
 	/**
 	 * A reader's last-known matching segment IDs, filtered to the site's active
-	 * segments — not the narrower set the inserter actually ships to the
-	 * browser (see class-newspack-popups-inserter.php), which also requires
-	 * non-empty criteria. A surplus ID here just matches nothing, so the
-	 * difference is harmless.
-	 *
-	 * The snapshot is client-asserted and only as fresh as the reader's last
-	 * visit — deliberately uncapped, so a dormant reader can be matched on old
-	 * evidence. IDs the browser doesn't know about would never match anything,
-	 * so they're dropped here rather than carried.
+	 * segments. The snapshot is client-asserted and only as fresh as the
+	 * reader's last visit; no age cap by design.
 	 *
 	 * @param int $account_id WordPress user ID from the inbound param.
 	 *
@@ -684,11 +611,7 @@ final class Newspack_Popups_Segmentation {
 			return [];
 		}
 
-		// The snapshot is client-asserted (see docblock above), so guard against a
-		// shape strval() would mishandle below: a nested array raises "Array to
-		// string conversion". A real segment ID is only ever an int or a numeric
-		// string. Unreachable through the real Reader_Data::get_matched_segments(),
-		// which already filters non-scalars — this is defence in depth.
+		// Client-asserted input: drop shapes strval() below would mishandle.
 		$snapshot = array_filter(
 			$snapshot,
 			function ( $value ) {
@@ -707,99 +630,45 @@ final class Newspack_Popups_Segmentation {
 	}
 
 	/**
-	 * The `setcookie()` options for the carried-segments cookie.
+	 * The setcookie() options for the carried-segments cookie. Extracted so
+	 * tests can reach these values — the setcookie() call itself never runs
+	 * under PHPUnit, where headers are already sent.
 	 *
-	 * Extracted purely so these values are reachable from a test:
-	 * set_carried_segments_cookie()'s own `setcookie()` call only runs when
-	 * `! headers_sent()`, which is never true under PHPUnit, so without this
-	 * extraction none of these option values would be exercised by any test in
-	 * the suite — e.g. an `httponly => true` typo would silently break the
-	 * view script's document.cookie read, and every other test would still
-	 * pass.
-	 *
-	 * Always a session cookie (`expires => 0`). That alone does not guarantee
-	 * a "matches nothing" resolution is ever delivered, though: PHP's
-	 * `setcookie()` sends a deletion whenever the cookie's *value* is empty,
-	 * regardless of the `expires` passed here — confirmed against Apache in
-	 * this project's container. Keeping the value non-empty is
-	 * get_carried_segments_cookie_value()'s job, not this method's; the two
-	 * only work together. See set_carried_segments_cookie()'s docblock.
-	 *
-	 * @return array `setcookie()`'s `$options` argument.
+	 * @return array setcookie() `$options` argument.
 	 */
 	private static function get_carried_segments_cookie_options(): array {
 		return [
 			'expires'  => 0,
 			'path'     => '/',
 			'secure'   => is_ssl(),
-			// Must stay readable by the view script; this is a segmentation
-			// hint, never a credential.
+			// Readable by the view script; a segmentation hint, not a credential.
 			'httponly' => false,
 			'samesite' => 'Lax',
 		];
 	}
 
 	/**
-	 * The carried-segments cookie *value* for a resolved set of segment IDs.
+	 * The cookie value for a resolved segment set. Never an empty string:
+	 * setcookie() sends a deletion for an empty value regardless of `expires`,
+	 * so "matches nothing" would never reach the browser. An empty set becomes
+	 * the CARRIED_SEGMENTS_NONE sentinel instead.
 	 *
-	 * Extracted into its own seam so it's reachable directly from a test:
-	 * set_carried_segments_cookie()'s own `setcookie()` call never runs under
-	 * PHPUnit (`headers_sent()` is always true there), so a test that only
-	 * exercises that method and inspects the $_COOKIE mirror can prove what
-	 * ends up in PHP's superglobal, but not what a real browser's Set-Cookie
-	 * header would actually carry — the exact gap that let this cookie ship
-	 * as a real-browser deletion twice under review.
+	 * @param string[] $segment_ids Active segment IDs; empty asserts no matches.
 	 *
-	 * Never empty: PHP's `setcookie()` treats an empty string value as a
-	 * request to delete the cookie, no matter what `expires` is passed (see
-	 * get_carried_segments_cookie_options()'s docblock) — a real browser then
-	 * never delivers the "matches nothing" assertion at all. CARRIED_SEGMENTS_NONE
-	 * is the non-empty sentinel used instead; it can never collide with a real
-	 * segment ID, which is always a positive integer term ID.
-	 *
-	 * @param string[] $segment_ids Active segment IDs; an empty array asserts
-	 *                               that the account matches no segments.
-	 *
-	 * @return string Comma-joined segment IDs, or CARRIED_SEGMENTS_NONE when
-	 *                $segment_ids is empty.
+	 * @return string Comma-joined IDs, or CARRIED_SEGMENTS_NONE.
 	 */
 	private static function get_carried_segments_cookie_value( array $segment_ids ): string {
 		return empty( $segment_ids ) ? self::CARRIED_SEGMENTS_NONE : implode( ',', $segment_ids );
 	}
 
 	/**
-	 * Hand the resolved segment IDs to the view script. An empty array is a
-	 * real assertion — "this account matches no segments" — and must reach
-	 * the browser as such, not as a deleted cookie.
+	 * Hand the resolved segment IDs to the view script in a session cookie.
+	 * Every call is authoritative: an empty set overwrites a previous arrival's
+	 * segments with the "matches nothing" sentinel rather than deleting the
+	 * cookie. Callers must skip values that never passed the account-ID gate —
+	 * those assert nothing about the reader.
 	 *
-	 * A session cookie, readable by JavaScript (the view script moves it into
-	 * sessionStorage and deletes it on first read) and named so Batcache does not
-	 * treat it as a cache-bypass signal — see CARRIED_SEGMENTS_COOKIE.
-	 *
-	 * Called for every arrival whose np_account value passes the
-	 * positive-integer gate (see handle_account_param()), so each such arrival
-	 * is authoritative — including overriding a previous arrival's segments
-	 * when this one resolves none. The cookie is always written with the same
-	 * session-lifetime options (see get_carried_segments_cookie_options()),
-	 * and the value written is never an empty string (see
-	 * get_carried_segments_cookie_value()): PHP's `setcookie()` sends a
-	 * deletion whenever the value is empty, no matter what `expires` is
-	 * passed, so a real browser would then never deliver the "matches
-	 * nothing" assertion at all — the view script would fall through to
-	 * whatever a previous arrival already left in sessionStorage, silently
-	 * keeping a stale, previously-matched segment set alive for the rest of
-	 * the session. The view script deletes the cookie on first read, but on
-	 * an arrival where that script never runs (a page with no prompts, JS
-	 * disabled), a previous arrival's segments would otherwise carry into the
-	 * next click.
-	 *
-	 * Not called at all for a value that never passed the gate: such a value
-	 * makes no assertion about the reader — e.g. an unsubstituted merge tag
-	 * from an already-delivered newsletter — so an existing carried set is left
-	 * alone rather than overwritten.
-	 *
-	 * @param string[] $segment_ids Active segment IDs; an empty array asserts
-	 *                              that the account matches no segments.
+	 * @param string[] $segment_ids Active segment IDs; empty asserts no matches.
 	 */
 	private static function set_carried_segments_cookie( $segment_ids ) {
 		$value = self::get_carried_segments_cookie_value( $segment_ids );
@@ -811,12 +680,8 @@ final class Newspack_Popups_Segmentation {
 				self::get_carried_segments_cookie_options()
 			);
 		}
-		// Unconditionally update $_COOKIE so same-request readers (and tests, where
-		// headers are already sent) see the same assertion a real browser would
-		// receive — including the CARRIED_SEGMENTS_NONE sentinel when nothing
-		// resolved, rather than an empty string (which setcookie() above would
-		// have sent as a deletion) or unsetting it (indistinguishable from no
-		// handoff at all).
+		// Mirror in $_COOKIE so same-request readers (and tests, where headers are
+		// already sent) see the same value a browser would receive.
 		$_COOKIE[ self::CARRIED_SEGMENTS_COOKIE ] = $value; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 	}
 
@@ -824,25 +689,15 @@ final class Newspack_Popups_Segmentation {
 	 * Action callback: resolve an inbound account ID to carried segments, hand
 	 * them off in a cookie, and redirect to the clean URL.
 	 *
-	 * The redirect is unconditional whenever the param is present, whether or not
-	 * anything resolved. That is what keeps the landing page a shared cacheable
-	 * URL — a per-reader query param would make every newsletter click a cache
-	 * miss during a send — and it is why this param is safe to emit for
-	 * ActiveCampaign: an unsubstituted `%FIELD%` is a malformed percent-escape
-	 * that throws in strict client-side decoders (NPPM-3032), and it never
-	 * survives into a rendered page.
-	 *
-	 * Only a plain positive integer is accepted. That single rule rejects every
-	 * unsubstituted merge-tag shape at once, so unlike
-	 * scrub_unsubstituted_donor_param() there is no need to inspect the raw,
-	 * still-encoded query string. Unlike the redirect, the cookie handoff below
-	 * is conditional on this gate: a value that fails it makes no assertion
-	 * about the reader, so it must not overwrite an existing carried set — see
-	 * set_carried_segments_cookie()'s docblock.
+	 * The redirect is unconditional whenever the param is present: it keeps the
+	 * landing page a shared cacheable URL, and it is what makes ActiveCampaign's
+	 * `%FIELD%` syntax safe to emit at all (NPPM-3032) — the param never
+	 * survives into a rendered page. Only a plain positive integer is accepted;
+	 * that one rule rejects every unsubstituted merge-tag shape. The cookie
+	 * handoff is conditional on that gate, the redirect is not.
 	 */
 	public static function handle_account_param() {
-		// Redirecting a POST would discard its body, and a redirect is only
-		// meaningful for a document request in a browser.
+		// Redirecting a POST would discard its body.
 		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
 			return;
 		}
@@ -857,10 +712,8 @@ final class Newspack_Popups_Segmentation {
 
 		$raw = sanitize_text_field( wp_unslash( $_GET[ self::ACCOUNT_QUERY_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( 1 === preg_match( '/^[1-9][0-9]*$/', $raw ) ) {
-			// A value reaching here passed the positive-integer gate, so it makes
-			// a real assertion about the reader — including "no segments match"
-			// when the resolved set is empty. Handing that off keeps every valid
-			// arrival authoritative; see set_carried_segments_cookie().
+			// Gate passed, so the value asserts something real — including "no
+			// segments" when the resolved set is empty.
 			self::set_carried_segments_cookie( self::get_carried_segments_for_account( (int) $raw ) );
 		}
 

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -40,6 +40,27 @@ final class Newspack_Popups_Segmentation {
 	const DONOR_SEGMENT_QUERY_PARAM = 'np_seg_donor';
 
 	/**
+	 * Query param appended to newsletter links carrying the reader's account ID.
+	 * Its value is the ESP merge tag for the synced Account field, which the ESP
+	 * substitutes with the recipient's WordPress user ID at send time. On arrival
+	 * the ID is resolved to that reader's last-known matching segments, which
+	 * count as matched for the browsing session — no login required.
+	 *
+	 * This is an unsigned, reader-visible, forgeable signal, and the ID space is
+	 * enumerable: it must only ever drive prompt segmentation, never content
+	 * access, never analytics identity, and never a write to the reader profile.
+	 * Restricted content stays behind the HMAC-signed newsletter pass (see
+	 * Newspack\Newsletters_Access).
+	 *
+	 * Unlike DONOR_SEGMENT_QUERY_PARAM, this param is emitted for every supported
+	 * ESP including ActiveCampaign, whose `%FIELD%` syntax is not URL-safe when
+	 * unsubstituted (NPPM-3032). It is safe here because handle_account_param()
+	 * always redirects the param away before any output, so no consumer that
+	 * percent-decodes query params ever sees it.
+	 */
+	const ACCOUNT_QUERY_PARAM = 'np_account';
+
+	/**
 	 * Installed version number of the custom table.
 	 */
 	const TABLE_VERSION = '1.0';
@@ -86,6 +107,11 @@ final class Newspack_Popups_Segmentation {
 		// The handler self-guards on the donor merge field being configured and
 		// the ESP being supported, so it's cheap to register unconditionally.
 		add_filter( 'newspack_newsletters_process_link', [ __CLASS__, 'append_donor_segment_param' ], 30, 3 );
+
+		// Append the reader's account ID to newsletter links so a logged-out click
+		// can be resolved to that reader's last-known segments. Self-guards on the
+		// Account field being synced, so it's cheap to register unconditionally.
+		add_filter( 'newspack_newsletters_process_link', [ __CLASS__, 'append_account_param' ], 30, 3 );
 
 		// Strip unsubstituted donor merge tags from inbound URLs. Newsletters
 		// already delivered carry tags this plugin can no longer stop emitting, and
@@ -277,6 +303,104 @@ final class Newspack_Popups_Segmentation {
 		// Restore the raw tag so the ESP substitutes the recipient's value at send
 		// time. An unsubstituted literal is ignored client-side, so this stays fail-safe.
 		return str_replace( urlencode( $merge_tag ), $merge_tag, $url );
+	}
+
+	/**
+	 * Filter callback: append the reader's account-ID merge tag to first-party
+	 * newsletter links.
+	 *
+	 * Skips when the Newsletters helpers are unavailable, the post isn't a
+	 * newsletter (ad links are proxied separately and wouldn't forward the
+	 * param), the link is third-party, the Account field can't be resolved, or
+	 * the ESP reports no tag for it — which also means the field isn't synced
+	 * there, so there would be nothing to substitute.
+	 *
+	 * @param string        $url          Processed URL (may already carry other params).
+	 * @param string        $original_url Original URL before processing.
+	 * @param \WP_Post|null $post         Newsletter post object, or null.
+	 *
+	 * @return string
+	 */
+	public static function append_account_param( $url, $original_url, $post ) {
+		// Guard on methods, not classes: these helpers postdate their classes, so
+		// an older newspack-newsletters or newspack-plugin can satisfy a
+		// class_exists() check while lacking them — calling one would fatal
+		// mid-render and break every newsletter on the site.
+		if ( ! method_exists( '\Newspack_Newsletters\Tracking\Utils', 'get_merge_tag' ) ) {
+			return $url;
+		}
+		if ( ! method_exists( '\Newspack\Reader_Activation\Sync\Metadata', 'get_key' ) ) {
+			return $url;
+		}
+		if ( ! self::is_newsletter_post( $post ) ) {
+			return $url;
+		}
+		if ( ! self::is_first_party_url( $url ) ) {
+			return $url;
+		}
+
+		$field_name = self::get_account_field_name();
+		if ( '' === $field_name ) {
+			return $url;
+		}
+
+		$tag_name = self::get_esp_field_tag_name( $field_name, $post );
+		if ( '' === $tag_name ) {
+			return $url;
+		}
+
+		$merge_tag = \Newspack_Newsletters\Tracking\Utils::get_merge_tag( $tag_name );
+		if ( empty( $merge_tag ) ) {
+			return $url;
+		}
+
+		$url = add_query_arg( self::ACCOUNT_QUERY_PARAM, $merge_tag, $url );
+		// add_query_arg() URL-encodes the value, but ESPs substitute only the raw
+		// merge-tag syntax. Restore the raw tag so the ESP resolves it.
+		return str_replace( urlencode( $merge_tag ), $merge_tag, $url );
+	}
+
+	/**
+	 * The prefixed ESP field name carrying the reader's account ID.
+	 *
+	 * The raw metadata key differs by schema version — 'Account' in v1, 'account'
+	 * in legacy — and the prefix is configurable per integration, so resolve
+	 * through Metadata::get_key() rather than hardcoding 'NP_Account'.
+	 *
+	 * @return string Prefixed field name, or '' when unresolvable.
+	 */
+	private static function get_account_field_name() {
+		foreach ( [ 'Account', 'account' ] as $raw_key ) {
+			$key = \Newspack\Reader_Activation\Sync\Metadata::get_key( $raw_key );
+			if ( ! empty( $key ) ) {
+				return (string) $key;
+			}
+		}
+		return '';
+	}
+
+	/**
+	 * Ask the connected ESP for its merge-tag name for a synced field.
+	 *
+	 * The tag is not derivable from the field name: ActiveCampaign generates a
+	 * perstag an admin can rename, and Mailchimp assigns its own tag per
+	 * audience — hence the newsletter's send list.
+	 *
+	 * @param string   $field_name Prefixed ESP field name.
+	 * @param \WP_Post $post       Newsletter post.
+	 *
+	 * @return string Tag name, or '' when unresolvable.
+	 */
+	private static function get_esp_field_tag_name( $field_name, $post ) {
+		if ( ! method_exists( '\Newspack_Newsletters', 'get_service_provider' ) ) {
+			return '';
+		}
+		$provider = \Newspack_Newsletters::get_service_provider();
+		if ( empty( $provider ) || ! method_exists( $provider, 'get_field_merge_tag_name' ) ) {
+			return '';
+		}
+		$list_id = (string) get_post_meta( $post->ID, 'send_list_id', true );
+		return (string) $provider->get_field_merge_tag_name( $field_name, '' === $list_id ? null : $list_id );
 	}
 
 	/**

--- a/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-segmentation.php
@@ -61,6 +61,17 @@ final class Newspack_Popups_Segmentation {
 	const ACCOUNT_QUERY_PARAM = 'np_account';
 
 	/**
+	 * Cookie used to hand the resolved segment IDs from the inbound redirect to
+	 * the view script, which moves them into sessionStorage and deletes the
+	 * cookie on first read.
+	 *
+	 * The name must NOT begin with `wp`, `wordpress`, or `comment_author`:
+	 * Batcache skips page cache for any request carrying such a cookie, which
+	 * would defeat the point of redirecting to a shared cacheable URL.
+	 */
+	const CARRIED_SEGMENTS_COOKIE = 'np_carried_segments';
+
+	/**
 	 * Installed version number of the custom table.
 	 */
 	const TABLE_VERSION = '1.0';
@@ -119,6 +130,11 @@ final class Newspack_Popups_Segmentation {
 		// consumers which decode query params strictly — see NPPM-3032. Priority 1
 		// so it runs before redirect_canonical() and before any HTML is generated.
 		add_action( 'template_redirect', [ __CLASS__, 'scrub_unsubstituted_donor_param' ], 1 );
+
+		// Resolve an inbound account ID to the reader's last-known segments and
+		// redirect the param away before any output. Priority 1 so it runs before
+		// redirect_canonical() and before any HTML is generated.
+		add_action( 'template_redirect', [ __CLASS__, 'handle_account_param' ], 1 );
 	}
 
 	/**
@@ -586,6 +602,126 @@ final class Newspack_Popups_Segmentation {
 			}
 		}
 		return '';
+	}
+
+	/**
+	 * A reader's last-known matching segment IDs, filtered to segments this site
+	 * still ships to the browser.
+	 *
+	 * The snapshot is client-asserted and only as fresh as the reader's last
+	 * visit — deliberately uncapped, so a dormant reader can be matched on old
+	 * evidence. IDs the browser doesn't know about would never match anything,
+	 * so they're dropped here rather than carried.
+	 *
+	 * @param int $account_id WordPress user ID from the inbound param.
+	 *
+	 * @return string[] Active segment IDs as strings.
+	 */
+	public static function get_carried_segments_for_account( int $account_id ): array {
+		if ( $account_id < 1 || ! method_exists( '\Newspack\Reader_Data', 'get_matched_segments' ) ) {
+			return [];
+		}
+
+		$snapshot = \Newspack\Reader_Data::get_matched_segments( $account_id );
+		if ( empty( $snapshot ) || ! is_array( $snapshot ) ) {
+			return [];
+		}
+
+		$active = [];
+		foreach ( self::get_segments( false ) as $segment ) {
+			if ( ! empty( $segment['id'] ) ) {
+				$active[] = (string) $segment['id'];
+			}
+		}
+
+		return array_values( array_intersect( array_map( 'strval', $snapshot ), $active ) );
+	}
+
+	/**
+	 * Hand the resolved segment IDs to the view script.
+	 *
+	 * A session cookie, readable by JavaScript (the view script moves it into
+	 * sessionStorage and deletes it on first read) and named so Batcache does not
+	 * treat it as a cache-bypass signal — see CARRIED_SEGMENTS_COOKIE.
+	 *
+	 * @param string[] $segment_ids Active segment IDs.
+	 */
+	private static function set_carried_segments_cookie( $segment_ids ) {
+		$value = implode( ',', $segment_ids );
+		if ( ! headers_sent() ) {
+			// phpcs:ignore WordPressVIPMinimum.Functions.RestrictedFunctions.cookies_setcookie
+			setcookie(
+				self::CARRIED_SEGMENTS_COOKIE,
+				$value,
+				[
+					'expires'  => 0,
+					'path'     => '/',
+					'secure'   => is_ssl(),
+					// Must stay readable by the view script; this is a segmentation
+					// hint, never a credential.
+					'httponly' => false,
+					'samesite' => 'Lax',
+				]
+			);
+		}
+		// Unconditionally update $_COOKIE so same-request readers (and tests, where
+		// headers are already sent) can see the handoff.
+		$_COOKIE[ self::CARRIED_SEGMENTS_COOKIE ] = $value; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+	}
+
+	/**
+	 * Action callback: resolve an inbound account ID to carried segments, hand
+	 * them off in a cookie, and redirect to the clean URL.
+	 *
+	 * The redirect is unconditional whenever the param is present, whether or not
+	 * anything resolved. That is what keeps the landing page a shared cacheable
+	 * URL — a per-reader query param would make every newsletter click a cache
+	 * miss during a send — and it is why this param is safe to emit for
+	 * ActiveCampaign: an unsubstituted `%FIELD%` is a malformed percent-escape
+	 * that throws in strict client-side decoders (NPPM-3032), and it never
+	 * survives into a rendered page.
+	 *
+	 * Only a plain positive integer is accepted. That single rule rejects every
+	 * unsubstituted merge-tag shape at once, so unlike
+	 * scrub_unsubstituted_donor_param() there is no need to inspect the raw,
+	 * still-encoded query string.
+	 */
+	public static function handle_account_param() {
+		// Redirecting a POST would discard its body, and a redirect is only
+		// meaningful for a document request in a browser.
+		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
+			return;
+		}
+		if ( ! isset( $_SERVER['REQUEST_URI'] ) ) {
+			return;
+		}
+		// Reading a URL param to decide where to redirect; there is no form
+		// submission or state change here to nonce-verify.
+		if ( ! isset( $_GET[ self::ACCOUNT_QUERY_PARAM ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			return;
+		}
+
+		$raw = sanitize_text_field( wp_unslash( $_GET[ self::ACCOUNT_QUERY_PARAM ] ) ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( 1 === preg_match( '/^[1-9][0-9]*$/', $raw ) ) {
+			$segment_ids = self::get_carried_segments_for_account( (int) $raw );
+			if ( ! empty( $segment_ids ) ) {
+				self::set_carried_segments_cookie( $segment_ids );
+			}
+		}
+
+		// This response carries a per-reader Set-Cookie and must never be stored.
+		if ( function_exists( 'batcache_cancel' ) ) {
+			batcache_cancel();
+		}
+		nocache_headers();
+
+		$clean_url = remove_query_arg(
+			self::ACCOUNT_QUERY_PARAM,
+			esc_url_raw( wp_unslash( $_SERVER['REQUEST_URI'] ) )
+		);
+		// Temporary: the param is a property of this one link, not of the page.
+		wp_safe_redirect( $clean_url, 302 );
+		exit;
 	}
 
 	/**

--- a/plugins/newspack-popups/src/view/segmentation.js
+++ b/plugins/newspack-popups/src/view/segmentation.js
@@ -28,8 +28,15 @@ export const handleSegmentation = prompts => {
 		// matching is live, so a snapshot from their last visit can only make it
 		// staler — and their own matched_segments write must stay criteria-only.
 		const carriedIds = getCarriedSegmentIds( Object.keys( segments ) );
-		const carried = ras?.store?.get( 'reader' )?.authenticated ? [] : carriedIds;
-		const matchingSegment = getBestPrioritySegment( segments, null, carried );
+		// Re-read the authenticated flag fresh each time this is called, rather
+		// than freezing it in a variable: RAS's setAuthenticated() can flip a
+		// reader to authenticated mid-page with no reload, and a delayed or
+		// scroll-triggered prompt's unhide() re-check (below) must see that
+		// change even though it runs long after this function returns. Reuses
+		// carriedIds itself rather than calling getCarriedSegmentIds() again —
+		// it already consumed the cookie, so a second call would find nothing.
+		const getCarried = () => ( ras?.store?.get( 'reader' )?.authenticated ? [] : carriedIds );
+		const matchingSegment = getBestPrioritySegment( segments, null, getCarried() );
 		debug( 'matchingSegment', matchingSegment );
 
 		// Register segments and set match via RAS if available.
@@ -71,8 +78,12 @@ export const handleSegmentation = prompts => {
 				};
 				const unhide = () => {
 					// Conditions may have changed since the prompt was delayed.
-					// Verify whether the prompt can still be displayed.
-					const updatedMatchingSegment = getBestPrioritySegment( segments, null, carried );
+					// Verify whether the prompt can still be displayed. Re-derive the
+					// carried set here (via getCarried()) rather than closing over the
+					// value computed above: a reader who authenticates mid-delay must
+					// have their live matching win over a stale carried snapshot even
+					// for a prompt that was already pending when that happened.
+					const updatedMatchingSegment = getBestPrioritySegment( segments, null, getCarried() );
 					if ( ras?.segments ) {
 						ras.segments.setMatch( updatedMatchingSegment );
 					}

--- a/plugins/newspack-popups/src/view/segmentation.js
+++ b/plugins/newspack-popups/src/view/segmentation.js
@@ -24,18 +24,13 @@ export const handleSegmentation = prompts => {
 			return;
 		}
 		const segments = newspack_popups_view?.segments || {};
-		// Always consume the handoff, so the cookie is cleared even for a reader
-		// whose carried IDs are then discarded. A signed-in reader's local
-		// matching is live, so a snapshot from their last visit can only make it
-		// staler — and their own matched_segments write must stay criteria-only.
+		// Always consume the handoff so the cookie is cleared even when the IDs
+		// are then discarded: a signed-in reader's live matching wins over any
+		// carried snapshot.
 		const carriedIds = getCarriedSegmentIds( Object.keys( segments ) );
-		// Re-read the authenticated flag fresh each time this is called, rather
-		// than freezing it in a variable: RAS's setAuthenticated() can flip a
-		// reader to authenticated mid-page with no reload, and a delayed or
-		// scroll-triggered prompt's unhide() re-check (below) must see that
-		// change even though it runs long after this function returns. Reuses
-		// carriedIds itself rather than calling getCarriedSegmentIds() again —
-		// it already consumed the cookie, so a second call would find nothing.
+		// Re-read the authenticated flag on every call: RAS can authenticate a
+		// reader mid-page, and a delayed prompt's unhide() re-check must see it.
+		// Reuses carriedIds — the cookie is already consumed.
 		const getCarried = () => ( ras?.store?.get( 'reader' )?.authenticated ? [] : carriedIds );
 		const matchingSegment = getBestPrioritySegment( segments, null, getCarried() );
 		debug( 'matchingSegment', matchingSegment );

--- a/plugins/newspack-popups/src/view/segmentation.js
+++ b/plugins/newspack-popups/src/view/segmentation.js
@@ -11,6 +11,7 @@ import {
 	shouldPromptBeDisplayed,
 	syncMatchedSegments,
 } from './utils';
+import { getCarriedSegmentIds } from './utils/carried-segments';
 
 /**
  * Match reader to segments.
@@ -22,7 +23,13 @@ export const handleSegmentation = prompts => {
 			return;
 		}
 		const segments = newspack_popups_view?.segments || {};
-		const matchingSegment = getBestPrioritySegment( segments );
+		// Always consume the handoff, so the cookie is cleared even for a reader
+		// whose carried IDs are then discarded. A signed-in reader's local
+		// matching is live, so a snapshot from their last visit can only make it
+		// staler — and their own matched_segments write must stay criteria-only.
+		const carriedIds = getCarriedSegmentIds( Object.keys( segments ) );
+		const carried = ras?.store?.get( 'reader' )?.authenticated ? [] : carriedIds;
+		const matchingSegment = getBestPrioritySegment( segments, null, carried );
 		debug( 'matchingSegment', matchingSegment );
 
 		// Register segments and set match via RAS if available.
@@ -65,7 +72,7 @@ export const handleSegmentation = prompts => {
 				const unhide = () => {
 					// Conditions may have changed since the prompt was delayed.
 					// Verify whether the prompt can still be displayed.
-					const updatedMatchingSegment = getBestPrioritySegment( segments );
+					const updatedMatchingSegment = getBestPrioritySegment( segments, null, carried );
 					if ( ras?.segments ) {
 						ras.segments.setMatch( updatedMatchingSegment );
 					}

--- a/plugins/newspack-popups/src/view/segmentation.test.js
+++ b/plugins/newspack-popups/src/view/segmentation.test.js
@@ -1,0 +1,113 @@
+/**
+ * Tests for the authenticated gate on carried segment IDs staying live
+ * across a delayed prompt re-check.
+ *
+ * The carried set and the `authenticated` check both used to be computed
+ * once in maybeDisplayPrompts() and closed over by the delayed unhide()
+ * path. RAS's setAuthenticated() can flip a reader to authenticated mid-page
+ * with no reload, so a still-pending delayed or scroll-triggered prompt's
+ * re-check must reflect that change — a signed-in reader's live matching
+ * always wins over a carried snapshot from a previous, logged-out visit.
+ *
+ * ./utils and ./utils/carried-segments are mocked so this test isolates
+ * segmentation.js's own closure/gating logic from the deeper segment-match
+ * and cookie-parsing logic those modules already cover in their own tests
+ * (segments.test.js, carried-segments.test.js).
+ */
+
+jest.mock( './utils', () => ( {
+	debug: jest.fn(),
+	closeOverlay: jest.fn(),
+	getBestPrioritySegment: jest.fn( () => null ),
+	getIntersectionObserver: jest.fn(),
+	getRawId: jest.fn( () => 1 ),
+	getOverride: jest.fn( () => null ),
+	handleSeen: jest.fn(),
+	shouldPromptBeDisplayed: jest.fn( () => true ),
+	syncMatchedSegments: jest.fn(),
+} ) );
+
+jest.mock( './utils/carried-segments', () => ( {
+	getCarriedSegmentIds: jest.fn( () => [ '5' ] ),
+} ) );
+
+import { getBestPrioritySegment } from './utils';
+import { handleSegmentation } from './segmentation';
+
+const testSegments = { s1: {} };
+
+/**
+ * An overlay prompt that displays on a delay rather than immediately, so its
+ * re-check in unhide() runs after a setTimeout — the only path this bug can
+ * reach. (A non-overlay prompt calls unhide() synchronously and never
+ * re-checks; see handleSegmentation()'s forEach.)
+ *
+ * @param {string} delay Milliseconds to delay, as the data-delay attribute expects.
+ * @return {HTMLElement} Prompt element.
+ */
+const createDelayedOverlayPrompt = ( delay = '1000' ) => {
+	const prompt = document.createElement( 'div' );
+	prompt.setAttribute( 'id', 'id_1' );
+	prompt.setAttribute( 'data-delay', delay );
+	prompt.classList.add( 'newspack-lightbox', 'hidden' );
+	return prompt;
+};
+
+/**
+ * A minimal RAS stand-in whose 'reader' record is a single mutable object —
+ * standing in for RAS's real store, where setAuthenticated() mutates the
+ * same record callers already hold a reference to, with no reload.
+ *
+ * @param {boolean} authenticated Initial authenticated state.
+ * @return {{ras: Object, reader: Object}} The mock RAS object and its mutable reader record.
+ */
+const createMockRas = authenticated => {
+	const reader = { authenticated };
+	const ras = {
+		store: {
+			get: key => ( 'reader' === key ? reader : undefined ),
+		},
+	};
+	return { ras, reader };
+};
+
+describe( 'handleSegmentation authenticated gate on carried IDs', () => {
+	beforeEach( () => {
+		window.newspackRAS = [];
+		window.newspack_popups_view = { segments: testSegments };
+		getBestPrioritySegment.mockClear();
+		jest.useFakeTimers();
+	} );
+
+	afterEach( () => {
+		jest.useRealTimers();
+	} );
+
+	it( 're-reads the authenticated flag when a delayed prompt re-checks, dropping carried IDs if RAS authenticated mid-delay', () => {
+		const prompt = createDelayedOverlayPrompt( '1000' );
+		handleSegmentation( [ prompt ] );
+
+		// RAS becomes ready and pushes the reader in as logged out — the state
+		// a still-anonymous visitor has when the prompt is first evaluated and
+		// its display delayed.
+		const { ras, reader } = createMockRas( false );
+		const maybeDisplayPrompts = window.newspackRAS[ 0 ];
+		maybeDisplayPrompts( ras );
+
+		// Initial, synchronous evaluation: not yet authenticated, so the
+		// carried snapshot from the newsletter click applies.
+		expect( getBestPrioritySegment ).toHaveBeenLastCalledWith( testSegments, null, [ '5' ] );
+
+		// RAS authenticates the reader mid-page — e.g. a magic-link or OTP
+		// completion — with no reload, while the prompt is still pending its
+		// delay.
+		reader.authenticated = true;
+		jest.advanceTimersByTime( 1000 );
+
+		// The delayed re-check must reflect the reader's now-live authenticated
+		// state and drop the carried snapshot, not reuse the frozen,
+		// pre-authentication value.
+		expect( getBestPrioritySegment ).toHaveBeenCalledTimes( 2 );
+		expect( getBestPrioritySegment ).toHaveBeenLastCalledWith( testSegments, null, [] );
+	} );
+} );

--- a/plugins/newspack-popups/src/view/utils/carried-segments.js
+++ b/plugins/newspack-popups/src/view/utils/carried-segments.js
@@ -1,38 +1,22 @@
 /**
- * Segment IDs carried in from a newsletter click.
+ * Segment IDs carried in from a newsletter click. The server resolves the
+ * account ID in the link to the reader's last-known matched segments and hands
+ * them off in a cookie; this module reads the cookie once, remembers the IDs in
+ * sessionStorage for the rest of the session, and deletes the cookie.
  *
- * A logged-out reader arriving from a newsletter is resolved server-side (from
- * the account ID the ESP substituted into the link) to their last-known matching
- * segments, handed to this script in a cookie, and redirected to the clean URL.
- * This module takes that handoff: it reads the cookie once, remembers the IDs in
- * sessionStorage so they keep applying as the reader navigates on, and deletes
- * the cookie so no later request carries it.
- *
- * These IDs are segmentation-only and transient. They are never written to the
- * persisted reader-data store — doing so would launder a forgeable,
- * link-supplied value into the snapshot the server trusts — and they never grant
- * content access.
+ * Segmentation-only and transient: never written to the reader-data store
+ * (forgeable, link-supplied), never grants content access.
  */
 
 const COOKIE_NAME = 'np_carried_segments';
 const SESSION_KEY = 'newspack-popups-carried-segments';
 
 /**
- * Sentinel cookie/session value asserting that an account matched no
- * segments — distinct from an absent cookie, which means no handoff
- * happened at all.
- *
- * Mirrors Newspack_Popups_Segmentation::CARRIED_SEGMENTS_NONE in
- * class-newspack-popups-segmentation.php — keep the two in sync. PHP never
- * writes an empty string here: `setcookie()` treats an empty value as a
- * request to delete the cookie regardless of the expiry passed, which a real
- * browser would then never actually deliver.
- *
- * No special-casing is needed below to handle it: the sentinel is not a
- * segment ID (real IDs are always numeric term IDs), so filterKnown()
- * already drops it like any other unrecognised value, naturally yielding
- * `[]` — while it's still written to sessionStorage verbatim below, which is
- * what lets it override a previously-remembered non-empty set.
+ * Cookie value asserting the account matched no segments, distinct from an
+ * absent cookie (no handoff). Mirrors CARRIED_SEGMENTS_NONE in
+ * class-newspack-popups-segmentation.php — keep in sync. Needs no
+ * special-casing: filterKnown() drops it like any unknown ID, yielding `[]`,
+ * while writing it to sessionStorage overrides a previously-remembered set.
  */
 export const CARRIED_SEGMENTS_NONE = 'none';
 
@@ -54,11 +38,8 @@ const deleteCookie = () => {
 };
 
 /**
- * Split a stored value into IDs the page actually knows about.
- *
- * An ID the page doesn't ship can't match anything, and the server already
- * filters to active segments — this is the client-side half of the same rule,
- * covering a stale sessionStorage value after a segment is deleted.
+ * Split a stored value into IDs the page actually knows about, dropping stale
+ * or unknown ones.
  *
  * @param {string}   value    Comma-joined segment IDs.
  * @param {string[]} knownIds Segment IDs present on the page.
@@ -81,8 +62,6 @@ const filterKnown = ( value, knownIds ) =>
 export const getCarriedSegmentIds = ( knownIds = [] ) => {
 	const fromCookie = readCookie();
 	if ( null !== fromCookie ) {
-		// The cookie is authoritative on the landing page. Consume it either way:
-		// leaving it set would keep it on every later request for nothing.
 		deleteCookie();
 		try {
 			window.sessionStorage.setItem( SESSION_KEY, fromCookie );

--- a/plugins/newspack-popups/src/view/utils/carried-segments.js
+++ b/plugins/newspack-popups/src/view/utils/carried-segments.js
@@ -18,6 +18,25 @@ const COOKIE_NAME = 'np_carried_segments';
 const SESSION_KEY = 'newspack-popups-carried-segments';
 
 /**
+ * Sentinel cookie/session value asserting that an account matched no
+ * segments — distinct from an absent cookie, which means no handoff
+ * happened at all.
+ *
+ * Mirrors Newspack_Popups_Segmentation::CARRIED_SEGMENTS_NONE in
+ * class-newspack-popups-segmentation.php — keep the two in sync. PHP never
+ * writes an empty string here: `setcookie()` treats an empty value as a
+ * request to delete the cookie regardless of the expiry passed, which a real
+ * browser would then never actually deliver.
+ *
+ * No special-casing is needed below to handle it: the sentinel is not a
+ * segment ID (real IDs are always numeric term IDs), so filterKnown()
+ * already drops it like any other unrecognised value, naturally yielding
+ * `[]` — while it's still written to sessionStorage verbatim below, which is
+ * what lets it override a previously-remembered non-empty set.
+ */
+export const CARRIED_SEGMENTS_NONE = 'none';
+
+/**
  * Read the handoff cookie.
  *
  * @return {string|null} Raw cookie value, or null when absent.

--- a/plugins/newspack-popups/src/view/utils/carried-segments.js
+++ b/plugins/newspack-popups/src/view/utils/carried-segments.js
@@ -1,0 +1,82 @@
+/**
+ * Segment IDs carried in from a newsletter click.
+ *
+ * A logged-out reader arriving from a newsletter is resolved server-side (from
+ * the account ID the ESP substituted into the link) to their last-known matching
+ * segments, handed to this script in a cookie, and redirected to the clean URL.
+ * This module takes that handoff: it reads the cookie once, remembers the IDs in
+ * sessionStorage so they keep applying as the reader navigates on, and deletes
+ * the cookie so no later request carries it.
+ *
+ * These IDs are segmentation-only and transient. They are never written to the
+ * persisted reader-data store — doing so would launder a forgeable,
+ * link-supplied value into the snapshot the server trusts — and they never grant
+ * content access.
+ */
+
+const COOKIE_NAME = 'np_carried_segments';
+const SESSION_KEY = 'newspack-popups-carried-segments';
+
+/**
+ * Read the handoff cookie.
+ *
+ * @return {string|null} Raw cookie value, or null when absent.
+ */
+const readCookie = () => {
+	const match = document.cookie.match( new RegExp( `(?:^|;\\s*)${ COOKIE_NAME }=([^;]*)` ) );
+	return match ? decodeURIComponent( match[ 1 ] ) : null;
+};
+
+/**
+ * Expire the handoff cookie.
+ */
+const deleteCookie = () => {
+	document.cookie = `${ COOKIE_NAME }=; path=/; max-age=0`;
+};
+
+/**
+ * Split a stored value into IDs the page actually knows about.
+ *
+ * An ID the page doesn't ship can't match anything, and the server already
+ * filters to active segments — this is the client-side half of the same rule,
+ * covering a stale sessionStorage value after a segment is deleted.
+ *
+ * @param {string}   value    Comma-joined segment IDs.
+ * @param {string[]} knownIds Segment IDs present on the page.
+ *
+ * @return {string[]} Validated segment IDs.
+ */
+const filterKnown = ( value, knownIds ) =>
+	String( value || '' )
+		.split( ',' )
+		.map( id => id.trim() )
+		.filter( id => id && knownIds.includes( id ) );
+
+/**
+ * The segment IDs carried in from a newsletter click, for this browsing session.
+ *
+ * @param {string[]} knownIds Segment IDs present on the page.
+ *
+ * @return {string[]} Validated carried segment IDs.
+ */
+export const getCarriedSegmentIds = ( knownIds = [] ) => {
+	const fromCookie = readCookie();
+	if ( null !== fromCookie ) {
+		// The cookie is authoritative on the landing page. Consume it either way:
+		// leaving it set would keep it on every later request for nothing.
+		deleteCookie();
+		try {
+			window.sessionStorage.setItem( SESSION_KEY, fromCookie );
+		} catch ( e ) {
+			// sessionStorage unavailable; the landing-page value still stands.
+		}
+		return filterKnown( fromCookie, knownIds );
+	}
+
+	try {
+		return filterKnown( window.sessionStorage.getItem( SESSION_KEY ), knownIds );
+	} catch ( e ) {
+		// sessionStorage unavailable. Fail closed.
+		return [];
+	}
+};

--- a/plugins/newspack-popups/src/view/utils/carried-segments.test.js
+++ b/plugins/newspack-popups/src/view/utils/carried-segments.test.js
@@ -1,4 +1,4 @@
-import { getCarriedSegmentIds } from './carried-segments';
+import { getCarriedSegmentIds, CARRIED_SEGMENTS_NONE } from './carried-segments';
 
 const COOKIE = 'np_carried_segments';
 const SESSION_KEY = 'newspack-popups-carried-segments';
@@ -60,15 +60,18 @@ describe( 'getCarriedSegmentIds', () => {
 		expect( getCarriedSegmentIds( [ '5', '7' ] ) ).toEqual( [ '5', '7' ] );
 		expect( window.sessionStorage.getItem( SESSION_KEY ) ).toBe( '5,7' );
 
-		// Second arrival: a different account resolves to zero segments. The
-		// fixed PHP side hands this off as a present-but-empty cookie — a
-		// session cookie, never a past-expiry deletion — precisely so this
-		// case is distinguishable from "no handoff happened" and can override
-		// what an earlier arrival remembered. See
-		// Newspack_Popups_Segmentation::set_carried_segments_cookie().
-		setCookie( '' );
+		// Second arrival: a different account resolves to zero segments. PHP
+		// hands this off as the CARRIED_SEGMENTS_NONE sentinel — a session
+		// cookie, never a past-expiry deletion, and never an empty string
+		// either: PHP's setcookie() sends an empty value as a deletion
+		// regardless of the expiry passed, which a real browser would then
+		// never actually deliver. The sentinel is what makes this case
+		// distinguishable from "no handoff happened" and lets it override what
+		// an earlier arrival remembered. See
+		// Newspack_Popups_Segmentation::get_carried_segments_cookie_value().
+		setCookie( CARRIED_SEGMENTS_NONE );
 		expect( getCarriedSegmentIds( [ '5', '7' ] ) ).toEqual( [] );
-		expect( window.sessionStorage.getItem( SESSION_KEY ) ).toBe( '' );
+		expect( window.sessionStorage.getItem( SESSION_KEY ) ).toBe( CARRIED_SEGMENTS_NONE );
 	} );
 
 	it( 'drops IDs the page does not know about', () => {

--- a/plugins/newspack-popups/src/view/utils/carried-segments.test.js
+++ b/plugins/newspack-popups/src/view/utils/carried-segments.test.js
@@ -37,6 +37,12 @@ describe( 'getCarriedSegmentIds', () => {
 	it( 'deletes the cookie so no later request carries it', () => {
 		setCookie( '11' );
 		getCarriedSegmentIds( [ '11' ] );
+		// jsdom's document.cookie is a simplified approximation of a real
+		// browser's cookie jar, so this alone cannot prove real-browser
+		// deletion — a browser only lets a `max-age=0` write remove a cookie
+		// whose Path (and Domain) match the original exactly. What makes this
+		// assertion meaningful is that setCookie() above and deleteCookie() in
+		// carried-segments.js both write `path=/`, satisfying that requirement.
 		expect( document.cookie ).not.toContain( COOKIE );
 	} );
 
@@ -46,6 +52,23 @@ describe( 'getCarriedSegmentIds', () => {
 		// Cookie is gone; a later pageview reads the remembered set.
 		expect( getCarriedSegmentIds( [ '11', '22' ] ) ).toEqual( [ '11', '22' ] );
 		expect( window.sessionStorage.getItem( SESSION_KEY ) ).toBe( '11,22' );
+	} );
+
+	it( 'overrides remembered segments when a later arrival resolves to none', () => {
+		// First arrival: a real match, remembered for the rest of the session.
+		setCookie( '5,7' );
+		expect( getCarriedSegmentIds( [ '5', '7' ] ) ).toEqual( [ '5', '7' ] );
+		expect( window.sessionStorage.getItem( SESSION_KEY ) ).toBe( '5,7' );
+
+		// Second arrival: a different account resolves to zero segments. The
+		// fixed PHP side hands this off as a present-but-empty cookie — a
+		// session cookie, never a past-expiry deletion — precisely so this
+		// case is distinguishable from "no handoff happened" and can override
+		// what an earlier arrival remembered. See
+		// Newspack_Popups_Segmentation::set_carried_segments_cookie().
+		setCookie( '' );
+		expect( getCarriedSegmentIds( [ '5', '7' ] ) ).toEqual( [] );
+		expect( window.sessionStorage.getItem( SESSION_KEY ) ).toBe( '' );
 	} );
 
 	it( 'drops IDs the page does not know about', () => {
@@ -68,7 +91,7 @@ describe( 'getCarriedSegmentIds', () => {
 		const setSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
 			throw new Error( 'sessionStorage unavailable' );
 		} );
-		expect( () => getCarriedSegmentIds( [ '11' ] ) ).not.toThrow();
+		expect( getCarriedSegmentIds( [ '11' ] ) ).toEqual( [ '11' ] );
 		setSpy.mockRestore();
 	} );
 

--- a/plugins/newspack-popups/src/view/utils/carried-segments.test.js
+++ b/plugins/newspack-popups/src/view/utils/carried-segments.test.js
@@ -1,0 +1,92 @@
+import { getCarriedSegmentIds } from './carried-segments';
+
+const COOKIE = 'np_carried_segments';
+const SESSION_KEY = 'newspack-popups-carried-segments';
+
+/**
+ * Set the handoff cookie as the inbound redirect would.
+ *
+ * @param {string} value Comma-joined segment IDs.
+ */
+const setCookie = value => {
+	document.cookie = `${ COOKIE }=${ value }; path=/`;
+};
+
+/**
+ * Remove the handoff cookie.
+ */
+const clearCookie = () => {
+	document.cookie = `${ COOKIE }=; path=/; max-age=0`;
+};
+
+describe( 'getCarriedSegmentIds', () => {
+	beforeEach( () => {
+		window.sessionStorage.clear();
+		clearCookie();
+	} );
+
+	it( 'returns nothing when there is no cookie and nothing remembered', () => {
+		expect( getCarriedSegmentIds( [ '11', '22' ] ) ).toEqual( [] );
+	} );
+
+	it( 'reads the cookie on the landing page', () => {
+		setCookie( '11,22' );
+		expect( getCarriedSegmentIds( [ '11', '22' ] ) ).toEqual( [ '11', '22' ] );
+	} );
+
+	it( 'deletes the cookie so no later request carries it', () => {
+		setCookie( '11' );
+		getCarriedSegmentIds( [ '11' ] );
+		expect( document.cookie ).not.toContain( COOKIE );
+	} );
+
+	it( 'remembers the IDs for the rest of the session', () => {
+		setCookie( '11,22' );
+		getCarriedSegmentIds( [ '11', '22' ] );
+		// Cookie is gone; a later pageview reads the remembered set.
+		expect( getCarriedSegmentIds( [ '11', '22' ] ) ).toEqual( [ '11', '22' ] );
+		expect( window.sessionStorage.getItem( SESSION_KEY ) ).toBe( '11,22' );
+	} );
+
+	it( 'drops IDs the page does not know about', () => {
+		setCookie( '11,999' );
+		expect( getCarriedSegmentIds( [ '11', '22' ] ) ).toEqual( [ '11' ] );
+	} );
+
+	it( 'drops every ID when the page knows no segments', () => {
+		setCookie( '11,22' );
+		expect( getCarriedSegmentIds( [] ) ).toEqual( [] );
+	} );
+
+	it( 'tolerates whitespace and empty entries', () => {
+		setCookie( ' 11 ,,22 ' );
+		expect( getCarriedSegmentIds( [ '11', '22' ] ) ).toEqual( [ '11', '22' ] );
+	} );
+
+	it( 'still returns the landing-page IDs when the sessionStorage write is blocked', () => {
+		setCookie( '11' );
+		const setSpy = jest.spyOn( Storage.prototype, 'setItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		expect( () => getCarriedSegmentIds( [ '11' ] ) ).not.toThrow();
+		setSpy.mockRestore();
+	} );
+
+	it( 'fails closed when sessionStorage is fully unavailable and no cookie is present', () => {
+		const getSpy = jest.spyOn( Storage.prototype, 'getItem' ).mockImplementation( () => {
+			throw new Error( 'sessionStorage unavailable' );
+		} );
+		expect( getCarriedSegmentIds( [ '11' ] ) ).toEqual( [] );
+		getSpy.mockRestore();
+	} );
+
+	it( 'decodes a percent-encoded cookie value as PHP setcookie() produces it', () => {
+		// PHP's setcookie() URL-encodes the value it writes, so a two-segment
+		// handoff of `5,7` arrives in document.cookie as `5%2C7`, not `5,7`.
+		// readCookie() must decodeURIComponent() the captured group, or every
+		// multi-segment reader silently loses their carried segments while
+		// single-segment readers (no comma to encode) keep working.
+		setCookie( '5%2C7' );
+		expect( getCarriedSegmentIds( [ '5', '7' ] ) ).toEqual( [ '5', '7' ] );
+	} );
+} );

--- a/plugins/newspack-popups/src/view/utils/carried-segments.test.js
+++ b/plugins/newspack-popups/src/view/utils/carried-segments.test.js
@@ -37,12 +37,9 @@ describe( 'getCarriedSegmentIds', () => {
 	it( 'deletes the cookie so no later request carries it', () => {
 		setCookie( '11' );
 		getCarriedSegmentIds( [ '11' ] );
-		// jsdom's document.cookie is a simplified approximation of a real
-		// browser's cookie jar, so this alone cannot prove real-browser
-		// deletion — a browser only lets a `max-age=0` write remove a cookie
-		// whose Path (and Domain) match the original exactly. What makes this
-		// assertion meaningful is that setCookie() above and deleteCookie() in
-		// carried-segments.js both write `path=/`, satisfying that requirement.
+		// A browser only honors a `max-age=0` delete when the Path matches the
+		// original write; setCookie() here and deleteCookie() in the module both
+		// use `path=/`.
 		expect( document.cookie ).not.toContain( COOKIE );
 	} );
 
@@ -60,15 +57,8 @@ describe( 'getCarriedSegmentIds', () => {
 		expect( getCarriedSegmentIds( [ '5', '7' ] ) ).toEqual( [ '5', '7' ] );
 		expect( window.sessionStorage.getItem( SESSION_KEY ) ).toBe( '5,7' );
 
-		// Second arrival: a different account resolves to zero segments. PHP
-		// hands this off as the CARRIED_SEGMENTS_NONE sentinel — a session
-		// cookie, never a past-expiry deletion, and never an empty string
-		// either: PHP's setcookie() sends an empty value as a deletion
-		// regardless of the expiry passed, which a real browser would then
-		// never actually deliver. The sentinel is what makes this case
-		// distinguishable from "no handoff happened" and lets it override what
-		// an earlier arrival remembered. See
-		// Newspack_Popups_Segmentation::get_carried_segments_cookie_value().
+		// Second arrival resolves to zero segments: PHP hands off the
+		// CARRIED_SEGMENTS_NONE sentinel, which overrides the remembered set.
 		setCookie( CARRIED_SEGMENTS_NONE );
 		expect( getCarriedSegmentIds( [ '5', '7' ] ) ).toEqual( [] );
 		expect( window.sessionStorage.getItem( SESSION_KEY ) ).toBe( CARRIED_SEGMENTS_NONE );
@@ -107,11 +97,8 @@ describe( 'getCarriedSegmentIds', () => {
 	} );
 
 	it( 'decodes a percent-encoded cookie value as PHP setcookie() produces it', () => {
-		// PHP's setcookie() URL-encodes the value it writes, so a two-segment
-		// handoff of `5,7` arrives in document.cookie as `5%2C7`, not `5,7`.
-		// readCookie() must decodeURIComponent() the captured group, or every
-		// multi-segment reader silently loses their carried segments while
-		// single-segment readers (no comma to encode) keep working.
+		// PHP's setcookie() URL-encodes the value, so `5,7` arrives as `5%2C7`;
+		// without decodeURIComponent(), multi-segment readers lose their carry.
 		setCookie( '5%2C7' );
 		expect( getCarriedSegmentIds( [ '5', '7' ] ) ).toEqual( [ '5', '7' ] );
 	} );

--- a/plugins/newspack-popups/src/view/utils/segments.js
+++ b/plugins/newspack-popups/src/view/utils/segments.js
@@ -80,12 +80,18 @@ const match = segmentCriteria => {
 /**
  * Get the reader's highest-priority segment match, or the segment to preview.
  *
+ * Carried segment IDs — resolved server-side from a newsletter click and handed
+ * to this session, see carried-segments.js — count as matched in addition to
+ * whatever the criteria match locally. They join the priority comparison because
+ * prompt targeting is decided against the single winner, not the matched set.
+ *
  * @param {Object}      segments     Segments.
  * @param {string|null} viewAsString Optional, for testing. A query string with viewAs params for previewing a segment.
+ * @param {string[]}    carriedIds   Segment IDs carried in from a newsletter click.
  *
  * @return {string|null} Segment ID, or null.
  */
-export const getBestPrioritySegment = ( segments, viewAsString = null ) => {
+export const getBestPrioritySegment = ( segments, viewAsString = null, carriedIds = [] ) => {
 	// If previewing as a specific segment.
 	const viewAs = parseViewAs( viewAsString );
 	if ( viewAs?.segment ) {
@@ -94,7 +100,7 @@ export const getBestPrioritySegment = ( segments, viewAsString = null ) => {
 
 	const matchingSegments = [];
 	for ( const segmentId in segments ) {
-		if ( match( segments[ segmentId ].criteria ) ) {
+		if ( carriedIds.includes( segmentId ) || match( segments[ segmentId ].criteria ) ) {
 			matchingSegments.push( {
 				id: segmentId,
 				priority: segments[ segmentId ].priority,
@@ -115,6 +121,11 @@ export const getBestPrioritySegment = ( segments, viewAsString = null ) => {
  * Get the IDs of every segment the reader currently matches, sorted for stable
  * serialization (so equal sets compare equal). Unlike getBestPrioritySegment,
  * this returns the full set, not just the highest-priority winner.
+ *
+ * Criteria matches only: segment IDs carried in from a newsletter click are
+ * deliberately excluded, because this set is what syncMatchedSegments() persists
+ * to reader data. A carried ID is forgeable and link-supplied; writing it to the
+ * snapshot the server trusts would feed it back out through the next newsletter.
  *
  * @param {Object} segments Segments keyed by ID with { criteria, priority } values.
  *

--- a/plugins/newspack-popups/src/view/utils/segments.js
+++ b/plugins/newspack-popups/src/view/utils/segments.js
@@ -80,10 +80,9 @@ const match = segmentCriteria => {
 /**
  * Get the reader's highest-priority segment match, or the segment to preview.
  *
- * Carried segment IDs — resolved server-side from a newsletter click and handed
- * to this session, see carried-segments.js — count as matched in addition to
- * whatever the criteria match locally. They join the priority comparison because
- * prompt targeting is decided against the single winner, not the matched set.
+ * Carried segment IDs (see carried-segments.js) count as matched in addition
+ * to local criteria matches. They join this comparison because prompt
+ * targeting is decided against the single winner, not the matched set.
  *
  * @param {Object}      segments     Segments.
  * @param {string|null} viewAsString Optional, for testing. A query string with viewAs params for previewing a segment.
@@ -122,10 +121,9 @@ export const getBestPrioritySegment = ( segments, viewAsString = null, carriedId
  * serialization (so equal sets compare equal). Unlike getBestPrioritySegment,
  * this returns the full set, not just the highest-priority winner.
  *
- * Criteria matches only: segment IDs carried in from a newsletter click are
- * deliberately excluded, because this set is what syncMatchedSegments() persists
- * to reader data. A carried ID is forgeable and link-supplied; writing it to the
- * snapshot the server trusts would feed it back out through the next newsletter.
+ * Criteria matches only: carried segment IDs are excluded, because this set is
+ * what syncMatchedSegments() persists to reader data and a carried ID is
+ * forgeable, link-supplied input.
  *
  * @param {Object} segments Segments keyed by ID with { criteria, priority } values.
  *

--- a/plugins/newspack-popups/src/view/utils/segments.test.js
+++ b/plugins/newspack-popups/src/view/utils/segments.test.js
@@ -293,4 +293,44 @@ describe( 'segmentation API', () => {
 		setWindowLocation( 'example.com', '' );
 		expect( shouldPromptBeDisplayed( prompt, null, ras ) ).toBeFalsy();
 	} );
+
+	it( 'should let a carried segment win the priority match', () => {
+		// Nothing matches locally: `simple` holds a value no segment expects and
+		// `list__in` is unset. Stands in for a logged-out reader whose browsing
+		// data alone cannot satisfy, say, a donors segment.
+		ras.store.set( 'simple', 'initial-value' );
+		expect( getBestPrioritySegment( segments ) ).toBeNull();
+		expect( getBestPrioritySegment( segments, null, [ 'segment2' ] ) ).toBe( 'segment2' );
+	} );
+
+	it( 'should respect priority across several carried segments', () => {
+		ras.store.set( 'simple', 'initial-value' );
+		// segment1 is priority 0, segment4 is priority 2.
+		expect( getBestPrioritySegment( segments, null, [ 'segment4', 'segment1' ] ) ).toBe( 'segment1' );
+	} );
+
+	it( 'should ignore a carried ID that is not a known segment', () => {
+		ras.store.set( 'simple', 'initial-value' );
+		expect( getBestPrioritySegment( segments, null, [ 'not-a-segment' ] ) ).toBeNull();
+	} );
+
+	it( 'should let a criteria match still win over a lower-priority carried segment', () => {
+		// Carried segments are additive, not overriding: segment2 matches locally
+		// on priority 1 and must beat a carried segment4 on priority 2.
+		ras.store.set( 'simple', 'simple-match' );
+		expect( getBestPrioritySegment( segments, null, [ 'segment4' ] ) ).toBe( 'segment2' );
+	} );
+
+	it( 'should keep carried segments out of the set persisted to reader data', () => {
+		// Carried IDs are forgeable and link-supplied. Persisting one would launder
+		// it into the snapshot the server trusts and feed it back out through the
+		// next newsletter. segment4 is carried but does not match locally, so it
+		// must be absent from what syncMatchedSegments writes.
+		window.sessionStorage.setItem( 'newspack-popups-carried-segments', 'segment4' );
+		ras.store.set( 'reader', { authenticated: true } );
+		ras.store.set( 'simple', 'simple-match' );
+		syncMatchedSegments( ras, segments );
+		expect( ras.store.get( 'matched_segments' ) ).toEqual( [ 'segment2', 'segment3' ] );
+		window.sessionStorage.removeItem( 'newspack-popups-carried-segments' );
+	} );
 } );

--- a/plugins/newspack-popups/src/view/utils/segments.test.js
+++ b/plugins/newspack-popups/src/view/utils/segments.test.js
@@ -295,9 +295,8 @@ describe( 'segmentation API', () => {
 	} );
 
 	it( 'should let a carried segment win the priority match', () => {
-		// Nothing matches locally: `simple` holds a value no segment expects and
-		// `list__in` is unset. Stands in for a logged-out reader whose browsing
-		// data alone cannot satisfy, say, a donors segment.
+		// Nothing matches locally: `simple` holds a value no segment expects
+		// and `list__in` is unset.
 		ras.store.set( 'simple', 'initial-value' );
 		expect( getBestPrioritySegment( segments ) ).toBeNull();
 		expect( getBestPrioritySegment( segments, null, [ 'segment2' ] ) ).toBe( 'segment2' );
@@ -322,10 +321,9 @@ describe( 'segmentation API', () => {
 	} );
 
 	it( 'should keep carried segments out of the set persisted to reader data', () => {
-		// Carried IDs are forgeable and link-supplied. Persisting one would launder
-		// it into the snapshot the server trusts and feed it back out through the
-		// next newsletter. segment4 is carried but does not match locally, so it
-		// must be absent from what syncMatchedSegments writes.
+		// Carried IDs are forgeable, link-supplied input and must never be
+		// persisted: segment4 is carried but does not match locally, so it must
+		// be absent from what syncMatchedSegments writes.
 		window.sessionStorage.setItem( 'newspack-popups-carried-segments', 'segment4' );
 		ras.store.set( 'reader', { authenticated: true } );
 		ras.store.set( 'simple', 'simple-match' );

--- a/plugins/newspack-popups/tests/mocks/class-metadata.php
+++ b/plugins/newspack-popups/tests/mocks/class-metadata.php
@@ -1,0 +1,36 @@
+<?php
+/**
+ * Mock of the newspack-plugin reader-activation sync Metadata class.
+ *
+ * Resolves an unprefixed metadata raw key to the prefixed ESP field name.
+ * Tests set $keys to control which raw keys resolve, mirroring the difference
+ * between the v1 schema (raw key 'Account') and legacy (raw key 'account').
+ *
+ * @package Newspack_Popups
+ */
+
+namespace Newspack\Reader_Activation\Sync;
+
+if ( ! class_exists( __NAMESPACE__ . '\Metadata' ) ) {
+	/**
+	 * Minimal stand-in for the reader-activation sync metadata helper.
+	 */
+	class Metadata {
+		/**
+		 * Raw key => prefixed ESP field name.
+		 *
+		 * @var array
+		 */
+		public static $keys = [ 'Account' => 'NP_Account' ];
+
+		/**
+		 * Resolve a raw metadata key to its prefixed field name.
+		 *
+		 * @param string $key Raw metadata key.
+		 * @return string|false Prefixed field name, or false when unknown.
+		 */
+		public static function get_key( $key ) {
+			return self::$keys[ $key ] ?? false;
+		}
+	}
+}

--- a/plugins/newspack-popups/tests/mocks/class-newspack-newsletters.php
+++ b/plugins/newspack-popups/tests/mocks/class-newspack-newsletters.php
@@ -15,5 +15,21 @@ if ( ! class_exists( 'Newspack_Newsletters' ) ) {
 	 */
 	class Newspack_Newsletters {
 		const NEWSPACK_NEWSLETTERS_CPT = 'newspack_nl_cpt';
+
+		/**
+		 * Provider instance returned by get_service_provider().
+		 *
+		 * @var object|null
+		 */
+		public static $provider = null;
+
+		/**
+		 * The connected ESP service provider.
+		 *
+		 * @return object|null
+		 */
+		public static function get_service_provider() {
+			return self::$provider;
+		}
 	}
 }

--- a/plugins/newspack-popups/tests/mocks/class-reader-data.php
+++ b/plugins/newspack-popups/tests/mocks/class-reader-data.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Mock of the newspack-plugin Reader_Data class.
+ *
+ * Only get_matched_segments() is needed: the account-param arrival handler
+ * reads a reader's last-known matching segment snapshot through it.
+ *
+ * Note this class is defined only inside the test files that require it, well
+ * after plugin boot — so it cannot retroactively flip
+ * Newspack_Popups::$segmentation_enabled, which is computed at boot.
+ *
+ * @package Newspack_Popups
+ */
+
+namespace Newspack;
+
+if ( ! class_exists( __NAMESPACE__ . '\Reader_Data' ) ) {
+	/**
+	 * Minimal stand-in for the reader-data store.
+	 */
+	class Reader_Data {
+		/**
+		 * User ID => matching segment IDs.
+		 *
+		 * @var array
+		 */
+		public static $matched_segments = [];
+
+		/**
+		 * A reader's last-known matching segment IDs.
+		 *
+		 * @param int $user_id User ID.
+		 * @return string[]
+		 */
+		public static function get_matched_segments( int $user_id ): array {
+			return self::$matched_segments[ $user_id ] ?? [];
+		}
+	}
+}

--- a/plugins/newspack-popups/tests/mocks/class-service-provider.php
+++ b/plugins/newspack-popups/tests/mocks/class-service-provider.php
@@ -1,0 +1,42 @@
+<?php // phpcs:ignore WordPress.Files.FileName.InvalidClassFileName
+/**
+ * Mock ESP service provider for popups tests.
+ *
+ * Stands in for a newspack-newsletters service provider so the account-param
+ * link handler can resolve a merge-tag name without the plugin loaded.
+ *
+ * @package Newspack_Popups
+ */
+
+if ( ! class_exists( 'Newspack_Popups_Test_Service_Provider' ) ) {
+	/**
+	 * Configurable stand-in provider.
+	 */
+	class Newspack_Popups_Test_Service_Provider {
+		/**
+		 * Tag name to return, keyed by field name.
+		 *
+		 * @var array
+		 */
+		public $tags = [];
+
+		/**
+		 * List ID the handler passed in on the last call.
+		 *
+		 * @var string|null
+		 */
+		public $received_list_id = 'unset';
+
+		/**
+		 * Resolve a field's merge-tag name.
+		 *
+		 * @param string      $field_name Field name.
+		 * @param string|null $list_id    Audience ID.
+		 * @return string
+		 */
+		public function get_field_merge_tag_name( $field_name, $list_id = null ) {
+			$this->received_list_id = $list_id;
+			return $this->tags[ $field_name ] ?? '';
+		}
+	}
+}

--- a/plugins/newspack-popups/tests/test-segmentation-account-arrival.php
+++ b/plugins/newspack-popups/tests/test-segmentation-account-arrival.php
@@ -145,12 +145,10 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	 * The setcookie() options get_carried_segments_cookie_options() returns,
 	 * via reflection — see $cookie_options_method.
 	 *
-	 * @param bool $clearing Whether to fetch the clearing form's options.
-	 *
 	 * @return array
 	 */
-	private function cookie_options( $clearing ) {
-		return self::$cookie_options_method->invoke( null, $clearing );
+	private function cookie_options() {
+		return self::$cookie_options_method->invoke( null );
 	}
 
 	/**
@@ -263,18 +261,25 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An account with no snapshot carries nothing and behaves as today.
+	 * An account with no snapshot resolves to no segments, which is an
+	 * explicit "matches nothing" assertion (see
+	 * set_carried_segments_cookie()'s docblock) — an empty-string cookie, not
+	 * an absent one.
 	 */
 	public function test_unknown_account_carries_nothing() {
 		$this->assertSame( '/p/?a=1', $this->arrive( '/p/?a=1&np_account=777' ) );
-		$this->assertNull( $this->cookie() );
+		$this->assertSame( '', $this->cookie() );
 	}
 
 	/**
 	 * Each arrival is authoritative: the view script deletes the cookie on
 	 * first read, but on an arrival where that script never runs (a page with
 	 * no prompts, JS disabled), a previous arrival's segments must not carry
-	 * into the next click. An arrival that resolves nothing must clear it.
+	 * into the next click. An arrival that resolves nothing must overwrite
+	 * the mirror with an empty string — the "matches nothing" assertion —
+	 * not leave the previous arrival's value in place, and not unset it
+	 * either, since an unset mirror is indistinguishable from no handoff
+	 * ever having happened.
 	 */
 	public function test_clears_a_previous_cookie_when_nothing_resolves() {
 		\Newspack\Reader_Data::$matched_segments = [ 42 => [ $this->segment_ids['carried-one'] ] ];
@@ -283,7 +288,7 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 
 		// A second, later arrival for an account with nothing to carry.
 		$this->arrive( '/p/?np_account=777' );
-		$this->assertNull( $this->cookie() );
+		$this->assertSame( '', $this->cookie() );
 	}
 
 	/**
@@ -361,46 +366,23 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The set_carried_segments_cookie() method's own setcookie() call never
-	 * runs under PHPUnit (headers_sent() is always true here), so no test that
-	 * goes through arrive() ever exercises the option values below — e.g. an
-	 * `httponly => true` typo would silently break the view script's
-	 * document.cookie read and every other test here would still pass.
-	 * Exercise get_carried_segments_cookie_options() directly instead, for
-	 * both the setting and clearing forms.
+	 * The cookie-options helper always returns one set of options: since an
+	 * empty resolution is itself the "matches nothing" assertion (see
+	 * set_carried_segments_cookie()'s docblock), there is no longer a separate
+	 * "clearing" form to distinguish it from. set_carried_segments_cookie()'s
+	 * own setcookie() call never runs under PHPUnit (headers_sent() is always
+	 * true here), so no test that goes through arrive() ever exercises the
+	 * option values below — e.g. an `httponly => true` typo would silently
+	 * break the view script's document.cookie read, or an `expires` other
+	 * than 0 would make a real browser delete an empty resolution instead of
+	 * delivering it — and every other test here would still pass. Exercise
+	 * get_carried_segments_cookie_options() directly instead.
 	 */
-	public function test_cookie_options_are_js_readable_and_site_wide() {
-		foreach ( [ false, true ] as $clearing ) {
-			$options = $this->cookie_options( $clearing );
-			$this->assertFalse( $options['httponly'], 'The view script reads this cookie via document.cookie; httponly would silently break the feature.' );
-			$this->assertSame( 'Lax', $options['samesite'] );
-			$this->assertSame( '/', $options['path'] );
-		}
-	}
-
-	/**
-	 * The setting form (a resolved, non-empty segment set) must be a session
-	 * cookie — expires at 0 — so it does not outlive the browsing session.
-	 */
-	public function test_setting_cookie_options_are_a_session_cookie() {
-		$this->assertSame( 0, $this->cookie_options( false )['expires'] );
-	}
-
-	/**
-	 * The clearing form (an empty resolved set) must expire in the past, or a
-	 * cookie set by an earlier arrival would never actually clear from the
-	 * reader's browser — see set_carried_segments_cookie()'s docblock.
-	 *
-	 * `assertLessThan( time(), ... )` alone would NOT catch an `expires => 0`
-	 * regression: 0 is itself less than time(), yet PHP's setcookie() treats a
-	 * literal 0 as the "no expiry" session-cookie sentinel, not as a past
-	 * timestamp — it would never clear anything. Asserting `expires > 0` first
-	 * rules that sentinel out, so only a genuine past Unix timestamp passes
-	 * both assertions.
-	 */
-	public function test_clearing_cookie_options_expire_in_the_past() {
-		$expires = $this->cookie_options( true )['expires'];
-		$this->assertGreaterThan( 0, $expires, 'expires must be a real past timestamp, not the 0 "session cookie" sentinel — that would never clear the cookie at all.' );
-		$this->assertLessThan( time(), $expires );
+	public function test_cookie_options_are_js_readable_session_scoped_and_site_wide() {
+		$options = $this->cookie_options();
+		$this->assertSame( 0, $options['expires'], 'Must always be a session cookie, including when the value is empty — a past expiry would make a real browser delete the cookie instead of delivering the "matches nothing" assertion.' );
+		$this->assertFalse( $options['httponly'], 'The view script reads this cookie via document.cookie; httponly would silently break the feature.' );
+		$this->assertSame( 'Lax', $options['samesite'] );
+		$this->assertSame( '/', $options['path'] );
 	}
 }

--- a/plugins/newspack-popups/tests/test-segmentation-account-arrival.php
+++ b/plugins/newspack-popups/tests/test-segmentation-account-arrival.php
@@ -1,12 +1,9 @@
 <?php
 /**
  * Tests for the inbound account-param handler,
- * Newspack_Popups_Segmentation::handle_account_param().
- *
- * The param is always redirected away before any output. That is what keeps the
- * landing page a shared cacheable URL and what makes ActiveCampaign's `%TAG%`
- * syntax safe to emit at all (NPPM-3032), so the always-redirect property is
- * load-bearing, not incidental.
+ * Newspack_Popups_Segmentation::handle_account_param(). The param must always
+ * be redirected away before output: it keeps the landing page cacheable and is
+ * what makes ActiveCampaign's `%TAG%` syntax safe to emit (NPPM-3032).
  *
  * @package Newspack_Popups
  */
@@ -29,23 +26,17 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	private $segment_ids = [];
 
 	/**
-	 * Reflection onto the private, static get_carried_segments_cookie_options().
-	 * set_carried_segments_cookie()'s own setcookie() call is gated on
-	 * `! headers_sent()`, which is never true under PHPUnit, so this is the
-	 * only way any test here can reach the option values it would pass. (Same
-	 * pattern as test-overlay-sort.php.)
+	 * Reflection onto the private get_carried_segments_cookie_options():
+	 * setcookie() itself never runs under PHPUnit (headers already sent), so
+	 * this is the only way to reach the option values.
 	 *
 	 * @var ReflectionMethod
 	 */
 	private static $cookie_options_method;
 
 	/**
-	 * Reflection onto the private, static get_carried_segments_cookie_value().
-	 * Same rationale as $cookie_options_method above: it isolates the cookie
-	 * *value* PHP computes from the delivery mechanism (`setcookie()`) that
-	 * never runs under PHPUnit, so a test can prove the value itself is never
-	 * empty independent of whatever arrive() happens to observe via the
-	 * $_COOKIE mirror.
+	 * Reflection onto the private get_carried_segments_cookie_value(); same
+	 * rationale as $cookie_options_method.
 	 *
 	 * @var ReflectionMethod
 	 */
@@ -222,10 +213,8 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A snapshot can also name a segment that still exists but has since been
-	 * disabled. This exercises the `false` (active-only) argument to
-	 * get_segments() inside get_carried_segments_for_account() specifically —
-	 * a nonexistent ID alone can't distinguish that from no filtering at all.
+	 * A disabled segment's ID is dropped. Exercises the active-only argument
+	 * to get_segments(), which a nonexistent ID alone cannot distinguish.
 	 */
 	public function test_drops_disabled_segment_ids() {
 		\Newspack\Reader_Data::$matched_segments = [
@@ -236,9 +225,8 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An unsubstituted merge tag still gets redirected away. This is the whole
-	 * reason ActiveCampaign can be supported: a malformed percent-escape must
-	 * never survive into a rendered page.
+	 * An unsubstituted merge tag still gets redirected away — a malformed
+	 * percent-escape must never survive into a rendered page (NPPM-3032).
 	 *
 	 * @param string $value Raw param value as it arrives.
 	 *
@@ -290,12 +278,9 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * An account with no snapshot resolves to no segments, which is an
-	 * explicit "matches nothing" assertion (see
-	 * set_carried_segments_cookie()'s docblock) — a cookie carrying the
-	 * CARRIED_SEGMENTS_NONE sentinel, not an absent one, and not an
-	 * empty-string one either: setcookie() would send an empty string as a
-	 * deletion, indistinguishable from no handoff ever having happened.
+	 * An account with no snapshot resolves to "matches nothing": the cookie
+	 * carries the CARRIED_SEGMENTS_NONE sentinel — never an empty string,
+	 * which setcookie() would send as a deletion.
 	 */
 	public function test_unknown_account_carries_nothing() {
 		$this->assertSame( '/p/?a=1', $this->arrive( '/p/?a=1&np_account=777' ) );
@@ -303,15 +288,9 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Each arrival is authoritative: the view script deletes the cookie on
-	 * first read, but on an arrival where that script never runs (a page with
-	 * no prompts, JS disabled), a previous arrival's segments must not carry
-	 * into the next click. An arrival that resolves nothing must overwrite
-	 * the mirror with the CARRIED_SEGMENTS_NONE sentinel — the "matches
-	 * nothing" assertion — not leave the previous arrival's value in place.
-	 * It must not become an empty string either (setcookie() would send that
-	 * as a deletion) or be unset (indistinguishable from no handoff ever
-	 * having happened).
+	 * Each valid arrival is authoritative: one that resolves nothing must
+	 * overwrite a previous arrival's cookie with the CARRIED_SEGMENTS_NONE
+	 * sentinel, not leave the old value, empty the string, or unset it.
 	 */
 	public function test_overwrites_a_previous_cookie_when_nothing_resolves() {
 		\Newspack\Reader_Data::$matched_segments = [ 42 => [ $this->segment_ids['carried-one'] ] ];
@@ -324,13 +303,9 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Unlike a valid ID that resolves to nothing (see
-	 * test_overwrites_a_previous_cookie_when_nothing_resolves() above), a
-	 * value that never passes the positive-integer gate makes no assertion
-	 * about the reader at all — e.g. an unsubstituted merge tag arriving from
-	 * a newsletter that already went out. It must leave an earlier arrival's
-	 * carried segments alone, even though the redirect itself still fires
-	 * unconditionally.
+	 * A value that never passes the positive-integer gate asserts nothing
+	 * about the reader, so an earlier arrival's carried segments stay put —
+	 * while the redirect still fires.
 	 *
 	 * @param string $value Raw param value as it arrives.
 	 *
@@ -357,11 +332,7 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * No param, nothing to do — the overwhelmingly common request. Also
-	 * confirms an existing cookie is left alone: without the early return, a
-	 * param-less pageview would otherwise fall through to the
-	 * cookie-assertion path and overwrite a legitimately carried set with the
-	 * "matches nothing" sentinel.
+	 * No param: no redirect, and an existing cookie is left alone.
 	 */
 	public function test_ignores_request_without_the_param() {
 		$_COOKIE[ Newspack_Popups_Segmentation::CARRIED_SEGMENTS_COOKIE ] = $this->segment_ids['carried-one']; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
@@ -370,10 +341,8 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Redirecting a POST would discard its body. Also confirms an existing
-	 * cookie is left alone: without the early return, a POST that happens to
-	 * carry np_account (e.g. a form submit on a page reached via a newsletter
-	 * link) would otherwise resolve and overwrite a legitimately carried set.
+	 * A POST is ignored (a redirect would discard its body) and an existing
+	 * cookie is left alone.
 	 */
 	public function test_ignores_non_get_requests() {
 		$_COOKIE[ Newspack_Popups_Segmentation::CARRIED_SEGMENTS_COOKIE ] = $this->segment_ids['carried-one']; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
@@ -382,12 +351,8 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The resolver is the seam the handler is built on; exercise it directly for
-	 * the degenerate inputs.
-	 *
-	 * The mock is seeded with a real, active segment ID under keys `0` and
-	 * `-1` so an empty result can only come from the $account_id < 1 guard,
-	 * not from the mock having nothing to return for those keys anyway.
+	 * Non-positive IDs are rejected by the resolver. The mock is seeded under
+	 * keys `0` and `-1`, so an empty result can only come from the guard.
 	 */
 	public function test_resolver_rejects_non_positive_ids() {
 		\Newspack\Reader_Data::$matched_segments = [
@@ -399,15 +364,9 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The cookie-options helper always returns one set of options, regardless
-	 * of the resolved value — keeping the value itself non-empty is
-	 * get_carried_segments_cookie_value()'s job, exercised separately below.
-	 * set_carried_segments_cookie()'s own setcookie() call never runs under
-	 * PHPUnit (headers_sent() is always true here), so no test that goes
-	 * through arrive() ever exercises the option values below — e.g. an
-	 * `httponly => true` typo would silently break the view script's
-	 * document.cookie read — and every other test here would still pass.
-	 * Exercise get_carried_segments_cookie_options() directly instead.
+	 * The cookie options must stay JS-readable, session-scoped, and site-wide.
+	 * Exercised via reflection because the setcookie() call never runs under
+	 * PHPUnit — an `httponly => true` typo would pass every other test.
 	 */
 	public function test_cookie_options_are_js_readable_session_scoped_and_site_wide() {
 		$options = $this->cookie_options();
@@ -418,15 +377,9 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The cookie value computed by get_carried_segments_cookie_value() must
-	 * never be an empty string: PHP's setcookie() sends a deletion whenever
-	 * the value is empty, no matter what `expires` is passed (see
-	 * get_carried_segments_cookie_options()'s docblock), so a real browser
-	 * would then never deliver the "matches nothing" assertion at all. This
-	 * is the defect two prior review passes missed — set_carried_segments_cookie()'s
-	 * own setcookie() call never runs under PHPUnit, so a test that only goes
-	 * through arrive() and inspects the $_COOKIE mirror could never observe
-	 * it; this test exercises the value-computation seam directly instead.
+	 * The cookie value is never an empty string: setcookie() sends a deletion
+	 * for an empty value regardless of `expires`, so the "matches nothing"
+	 * assertion would never reach a browser.
 	 */
 	public function test_cookie_value_for_no_segments_is_the_sentinel_not_empty() {
 		$value = $this->cookie_value( [] );

--- a/plugins/newspack-popups/tests/test-segmentation-account-arrival.php
+++ b/plugins/newspack-popups/tests/test-segmentation-account-arrival.php
@@ -29,11 +29,26 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	private $segment_ids = [];
 
 	/**
+	 * Reflection onto the private, static get_carried_segments_cookie_options().
+	 * set_carried_segments_cookie()'s own setcookie() call is gated on
+	 * `! headers_sent()`, which is never true under PHPUnit, so this is the
+	 * only way any test here can reach the option values it would pass. (Same
+	 * pattern as test-overlay-sort.php.)
+	 *
+	 * @var ReflectionMethod
+	 */
+	private static $cookie_options_method;
+
+	/**
 	 * Set up: two active segments, one disabled segment, and an empty snapshot
 	 * store.
 	 */
 	public function set_up() {
 		parent::set_up();
+		if ( ! self::$cookie_options_method ) {
+			self::$cookie_options_method = new ReflectionMethod( 'Newspack_Popups_Segmentation', 'get_carried_segments_cookie_options' );
+			self::$cookie_options_method->setAccessible( true );
+		}
 		Newspack_Segments_Model::delete_all_segments();
 		Newspack_Popups_Segmentation::create_segment(
 			[
@@ -124,6 +139,18 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	private function cookie() {
 		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
 		return $_COOKIE[ Newspack_Popups_Segmentation::CARRIED_SEGMENTS_COOKIE ] ?? null;
+	}
+
+	/**
+	 * The setcookie() options get_carried_segments_cookie_options() returns,
+	 * via reflection — see $cookie_options_method.
+	 *
+	 * @param bool $clearing Whether to fetch the clearing form's options.
+	 *
+	 * @return array
+	 */
+	private function cookie_options( $clearing ) {
+		return self::$cookie_options_method->invoke( null, $clearing );
 	}
 
 	/**
@@ -260,6 +287,29 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Unlike a valid ID that resolves to nothing (see
+	 * test_clears_a_previous_cookie_when_nothing_resolves() above), a value
+	 * that never passes the positive-integer gate makes no assertion about the
+	 * reader at all — e.g. an unsubstituted merge tag arriving from a
+	 * newsletter that already went out. It must leave an earlier arrival's
+	 * carried segments alone, even though the redirect itself still fires
+	 * unconditionally.
+	 *
+	 * @param string $value Raw param value as it arrives.
+	 *
+	 * @dataProvider unresolvable_value_provider
+	 */
+	public function test_unresolvable_value_leaves_existing_cookie_intact( $value ) {
+		\Newspack\Reader_Data::$matched_segments = [ 42 => [ $this->segment_ids['carried-one'] ] ];
+		$this->arrive( '/p/?np_account=42' );
+		$this->assertSame( $this->segment_ids['carried-one'], $this->cookie() );
+
+		// A second, later arrival carrying a value that never resolves.
+		$this->assertSame( '/p/?a=1', $this->arrive( '/p/?a=1&np_account=' . $value ) );
+		$this->assertSame( $this->segment_ids['carried-one'], $this->cookie() );
+	}
+
+	/**
 	 * The redirect target must not itself trigger another redirect.
 	 */
 	public function test_redirect_result_does_not_redirect_again() {
@@ -270,17 +320,27 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * No param, nothing to do — the overwhelmingly common request.
+	 * No param, nothing to do — the overwhelmingly common request. Also
+	 * confirms an existing cookie is left alone: without the early return, a
+	 * param-less pageview would otherwise fall through to the cookie-clearing
+	 * path and wipe a legitimately carried set.
 	 */
 	public function test_ignores_request_without_the_param() {
+		$_COOKIE[ Newspack_Popups_Segmentation::CARRIED_SEGMENTS_COOKIE ] = $this->segment_ids['carried-one']; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 		$this->assertNull( $this->arrive( '/p/?utm_medium=email' ) );
+		$this->assertSame( $this->segment_ids['carried-one'], $this->cookie() );
 	}
 
 	/**
-	 * Redirecting a POST would discard its body.
+	 * Redirecting a POST would discard its body. Also confirms an existing
+	 * cookie is left alone: without the early return, a POST that happens to
+	 * carry np_account (e.g. a form submit on a page reached via a newsletter
+	 * link) would otherwise resolve and overwrite a legitimately carried set.
 	 */
 	public function test_ignores_non_get_requests() {
+		$_COOKIE[ Newspack_Popups_Segmentation::CARRIED_SEGMENTS_COOKIE ] = $this->segment_ids['carried-one']; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 		$this->assertNull( $this->arrive( '/p/?np_account=42', 'POST' ) );
+		$this->assertSame( $this->segment_ids['carried-one'], $this->cookie() );
 	}
 
 	/**
@@ -298,5 +358,49 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 		];
 		$this->assertSame( [], Newspack_Popups_Segmentation::get_carried_segments_for_account( 0 ) );
 		$this->assertSame( [], Newspack_Popups_Segmentation::get_carried_segments_for_account( -1 ) );
+	}
+
+	/**
+	 * The set_carried_segments_cookie() method's own setcookie() call never
+	 * runs under PHPUnit (headers_sent() is always true here), so no test that
+	 * goes through arrive() ever exercises the option values below — e.g. an
+	 * `httponly => true` typo would silently break the view script's
+	 * document.cookie read and every other test here would still pass.
+	 * Exercise get_carried_segments_cookie_options() directly instead, for
+	 * both the setting and clearing forms.
+	 */
+	public function test_cookie_options_are_js_readable_and_site_wide() {
+		foreach ( [ false, true ] as $clearing ) {
+			$options = $this->cookie_options( $clearing );
+			$this->assertFalse( $options['httponly'], 'The view script reads this cookie via document.cookie; httponly would silently break the feature.' );
+			$this->assertSame( 'Lax', $options['samesite'] );
+			$this->assertSame( '/', $options['path'] );
+		}
+	}
+
+	/**
+	 * The setting form (a resolved, non-empty segment set) must be a session
+	 * cookie — expires at 0 — so it does not outlive the browsing session.
+	 */
+	public function test_setting_cookie_options_are_a_session_cookie() {
+		$this->assertSame( 0, $this->cookie_options( false )['expires'] );
+	}
+
+	/**
+	 * The clearing form (an empty resolved set) must expire in the past, or a
+	 * cookie set by an earlier arrival would never actually clear from the
+	 * reader's browser — see set_carried_segments_cookie()'s docblock.
+	 *
+	 * `assertLessThan( time(), ... )` alone would NOT catch an `expires => 0`
+	 * regression: 0 is itself less than time(), yet PHP's setcookie() treats a
+	 * literal 0 as the "no expiry" session-cookie sentinel, not as a past
+	 * timestamp — it would never clear anything. Asserting `expires > 0` first
+	 * rules that sentinel out, so only a genuine past Unix timestamp passes
+	 * both assertions.
+	 */
+	public function test_clearing_cookie_options_expire_in_the_past() {
+		$expires = $this->cookie_options( true )['expires'];
+		$this->assertGreaterThan( 0, $expires, 'expires must be a real past timestamp, not the 0 "session cookie" sentinel — that would never clear the cookie at all.' );
+		$this->assertLessThan( time(), $expires );
 	}
 }

--- a/plugins/newspack-popups/tests/test-segmentation-account-arrival.php
+++ b/plugins/newspack-popups/tests/test-segmentation-account-arrival.php
@@ -1,0 +1,232 @@
+<?php
+/**
+ * Tests for the inbound account-param handler,
+ * Newspack_Popups_Segmentation::handle_account_param().
+ *
+ * The param is always redirected away before any output. That is what keeps the
+ * landing page a shared cacheable URL and what makes ActiveCampaign's `%TAG%`
+ * syntax safe to emit at all (NPPM-3032), so the always-redirect property is
+ * load-bearing, not incidental.
+ *
+ * @package Newspack_Popups
+ */
+
+// Stand-ins for the exit()-halting exception and the cross-plugin reader-data
+// store; the popups test suite loads only newspack-popups.
+require_once __DIR__ . '/mocks/class-segmentation-redirect-exception.php';
+require_once __DIR__ . '/mocks/class-reader-data.php';
+
+/**
+ * Test the inbound account-param handler.
+ */
+class SegmentationAccountArrivalTest extends WP_UnitTestCase {
+
+	/**
+	 * Segment IDs created for the test, in creation order.
+	 *
+	 * @var string[]
+	 */
+	private $segment_ids = [];
+
+	/**
+	 * Set up: two active segments and an empty snapshot store.
+	 */
+	public function set_up() {
+		parent::set_up();
+		Newspack_Segments_Model::delete_all_segments();
+		Newspack_Popups_Segmentation::create_segment(
+			[
+				'name'          => 'carried-one',
+				'configuration' => [],
+			]
+		);
+		Newspack_Popups_Segmentation::create_segment(
+			[
+				'name'          => 'carried-two',
+				'configuration' => [],
+			]
+		);
+		$this->segment_ids = [];
+		foreach ( Newspack_Popups_Segmentation::get_segments( false ) as $segment ) {
+			$this->segment_ids[ $segment['name'] ] = (string) $segment['id'];
+		}
+		\Newspack\Reader_Data::$matched_segments = [];
+		unset( $_COOKIE[ Newspack_Popups_Segmentation::CARRIED_SEGMENTS_COOKIE ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		unset( $_COOKIE[ Newspack_Popups_Segmentation::CARRIED_SEGMENTS_COOKIE ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		parent::tear_down();
+	}
+
+	/**
+	 * Run the handler against a simulated request, capturing the redirect
+	 * instead of letting the handler exit.
+	 *
+	 * @param string $request_uri Request URI, including query string.
+	 * @param string $method      HTTP method.
+	 *
+	 * @return string|null Redirect target, or null when no redirect was issued.
+	 */
+	private function arrive( $request_uri, $method = 'GET' ) {
+		$captured = null;
+		$filter   = function ( $location ) use ( &$captured ) {
+			$captured = $location;
+			throw new Segmentation_Redirect_Exception();
+		};
+
+		// Simulating an inbound request, so populating the superglobals the
+		// handler reads is the point of this helper.
+		// phpcs:disable WordPress.Security.NonceVerification.Recommended
+		$_SERVER['REQUEST_URI']    = $request_uri;
+		$_SERVER['REQUEST_METHOD'] = $method;
+		$_GET                      = [];
+		$query                     = wp_parse_url( $request_uri, PHP_URL_QUERY );
+		if ( $query ) {
+			parse_str( $query, $_GET );
+		}
+		// phpcs:enable WordPress.Security.NonceVerification.Recommended
+
+		add_filter( 'wp_redirect', $filter );
+		try {
+			Newspack_Popups_Segmentation::handle_account_param();
+		} catch ( Segmentation_Redirect_Exception $e ) {
+			unset( $e ); // Expected: stands in for the exit() after the redirect.
+		} finally {
+			remove_filter( 'wp_redirect', $filter );
+			unset( $_SERVER['REQUEST_URI'], $_SERVER['REQUEST_METHOD'] );
+			$_GET = [];
+		}
+
+		return $captured;
+	}
+
+	/**
+	 * The cookie value the handler handed off, or null.
+	 *
+	 * @return string|null
+	 */
+	private function cookie() {
+		// phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE, WordPress.Security.ValidatedSanitizedInput.InputNotSanitized
+		return $_COOKIE[ Newspack_Popups_Segmentation::CARRIED_SEGMENTS_COOKIE ] ?? null;
+	}
+
+	/**
+	 * The happy path: a known account's snapshot is handed off and the param is
+	 * stripped, leaving every other param intact.
+	 */
+	public function test_resolves_snapshot_and_strips_the_param() {
+		\Newspack\Reader_Data::$matched_segments = [ 42 => [ $this->segment_ids['carried-one'] ] ];
+
+		$this->assertSame(
+			'/2026/07/20/some-post/?utm_medium=email&npnl=ABC123',
+			$this->arrive( '/2026/07/20/some-post/?utm_medium=email&np_account=42&npnl=ABC123' )
+		);
+		$this->assertSame( $this->segment_ids['carried-one'], $this->cookie() );
+	}
+
+	/**
+	 * Multiple segments are handed off as a comma-joined list.
+	 */
+	public function test_hands_off_multiple_segment_ids() {
+		\Newspack\Reader_Data::$matched_segments = [
+			42 => [ $this->segment_ids['carried-one'], $this->segment_ids['carried-two'] ],
+		];
+		$this->arrive( '/p/?np_account=42' );
+		$this->assertSame(
+			$this->segment_ids['carried-one'] . ',' . $this->segment_ids['carried-two'],
+			$this->cookie()
+		);
+	}
+
+	/**
+	 * A snapshot can name a segment that has since been deleted or disabled.
+	 * Only IDs the site still ships to the browser are worth carrying.
+	 */
+	public function test_drops_segment_ids_that_are_not_active() {
+		\Newspack\Reader_Data::$matched_segments = [
+			42 => [ $this->segment_ids['carried-one'], '999999' ],
+		];
+		$this->arrive( '/p/?np_account=42' );
+		$this->assertSame( $this->segment_ids['carried-one'], $this->cookie() );
+	}
+
+	/**
+	 * An unsubstituted merge tag still gets redirected away. This is the whole
+	 * reason ActiveCampaign can be supported: a malformed percent-escape must
+	 * never survive into a rendered page.
+	 *
+	 * @param string $value Raw param value as it arrives.
+	 *
+	 * @dataProvider unresolvable_value_provider
+	 */
+	public function test_redirects_away_unresolvable_values( $value ) {
+		$this->assertSame( '/p/?a=1', $this->arrive( '/p/?a=1&np_account=' . $value ) );
+		$this->assertNull( $this->cookie() );
+	}
+
+	/**
+	 * Values that are not a plain positive integer: unsubstituted tags from each
+	 * supported ESP, and junk.
+	 *
+	 * @return array[]
+	 */
+	public function unresolvable_value_provider() {
+		return [
+			'mailchimp tag'        => [ '*|NP_ACCOUNT|*' ],
+			'activecampaign tag'   => [ '%NP_ACCOUNT%' ],
+			'constant contact tag' => [ '[[NP_ACCOUNT]]' ],
+			'campaign monitor tag' => [ '[NP_ACCOUNT]' ],
+			'hex-shaped tag'       => [ '%CAFE%' ],
+			'empty'                => [ '' ],
+			'zero'                 => [ '0' ],
+			'negative'             => [ '-5' ],
+			'not a number'         => [ 'abc' ],
+			'float'                => [ '4.2' ],
+		];
+	}
+
+	/**
+	 * An account with no snapshot carries nothing and behaves as today.
+	 */
+	public function test_unknown_account_carries_nothing() {
+		$this->assertSame( '/p/?a=1', $this->arrive( '/p/?a=1&np_account=777' ) );
+		$this->assertNull( $this->cookie() );
+	}
+
+	/**
+	 * The redirect target must not itself trigger another redirect.
+	 */
+	public function test_redirect_result_does_not_redirect_again() {
+		\Newspack\Reader_Data::$matched_segments = [ 42 => [ $this->segment_ids['carried-one'] ] ];
+		$once = $this->arrive( '/p/?a=1&np_account=42' );
+		$this->assertSame( '/p/?a=1', $once );
+		$this->assertNull( $this->arrive( $once ) );
+	}
+
+	/**
+	 * No param, nothing to do — the overwhelmingly common request.
+	 */
+	public function test_ignores_request_without_the_param() {
+		$this->assertNull( $this->arrive( '/p/?utm_medium=email' ) );
+	}
+
+	/**
+	 * Redirecting a POST would discard its body.
+	 */
+	public function test_ignores_non_get_requests() {
+		$this->assertNull( $this->arrive( '/p/?np_account=42', 'POST' ) );
+	}
+
+	/**
+	 * The resolver is the seam the handler is built on; exercise it directly for
+	 * the degenerate inputs.
+	 */
+	public function test_resolver_rejects_non_positive_ids() {
+		$this->assertSame( [], Newspack_Popups_Segmentation::get_carried_segments_for_account( 0 ) );
+		$this->assertSame( [], Newspack_Popups_Segmentation::get_carried_segments_for_account( -1 ) );
+	}
+}

--- a/plugins/newspack-popups/tests/test-segmentation-account-arrival.php
+++ b/plugins/newspack-popups/tests/test-segmentation-account-arrival.php
@@ -40,6 +40,18 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	private static $cookie_options_method;
 
 	/**
+	 * Reflection onto the private, static get_carried_segments_cookie_value().
+	 * Same rationale as $cookie_options_method above: it isolates the cookie
+	 * *value* PHP computes from the delivery mechanism (`setcookie()`) that
+	 * never runs under PHPUnit, so a test can prove the value itself is never
+	 * empty independent of whatever arrive() happens to observe via the
+	 * $_COOKIE mirror.
+	 *
+	 * @var ReflectionMethod
+	 */
+	private static $cookie_value_method;
+
+	/**
 	 * Set up: two active segments, one disabled segment, and an empty snapshot
 	 * store.
 	 */
@@ -48,6 +60,10 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 		if ( ! self::$cookie_options_method ) {
 			self::$cookie_options_method = new ReflectionMethod( 'Newspack_Popups_Segmentation', 'get_carried_segments_cookie_options' );
 			self::$cookie_options_method->setAccessible( true );
+		}
+		if ( ! self::$cookie_value_method ) {
+			self::$cookie_value_method = new ReflectionMethod( 'Newspack_Popups_Segmentation', 'get_carried_segments_cookie_value' );
+			self::$cookie_value_method->setAccessible( true );
 		}
 		Newspack_Segments_Model::delete_all_segments();
 		Newspack_Popups_Segmentation::create_segment(
@@ -149,6 +165,19 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	 */
 	private function cookie_options() {
 		return self::$cookie_options_method->invoke( null );
+	}
+
+	/**
+	 * The carried-segments cookie value get_carried_segments_cookie_value()
+	 * computes for a given resolved set — via reflection, see
+	 * $cookie_value_method.
+	 *
+	 * @param string[] $segment_ids Active segment IDs.
+	 *
+	 * @return string
+	 */
+	private function cookie_value( $segment_ids ) {
+		return self::$cookie_value_method->invoke( null, $segment_ids );
 	}
 
 	/**
@@ -263,12 +292,14 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	/**
 	 * An account with no snapshot resolves to no segments, which is an
 	 * explicit "matches nothing" assertion (see
-	 * set_carried_segments_cookie()'s docblock) — an empty-string cookie, not
-	 * an absent one.
+	 * set_carried_segments_cookie()'s docblock) — a cookie carrying the
+	 * CARRIED_SEGMENTS_NONE sentinel, not an absent one, and not an
+	 * empty-string one either: setcookie() would send an empty string as a
+	 * deletion, indistinguishable from no handoff ever having happened.
 	 */
 	public function test_unknown_account_carries_nothing() {
 		$this->assertSame( '/p/?a=1', $this->arrive( '/p/?a=1&np_account=777' ) );
-		$this->assertSame( '', $this->cookie() );
+		$this->assertSame( Newspack_Popups_Segmentation::CARRIED_SEGMENTS_NONE, $this->cookie() );
 	}
 
 	/**
@@ -276,27 +307,28 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	 * first read, but on an arrival where that script never runs (a page with
 	 * no prompts, JS disabled), a previous arrival's segments must not carry
 	 * into the next click. An arrival that resolves nothing must overwrite
-	 * the mirror with an empty string — the "matches nothing" assertion —
-	 * not leave the previous arrival's value in place, and not unset it
-	 * either, since an unset mirror is indistinguishable from no handoff
-	 * ever having happened.
+	 * the mirror with the CARRIED_SEGMENTS_NONE sentinel — the "matches
+	 * nothing" assertion — not leave the previous arrival's value in place.
+	 * It must not become an empty string either (setcookie() would send that
+	 * as a deletion) or be unset (indistinguishable from no handoff ever
+	 * having happened).
 	 */
-	public function test_clears_a_previous_cookie_when_nothing_resolves() {
+	public function test_overwrites_a_previous_cookie_when_nothing_resolves() {
 		\Newspack\Reader_Data::$matched_segments = [ 42 => [ $this->segment_ids['carried-one'] ] ];
 		$this->arrive( '/p/?np_account=42' );
 		$this->assertSame( $this->segment_ids['carried-one'], $this->cookie() );
 
 		// A second, later arrival for an account with nothing to carry.
 		$this->arrive( '/p/?np_account=777' );
-		$this->assertSame( '', $this->cookie() );
+		$this->assertSame( Newspack_Popups_Segmentation::CARRIED_SEGMENTS_NONE, $this->cookie() );
 	}
 
 	/**
 	 * Unlike a valid ID that resolves to nothing (see
-	 * test_clears_a_previous_cookie_when_nothing_resolves() above), a value
-	 * that never passes the positive-integer gate makes no assertion about the
-	 * reader at all — e.g. an unsubstituted merge tag arriving from a
-	 * newsletter that already went out. It must leave an earlier arrival's
+	 * test_overwrites_a_previous_cookie_when_nothing_resolves() above), a
+	 * value that never passes the positive-integer gate makes no assertion
+	 * about the reader at all — e.g. an unsubstituted merge tag arriving from
+	 * a newsletter that already went out. It must leave an earlier arrival's
 	 * carried segments alone, even though the redirect itself still fires
 	 * unconditionally.
 	 *
@@ -327,8 +359,9 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	/**
 	 * No param, nothing to do — the overwhelmingly common request. Also
 	 * confirms an existing cookie is left alone: without the early return, a
-	 * param-less pageview would otherwise fall through to the cookie-clearing
-	 * path and wipe a legitimately carried set.
+	 * param-less pageview would otherwise fall through to the
+	 * cookie-assertion path and overwrite a legitimately carried set with the
+	 * "matches nothing" sentinel.
 	 */
 	public function test_ignores_request_without_the_param() {
 		$_COOKIE[ Newspack_Popups_Segmentation::CARRIED_SEGMENTS_COOKIE ] = $this->segment_ids['carried-one']; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
@@ -366,23 +399,53 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * The cookie-options helper always returns one set of options: since an
-	 * empty resolution is itself the "matches nothing" assertion (see
-	 * set_carried_segments_cookie()'s docblock), there is no longer a separate
-	 * "clearing" form to distinguish it from. set_carried_segments_cookie()'s
-	 * own setcookie() call never runs under PHPUnit (headers_sent() is always
-	 * true here), so no test that goes through arrive() ever exercises the
-	 * option values below — e.g. an `httponly => true` typo would silently
-	 * break the view script's document.cookie read, or an `expires` other
-	 * than 0 would make a real browser delete an empty resolution instead of
-	 * delivering it — and every other test here would still pass. Exercise
-	 * get_carried_segments_cookie_options() directly instead.
+	 * The cookie-options helper always returns one set of options, regardless
+	 * of the resolved value — keeping the value itself non-empty is
+	 * get_carried_segments_cookie_value()'s job, exercised separately below.
+	 * set_carried_segments_cookie()'s own setcookie() call never runs under
+	 * PHPUnit (headers_sent() is always true here), so no test that goes
+	 * through arrive() ever exercises the option values below — e.g. an
+	 * `httponly => true` typo would silently break the view script's
+	 * document.cookie read — and every other test here would still pass.
+	 * Exercise get_carried_segments_cookie_options() directly instead.
 	 */
 	public function test_cookie_options_are_js_readable_session_scoped_and_site_wide() {
 		$options = $this->cookie_options();
-		$this->assertSame( 0, $options['expires'], 'Must always be a session cookie, including when the value is empty — a past expiry would make a real browser delete the cookie instead of delivering the "matches nothing" assertion.' );
+		$this->assertSame( 0, $options['expires'], 'Must always be a session cookie.' );
 		$this->assertFalse( $options['httponly'], 'The view script reads this cookie via document.cookie; httponly would silently break the feature.' );
 		$this->assertSame( 'Lax', $options['samesite'] );
 		$this->assertSame( '/', $options['path'] );
+	}
+
+	/**
+	 * The cookie value computed by get_carried_segments_cookie_value() must
+	 * never be an empty string: PHP's setcookie() sends a deletion whenever
+	 * the value is empty, no matter what `expires` is passed (see
+	 * get_carried_segments_cookie_options()'s docblock), so a real browser
+	 * would then never deliver the "matches nothing" assertion at all. This
+	 * is the defect two prior review passes missed — set_carried_segments_cookie()'s
+	 * own setcookie() call never runs under PHPUnit, so a test that only goes
+	 * through arrive() and inspects the $_COOKIE mirror could never observe
+	 * it; this test exercises the value-computation seam directly instead.
+	 */
+	public function test_cookie_value_for_no_segments_is_the_sentinel_not_empty() {
+		$value = $this->cookie_value( [] );
+		$this->assertNotSame( '', $value, 'An empty string would be sent by setcookie() as a deletion, indistinguishable from no handoff at all.' );
+		$this->assertSame( Newspack_Popups_Segmentation::CARRIED_SEGMENTS_NONE, $value );
+	}
+
+	/**
+	 * A single resolved segment is carried as-is, with nothing to join.
+	 */
+	public function test_cookie_value_for_one_segment_is_just_that_id() {
+		$this->assertSame( '5', $this->cookie_value( [ '5' ] ) );
+	}
+
+	/**
+	 * Multiple resolved segments are carried as a comma-joined list — the
+	 * form the view script's carried-segments.js splits back apart.
+	 */
+	public function test_cookie_value_for_multiple_segments_is_comma_joined() {
+		$this->assertSame( '5,7', $this->cookie_value( [ '5', '7' ] ) );
 	}
 }

--- a/plugins/newspack-popups/tests/test-segmentation-account-arrival.php
+++ b/plugins/newspack-popups/tests/test-segmentation-account-arrival.php
@@ -29,7 +29,8 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	private $segment_ids = [];
 
 	/**
-	 * Set up: two active segments and an empty snapshot store.
+	 * Set up: two active segments, one disabled segment, and an empty snapshot
+	 * store.
 	 */
 	public function set_up() {
 		parent::set_up();
@@ -46,8 +47,19 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 				'configuration' => [],
 			]
 		);
+		// Disabled, not deleted: exercises the `false` argument to get_segments()
+		// in get_carried_segments_for_account(), which a nonexistent ID cannot.
+		Newspack_Popups_Segmentation::create_segment(
+			[
+				'name'          => 'carried-disabled',
+				'configuration' => [ 'is_disabled' => true ],
+			]
+		);
+		// Include inactive here so $this->segment_ids also carries the disabled
+		// segment's real ID; get_carried_segments_for_account() does its own
+		// active-only filtering internally via get_segments( false ).
 		$this->segment_ids = [];
-		foreach ( Newspack_Popups_Segmentation::get_segments( false ) as $segment ) {
+		foreach ( Newspack_Popups_Segmentation::get_segments() as $segment ) {
 			$this->segment_ids[ $segment['name'] ] = (string) $segment['id'];
 		}
 		\Newspack\Reader_Data::$matched_segments = [];
@@ -143,12 +155,27 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * A snapshot can name a segment that has since been deleted or disabled.
-	 * Only IDs the site still ships to the browser are worth carrying.
+	 * A snapshot can name a segment ID that no longer exists at all (e.g.
+	 * deleted since the snapshot was taken). An ID with no matching term can
+	 * never match anything, so it's dropped here rather than carried.
 	 */
-	public function test_drops_segment_ids_that_are_not_active() {
+	public function test_drops_unknown_segment_ids() {
 		\Newspack\Reader_Data::$matched_segments = [
 			42 => [ $this->segment_ids['carried-one'], '999999' ],
+		];
+		$this->arrive( '/p/?np_account=42' );
+		$this->assertSame( $this->segment_ids['carried-one'], $this->cookie() );
+	}
+
+	/**
+	 * A snapshot can also name a segment that still exists but has since been
+	 * disabled. This exercises the `false` (active-only) argument to
+	 * get_segments() inside get_carried_segments_for_account() specifically —
+	 * a nonexistent ID alone can't distinguish that from no filtering at all.
+	 */
+	public function test_drops_disabled_segment_ids() {
+		\Newspack\Reader_Data::$matched_segments = [
+			42 => [ $this->segment_ids['carried-one'], $this->segment_ids['carried-disabled'] ],
 		];
 		$this->arrive( '/p/?np_account=42' );
 		$this->assertSame( $this->segment_ids['carried-one'], $this->cookie() );
@@ -190,10 +217,45 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	}
 
 	/**
+	 * `np_account[]=…` puts an array in $_GET rather than a string — the one
+	 * value shape not covered by unresolvable_value_provider(), because it
+	 * can't be interpolated into a URL as a scalar. Confirmed safe rather than
+	 * assumed: core's sanitize_text_field() (via _sanitize_text_fields())
+	 * returns '' for an array, so preg_match() never sees one, and the
+	 * redirect still fires with nothing carried.
+	 *
+	 * Account 42 is seeded with a real snapshot so this also catches a
+	 * regression where the array is naively reduced to its first element
+	 * ('42') instead of being rejected outright — that would resolve and
+	 * cookie a match, which must not happen here.
+	 */
+	public function test_ignores_array_shaped_param_value() {
+		\Newspack\Reader_Data::$matched_segments = [ 42 => [ $this->segment_ids['carried-one'] ] ];
+		$this->assertSame( '/p/?a=1', $this->arrive( '/p/?a=1&np_account[]=42' ) );
+		$this->assertNull( $this->cookie() );
+	}
+
+	/**
 	 * An account with no snapshot carries nothing and behaves as today.
 	 */
 	public function test_unknown_account_carries_nothing() {
 		$this->assertSame( '/p/?a=1', $this->arrive( '/p/?a=1&np_account=777' ) );
+		$this->assertNull( $this->cookie() );
+	}
+
+	/**
+	 * Each arrival is authoritative: the view script deletes the cookie on
+	 * first read, but on an arrival where that script never runs (a page with
+	 * no prompts, JS disabled), a previous arrival's segments must not carry
+	 * into the next click. An arrival that resolves nothing must clear it.
+	 */
+	public function test_clears_a_previous_cookie_when_nothing_resolves() {
+		\Newspack\Reader_Data::$matched_segments = [ 42 => [ $this->segment_ids['carried-one'] ] ];
+		$this->arrive( '/p/?np_account=42' );
+		$this->assertSame( $this->segment_ids['carried-one'], $this->cookie() );
+
+		// A second, later arrival for an account with nothing to carry.
+		$this->arrive( '/p/?np_account=777' );
 		$this->assertNull( $this->cookie() );
 	}
 
@@ -224,8 +286,16 @@ class SegmentationAccountArrivalTest extends WP_UnitTestCase {
 	/**
 	 * The resolver is the seam the handler is built on; exercise it directly for
 	 * the degenerate inputs.
+	 *
+	 * The mock is seeded with a real, active segment ID under keys `0` and
+	 * `-1` so an empty result can only come from the $account_id < 1 guard,
+	 * not from the mock having nothing to return for those keys anyway.
 	 */
 	public function test_resolver_rejects_non_positive_ids() {
+		\Newspack\Reader_Data::$matched_segments = [
+			0  => [ $this->segment_ids['carried-one'] ],
+			-1 => [ $this->segment_ids['carried-one'] ],
+		];
 		$this->assertSame( [], Newspack_Popups_Segmentation::get_carried_segments_for_account( 0 ) );
 		$this->assertSame( [], Newspack_Popups_Segmentation::get_carried_segments_for_account( -1 ) );
 	}

--- a/plugins/newspack-popups/tests/test-segmentation-account-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-account-link.php
@@ -216,4 +216,50 @@ class SegmentationAccountLinkTest extends WP_UnitTestCase {
 			Newspack_Popups_Segmentation::append_account_param( $url, $url, $this->make_newsletter() )
 		);
 	}
+
+	/**
+	 * Mailchimp's own process_link() filter hands the whole URL back as a bare
+	 * merge-tag placeholder for links like *|UNSUB|*. Those have no host, so
+	 * is_first_party_url() reads them as first-party — but decorating one yields
+	 * `*|UNSUB|*?np_account=...`, which the ESP expands into an unsubscribe URL
+	 * that already carries its own query string. Unsubscribe is required by law
+	 * and by Mailchimp's terms, so these links must pass through untouched.
+	 *
+	 * @param string $url Placeholder URL as the ESP filter hands it over.
+	 *
+	 * @dataProvider placeholder_url_provider
+	 */
+	public function test_skips_esp_placeholder_url( $url ) {
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_account_param( $url, $url, $this->make_newsletter() )
+		);
+	}
+
+	/**
+	 * Whole-URL merge-tag placeholders: the Mailchimp links that carry real
+	 * consequences, plus one shape per other supported ESP.
+	 *
+	 * @return array[]
+	 */
+	public function placeholder_url_provider() {
+		return [
+			'mailchimp unsubscribe'    => [ '*|UNSUB|*' ],
+			'mailchimp update profile' => [ '*|UPDATE_PROFILE|*' ],
+			'mailchimp forward'        => [ '*|FORWARD|*' ],
+			'constant contact'         => [ '[[UNSUBSCRIBE]]' ],
+			'active campaign'          => [ '%UNSUBSCRIBE%' ],
+			'campaign monitor'         => [ '[unsubscribe]' ],
+		];
+	}
+
+	/**
+	 * A real URL that merely carries a merge tag in a query value is still a real
+	 * URL. Only a whole-URL placeholder is skipped.
+	 */
+	public function test_still_decorates_url_carrying_a_merge_tag_value() {
+		$url    = home_url( '/some-article/?utm_content=*|CAMPAIGN_UID|*' );
+		$result = Newspack_Popups_Segmentation::append_account_param( $url, $url, $this->make_newsletter() );
+		$this->assertStringContainsString( 'np_account=*|NP_ACCOUNT|*', $result );
+	}
 }

--- a/plugins/newspack-popups/tests/test-segmentation-account-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-account-link.php
@@ -1,0 +1,185 @@
+<?php
+/**
+ * Tests for the account-ID param appended to newsletter links by
+ * Newspack_Popups_Segmentation::append_account_param().
+ *
+ * @package Newspack_Popups
+ */
+
+// Stand-ins for the cross-plugin classes the handler guards on, plus a fake
+// ESP provider; the popups test suite loads only newspack-popups.
+require_once __DIR__ . '/mocks/class-newspack-newsletters.php';
+require_once __DIR__ . '/mocks/class-utils.php';
+require_once __DIR__ . '/mocks/class-metadata.php';
+require_once __DIR__ . '/mocks/class-service-provider.php';
+
+/**
+ * Test appending the account param to newsletter links.
+ */
+class SegmentationAccountLinkTest extends WP_UnitTestCase {
+
+	/**
+	 * The stand-in provider.
+	 *
+	 * @var Newspack_Popups_Test_Service_Provider
+	 */
+	private $provider;
+
+	/**
+	 * Set up: a Mailchimp-syntax provider that knows the Account field's tag.
+	 */
+	public function set_up() {
+		parent::set_up();
+		$this->provider                     = new Newspack_Popups_Test_Service_Provider();
+		$this->provider->tags               = [ 'NP_Account' => 'NP_ACCOUNT' ];
+		Newspack_Newsletters::$provider     = $this->provider;
+		\Newspack_Newsletters\Tracking\Utils::$syntax = '*|%s|*';
+		\Newspack\Reader_Activation\Sync\Metadata::$keys = [ 'Account' => 'NP_Account' ];
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		Newspack_Newsletters::$provider = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Make a newsletter post.
+	 *
+	 * @param string $send_list_id Optional audience ID to store as post meta.
+	 *
+	 * @return WP_Post
+	 */
+	private function make_newsletter( $send_list_id = '' ) {
+		$post = self::factory()->post->create_and_get(
+			[ 'post_type' => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT ]
+		);
+		if ( '' !== $send_list_id ) {
+			update_post_meta( $post->ID, 'send_list_id', $send_list_id );
+		}
+		return $post;
+	}
+
+	/**
+	 * A first-party newsletter link gets the account merge tag, raw, so the ESP
+	 * substitutes the recipient's account ID at send time.
+	 */
+	public function test_appends_raw_merge_tag_to_first_party_link() {
+		$url    = home_url( '/some-article/' );
+		$result = Newspack_Popups_Segmentation::append_account_param( $url, $url, $this->make_newsletter() );
+
+		$args = wp_parse_args( wp_parse_url( $result, PHP_URL_QUERY ) );
+		$this->assertArrayHasKey( 'np_account', $args );
+		$this->assertSame( '*|NP_ACCOUNT|*', $args['np_account'] );
+
+		// ESPs substitute only the literal syntax; add_query_arg() encodes by
+		// default, so this guards the str_replace that restores the raw tag.
+		$this->assertStringContainsString( 'np_account=*|NP_ACCOUNT|*', $result );
+		$this->assertStringNotContainsString( '%2A%7C', $result );
+	}
+
+	/**
+	 * ActiveCampaign's `%TAG%` syntax is emitted here, unlike np_seg_donor: the
+	 * account param is always redirected away before any output, so an
+	 * unsubstituted tag can never reach a consumer that decodes query params
+	 * (NPPM-3032).
+	 */
+	public function test_appends_activecampaign_percent_syntax() {
+		\Newspack_Newsletters\Tracking\Utils::$syntax = '%%%s%%';
+		$url    = home_url( '/some-article/' );
+		$result = Newspack_Popups_Segmentation::append_account_param( $url, $url, $this->make_newsletter() );
+		$this->assertStringContainsString( 'np_account=%NP_ACCOUNT%', $result );
+	}
+
+	/**
+	 * Relative links are first-party by definition.
+	 */
+	public function test_appends_to_relative_link() {
+		$result = Newspack_Popups_Segmentation::append_account_param( '/some-article/', '/some-article/', $this->make_newsletter() );
+		$this->assertStringContainsString( 'np_account=*|NP_ACCOUNT|*', $result );
+	}
+
+	/**
+	 * Third-party links are untouched: the account ID must not leak into
+	 * external logs or Referer headers.
+	 */
+	public function test_skips_external_link() {
+		$url = 'https://example.com/elsewhere/';
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_account_param( $url, $url, $this->make_newsletter() )
+		);
+	}
+
+	/**
+	 * Newsletter ads and other non-newsletter posts are proxied separately and
+	 * would not forward the param.
+	 */
+	public function test_skips_non_newsletter_post() {
+		$post = self::factory()->post->create_and_get( [ 'post_type' => 'post' ] );
+		$url  = home_url( '/some-article/' );
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_account_param( $url, $url, $post )
+		);
+	}
+
+	/**
+	 * No tag for the field means the field isn't synced to this ESP, so there is
+	 * nothing for the ESP to substitute. Emit nothing rather than a dead tag.
+	 */
+	public function test_skips_when_field_has_no_tag() {
+		$this->provider->tags = [];
+		$url = home_url( '/some-article/' );
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_account_param( $url, $url, $this->make_newsletter() )
+		);
+	}
+
+	/**
+	 * The legacy metadata schema keys the Account field as 'account'. Both
+	 * schemas must resolve.
+	 */
+	public function test_resolves_legacy_metadata_raw_key() {
+		\Newspack\Reader_Activation\Sync\Metadata::$keys = [ 'account' => 'NP_Account' ];
+		$url    = home_url( '/some-article/' );
+		$result = Newspack_Popups_Segmentation::append_account_param( $url, $url, $this->make_newsletter() );
+		$this->assertStringContainsString( 'np_account=*|NP_ACCOUNT|*', $result );
+	}
+
+	/**
+	 * Mailchimp merge-field tags are per-audience, so the newsletter's audience
+	 * has to reach the resolver.
+	 */
+	public function test_passes_newsletter_send_list_to_the_resolver() {
+		$url = home_url( '/some-article/' );
+		Newspack_Popups_Segmentation::append_account_param( $url, $url, $this->make_newsletter( 'abc123' ) );
+		$this->assertSame( 'abc123', $this->provider->received_list_id );
+	}
+
+	/**
+	 * A newsletter with no audience set passes null, letting providers whose
+	 * fields are account-wide (ActiveCampaign) still resolve.
+	 */
+	public function test_passes_null_list_id_when_no_send_list() {
+		$url = home_url( '/some-article/' );
+		Newspack_Popups_Segmentation::append_account_param( $url, $url, $this->make_newsletter() );
+		$this->assertNull( $this->provider->received_list_id );
+	}
+
+	/**
+	 * A missing or version-skewed provider must not fatal mid-render — that
+	 * would break every newsletter on the site.
+	 */
+	public function test_skips_when_provider_is_absent() {
+		Newspack_Newsletters::$provider = null;
+		$url = home_url( '/some-article/' );
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_account_param( $url, $url, $this->make_newsletter() )
+		);
+	}
+}

--- a/plugins/newspack-popups/tests/test-segmentation-account-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-account-link.php
@@ -74,10 +74,44 @@ class SegmentationAccountLinkTest extends WP_UnitTestCase {
 		$this->assertArrayHasKey( 'np_account', $args );
 		$this->assertSame( '*|NP_ACCOUNT|*', $args['np_account'] );
 
-		// ESPs substitute only the literal syntax; add_query_arg() encodes by
-		// default, so this guards the str_replace that restores the raw tag.
+		// ESPs substitute only the literal syntax, never a percent-encoded form,
+		// so the tag must appear raw in the URL for the ESP to resolve it.
 		$this->assertStringContainsString( 'np_account=*|NP_ACCOUNT|*', $result );
 		$this->assertStringNotContainsString( '%2A%7C', $result );
+	}
+
+	/**
+	 * A query param appended after a URL fragment would become part of the
+	 * fragment instead of a real query param — e.g. the unparseable
+	 * `/post/#section?np_account=TAG` — so the tag must land before it.
+	 */
+	public function test_appends_before_url_fragment() {
+		$base   = home_url( '/some-article/' );
+		$url    = $base . '#section';
+		$result = Newspack_Popups_Segmentation::append_account_param( $url, $url, $this->make_newsletter() );
+
+		$this->assertSame( $base . '?np_account=*|NP_ACCOUNT|*#section', $result );
+	}
+
+	/**
+	 * Regression test for the REAL newspack_newsletters_process_link chain, not
+	 * a handler called standalone. append_donor_segment_param() is registered
+	 * first (see the constructor) and restores its own tag raw; if
+	 * append_account_param() ran that URL through add_query_arg(), WordPress's
+	 * urlencode_deep() would re-encode the donor handler's already-raw tag right
+	 * back into the unresolvable %2A%7C... form. Every other test in this file
+	 * calls a single handler directly, which cannot catch this — the corruption
+	 * only appears when both handlers actually run back-to-back through the
+	 * filter, which is exactly what this test does.
+	 */
+	public function test_real_filter_chain_keeps_both_tags_raw() {
+		update_option( 'newspack_popups_mc_donor_merge_field', 'HUB-MEMBER' );
+
+		$url    = home_url( '/some-article/' );
+		$result = apply_filters( 'newspack_newsletters_process_link', $url, $url, $this->make_newsletter() );
+
+		$this->assertStringContainsString( 'np_seg_donor=*|HUB-MEMBER|*', $result );
+		$this->assertStringContainsString( 'np_account=*|NP_ACCOUNT|*', $result );
 	}
 
 	/**

--- a/plugins/newspack-popups/tests/test-segmentation-account-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-account-link.php
@@ -94,15 +94,10 @@ class SegmentationAccountLinkTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Regression test for the REAL newspack_newsletters_process_link chain, not
-	 * a handler called standalone. append_donor_segment_param() is registered
-	 * first (see the constructor) and restores its own tag raw; if
-	 * append_account_param() ran that URL through add_query_arg(), WordPress's
-	 * urlencode_deep() would re-encode the donor handler's already-raw tag right
-	 * back into the unresolvable %2A%7C... form. Every other test in this file
-	 * calls a single handler directly, which cannot catch this — the corruption
-	 * only appears when both handlers actually run back-to-back through the
-	 * filter, which is exactly what this test does.
+	 * Runs the real newspack_newsletters_process_link chain: add_query_arg() in
+	 * the account handler would re-encode the donor handler's already-raw tag
+	 * into the unresolvable %2A%7C... form, which single-handler tests cannot
+	 * catch.
 	 */
 	public function test_real_filter_chain_keeps_both_tags_raw() {
 		update_option( 'newspack_popups_mc_donor_merge_field', 'HUB-MEMBER' );
@@ -218,12 +213,9 @@ class SegmentationAccountLinkTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Mailchimp's own process_link() filter hands the whole URL back as a bare
-	 * merge-tag placeholder for links like *|UNSUB|*. Those have no host, so
-	 * is_first_party_url() reads them as first-party — but decorating one yields
-	 * `*|UNSUB|*?np_account=...`, which the ESP expands into an unsubscribe URL
-	 * that already carries its own query string. Unsubscribe is required by law
-	 * and by Mailchimp's terms, so these links must pass through untouched.
+	 * A whole-URL merge-tag placeholder (e.g. Mailchimp's *|UNSUB|*) is host-less
+	 * and reads as first-party, but decorating it breaks the expanded link — and
+	 * unsubscribe links are required by law. They must pass through untouched.
 	 *
 	 * @param string $url Placeholder URL as the ESP filter hands it over.
 	 *

--- a/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
@@ -358,12 +358,9 @@ class SegmentationNewsletterLinkTest extends WP_UnitTestCase {
 	}
 
 	/**
-	 * Mailchimp's own process_link() filter hands the whole URL back as a bare
-	 * merge-tag placeholder for links like *|UNSUB|*. Those have no host, so
-	 * is_first_party_url() reads them as first-party — but decorating one yields
-	 * `*|UNSUB|*?np_seg_donor=...`, which the ESP expands into an unsubscribe URL
-	 * that already carries its own query string. Unsubscribe is required by law
-	 * and by Mailchimp's terms, so these links must pass through untouched.
+	 * A whole-URL merge-tag placeholder (e.g. Mailchimp's *|UNSUB|*) is host-less
+	 * and reads as first-party, but decorating it breaks the expanded link — and
+	 * unsubscribe links are required by law. They must pass through untouched.
 	 *
 	 * @param string $url Placeholder URL as the ESP filter hands it over.
 	 *

--- a/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
+++ b/plugins/newspack-popups/tests/test-segmentation-newsletter-link.php
@@ -356,4 +356,40 @@ class SegmentationNewsletterLinkTest extends WP_UnitTestCase {
 		$args = wp_parse_args( wp_parse_url( $result, PHP_URL_QUERY ) );
 		$this->assertSame( '*|HUB-MEMBER|*', $args['np_seg_donor'] );
 	}
+
+	/**
+	 * Mailchimp's own process_link() filter hands the whole URL back as a bare
+	 * merge-tag placeholder for links like *|UNSUB|*. Those have no host, so
+	 * is_first_party_url() reads them as first-party — but decorating one yields
+	 * `*|UNSUB|*?np_seg_donor=...`, which the ESP expands into an unsubscribe URL
+	 * that already carries its own query string. Unsubscribe is required by law
+	 * and by Mailchimp's terms, so these links must pass through untouched.
+	 *
+	 * @param string $url Placeholder URL as the ESP filter hands it over.
+	 *
+	 * @dataProvider placeholder_url_provider
+	 */
+	public function test_skips_esp_placeholder_url( $url ) {
+		$this->assertSame(
+			$url,
+			Newspack_Popups_Segmentation::append_donor_segment_param( $url, $url, $this->make_newsletter() )
+		);
+	}
+
+	/**
+	 * Whole-URL merge-tag placeholders: the Mailchimp links that carry real
+	 * consequences, plus one shape per other supported ESP.
+	 *
+	 * @return array[]
+	 */
+	public function placeholder_url_provider() {
+		return [
+			'mailchimp unsubscribe'    => [ '*|UNSUB|*' ],
+			'mailchimp update profile' => [ '*|UPDATE_PROFILE|*' ],
+			'mailchimp forward'        => [ '*|FORWARD|*' ],
+			'constant contact'         => [ '[[UNSUBSCRIBE]]' ],
+			'active campaign'          => [ '%UNSUBSCRIBE%' ],
+			'campaign monitor'         => [ '[unsubscribe]' ],
+		];
+	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

A reader clicking a newsletter link while logged out is invisible to Campaigns segmentation, so prompts fall back to generic targeting. This gives them their last-known segments for that browsing session.

Newsletter links now carry `np_account`, filled per recipient by the ESP from the Account field Newspack already syncs. On arrival the site resolves that account's segments, hands them to the view script in a session cookie, and redirects to the clean URL. The landing page stays cacheable and the parameter never reaches a rendered page. Those segments then join the priority match, which is what makes prompt targeting honor them.

The signal is forgeable by design: segmentation only, session only, never content access, never written to the reader profile. Signed-in readers keep their live matching. ActiveCampaign and Mailchimp are supported; other ESPs emit nothing and behave as today.

Closes NPPD-2152.

### How to test the changes in this Pull Request:

1. Connect Mailchimp or ActiveCampaign, with the Account field enabled for sync.
2. Sign in as a reader and browse until a segment matches. A snapshot is recorded.
3. Create a prompt targeted to that segment.
4. Send a newsletter to that reader. Its links carry `np_account` with the ESP merge tag.
5. Open a link in a logged-out browser. The parameter disappears from the URL and the prompt shows.
6. Browse to another page. The prompt still honors the segment.
7. Open `?np_account=%NP_ACCOUNT%` directly. The page renders normally and no segment is carried.
8. Open `?np_account=<id of an account with no segments>`. Any carried segments stop applying.
9. Sign in and repeat step 5. Local matching applies instead of the carried set.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Unlike the sibling `np_seg_donor` parameter, this one is emitted for ActiveCampaign. An unsubstituted `%FIELD%` is a malformed percent-escape that blanks the page in strict decoders (NPPM-3032), and it is safe here only because `np_account` is always redirected away before any output. Requests WordPress never routes through `template_redirect` keep the raw parameter in the address bar; nothing renders, so nothing breaks.

Live merge-tag substitution is not verified yet: a real send on each ESP is still owed.

<details>
<summary>Two platform behaviors that shaped the code</summary>

`add_query_arg()` runs `urlencode_deep()` over the existing query string, re-encoding a raw merge tag an earlier handler already placed. That corrupted `np_seg_donor` into the unresolvable `%2A%7C…` form, hence the manual parameter append.

`setcookie()` emits a deletion whenever the value is empty, ignoring the expiry passed. An empty handoff would be invisible to the browser and stale segments would survive, hence the `none` sentinel.

</details>
