### PR TITLE
fix(newsletters): refresh only Mailchimp audiences in use (NPPM-3070)

### DIFF
--- a/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailchimp/class-newspack-newsletters-mailchimp-cached-data.php
@@ -8,6 +8,7 @@
 defined( 'ABSPATH' ) || exit;
 
 use Newspack_Newsletters_Mailchimp_Api as Mailchimp;
+use Newspack\Newsletters\Subscription_Lists;
 
 /**
  * Mailchimp cached class data
@@ -576,7 +577,55 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 	}
 
 	/**
-	 * Handles the cron job and triggers the async requests to refresh the cache for all lists
+	 * Gets the IDs of the audiences this site actually uses.
+	 *
+	 * A Mailchimp account can hold far more audiences than a site sends to, and
+	 * refreshing all of them is what makes the cron expensive. An audience is
+	 * considered in use when it is behind a configured Subscription List (as the
+	 * audience itself, or as the parent of a group or tag), or when a newsletter
+	 * is set to send to it.
+	 *
+	 * Audiences left out are not broken: reads self-heal, because get_data()
+	 * dispatches a refresh when the cache is missing or stale.
+	 *
+	 * @return string[] The audience IDs.
+	 */
+	private static function get_audiences_in_use() {
+		global $wpdb;
+
+		$audience_ids = [];
+
+		foreach ( Subscription_Lists::get_configured_for_current_provider() as $list ) {
+			$audience_ids[] = $list->mailchimp_get_audience_id();
+		}
+
+		// Audiences a newsletter sends to, which are not necessarily Subscription Lists.
+		$send_list_ids = $wpdb->get_col( // phpcs:ignore WordPress.DB.DirectDatabaseQuery
+			$wpdb->prepare(
+				"SELECT DISTINCT pm.meta_value
+				 FROM {$wpdb->postmeta} pm
+				 INNER JOIN {$wpdb->posts} p ON p.ID = pm.post_id
+				 WHERE pm.meta_key = 'send_list_id'
+				   AND pm.meta_value <> ''
+				   AND p.post_type = %s
+				   AND p.post_status NOT IN ( 'auto-draft', 'trash' )",
+				Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT
+			)
+		);
+
+		$audience_ids = array_values( array_unique( array_filter( array_merge( $audience_ids, $send_list_ids ) ) ) );
+
+		/**
+		 * Filters the Mailchimp audiences the cron keeps warm. Useful on accounts with
+		 * a very large number of audiences, to pin an explicit set.
+		 *
+		 * @param string[] $audience_ids The IDs of the audiences considered in use.
+		 */
+		return apply_filters( 'newspack_newsletters_mailchimp_audiences_to_refresh', $audience_ids );
+	}
+
+	/**
+	 * Handles the cron job and triggers the async requests to refresh the cache for the lists in use
 	 *
 	 * @return void
 	 */
@@ -590,7 +639,12 @@ final class Newspack_Newsletters_Mailchimp_Cached_Data {
 			return;
 		}
 
+		$audiences_in_use = self::get_audiences_in_use();
+
 		foreach ( $lists as $list ) {
+			if ( ! in_array( $list['id'], $audiences_in_use, true ) ) {
+				continue;
+			}
 			Newspack_Newsletters_Logger::log( 'Mailchimp cache: Dispatching request to refresh cache for list ' . $list['id'] );
 			self::dispatch_refresh( $list['id'] );
 		}

--- a/plugins/newspack-newsletters/tests/test-mailchimp-cached-data.php
+++ b/plugins/newspack-newsletters/tests/test-mailchimp-cached-data.php
@@ -5,16 +5,65 @@
  * @package Newspack_Newsletters
  */
 
+use Newspack\Newsletters\Subscription_List;
+use Newspack\Newsletters\Subscription_Lists;
+
 /**
  * Tests the Mailchimp Cached Data Class.
  */
 class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
