### PR TITLE
feat(cli): record per-post exemptions from the Memberships force-public flag (NPPD-2199)

### DIFF
--- a/plugins/newspack-plugin/includes/cli/class-initializer.php
+++ b/plugins/newspack-plugin/includes/cli/class-initializer.php
@@ -135,6 +135,11 @@ class Initializer {
 			WP_CLI::add_command( 'newspack migrate-premium-newsletters', [ 'Newspack\CLI\Premium_Newsletters_Migration', 'migrate_premium_newsletters' ] );
 		}
 
+		// Registered whether or not WooCommerce Memberships is active, unlike the
+		// commands above: it reads `_wc_memberships_force_public`, ordinary postmeta
+		// that outlives the plugin, and already-flipped sites are the ones needing it.
+		WP_CLI::add_command( 'newspack migrate-post-exemptions', [ 'Newspack\CLI\Membership_Gates_Migration', 'migrate_post_exemptions' ] );
+
 		// Only register the fix-memberships command when WC Memberships is active.
 		if ( function_exists( 'wc_memberships' ) ) {
 			WP_CLI::add_command(

--- a/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
+++ b/plugins/newspack-plugin/includes/cli/class-membership-gates-migration.php
@@ -1,15 +1,14 @@
 <?php
 /**
- * WP-CLI command to migrate WooCommerce Membership plans and their content gate
- * layouts to Newspack Access Control content gates.
+ * WP-CLI commands to migrate WooCommerce Memberships content restriction to
+ * Newspack Access Control: `migrate-membership-gates` for the plans and their
+ * content gate layouts, `migrate-post-exemptions` for the per-post "public"
+ * overrides those plans never carried.
  *
  * Ported from the standalone `migrate-memberships` drop-in so the tooling ships
  * with the plugin. The class file is included on every request (like the other
  * CLI classes), but only the command registration is gated on WP_CLI, so the
- * runtime cost outside CLI is a class definition. The command reads each
- * published Membership plan's content
- * restriction rules plus the `np_memberships_gate` layout posts and writes the
- * equivalent Access Control gate(s), content rules, and gate layouts through the
+ * runtime cost outside CLI is a class definition. Both write through the
  * Content_Gate / Content_Rules data layer.
  *
  * @package Newspack
@@ -1581,5 +1580,253 @@ class Membership_Gates_Migration {
 			}
 		}
 		return false;
+	}
+
+	/**
+	 * Record Access Control exemptions for the posts WooCommerce Memberships forced public.
+	 *
+	 * Memberships' "This content is public" checkbox writes
+	 * `_wc_memberships_force_public = 'yes'` and short-circuits every restriction rule.
+	 * Access Control's equivalent is the "Disable access control restrictions for this
+	 * post" toggle. Nothing bridges the two, so without this step those posts are gated
+	 * the moment Memberships is deactivated.
+	 *
+	 * A post already carrying a falsy exemption row is included, not skipped: that row
+	 * is invisible to any fallback that answers only where no row exists, so it would
+	 * stay gated. Those are overwritten and their IDs listed — a falsy row is either the
+	 * editor echoing the meta back on save or an editor revoking the exemption, and the
+	 * two are indistinguishable from the meta alone.
+	 *
+	 * Migrates only the post types the exemption applies to; rows on any other type are
+	 * counted and reported, so a census of the raw Memberships meta reconciles with what
+	 * was migrated.
+	 *
+	 * Idempotent. Publishers keep using the checkbox up to cutover, so the run that
+	 * counts is the one immediately before Memberships is deactivated.
+	 *
+	 * Dry-run by default; pass --live to write.
+	 *
+	 * ## OPTIONS
+	 *
+	 * [--live]
+	 * : Apply the changes. Without this flag the command runs as a dry-run and writes nothing.
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     wp newspack migrate-post-exemptions
+	 *     wp newspack migrate-post-exemptions --live
+	 *
+	 * @param array $args       Positional args (unused).
+	 * @param array $assoc_args Named args.
+	 *
+	 * @return void
+	 */
+	public function migrate_post_exemptions( $args, $assoc_args ) {
+		$dry_run = ! (bool) \WP_CLI\Utils\get_flag_value( $assoc_args, 'live', false );
+
+		if ( ! class_exists( 'Newspack\Content_Restriction_Control' ) ) {
+			WP_CLI::error( 'Newspack\Content_Restriction_Control class not found. Is newspack-plugin active? Aborting.' );
+		}
+
+		if ( $dry_run ) {
+			WP_CLI::line( '' );
+			WP_CLI::line( '*** DRY RUN MODE — no data will be modified. Pass --live to write. ***' );
+			WP_CLI::line( '' );
+		}
+
+		if ( ! \Newspack\Content_Gate::is_newspack_feature_enabled() ) {
+			WP_CLI::warning( 'Content gates are disabled on this site (NEWSPACK_CONTENT_GATES). The exemptions will be recorded, but nothing reads them until the feature is enabled.' );
+		}
+
+		$flagged = self::get_force_public_posts();
+		if ( null === $flagged ) {
+			WP_CLI::error( 'Could not read the force-public flags. Aborting rather than reporting an empty set to an operator about to deactivate Memberships.' );
+		}
+
+		$post_types   = array_column( (array) \Newspack\Content_Restriction_Control::get_available_post_types(), 'value' );
+		$in_scope     = [];
+		$out_of_scope = [];
+		foreach ( $flagged as $post ) {
+			if ( in_array( $post['post_type'], $post_types, true ) ) {
+				$in_scope[] = $post;
+			} else {
+				$out_of_scope[ $post['post_type'] ] = ( $out_of_scope[ $post['post_type'] ] ?? 0 ) + 1;
+			}
+		}
+
+		if ( empty( $in_scope ) ) {
+			WP_CLI::line( 'No posts carry the WooCommerce Memberships force-public flag on a post type the exemption applies to.' );
+			self::report_out_of_scope_force_public( $out_of_scope );
+			return;
+		}
+
+		$missing   = [];
+		$falsy     = [];
+		$breakdown = [];
+		foreach ( array_chunk( $in_scope, 200 ) as $chunk ) {
+			// Prime the meta cache a chunk at a time so it does not grow with the site.
+			\update_meta_cache( 'post', array_column( $chunk, 'ID' ) );
+			foreach ( $chunk as $post ) {
+				$post_id = (int) $post['ID'];
+				$state   = self::classify_exemption_state( $post_id );
+				if ( 'missing' === $state ) {
+					$missing[] = $post_id;
+				} elseif ( 'falsy' === $state ) {
+					$falsy[] = $post_id;
+				}
+
+				$key                 = $post['post_type'] . '|' . $post['post_status'];
+				$breakdown[ $key ] ??= [
+					'post_type'   => $post['post_type'],
+					'post_status' => $post['post_status'],
+					'missing'     => 0,
+					'falsy'       => 0,
+					'already'     => 0,
+				];
+				++$breakdown[ $key ][ $state ];
+			}
+			\WP_CLI\Utils\wp_clear_object_cache();
+		}
+
+		$failed = [];
+		if ( ! $dry_run ) {
+			foreach ( array_merge( $missing, $falsy ) as $post_id ) {
+				if ( ! \update_post_meta( $post_id, \Newspack\Content_Restriction_Control::IS_EXEMPT_META_KEY, true ) ) {
+					$failed[] = $post_id;
+				}
+			}
+			$missing = array_values( array_diff( $missing, $failed ) );
+			$falsy   = array_values( array_diff( $falsy, $failed ) );
+		}
+
+		WP_CLI::line( '' );
+		WP_CLI::line( $dry_run ? '=== DRY RUN SUMMARY ===' : '=== MIGRATION SUMMARY ===' );
+		WP_CLI::line( '' );
+
+		\WP_CLI\Utils\format_items(
+			'table',
+			array_map(
+				fn( $row ) => [
+					'Post Type'      => $row['post_type'],
+					'Status'         => $row['post_status'],
+					'No Row'         => $row['missing'],
+					'Falsy Row'      => $row['falsy'],
+					'Already Exempt' => $row['already'],
+				],
+				array_values( $breakdown )
+			),
+			[ 'Post Type', 'Status', 'No Row', 'Falsy Row', 'Already Exempt' ]
+		);
+
+		WP_CLI::line( '' );
+
+		// The operator's audit record of every exemption whose falsy row was replaced.
+		if ( ! empty( $falsy ) ) {
+			WP_CLI::warning(
+				sprintf(
+					'%d post(s) carried a falsy exemption row and %s: %s',
+					count( $falsy ),
+					$dry_run ? 'would be overwritten' : 'were overwritten',
+					implode( ', ', $falsy )
+				)
+			);
+		}
+
+		if ( ! empty( $failed ) ) {
+			WP_CLI::warning( sprintf( '%d exemption(s) could not be written: %s', count( $failed ), implode( ', ', $failed ) ) );
+		}
+
+		self::report_out_of_scope_force_public( $out_of_scope );
+
+		WP_CLI::success(
+			sprintf(
+				'Done. %d exemption(s) %s (%d with no row, %d overwriting a falsy row). %d post(s) were already exempt.',
+				count( $missing ) + count( $falsy ),
+				$dry_run ? 'would be recorded' : 'recorded',
+				count( $missing ),
+				count( $falsy ),
+				count( $in_scope ) - count( $missing ) - count( $falsy ) - count( $failed )
+			)
+		);
+
+		if ( ! $dry_run ) {
+			WP_CLI::line( 'Keep the `_wc_memberships_force_public` meta until this has run for the last time — it is what this command reads.' );
+		}
+	}
+
+	/**
+	 * Every post carrying the Memberships force-public flag, whatever its post type.
+	 *
+	 * The `meta_value = 'yes'` filter is not optional: the checkbox writes a `no` row for
+	 * every post it was ever rendered on, and those outnumber the real ones by an order
+	 * of magnitude.
+	 *
+	 * @return array[]|null Rows of ID / post_type / post_status ordered by ID, or null
+	 *                      if the query failed.
+	 */
+	private static function get_force_public_posts(): ?array {
+		global $wpdb;
+
+		$rows = $wpdb->get_results( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare(
+				"SELECT DISTINCT p.ID, p.post_type, p.post_status
+				FROM {$wpdb->posts} p
+				INNER JOIN {$wpdb->postmeta} pm ON pm.post_id = p.ID
+				WHERE pm.meta_key = %s AND pm.meta_value = 'yes'
+				ORDER BY p.ID",
+				\Newspack\Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY
+			),
+			ARRAY_A
+		);
+
+		// get_results() reports a failed query as an empty set, which here would read as
+		// "no post was ever forced public" to an operator about to deactivate Memberships.
+		return $wpdb->last_error ? null : (array) $rows;
+	}
+
+	/**
+	 * Report the force-public rows on post types the exemption does not apply to.
+	 *
+	 * @param array<string,int> $out_of_scope Post type => row count.
+	 *
+	 * @return void
+	 */
+	private static function report_out_of_scope_force_public( array $out_of_scope ): void {
+		if ( empty( $out_of_scope ) ) {
+			return;
+		}
+		arsort( $out_of_scope );
+		$parts = [];
+		foreach ( $out_of_scope as $post_type => $count ) {
+			$parts[] = sprintf( '%s (%d)', $post_type, $count );
+		}
+		WP_CLI::line(
+			sprintf(
+				'Ignored %d force-public row(s) on post types the exemption does not apply to: %s.',
+				array_sum( $out_of_scope ),
+				implode( ', ', $parts )
+			)
+		);
+	}
+
+	/**
+	 * Where a post stands with respect to the Access Control exemption.
+	 *
+	 * Reads through metadata_exists() rather than get_post_meta(), because
+	 * Content_Restriction_Control answers `default_post_metadata` for exactly the posts
+	 * this command selects: get_post_meta() would report every unrecorded exemption as
+	 * already true and the command would write nothing at all.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return string 'missing' (no row), 'falsy' (a row the inference cannot reach), or
+	 *                'already' (a real exemption, left alone).
+	 */
+	private static function classify_exemption_state( int $post_id ): string {
+		$meta_key = \Newspack\Content_Restriction_Control::IS_EXEMPT_META_KEY;
+		if ( ! \metadata_exists( 'post', $post_id, $meta_key ) ) {
+			return 'missing';
+		}
+		return \get_post_meta( $post_id, $meta_key, true ) ? 'already' : 'falsy';
 	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/cli/class-test-post-exemptions-migration.php
+++ b/plugins/newspack-plugin/tests/unit-tests/cli/class-test-post-exemptions-migration.php
@@ -1,0 +1,164 @@
+<?php
+/**
+ * Tests for the migrate-post-exemptions CLI (NPPD-2199).
+ *
+ * Pins what makes the command more than a two-line loop; each case below names its own.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\CLI\Membership_Gates_Migration;
+use Newspack\Content_Restriction_Control;
+
+require_once dirname( __DIR__, 2 ) . '/mocks/wp-cli-mocks.php';
+require_once dirname( __DIR__, 3 ) . '/includes/cli/trait-one-time-purchase-migration.php';
+require_once dirname( __DIR__, 3 ) . '/includes/cli/class-membership-gates-migration.php';
+
+/**
+ * Test the migrate-post-exemptions command.
+ *
+ * @group content-gate
+ */
+class Test_Post_Exemptions_Migration extends WP_UnitTestCase {
+
+	/**
+	 * Enable content gates and register the exemption meta, so the fallback the command
+	 * has to see past is live — without it these tests would pass against an
+	 * implementation that naively trusts get_post_meta().
+	 */
+	public function set_up() {
+		parent::set_up();
+		if ( ! defined( 'NEWSPACK_CONTENT_GATES' ) ) {
+			define( 'NEWSPACK_CONTENT_GATES', true );
+		}
+		Content_Restriction_Control::register_meta();
+	}
+
+	/**
+	 * Unregister the exemption meta so the fallback does not leak into other suites.
+	 */
+	public function tear_down() {
+		foreach ( array_column( (array) Content_Restriction_Control::get_available_post_types(), 'value' ) as $subtype ) {
+			unregister_meta_key( 'post', Content_Restriction_Control::IS_EXEMPT_META_KEY, $subtype );
+		}
+		parent::tear_down();
+	}
+
+	/**
+	 * Create a post carrying Memberships' force-public flag.
+	 *
+	 * @param array $args Post args passed to the factory.
+	 *
+	 * @return int Post ID.
+	 */
+	private function create_force_public_post( array $args = [] ): int {
+		$post_id = self::factory()->post->create( $args );
+		update_post_meta( $post_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'yes' );
+		return $post_id;
+	}
+
+	/**
+	 * Run the command and return its whole transcript.
+	 *
+	 * @param array $assoc_args Named args, e.g. [ 'live' => true ].
+	 *
+	 * @return string
+	 */
+	private function run_migration( array $assoc_args = [] ): string {
+		WP_CLI::reset();
+		( new Membership_Gates_Migration() )->migrate_post_exemptions( [], $assoc_args );
+		return implode( "\n", WP_CLI::$output );
+	}
+
+	/**
+	 * Whether a real exemption row exists, read past the Memberships fallback.
+	 *
+	 * @param int $post_id Post ID.
+	 *
+	 * @return bool
+	 */
+	private function has_recorded_exemption( int $post_id ): bool {
+		$meta_key = Content_Restriction_Control::IS_EXEMPT_META_KEY;
+		return metadata_exists( 'post', $post_id, $meta_key ) && (bool) get_post_meta( $post_id, $meta_key, true );
+	}
+
+	/**
+	 * The central case. The NPPD-2176 fallback already reports a force-public post as
+	 * exempt while it carries no row of its own, so an implementation that decided from
+	 * get_post_meta() would write nothing at all. A second run has nothing left to do.
+	 */
+	public function test_records_an_exemption_the_fallback_only_infers() {
+		$post_id = $this->create_force_public_post();
+		$this->assertFalse( metadata_exists( 'post', $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ) );
+
+		$this->run_migration( [ 'live' => true ] );
+		$this->assertTrue( $this->has_recorded_exemption( $post_id ) );
+
+		$output = $this->run_migration( [ 'live' => true ] );
+		$this->assertStringContainsString( '0 exemption(s) recorded', $output );
+		$this->assertStringContainsString( '1 post(s) were already exempt', $output );
+	}
+
+	/**
+	 * A falsy row beats any fallback that answers only where no row exists, so the post
+	 * stays gated. That row is overwritten, not skipped, and its ID reported.
+	 */
+	public function test_overwrites_a_falsy_exemption_row_the_fallback_cannot_reach() {
+		$post_id = $this->create_force_public_post();
+		update_post_meta( $post_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, '' );
+
+		$output = $this->run_migration( [ 'live' => true ] );
+
+		$this->assertTrue( $this->has_recorded_exemption( $post_id ) );
+		$this->assertStringContainsString( '1 post(s) carried a falsy exemption row', $output );
+		$this->assertStringContainsString( (string) $post_id, $output );
+	}
+
+	/**
+	 * The checkbox writes a `no` row for every post it was ever rendered on, and those
+	 * outnumber the real ones by an order of magnitude.
+	 */
+	public function test_ignores_force_public_no_rows() {
+		$declined_id = self::factory()->post->create();
+		update_post_meta( $declined_id, Content_Restriction_Control::WC_FORCE_PUBLIC_META_KEY, 'no' );
+
+		$output = $this->run_migration( [ 'live' => true ] );
+
+		$this->assertFalse( metadata_exists( 'post', $declined_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ) );
+		$this->assertStringContainsString( 'No posts carry the WooCommerce Memberships force-public flag', $output );
+	}
+
+	/**
+	 * A row on a post type the exemption is not registered for is inert, so it is counted
+	 * rather than migrated — that is what lets a census of the raw meta key reconcile.
+	 */
+	public function test_ignores_post_types_the_exemption_is_not_registered_for() {
+		$gateable_id = $this->create_force_public_post();
+		$inert_id    = $this->create_force_public_post( [ 'post_type' => 'attachment' ] );
+
+		$output = $this->run_migration( [ 'live' => true ] );
+
+		$this->assertTrue( $this->has_recorded_exemption( $gateable_id ) );
+		$this->assertFalse( metadata_exists( 'post', $inert_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ) );
+		$this->assertStringContainsString( 'Ignored 1 force-public row(s) on post types the exemption does not apply to: attachment (1)', $output );
+	}
+
+	/**
+	 * Dry-run is the default: it reports the split it would write, and writes neither the
+	 * missing row nor the overwrite.
+	 */
+	public function test_dry_run_reports_the_split_and_writes_nothing() {
+		$missing_row_id = $this->create_force_public_post();
+		$falsy_row_id   = $this->create_force_public_post();
+		update_post_meta( $falsy_row_id, Content_Restriction_Control::IS_EXEMPT_META_KEY, '' );
+
+		$output = $this->run_migration();
+
+		$this->assertFalse( metadata_exists( 'post', $missing_row_id, Content_Restriction_Control::IS_EXEMPT_META_KEY ) );
+		$this->assertFalse( $this->has_recorded_exemption( $falsy_row_id ) );
+		$this->assertStringContainsString(
+			'2 exemption(s) would be recorded (1 with no row, 1 overwriting a falsy row)',
+			$output
+		);
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

**Forward-port of #934** (`hotfix/… → release`). Merge that one first; this keeps the command from being lost on the next release cycle.

Adds `wp newspack migrate-post-exemptions`, which writes a real `newspack_content_restriction_is_exempt` row for every post carrying `_wc_memberships_force_public = 'yes'`. Nothing did this before — `migrate-membership-gates` works plan-to-gate and has no per-post loop — so posts a publisher marked always-public are gated the moment Memberships is deactivated. One migrated site lost 725 of 730.

#855 already lands on this branch and infers the exemption where no row exists, which covers most of the class. It is consulted only where no row exists, so a post already carrying a falsy row stays gated; those are overwritten, not skipped, and every ID prints. Recording the rows also retires the legacy meta as the de-facto exemption and makes the opt-out filter safe to use.

Identical to #934 apart from the `trait-one-time-purchase-migration.php` require the class needs here. The `WC_FORCE_PUBLIC_META_KEY` constant and `tests/mocks/wp-cli-mocks.php` hunks are absent because this branch already has both.

Closes NPPD-2199.

### How to test the changes in this Pull Request:

1. Set `NEWSPACK_CONTENT_GATES` to true in `wp-config.php`.
2. Enable Reader Activation.
3. Create a published post. Set its `_wc_memberships_force_public` meta to `yes`.
4. Create a second published post. Set the same meta to `yes`.
5. Set the second post's `newspack_content_restriction_is_exempt` meta to an empty string.
6. Create a published content gate. Restrict all Posts to registered readers.
7. Open the second post in a logged-out browser. Confirm it shows the gate.
8. Run `wp newspack migrate-post-exemptions`.
9. Confirm the summary reports one "No Row" and one "Falsy Row".
10. Confirm neither post's exemption meta changed.
11. Run `wp newspack migrate-post-exemptions --live`.
12. Confirm both posts now hold `newspack_content_restriction_is_exempt` = `1`.
13. Open both posts in a logged-out browser. Confirm neither shows the gate.
14. Run `wp newspack migrate-post-exemptions --live` again.
15. Confirm it reports 0 recorded and 2 already exempt.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

Full `newspack-plugin` PHPUnit suite and PHPCS pass on this base. The five new tests were mutation-checked: reading the exemption through `get_post_meta()`, skipping falsy rows, dropping the `meta_value = 'yes'` filter, widening the post-type scope, and writing during a dry-run each turn at least one of them red.

* Follow-up worth its own issue: with #855 present, a falsy row on a force-public post is more likely a deliberate revocation than editor noise. A `--skip-falsy` flag would let an operator take the safe half on an already-flipped site.
