### PR TITLE
fix(newsletters): keep subscription lists on a cold ESP cache

### DIFF
--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-subscription.php
@@ -529,15 +529,36 @@ class Newspack_Newsletters_Subscription {
 			);
 
 			/**
+			 * Filters whether the ESP reported its full set of lists.
+			 *
+			 * A provider that serves sublists from its own cache returns a partial
+			 * set while that cache is still warming. Acting on a partial set is
+			 * destructive, so providers report it here and this method stands down.
+			 *
+			 * @param bool $is_complete Whether the list set is complete.
+			 */
+			$is_complete = (bool) apply_filters( 'newspack_newsletters_lists_are_complete', true );
+
+			/**
 			 * Remove from the local DB lists that no longer exist in the ESP.
 			 * This also cleans up the DB in case we accidentally created more than one list for the same ESP list.
+			 *
+			 * Skipped on a partial set: the collector deletes every stored remote
+			 * list absent from the payload, so a list the ESP simply could not
+			 * report yet would be deleted along with its local configuration.
 			 */
-			Subscription_Lists::garbage_collector( wp_list_pluck( $return_lists, 'db_id' ) );
+			if ( $is_complete ) {
+				Subscription_Lists::garbage_collector( wp_list_pluck( $return_lists, 'db_id' ) );
+			}
 
 			foreach ( Subscription_Lists::get_locals_for_current_provider() as $local_list ) {
 				$return_lists[] = $local_list->to_array();
 			}