+
+	/**
+	 * Audience configured directly as a subscription list.
+	 */
+	const AUDIENCE_DIRECT = 'audDirect';
+
+	/**
+	 * Audience that owns a group configured as a subscription list.
+	 */
+	const AUDIENCE_SUBLIST = 'audSublist';
+
+	/**
+	 * Audience only referenced by a newsletter's send_list_id.
+	 */
+	const AUDIENCE_SEND = 'audSend';
+
+	/**
+	 * Audience the site does not use in any way.
+	 */
+	const AUDIENCE_UNUSED = 'audUnused';
+
+	/**
+	 * Audience configured as a subscription list for a different provider.
+	 */
+	const AUDIENCE_OTHER_PROVIDER = 'audOtherProvider';
+
+	/**
+	 * Audience IDs dispatched for refresh during the test.
+	 *
+	 * @var string[]
+	 */
+	private $dispatched = [];
+
 	/**
 	 * Setup.
 	 */
 	public function set_up() {
+		parent::set_up();
 		// Reset the API key.
 		delete_option( 'newspack_mailchimp_api_key' );
+		$this->dispatched = [];
+	}
+
+	/**
+	 * Tear down.
+	 */
+	public function tear_down() {
+		remove_filter( 'mailchimp_mock_get', [ $this, 'mock_lists_response' ] );
+		remove_filter( 'pre_http_request', [ $this, 'capture_dispatch' ] );
+		delete_option( 'newspack_newsletters_service_provider' );
+		delete_option( 'newspack_mailchimp_api_key' );
+		parent::tear_down();
 	}
 
 	/**
@@ -109,5 +158,203 @@ class Newsletters_Mailchimp_Cached_Data_Test extends WP_UnitTestCase {
 				'message' => 'OK',
 			],
 		];
+	}
+
+	/**
+	 * The cron must only warm the audiences the site actually uses, not every
+	 * audience in the Mailchimp account.
+	 */
+	public function test_handle_cron_only_dispatches_audiences_in_use() {
+		$this->set_up_mailchimp();
+
+		// An audience configured directly as a subscription list.
+		$this->create_remote_list( self::AUDIENCE_DIRECT, 'mailchimp' );
+
+		// A group configured as a subscription list: its parent audience is in use.
+		$this->create_remote_list(
+			Subscription_List::mailchimp_generate_public_id( 'grp1', self::AUDIENCE_SUBLIST ),
+			'mailchimp'
+		);
+
+		// A list belonging to another provider must not put its audience in scope.
+		$this->create_remote_list( self::AUDIENCE_OTHER_PROVIDER, 'active_campaign' );
+
+		// A newsletter that sends to an audience which is not a subscription list.
+		$this->create_newsletter( self::AUDIENCE_SEND );
+
+		Newspack_Newsletters_Mailchimp_Cached_Data::handle_cron();
+
+		$this->assertSame(
+			[ self::AUDIENCE_DIRECT, self::AUDIENCE_SEND, self::AUDIENCE_SUBLIST ],
+			$this->get_dispatched()
+		);
+	}
+
+	/**
+	 * The set of audiences to refresh can be overridden with a filter, so a site
+	 * with a very large account can pin an explicit list.
+	 */
+	public function test_handle_cron_audiences_are_filterable() {
+		$this->set_up_mailchimp();
+		$this->create_remote_list( self::AUDIENCE_DIRECT, 'mailchimp' );
+
+		$filter = function () {
+			return [ self::AUDIENCE_UNUSED ];
+		};
+		add_filter( 'newspack_newsletters_mailchimp_audiences_to_refresh', $filter );
+
+		Newspack_Newsletters_Mailchimp_Cached_Data::handle_cron();
+
+		remove_filter( 'newspack_newsletters_mailchimp_audiences_to_refresh', $filter );
+
+		$this->assertSame( [ self::AUDIENCE_UNUSED ], $this->get_dispatched() );
+	}
+
+	/**
+	 * An audience returned by the filter that no longer exists in the account is
+	 * not dispatched.
+	 */
+	public function test_handle_cron_skips_audiences_missing_from_the_account() {
+		$this->set_up_mailchimp();
+
+		$filter = function () {
+			return [ self::AUDIENCE_DIRECT, 'audDeletedInMailchimp' ];
+		};
+		add_filter( 'newspack_newsletters_mailchimp_audiences_to_refresh', $filter );
+
+		Newspack_Newsletters_Mailchimp_Cached_Data::handle_cron();
+
+		remove_filter( 'newspack_newsletters_mailchimp_audiences_to_refresh', $filter );
+
+		$this->assertSame( [ self::AUDIENCE_DIRECT ], $this->get_dispatched() );
+	}
+
+	/**
+	 * With nothing configured and nothing sent, there is nothing to keep warm.
+	 */
+	public function test_handle_cron_dispatches_nothing_when_no_audience_is_used() {
+		$this->set_up_mailchimp();
+
+		Newspack_Newsletters_Mailchimp_Cached_Data::handle_cron();
+
+		$this->assertSame( [], $this->get_dispatched() );
+	}
+
+	/**
+	 * Configure Mailchimp as the provider and stub the audiences the account has.
+	 */
+	private function set_up_mailchimp() {
+		update_option( 'newspack_newsletters_service_provider', 'mailchimp' );
+		update_option( 'newspack_mailchimp_api_key', 'test-us' );
+		add_filter( 'mailchimp_mock_get', [ $this, 'mock_lists_response' ], 10, 2 );
+		add_filter( 'pre_http_request', [ $this, 'capture_dispatch' ], 10, 3 );
+	}
+
+	/**
+	 * Stubs the Mailchimp `lists` endpoint with an account holding both used and
+	 * unused audiences.
+	 *
+	 * @param array  $response The mocked response.
+	 * @param string $endpoint The requested endpoint.
+	 * @return array
+	 */
+	public function mock_lists_response( $response, $endpoint ) {
+		if ( 'lists' !== $endpoint ) {
+			return $response;
+		}
+		$audiences = [
+			self::AUDIENCE_DIRECT,
+			self::AUDIENCE_SUBLIST,
+			self::AUDIENCE_SEND,
+			self::AUDIENCE_UNUSED,
+			self::AUDIENCE_OTHER_PROVIDER,
+		];
+		return [
+			'lists' => array_map(
+				function ( $id ) {
+					return [
+						'id'   => $id,
+						'name' => $id,
+					];
+				},
+				$audiences
+			),
+		];
+	}
+
+	/**
+	 * Records the audience IDs the cron dispatches async refresh requests for.
+	 *
+	 * @param mixed  $preempt Whether to preempt the request.
+	 * @param array  $args    The request arguments.
+	 * @param string $url     The request URL.
+	 * @return mixed
+	 */
+	public function capture_dispatch( $preempt, $args, $url ) {
+		if ( false === strpos( $url, 'admin-ajax.php' ) ) {
+			return $preempt;
+		}
+		if ( ! empty( $args['body']['list_id'] ) ) {
+			$this->dispatched[] = $args['body']['list_id'];
+		}
+		return [
+			'headers'  => [],
+			'body'     => '',
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+		];
+	}
+
+	/**
+	 * The dispatched audience IDs, sorted so assertions do not depend on order.
+	 *
+	 * @return string[]
+	 */
+	private function get_dispatched() {
+		$dispatched = $this->dispatched;
+		sort( $dispatched );
+		return $dispatched;
+	}
+
+	/**
+	 * Creates a remote subscription list for a provider.
+	 *
+	 * @param string $remote_id The remote (public) ID.
+	 * @param string $provider  The provider slug.
+	 * @return Subscription_List
+	 */
+	private function create_remote_list( $remote_id, $provider ) {
+		$post_id = wp_insert_post(
+			[
+				'post_title'  => 'List ' . $remote_id,
+				'post_type'   => Subscription_Lists::CPT,
+				'post_status' => 'publish',
+			]
+		);
+		$list    = new Subscription_List( $post_id );
+		$list->set_remote_id( $remote_id );
+		$list->set_type( 'remote' );
+		$list->set_provider( $provider );
+		return $list;
+	}
+
+	/**
+	 * Creates a newsletter that sends to a given audience.
+	 *
+	 * @param string $send_list_id The audience ID.
+	 * @return int
+	 */
+	private function create_newsletter( $send_list_id ) {
+		$post_id = wp_insert_post(
+			[
+				'post_title'  => 'Newsletter for ' . $send_list_id,
+				'post_type'   => Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+				'post_status' => 'draft',
+			]
+		);
+		update_post_meta( $post_id, 'send_list_id', $send_list_id );
+		return $post_id;
 	}
 }


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Every ten minutes, the Mailchimp cache cron dispatched one async admin-ajax request per audience in the account, each making about five API calls. Accounts hold far more audiences than a site sends to, so the work scaled with the account rather than with the site. On thestranger.com this was the largest single admin-ajax cost, roughly 19.9 minutes of cumulative request time in the observed window.

