### PR TITLE
ci: unbreak the type gate and stop PHPUnit hanging on a stalled download

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -345,14 +345,30 @@ jobs:
           fi
       - name: Install WordPress test suite
         if: steps.check.outputs.has_tests == 'true'
+        # Every download here talks to wordpress.org, and none of them had a time
+        # limit. A stalled connection therefore held the step open until the six-hour
+        # job limit killed it, and the run reported a red PHPUnit that had never
+        # executed a test. The cap turns that into a failure within minutes, and the
+        # retries below let an ordinary blip recover on its own.
+        timeout-minutes: 10
         run: |
+          set -eo pipefail
           # svn isn't on ubuntu-latest runners by default; the WP develop
           # repo's phpunit test library is published over svn.
           sudo apt-get update -qq
           sudo apt-get install -y -qq subversion
           # Download WP core and test library.
           mkdir -p "$WP_TESTS_DIR"
-          WP_TESTS_TAG=$(curl -s "https://api.wordpress.org/core/version-check/1.7/" | jq -r '.offers[0].version')
+          WP_TESTS_TAG=$(curl --fail --silent --show-error --location \
+            --retry 3 --retry-delay 5 --max-time 30 \
+            "https://api.wordpress.org/core/version-check/1.7/" | jq -r '.offers[0].version')
+
+          # An empty version builds URLs that 404 or hang, and the failure then lands
+          # somewhere that reads like a test problem. Say what actually went wrong.
+          if [ -z "$WP_TESTS_TAG" ] || [ "$WP_TESTS_TAG" = "null" ]; then
+            echo "Could not resolve the current WordPress version from api.wordpress.org." >&2
+            exit 1
+          fi
 
           # The tarball's top-level directory is "wordpress/". Extract to
           # $WP_CORE_DIR's parent and strip that prefix so files land at
@@ -360,11 +376,29 @@ jobs:
           # $WP_CORE_DIR happens to be /tmp/wordpress.
           rm -rf "$WP_CORE_DIR"
           mkdir -p "$WP_CORE_DIR"
-          curl -s "https://wordpress.org/wordpress-$WP_TESTS_TAG.tar.gz" \
+          curl --fail --silent --show-error --location \
+            --retry 3 --retry-delay 5 --max-time 180 \
+            "https://wordpress.org/wordpress-$WP_TESTS_TAG.tar.gz" \
             | tar xz --strip-components=1 -C "$WP_CORE_DIR"
 
-          svn co --quiet "https://develop.svn.wordpress.org/tags/$WP_TESTS_TAG/tests/phpunit/includes/" "$WP_TESTS_DIR/includes"
-          svn co --quiet "https://develop.svn.wordpress.org/tags/$WP_TESTS_TAG/tests/phpunit/data/" "$WP_TESTS_DIR/data"
+          # svn applies no timeout of its own, so a stalled server holds the connection
+          # open indefinitely. http-timeout bounds each attempt, and a partial checkout
+          # is discarded so the next attempt starts clean.
+          svn_checkout() {
+            for attempt in 1 2 3; do
+              if svn co --quiet --non-interactive \
+                --config-option "servers:global:http-timeout=60" \
+                "$1" "$2"; then
+                return 0
+              fi
+              echo "svn checkout of $1 failed (attempt $attempt of 3); retrying." >&2
+              rm -rf "$2"
+              sleep 5
+            done
+            return 1
+          }
+          svn_checkout "https://develop.svn.wordpress.org/tags/$WP_TESTS_TAG/tests/phpunit/includes/" "$WP_TESTS_DIR/includes"
+          svn_checkout "https://develop.svn.wordpress.org/tags/$WP_TESTS_TAG/tests/phpunit/data/" "$WP_TESTS_DIR/data"
 
           # Write wp-tests-config.php.
           cat > "$WP_TESTS_DIR/wp-tests-config.php" << 'WPCFG'

--- a/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/rule-form.tsx
+++ b/plugins/newspack-plugin/src/wizards/audience/views/pricing-rules/rule-form.tsx
@@ -629,7 +629,7 @@ export default function RuleForm( { isNew, initialPath = null, rule, vocab, onDo
 					<ToggleGroupControl
 						label={ __( 'Status', 'newspack-plugin' ) }
 						value={ status }
-						onChange={ v => setStatus( String( v ) ) }
+						onChange={ v => setStatus( v === 'publish' ? 'publish' : 'draft' ) }
 						isBlock
 						__next40pxDefaultSize
 						__nextHasNoMarginBottom


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Two unrelated CI failures on `main`, both of which currently block every open PR.

**The type gate is red on `main`.** `rule-form.tsx` holds the pricing rule status as `useState< 'publish' | 'draft' >`, and the toggle's `onChange` widened it back to `string` via `String( v )`. That landed in #825, shortly after #914 turned the type check into a gate, so `JS / newspack` has failed on every run since:

```
src/wizards/audience/views/pricing-rules/rule-form.tsx(632,34): error TS2345:
Argument of type 'string' is not assignable to parameter of type 'SetStateAction<"publish" | "draft">'.
```

The setter now narrows to the same union the state declares, matching what the initializer on line 233 already does. No behaviour change: the toggle only ever emits `publish` or `draft`.

**PHPUnit can hang for six hours and report a red job that ran no tests.** Every download in "Install WordPress test suite" talked to wordpress.org with no time limit, and `svn` applies none of its own. When wordpress.org stalls, the step sits on a silent connection until the six-hour job limit kills it; the PHPUnit step is then skipped, so the run reports a PHPUnit failure that never executed a test.

Two runs were caught in that state today within minutes of each other, on unrelated PRs, while a run started 20 minutes later passed in 4½ minutes — an intermittent upstream stall rather than anything in the branches. The step now has a 10 minute cap, `curl` and `svn` retry with per-attempt timeouts, and an empty version lookup fails with a message that says so instead of building URLs that hang.

### How to test the changes in this Pull Request:

1. Check out this branch and run `pnpm --filter newspack run typescript:check` from the repo root. It passes. On `main` the same command fails with the TS2345 above.
2. Open the pricing rule editor in the Audience wizard and switch the Status toggle between Published and Draft. The value saves as before.
3. Read the `Install WordPress test suite` step in `.github/workflows/ci.yml`. Confirm `timeout-minutes: 10`, the `--max-time`/`--retry` flags on both `curl` calls, the empty-version guard, and the `svn_checkout` retry helper.
4. Watch this PR's own `PHPUnit / newspack` job complete in the usual few minutes.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? — n/a: a one-line type narrowing and a CI workflow step, neither of which the suites cover.
* [x] Have you successfully run tests with your changes locally?

Verification I ran, rather than assuming:

- `tsc --noEmit` exits 0 with the fix. As a control, reverting just that line reproduces CI's exact error, same file and line, so the local check genuinely exercises the gate.
- The workflow parses as YAML, the step's script passes `bash -n`, and `shellcheck` is clean.
- The empty-version guard and the retry helper were exercised in isolation: `""` and `null` both refuse with the intended message while a real version proceeds, and the retry loop stops after exactly three attempts and returns non-zero.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