-			set_transient( $cache_key, $return_lists, self::get_lists_cache_ttl() );
+			// Caching a partial set would keep serving it for the whole TTL, long
+			// after the provider's own cache has filled in.
+			if ( $is_complete ) {
+				set_transient( $cache_key, $return_lists, self::get_lists_cache_ttl() );
+			}
 			return $return_lists;
 		} catch ( \Exception $e ) {
 			return new WP_Error(

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -71,6 +71,16 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	private static $memoized_data = [];
 
 	/**
+	 * Whether any audience's cached data was missing during this request.
+	 *
+	 * A miss means the data is being fetched in the background, not that the
+	 * audience has none, so anything built from it this request is partial.
+	 *
+	 * @var bool
+	 */
+	private static $has_cold_cache = false;
+
+	/**
 	 * Initializes this class
 	 */
 	public static function init() {
@@ -93,6 +103,22 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		}
 
 		add_action( 'admin_notices', [ __CLASS__, 'maybe_show_error' ] );
+
+		add_filter( 'newspack_newsletters_lists_are_complete', [ __CLASS__, 'filter_lists_are_complete' ] );
+	}
+
+	/**
+	 * Reports the list set as partial when any audience was served from a cold cache.
+	 *
+	 * Groups and tags are read from this cache while building the list set, and a
+	 * cold read yields an empty array. Callers need to tell that apart from an
+	 * audience that genuinely has none.
+	 *
+	 * @param bool $is_complete Whether the list set is complete so far.
+	 * @return bool
+	 */
+	public static function filter_lists_are_complete( $is_complete ) {
+		return $is_complete && ! self::$has_cold_cache;
 	}
 
 	/**
@@ -413,6 +439,7 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 		}
 
 		Newspack_Newsletters_Logger::log( 'Mailchimp cache: No data found. Dispatching refresh' );
+		self::$has_cold_cache = true;
 		self::dispatch_refresh( $list_id );
 
 		return [];

--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -440,9 +440,34 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 
 		Newspack_Newsletters_Logger::log( 'Mailchimp cache: No data found. Dispatching refresh' );
 		self::$has_cold_cache = true;
+		self::forget_missing_option( self::get_cache_key( $list_id ) );
 		self::dispatch_refresh( $list_id );
 
 		return [];
+	}
+
+	/**
+	 * Forgets that an option was missing.
+	 *
+	 * WordPress records a missing option in the `notoptions` cache and answers
+	 * later reads from that record without querying the database. The refresh
+	 * dispatched just above writes this option moments later from its own
+	 * request, so keeping the record hides that write: with a persistent object
+	 * cache it outlives the request, every later read is told the option is still
+	 * missing, and the data never appears.
+	 *
+	 * Clearing it here, in the same request that recorded it, also keeps that
+	 * request from writing the record back when it reads its next missing option.
+	 *
+	 * @param string $option The option name.
+	 * @return void
+	 */
+	private static function forget_missing_option( $option ) {
+		$notoptions = wp_cache_get( 'notoptions', 'options' );
+		if ( is_array( $notoptions ) && isset( $notoptions[ $option ] ) ) {
+			unset( $notoptions[ $option ] );
+			wp_cache_set( 'notoptions', $notoptions, 'options' );
+		}
 	}
 
 	/**

--- a/plugins/newspack-newsletters/tests/test-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/tests/test-mailchimp-cached-data.php
@@ -25,4 +25,89 @@ class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
 		$this->expectException( Exception::class );
 		$segments = Newspack_Newsletters_Mailchimp_Cached_Data::fetch_segments( 'list1' );
 	}
+
+	/**
+	 * A cache miss dispatches a background refresh that writes the option moments
+	 * later, from another request. WordPress remembers a missing option in its
+	 * `notoptions` cache and then answers later reads from that memory without
+	 * querying the database, so the write stays invisible and the data never
+	 * appears. Reading the cache must not leave that memory behind.
+	 */
+	public function test_cold_read_does_not_remember_the_option_as_missing() {
+		$list_id = 'audColdRead';
+		$key     = 'newspack_nl_mailchimp_cache_' . $list_id;
+
+		delete_option( $key );
+		wp_cache_delete( 'notoptions', 'options' );
+
+		add_filter( 'pre_http_request', [ $this, 'block_http' ], 10, 3 );
+		Newspack_Newsletters_Mailchimp_Cached_Data::get_tags( $list_id );
+		remove_filter( 'pre_http_request', [ $this, 'block_http' ], 10 );
+
+		$notoptions = wp_cache_get( 'notoptions', 'options' );
+
+		$this->assertFalse(
+			is_array( $notoptions ) && isset( $notoptions[ $key ] ),
+			'A cold read must not leave the option remembered as missing.'
+		);
+	}
+
+	/**
+	 * Once the option has been forgotten, a value written by another process is
+	 * visible to the next read instead of being masked by the cached absence.
+	 */
+	public function test_value_written_after_a_cold_read_is_visible() {
+		$list_id = 'audWrittenAfter';
+		$key     = 'newspack_nl_mailchimp_cache_' . $list_id;
+
+		delete_option( $key );
+		wp_cache_delete( 'notoptions', 'options' );
+
+		add_filter( 'pre_http_request', [ $this, 'block_http' ], 10, 3 );
+		Newspack_Newsletters_Mailchimp_Cached_Data::get_tags( $list_id );
+		remove_filter( 'pre_http_request', [ $this, 'block_http' ], 10 );
+
+		// Stand in for the background refresh writing straight to the database,
+		// as it does from its own request.
+		global $wpdb;
+		// phpcs:ignore WordPress.DB.DirectDatabaseQuery
+		$wpdb->insert(
+			$wpdb->options,
+			[
+				'option_name'  => $key,
+				'option_value' => maybe_serialize(
+					[
+						'tags' => [
+							[
+								'id'   => 1,
+								'name' => 'Warm',
+							],
+						],
+					] 
+				),
+				'autoload'     => 'no',
+			]
+		);
+
+		$this->assertIsArray( get_option( $key ), 'The written value must be visible to the next read.' );
+	}
+
+	/**
+	 * Swallow the async refresh request the cache dispatches on a miss.
+	 *
+	 * @param mixed  $preempt Whether to preempt the request.
+	 * @param array  $args    The request arguments.
+	 * @param string $url     The request URL.
+	 * @return array
+	 */
+	public function block_http( $preempt, $args, $url ) {
+		return [
+			'headers'  => [],
+			'body'     => '',
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+		];
+	}
 }