The cron now refreshes only the audiences in use: those behind a configured subscription list, as the audience itself or as the parent of a group or tag, and those a newsletter sends to. Audiences left out still self-heal, because a read dispatches its own refresh when the cache is missing or stale.

`newspack_newsletters_mailchimp_audiences_to_refresh` overrides the set, so an account with an unusual shape can pin an explicit list.

Closes NPPM-3070.

### How to test the changes in this Pull Request:

1. Connect a Mailchimp account with several audiences, only one of which is configured as a subscription list.
2. Enable logging so cron dispatches are visible: `wp config set NEWSPACK_NEWSLETTERS_DEBUG_MODE true --raw`.
3. Run the cron: `wp cron event run newspack_nl_mailchimp_refresh_cache`.
4. Check the log. A refresh is dispatched for the configured audience only, not for the others.
5. Set a newsletter's send list to a second, unconfigured audience, then run the cron again.
6. Check the log. That audience is now dispatched too.
7. Open the Newsletters editor on an audience the cron skipped. Its groups and tags load, confirming reads still self-heal.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Stacked on #916, which is what makes this safe: before it, an audience left cold could be deleted from the stored subscription lists on the next settings-screen load. Review and merge #916 first; this PR targets that branch.

Only the audience-scoping lever from NPPM-3070 is here. Caching campaign folders once per account, merging the segments and tags calls, the interest-groups N+1, and the cron interval are all untouched.