--- a/plugins/newspack-newsletters/tests/test-subscription-get-lists.php
+++ b/plugins/newspack-newsletters/tests/test-subscription-get-lists.php
@@ -33,6 +33,13 @@ class Subscription_Get_Lists_Test extends WP_UnitTestCase {
 	private $provider_replaced = false;
 
 	/**
+	 * Whether the incomplete-payload filter is currently installed.
+	 *
+	 * @var bool
+	 */
+	private $incomplete_filter_added = false;
+
+	/**
 	 * Point the plugin at the provider slug and start from a cold list cache.
 	 *
 	 * The option is written directly rather than through set_service_provider(),
@@ -55,6 +62,10 @@ class Subscription_Get_Lists_Test extends WP_UnitTestCase {
 		if ( $this->provider_replaced ) {
 			$this->provider_property()->setValue( null, $this->original_provider );
 			$this->provider_replaced = false;
+		}
+		if ( $this->incomplete_filter_added ) {
+			remove_filter( 'newspack_newsletters_lists_are_complete', '__return_false' );
+			$this->incomplete_filter_added = false;
 		}
 		$this->clear_lists_cache();
 		parent::tear_down();
@@ -182,6 +193,120 @@ class Subscription_Get_Lists_Test extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A provider that could only report part of its lists (a cold ESP cache, say)
+	 * must not authorize deleting the ones it could not see. The garbage
+	 * collector deletes every stored remote list absent from the payload, so
+	 * acting on a partial read destroys configured lists.
+	 */
+	public function test_incomplete_payload_does_not_garbage_collect_stored_lists() {
+		$stored = $this->create_remote_list( '9999' );
+
+		$this->stub_provider_lists(
+			[
+				[
+					'id'   => '9001',
+					'name' => 'Weekly digest',
+				],
+			]
+		);
+		$this->mark_lists_incomplete();
+
+		$result = Newspack_Newsletters_Subscription::get_lists();
+
+		$this->assertNotWPError( $result );
+		$this->assertSame(
+			'publish',
+			get_post_status( $stored ),
+			'A list missing from an incomplete payload must survive.'
+		);
+	}
+
+	/**
+	 * An incomplete payload must not be cached either, or the screen keeps
+	 * serving the partial set for the whole TTL even once the ESP data lands.
+	 */
+	public function test_incomplete_payload_is_not_cached() {
+		$this->stub_provider_lists(
+			[
+				[
+					'id'   => '9001',
+					'name' => 'Weekly digest',
+				],
+			]
+		);
+		$this->mark_lists_incomplete();
+
+		Newspack_Newsletters_Subscription::get_lists();
+
+		$this->assertFalse(
+			get_transient( Newspack_Newsletters_Subscription::LISTS_CACHE_PREFIX . self::PROVIDER ),
+			'An incomplete payload must not be cached.'
+		);
+	}
+
+	/**
+	 * The guard must stay out of the way of a complete read: it still caches,
+	 * and it still cleans up lists the ESP no longer has.
+	 */
+	public function test_complete_payload_still_caches_and_garbage_collects() {
+		$stored = $this->create_remote_list( '9999' );
+
+		$this->stub_provider_lists(
+			[
+				[
+					'id'   => '9001',
+					'name' => 'Weekly digest',
+				],
+			]
+		);
+
+		$result = Newspack_Newsletters_Subscription::get_lists();
+
+		$this->assertNotWPError( $result );
+		$this->assertNotFalse(
+			get_transient( Newspack_Newsletters_Subscription::LISTS_CACHE_PREFIX . self::PROVIDER ),
+			'A complete payload must still be cached.'
+		);
+		$this->assertNotSame(
+			'publish',
+			get_post_status( $stored ),
+			'A complete payload must still garbage collect lists the ESP dropped.'
+		);
+	}
+
+	/**
+	 * Declare the next read partial, the way a provider does when its own cache
+	 * could not serve every list.
+	 *
+	 * @return void
+	 */
+	private function mark_lists_incomplete() {
+		add_filter( 'newspack_newsletters_lists_are_complete', '__return_false' );
+		$this->incomplete_filter_added = true;
+	}
+
+	/**
+	 * Store a remote list for the provider under test.
+	 *
+	 * @param string $remote_id The list ID in the ESP.
+	 * @return int The Subscription_List post ID.
+	 */
+	private function create_remote_list( $remote_id ) {
+		$post_id = wp_insert_post(
+			[
+				'post_title'  => 'Stored list ' . $remote_id,
+				'post_type'   => \Newspack\Newsletters\Subscription_Lists::CPT,
+				'post_status' => 'publish',
+			]
+		);
+		$list    = new \Newspack\Newsletters\Subscription_List( $post_id );
+		$list->set_remote_id( $remote_id );
+		$list->set_type( 'remote' );
+		$list->set_provider( self::PROVIDER );
+		return $post_id;
+	}
+
+	/**
 	 * Install a provider double whose get_lists() returns a fixed payload.
 	 *
 	 * @param array[] $lists Lists the stubbed ESP should return.
@@ -193,6 +318,10 @@ class Subscription_Get_Lists_Test extends WP_UnitTestCase {
 			->onlyMethods( [ 'get_lists' ] )
 			->getMockForAbstractClass();
 		$provider->method( 'get_lists' )->willReturn( $lists );
+		// Subscription_Lists::garbage_collector() reads the slug off the provider
+		// to decide which stored lists are in scope; left unset it matches none,
+		// and the collector silently becomes a no-op.
+		$provider->service = self::PROVIDER;
 
 		// Newspack_Newsletters memoizes the provider in a protected static and
 		// only ever fills it from a registered slug, which would build a real


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Groups and tags are read from the Mailchimp cache while the subscription list set is assembled. A cache miss returns an empty array, which is indistinguishable from an audience that genuinely has none. On a site whose cache has not warmed yet, that partial set was treated as authoritative: the garbage collector deleted every stored group and tag list, and the partial set was cached for the full TTL, so the settings screen kept showing audiences only long after the data landed.

The cache now records a cold read and reports it through a new `newspack_newsletters_lists_are_complete` filter. When the set is partial, `get_lists()` skips both the garbage collector and the transient write. A complete read behaves as before.

A second commit fixes the other half. WordPress records a missing option in its `notoptions` cache and answers later reads from that record without querying the database. Because a cache miss dispatches a refresh that writes the option moments later from its own request, that record hid the write: on a site with a persistent object cache it outlived the request, every later read was told the option was still missing, and the data never appeared. The cache now clears the record as soon as it misses.

Other ESPs are unaffected: the filter is registered from the Mailchimp cache, which only initializes when Mailchimp is the configured provider.

### How to test the changes in this Pull Request:

1. Connect a Mailchimp account with an audience that has groups or tags. This setup is what the bug needs.
2. Go to Newsletters > Settings. Group and tag rows are listed under the audience.
3. Record the stored list count: `wp post list --post_type=newspack_nl_list --format=count`.
4. Clear the audience cache: `wp option delete newspack_nl_mailchimp_cache_<audience_id> && wp cache flush`. Editing the row in SQL needs the flush too.
5. Delete the list transient: `wp transient delete newspack_newsletters_lists_mailchimp`.
6. Reload Newsletters > Settings. Only the audience shows, which is expected while the cache warms.
7. Re-run the count from step 3. It is unchanged, so no lists were deleted.
8. Wait a few seconds for the background refresh, then reload. Groups and tags are listed again.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Step 4 needs `wp cache flush` on any site with a persistent object cache, so the run starts from a coherent state. Changing the option outside WordPress, in SQL, needs it as well: the object cache keeps its own copy either way.

The provider test double left `$service` unset, and the garbage collector matches stored lists on that slug, so the collector was a silent no-op in every existing `get_lists()` test. The double now sets it, which is what lets the new tests exercise deletion.
