### PR TITLE
fix(network): process each hub webhook delivery at most once

### DIFF
--- a/plugins/newspack-network/includes/class-initializer.php
+++ b/plugins/newspack-network/includes/class-initializer.php
@@ -80,5 +80,11 @@ class Initializer {
 	 */
 	public static function activation_hook() {
 		add_role( NEWSPACK_NETWORK_READER_ROLE, __( 'Network Reader', 'newspack-network' ) ); // phpcs:ignore
+		// Create the Hub's used-nonce table up front on a site already configured as a
+		// Hub. Everywhere else it is created lazily on first use — which is also what
+		// installs it on a Hub updated in place, since an update does not fire this hook.
+		if ( Site_Role::is_hub() ) {
+			Hub\Used_Nonces::install();
+		}
 	}
 }

--- a/plugins/newspack-network/includes/hub/class-used-nonces.php
+++ b/plugins/newspack-network/includes/hub/class-used-nonces.php
@@ -1,0 +1,313 @@
+<?php
+/**
+ * Newspack Hub record of processed message nonces.
+ *
+ * @package Newspack
+ */
+
+namespace Newspack_Network\Hub;
+
+/**
+ * Durable record of the delivery nonces the Hub has processed or is processing.
+ *
+ * A Node signs each event under a fresh nonce ({@see \Newspack_Network\Crypto::generate_nonce()})
+ * and the nonce travels with the delivery, so it identifies one delivery uniquely.
+ * Each delivery moves through a two-phase lifecycle: {@see self::claim()} records
+ * its nonce as `pending` before processing starts, and {@see self::complete()}
+ * marks it `completed` once processing has finished. A claim of a nonce already on
+ * record reports which of those states the delivery is in, so the caller can
+ * acknowledge a completed delivery without reprocessing it and answer an
+ * unfinished one with a retryable error.
+ *
+ * Two properties matter and both are deliberate:
+ *
+ * - **Atomic.** The claim is a single INSERT against a UNIQUE column, so two
+ *   deliveries of the same nonce arriving at once cannot both be treated as
+ *   first-seen. A check-then-insert would leave that gap.
+ * - **Durable.** The record lives in the database, not the object cache, so an
+ *   eviction under memory pressure cannot drop a nonce and let its delivery be
+ *   processed a second time.
+ *
+ * **Completed records are kept indefinitely; there is no purge.** Removing one
+ * would let its delivery be processed again, so do not add one. A pending record
+ * normally ends as completed, or is removed by {@see self::release()} when
+ * processing fails; one whose outcome was never written — the marking write
+ * itself failed, or the request died first — stays pending, and every later
+ * arrival of that delivery is answered with a retryable error until the Node
+ * stops resending it. If the event was persisted before the marking failed,
+ * nothing is lost; if it was not, the delivery surfaces as a failed request
+ * rather than a silent success. Do not add time-based cleanup for pending
+ * records either: they record a delivery whose outcome is unknown, and removing
+ * one on a timer would let that delivery be processed twice.
+ *
+ * The store is intentionally caller-agnostic — it records and recognises nonces and
+ * nothing more — so other Hub code can reuse it.
+ */
+class Used_Nonces {
+
+	/**
+	 * Schema version. Bump whenever the table definition changes:
+	 * {@see self::maybe_create_table()} gates on the stored version, not the
+	 * table's actual shape, so without a bump an existing table never picks up
+	 * the change.
+	 *
+	 * @var string
+	 */
+	const DB_VERSION = '2';
+
+	/**
+	 * Option that stores the installed schema version.
+	 *
+	 * @var string
+	 */
+	const DB_VERSION_OPTION = 'newspack_network_used_nonces_db_version';
+
+	/**
+	 * Return value of {@see self::claim()}: the caller now holds the claim, and
+	 * should process the delivery and then record the outcome with
+	 * {@see self::complete()} or {@see self::release()}.
+	 *
+	 * @var string
+	 */
+	const CLAIMED = 'claimed';
+
+	/**
+	 * Record status: the delivery is being processed and its outcome is not yet
+	 * recorded.
+	 *
+	 * @var string
+	 */
+	const STATUS_PENDING = 'pending';
+
+	/**
+	 * Record status: the delivery was processed to completion. Permanent — this is
+	 * what lets a repeat of the delivery be recognised and skipped.
+	 *
+	 * @var string
+	 */
+	const STATUS_COMPLETED = 'completed';
+
+	/**
+	 * Creates the table on activation. It is also created lazily on first use
+	 * ({@see self::get_table_name()}), which is what installs it on an existing
+	 * Hub updated in place, where the activation hook does not run.
+	 *
+	 * @return void
+	 */
+	public static function install() {
+		self::maybe_create_table();
+	}
+
+	/**
+	 * Returns the table name, creating the table if it does not yet exist.
+	 *
+	 * @return string
+	 */
+	public static function get_table_name() {
+		self::maybe_create_table();
+		global $wpdb;
+		return $wpdb->prefix . 'newspack_network_used_nonces';
+	}
+
+	/**
+	 * Claims a nonce for processing, atomically, and reports the delivery's state.
+	 *
+	 * The nonce is expected to be a 48-character hex string — the length and
+	 * alphabet {@see \Newspack_Network\Crypto::generate_nonce()} produces, and the
+	 * width of the storage column. On the webhook path libsodium already rejects any
+	 * other shape before this is reached; the guard here makes that a precondition of
+	 * the store itself, so a future caller cannot silently truncate a longer value
+	 * into a colliding key. The nonce is recorded in a single casing, so recognising a
+	 * repeat does not depend on the storage column's collation.
+	 *
+	 * @param string $nonce The nonce to claim.
+	 * @return string|null Where the delivery stands:
+	 *                     - `claimed`: first time seen; the caller now holds the
+	 *                       claim and should process the delivery.
+	 *                     - `completed`: the delivery was already processed to
+	 *                       completion, and can be acknowledged without reprocessing.
+	 *                     - `pending`: an attempt to process the delivery is on
+	 *                       record with no outcome yet; retryable.
+	 *                     - null: no state could be determined — a malformed nonce,
+	 *                       or a write that failed outright — so the caller can ask
+	 *                       for a retry rather than guess.
+	 */
+	public static function claim( $nonce ): ?string {
+		$nonce = self::normalize( $nonce );
+		if ( null === $nonce ) {
+			return null;
+		}
+
+		global $wpdb;
+		$table = self::get_table_name();
+
+		// A nonce already on record trips the UNIQUE key and makes insert() return
+		// false; we expect that, so silence the resulting DB error rather than log
+		// it. `status` is written explicitly rather than left to the column
+		// default, so a table missing the column fails on the first claim instead
+		// of misbehaving only on repeats.
+		$suppress = $wpdb->suppress_errors( true );
+		$inserted = $wpdb->insert( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$table,
+			[
+				'nonce'      => $nonce,
+				'status'     => self::STATUS_PENDING,
+				'created_at' => time(),
+			],
+			[ '%s', '%s', '%d' ]
+		);
+		$wpdb->suppress_errors( $suppress );
+
+		if ( false !== $inserted ) {
+			return self::CLAIMED;
+		}
+
+		// The insert failed. An existing record says where the delivery stands:
+		// completed, or pending. No record at all means the write failed for some
+		// other reason — report no state, so the caller retries rather than treats
+		// the delivery as either fresh or already handled.
+		$status = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare( "SELECT status FROM $table WHERE nonce = %s", $nonce ) // phpcs:ignore WordPress.DB.PreparedSQL.InterpolatedNotPrepared
+		);
+
+		if ( self::STATUS_COMPLETED === $status || self::STATUS_PENDING === $status ) {
+			return $status;
+		}
+
+		return null;
+	}
+
+	/**
+	 * Marks a claimed nonce's delivery as fully processed.
+	 *
+	 * A completed record is permanent: it is what lets a later arrival of the same
+	 * delivery be recognised and skipped.
+	 *
+	 * @param string $nonce The nonce to mark completed.
+	 * @return bool False if the nonce is malformed or the write failed.
+	 */
+	public static function complete( $nonce ): bool {
+		$nonce = self::normalize( $nonce );
+		if ( null === $nonce ) {
+			return false;
+		}
+
+		global $wpdb;
+		$updated = $wpdb->update( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			self::get_table_name(),
+			[ 'status' => self::STATUS_COMPLETED ],
+			[ 'nonce' => $nonce ],
+			[ '%s' ],
+			[ '%s' ]
+		);
+
+		return false !== $updated;
+	}
+
+	/**
+	 * Removes a pending nonce record so a redelivery can be processed again.
+	 *
+	 * Used to undo a claim when processing failed, so the delivery is not treated
+	 * as already-handled on the Node's retry. Only a pending record is removed: a
+	 * completed one records a delivery that was fully processed, and removing it
+	 * would let that delivery be processed again.
+	 *
+	 * @param string $nonce The nonce to release.
+	 * @return bool False if the nonce is malformed or the delete failed.
+	 */
+	public static function release( $nonce ): bool {
+		$nonce = self::normalize( $nonce );
+		if ( null === $nonce ) {
+			return false;
+		}
+
+		global $wpdb;
+		$deleted = $wpdb->delete( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			self::get_table_name(),
+			[
+				'nonce'  => $nonce,
+				'status' => self::STATUS_PENDING,
+			],
+			[ '%s', '%s' ]
+		);
+
+		return false !== $deleted;
+	}
+
+	/**
+	 * Validates a nonce and returns it in the single casing the store records.
+	 *
+	 * Every public method keys records on the value this returns, so a claim made
+	 * under one casing can always be completed or released under another.
+	 *
+	 * @param string $nonce The nonce as the caller received it.
+	 * @return string|null The normalized nonce, or null if it is not a
+	 *                     48-character hex string.
+	 */
+	private static function normalize( $nonce ): ?string {
+		if ( ! is_string( $nonce ) || 48 !== strlen( $nonce ) || ! ctype_xdigit( $nonce ) ) {
+			return null;
+		}
+		return strtolower( $nonce );
+	}
+
+	/**
+	 * Creates the table with dbDelta, guarded by a stored schema version so the
+	 * check is cheap on the common path.
+	 *
+	 * The version option is written only once the table is confirmed to exist, so a
+	 * dbDelta that silently fails (a host that restricts DDL, say) is retried on the
+	 * next call rather than being marked done. The fast path trusts the option and
+	 * does not re-verify existence, so a table dropped *after* the option was set
+	 * (a partial DB restore that keeps `wp_options`) is a known limitation — the same
+	 * one the sibling event-log table carries.
+	 *
+	 * @return void
+	 */
+	protected static function maybe_create_table() {
+		if ( self::DB_VERSION === get_option( self::DB_VERSION_OPTION ) ) {
+			return;
+		}
+
+		global $wpdb;
+		$table_name      = $wpdb->prefix . 'newspack_network_used_nonces';
+		$charset_collate = $wpdb->get_charset_collate();
+
+		require_once ABSPATH . 'wp-admin/includes/upgrade.php';
+
+		// A generated nonce is a fixed 48-character hex string, and it is not secret,
+		// so it is stored under a UNIQUE key (in one casing) — the key is the atomic
+		// claim. `status` is where the delivery stands in its lifecycle: pending from
+		// claim until it is completed or released. `created_at` is kept for
+		// diagnostics only; nothing prunes by it (see the class docblock on
+		// retention), so it carries no index.
+		$sql = "CREATE TABLE $table_name (
+			id bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+			nonce varchar(48) NOT NULL,
+			status varchar(16) NOT NULL DEFAULT 'pending',
+			created_at bigint(20) unsigned NOT NULL,
+			PRIMARY KEY  (id),
+			UNIQUE KEY nonce (nonce)
+		) $charset_collate;";
+
+		dbDelta( $sql );
+
+		if ( self::table_exists( $table_name ) ) {
+			update_option( self::DB_VERSION_OPTION, self::DB_VERSION );
+		}
+	}
+
+	/**
+	 * Whether a table exists.
+	 *
+	 * @param string $table_name Fully-prefixed table name.
+	 * @return bool
+	 */
+	private static function table_exists( $table_name ) {
+		global $wpdb;
+		$found = $wpdb->get_var( // phpcs:ignore WordPress.DB.DirectDatabaseQuery.DirectQuery, WordPress.DB.DirectDatabaseQuery.NoCaching
+			$wpdb->prepare( 'SHOW TABLES LIKE %s', $wpdb->esc_like( $table_name ) )
+		);
+		return $found === $table_name;
+	}
+}

--- a/plugins/newspack-network/includes/hub/class-webhook.php
+++ b/plugins/newspack-network/includes/hub/class-webhook.php
@@ -97,11 +97,55 @@ class Webhook {
 		Debugger::log( 'Successfully verified data' );
 		Debugger::log( $verified_data );
 
+		// Claim this delivery's nonce before processing. The claim holds the
+		// delivery as pending until processing completes, so each delivery is
+		// handled at most once no matter how many times, or how close together,
+		// its copies arrive.
+		$claim = Used_Nonces::claim( $nonce );
+		if ( Used_Nonces::STATUS_COMPLETED === $claim ) {
+			// Already processed to completion. Acknowledge so the Node stops
+			// retrying, but do not run the event a second time.
+			Debugger::log( 'Webhook nonce already completed; acknowledging without reprocessing.' );
+			return new WP_REST_Response( 'success' );
+		}
+		if ( Used_Nonces::CLAIMED !== $claim ) {
+			// Pending (an attempt to process this delivery is on record with no
+			// outcome yet), or no state could be recorded at all. Either way, ask
+			// the Node to retry rather than process a delivery that may also be
+			// handled elsewhere.
+			Debugger::log( 'Webhook delivery not claimable (' . ( $claim ?? 'no recorded state' ) . '); requesting retry.' );
+			return new WP_REST_Response( array( 'error' => 'Could not record delivery.' ), 500 );
+		}
+
 		$incoming_event_class = 'Newspack_Network\\Incoming_Events\\' . $incoming_events[ $action ];
 
-		$incoming_event = new $incoming_event_class( $site, $verified_data, $timestamp );
+		// The claim is held while the event is processed. Processing that does not
+		// complete releases it and returns a 5xx, so the Node's retry can reprocess
+		// rather than the failure being acknowledged silently: a throw is caught
+		// below, and a failed Event Log write is caught by the `false` return. A
+		// delivery already in the Event Log (`null`) is a no-op whose handlers do
+		// not re-run — the pipeline's existing at-most-once behaviour — and is
+		// acknowledged as success.
+		try {
+			$incoming_event = new $incoming_event_class( $site, $verified_data, $timestamp );
+			$persisted      = $incoming_event->process_in_hub();
+		} catch ( \Throwable $e ) {
+			Used_Nonces::release( $nonce );
+			Debugger::log( 'Webhook processing threw; released nonce for retry: ' . $e->getMessage() );
+			return new WP_REST_Response( array( 'error' => 'Could not process delivery.' ), 500 );
+		}
 
-		$incoming_event->process_in_hub();
+		if ( false === $persisted ) {
+			Used_Nonces::release( $nonce );
+			Debugger::log( 'Webhook delivery could not be recorded; released nonce for retry.' );
+			return new WP_REST_Response( array( 'error' => 'Could not record delivery.' ), 500 );
+		}
+
+		// Mark the delivery completed. Best-effort: processing has already
+		// succeeded, so the delivery is acknowledged either way. A claim whose
+		// completion could not be written stays pending, and a later arrival of
+		// the delivery draws a retryable error rather than being reprocessed.
+		Used_Nonces::complete( $nonce );
 
 		return new WP_REST_Response( 'success' );
 	}

--- a/plugins/newspack-network/includes/incoming-events/class-abstract-incoming-event.php
+++ b/plugins/newspack-network/includes/incoming-events/class-abstract-incoming-event.php
@@ -76,7 +76,9 @@ class Abstract_Incoming_Event {
 	/**
 	 * Processes the event in the hub by persisting it in the Event Log
 	 *
-	 * @return void
+	 * @return int|false|null The Event Log row ID on success; false if the row could
+	 *                        not be written (a storage failure the caller can retry);
+	 *                        null if the event was already logged (a no-op).
 	 */
 	public function process_in_hub() {
 		Debugger::log( 'Processing event' );
@@ -88,6 +90,7 @@ class Abstract_Incoming_Event {
 			}
 			$this->always_process_in_hub();
 		}
+		return $event_id;
 	}
 
 	/**

--- a/plugins/newspack-network/tests/unit-tests/test-hub-webhook.php
+++ b/plugins/newspack-network/tests/unit-tests/test-hub-webhook.php
@@ -1,0 +1,335 @@
+<?php
+/**
+ * Tests for the Hub webhook handler's delivery de-duplication.
+ *
+ * The Hub processes each incoming Node webhook at most once. A Node generates a
+ * fresh nonce per event and encrypts the payload under it, so the nonce uniquely
+ * identifies a delivery. The nonce store follows each delivery from claim to
+ * completion, and these tests exercise that lifecycle through
+ * {@see Webhook::handle_webhook()} and against {@see Used_Nonces} directly: a
+ * repeated delivery is acknowledged but not reprocessed, a delivery still being
+ * processed is answered with a retryable error, and a failed delivery stays
+ * retryable.
+ *
+ * @package Newspack_Network
+ */
+
+use Newspack_Network\Crypto;
+use Newspack_Network\Hub\Nodes;
+use Newspack_Network\Hub\Webhook;
+use Newspack_Network\Hub\Used_Nonces;
+use Newspack_Network\Hub\Database\Event_Log as Event_Log_Database;
+
+/**
+ * Test the Hub webhook handler.
+ *
+ * @group hub-webhook
+ */
+class TestHubWebhook extends \WP_UnitTestCase {
+
+	/**
+	 * A registered Node URL the Hub resolves the delivery against.
+	 */
+	const NODE_URL = 'https://sync-node.example.test';
+
+	/**
+	 * Email carried in the payload, used to isolate this test's event-log rows.
+	 */
+	const PROBE_EMAIL = 'probe@example.test';
+
+	/**
+	 * An action whose incoming-event class only persists (no handler side effects,
+	 * no dependency on the Newspack plugin), so the event-log row count is a clean
+	 * signal of how many times the delivery was processed.
+	 */
+	const ACTION = 'network_hub_name_updated';
+
+	/**
+	 * The shared secret the fixture Node signs with.
+	 *
+	 * @var string
+	 */
+	private $secret_key;
+
+	/**
+	 * Create the custom tables once, before the per-test transaction.
+	 *
+	 * Both the used-nonce store and the event log create their table lazily via
+	 * dbDelta, and DDL implicitly commits the open transaction. Triggering that here,
+	 * outside any test's transaction, keeps a later in-test insert from being
+	 * committed and leaking into the next test.
+	 *
+	 * @param \WP_UnitTest_Factory $factory Test factory.
+	 */
+	public static function wpSetUpBeforeClass( $factory ) {
+		Used_Nonces::get_table_name();
+		Event_Log_Database::get_table_name();
+	}
+
+	/**
+	 * Register a fixture Node on the Hub.
+	 */
+	public function set_up() {
+		parent::set_up();
+
+		$this->secret_key = Crypto::generate_secret_key();
+
+		$node_id = self::factory()->post->create(
+			[
+				'post_type'   => Nodes::POST_TYPE_SLUG,
+				'post_title'  => 'Sync Node',
+				'post_status' => 'publish',
+			]
+		);
+		update_post_meta( $node_id, 'node-url', self::NODE_URL );
+		update_post_meta( $node_id, 'secret-key', $this->secret_key );
+	}
+
+	/**
+	 * Build a webhook request the way a Node would: the payload is encrypted under
+	 * the nonce, and the request carries the same `site`/`action`/`timestamp`/`nonce`
+	 * fields a Node sends.
+	 *
+	 * @param int    $timestamp Event timestamp.
+	 * @param string $nonce     Nonce.
+	 * @param string $data_json JSON payload to encrypt.
+	 * @return \WP_REST_Request
+	 */
+	private function build_request( $timestamp, $nonce, $data_json ) {
+		$request = new \WP_REST_Request( 'POST', '/newspack-network/v1/webhook' );
+		$request->set_param( 'site', self::NODE_URL );
+		$request->set_param( 'action', self::ACTION );
+		$request->set_param( 'data', Crypto::encrypt_message( $data_json, $this->secret_key, $nonce ) );
+		$request->set_param( 'timestamp', $timestamp );
+		$request->set_param( 'nonce', $nonce );
+		return $request;
+	}
+
+	/**
+	 * The payload the fixture Node delivers.
+	 *
+	 * @return string
+	 */
+	private function probe_payload() {
+		return wp_json_encode(
+			[
+				'email' => self::PROBE_EMAIL,
+				'name'  => 'Probe Hub',
+			]
+		);
+	}
+
+	/**
+	 * Count event-log rows for this test's probe email.
+	 *
+	 * @return int
+	 */
+	private function event_log_count() {
+		global $wpdb;
+		$table = Event_Log_Database::get_table_name();
+		return (int) $wpdb->get_var( $wpdb->prepare( "SELECT COUNT(*) FROM $table WHERE email = %s", self::PROBE_EMAIL ) ); // phpcs:ignore WordPress.DB
+	}
+
+	/**
+	 * A delivery received more than once is processed only once.
+	 *
+	 * The nonce that accompanies each delivery identifies it, so a repeat is recognised
+	 * and skipped. The test sends the same signed payload three times and asserts a
+	 * single event-log row.
+	 */
+	public function test_repeat_delivery_is_not_reprocessed() {
+		$data_json = $this->probe_payload();
+		$timestamp = time();
+		$nonce     = Crypto::generate_nonce();
+
+		// First delivery: persisted once.
+		$first = Webhook::handle_webhook( $this->build_request( $timestamp, $nonce, $data_json ) );
+		$this->assertSame( 200, $first->get_status() );
+		$this->assertSame( 1, $this->event_log_count(), 'First delivery should persist exactly one event.' );
+
+		// The same delivery again.
+		$again = Webhook::handle_webhook( $this->build_request( $timestamp, $nonce, $data_json ) );
+		$this->assertSame( 200, $again->get_status() );
+		$this->assertSame( 1, $this->event_log_count(), 'A repeat delivery must not add a second event.' );
+
+		// The same delivery once more, with a later timestamp.
+		$later = Webhook::handle_webhook( $this->build_request( $timestamp + HOUR_IN_SECONDS, $nonce, $data_json ) );
+		$this->assertSame( 200, $later->get_status(), 'A repeat delivery is acknowledged, not errored.' );
+		$this->assertSame( 1, $this->event_log_count(), 'A repeat delivery with a later timestamp must not add a second event.' );
+	}
+
+	/**
+	 * A fresh nonce still processes after another nonce has been claimed, so the
+	 * guard blocks repeats without blocking distinct deliveries.
+	 */
+	public function test_distinct_nonce_is_not_blocked() {
+		$data_json = $this->probe_payload();
+		$timestamp = time();
+
+		$first = Webhook::handle_webhook( $this->build_request( $timestamp, Crypto::generate_nonce(), $data_json ) );
+		$this->assertSame( 200, $first->get_status() );
+		$this->assertSame( 1, $this->event_log_count() );
+
+		// A different delivery (fresh nonce, distinct timestamp so the event-log
+		// dedupe does not absorb it) must be processed, not treated as a repeat.
+		$second = Webhook::handle_webhook( $this->build_request( $timestamp + HOUR_IN_SECONDS, Crypto::generate_nonce(), $data_json ) );
+		$this->assertSame( 200, $second->get_status() );
+		$this->assertSame( 2, $this->event_log_count(), 'A distinct delivery under a fresh nonce must still process.' );
+	}
+
+	/**
+	 * A delivery whose nonce is claimed but not yet completed is answered with a
+	 * retryable error, not processed alongside the attempt that holds the claim and
+	 * not falsely acknowledged. This is what keeps two copies of the same delivery
+	 * arriving at once from both being processed.
+	 */
+	public function test_delivery_in_progress_is_not_processed_again() {
+		$nonce = Crypto::generate_nonce();
+		$this->assertSame( 'claimed', Used_Nonces::claim( $nonce ), 'The first attempt holds the claim.' );
+
+		$response = Webhook::handle_webhook( $this->build_request( time(), $nonce, $this->probe_payload() ) );
+
+		$this->assertSame( 500, $response->get_status(), 'A delivery already being processed gets a retryable error, not an acknowledgement.' );
+		$this->assertSame( 0, $this->event_log_count(), 'The second copy of the delivery is not processed.' );
+	}
+
+	/**
+	 * A failed Event Log write releases the claim and returns a 5xx, so the delivery
+	 * is retryable rather than acknowledged as lost.
+	 */
+	public function test_failed_event_log_write_releases_nonce() {
+		global $wpdb;
+		$table = Event_Log_Database::get_table_name();
+
+		// Force the Event Log INSERT to fail, standing in for a transient write error.
+		$break_insert = function ( $query ) use ( $table ) {
+			if ( 0 === stripos( ltrim( $query ), 'INSERT' ) && false !== strpos( $query, $table ) ) {
+				return "INSERT INTO {$table}_missing ( x ) VALUES ( 1 )";
+			}
+			return $query;
+		};
+		add_filter( 'query', $break_insert );
+		$suppress = $wpdb->suppress_errors( true );
+
+		$nonce    = Crypto::generate_nonce();
+		$response = Webhook::handle_webhook( $this->build_request( time(), $nonce, $this->probe_payload() ) );
+
+		$wpdb->suppress_errors( $suppress );
+		remove_filter( 'query', $break_insert );
+
+		$this->assertSame( 500, $response->get_status(), 'A failed write returns a retryable 5xx.' );
+		$this->assertSame( 0, $this->event_log_count(), 'Nothing is persisted when the write fails.' );
+		$this->assertSame( 'claimed', Used_Nonces::claim( $nonce ), 'The claim is released so the retry can reprocess.' );
+	}
+
+	/**
+	 * The nonce store claims a nonce once, releases it on request, and refuses a
+	 * malformed one.
+	 */
+	public function test_used_nonces_claim_release_and_validation() {
+		$nonce = Crypto::generate_nonce();
+
+		$this->assertSame( 'claimed', Used_Nonces::claim( $nonce ), 'A fresh nonce is claimable.' );
+		$this->assertSame( 'claimed', Used_Nonces::claim( Crypto::generate_nonce() ), 'A distinct nonce is claimable while another is pending.' );
+
+		$this->assertNull( Used_Nonces::claim( 'not-a-valid-nonce' ), 'A malformed nonce cannot be recorded.' );
+
+		$this->assertTrue( Used_Nonces::release( $nonce ), 'An unfinished claim can be released.' );
+		$this->assertSame( 'claimed', Used_Nonces::claim( $nonce ), 'A released nonce is claimable again.' );
+	}
+
+	/**
+	 * A second claim of a nonce whose delivery has not yet completed reports it as
+	 * pending, so the caller can answer with a retryable error instead of processing
+	 * the delivery again or acknowledging it as done.
+	 */
+	public function test_claim_reports_a_delivery_still_in_progress() {
+		$nonce = Crypto::generate_nonce();
+
+		$this->assertSame( 'claimed', Used_Nonces::claim( $nonce ) );
+		$this->assertSame( 'pending', Used_Nonces::claim( $nonce ), 'While the delivery is unfinished, a further claim reports it pending.' );
+	}
+
+	/**
+	 * Once a delivery is marked completed, every later claim of its nonce reports
+	 * that, so the delivery is acknowledged without being reprocessed.
+	 */
+	public function test_claim_recognises_a_completed_delivery() {
+		$nonce = Crypto::generate_nonce();
+
+		$this->assertSame( 'claimed', Used_Nonces::claim( $nonce ) );
+		$this->assertTrue( Used_Nonces::complete( $nonce ), 'The delivery is marked completed.' );
+		$this->assertSame( 'completed', Used_Nonces::claim( $nonce ), 'A completed delivery is reported as such on any later claim.' );
+	}
+
+	/**
+	 * Releasing removes an unfinished claim so a retry can process the delivery, and
+	 * leaves a completed record in place, since removing that would let its delivery
+	 * be processed again.
+	 */
+	public function test_release_removes_only_pending_claims() {
+		$pending   = Crypto::generate_nonce();
+		$completed = Crypto::generate_nonce();
+
+		Used_Nonces::claim( $pending );
+		Used_Nonces::claim( $completed );
+		Used_Nonces::complete( $completed );
+
+		$this->assertTrue( Used_Nonces::release( $pending ), 'A pending claim is released.' );
+		$this->assertSame( 'claimed', Used_Nonces::claim( $pending ), 'Releasing a pending claim makes the nonce claimable again.' );
+
+		Used_Nonces::release( $completed );
+		$this->assertSame( 'completed', Used_Nonces::claim( $completed ), 'A completed record survives a release, so its delivery stays recognised.' );
+	}
+
+	/**
+	 * Completing and releasing find the record whatever hex casing they are handed,
+	 * matching how the claim recorded it, so a claim can always be finished or undone.
+	 */
+	public function test_complete_and_release_normalise_casing() {
+		$completed = Crypto::generate_nonce();
+		Used_Nonces::claim( $completed );
+		$this->assertTrue( Used_Nonces::complete( strtoupper( $completed ) ), 'Completion accepts the other casing.' );
+		$this->assertSame( 'completed', Used_Nonces::claim( $completed ), 'Completion under a different casing marks the same record.' );
+
+		$released = Crypto::generate_nonce();
+		Used_Nonces::claim( $released );
+		$this->assertTrue( Used_Nonces::release( strtoupper( $released ) ), 'Release accepts the other casing.' );
+		$this->assertSame( 'claimed', Used_Nonces::claim( $released ), 'Release under a different casing removes the same record.' );
+	}
+
+	/**
+	 * The same nonce in different hex casing is recognised as one delivery, so
+	 * recognising a repeat does not depend on the storage column's collation.
+	 */
+	public function test_nonce_claim_normalises_casing() {
+		$nonce = Crypto::generate_nonce();
+
+		$this->assertSame( 'claimed', Used_Nonces::claim( $nonce ), 'The nonce is claimable the first time.' );
+		$this->assertSame( 'pending', Used_Nonces::claim( strtoupper( $nonce ) ), 'The same nonce in a different casing is recognised as the same delivery.' );
+	}
+
+	/**
+	 * When the claim INSERT fails and no record results, claim() reports null rather
+	 * than guessing a state: the caller answers with a retryable error, and the retry
+	 * claims afresh.
+	 */
+	public function test_failed_claim_write_is_reported_as_indeterminate() {
+		$table = Used_Nonces::get_table_name();
+
+		// Force the claim INSERT to fail, standing in for a transient write error.
+		$break_insert = function ( $query ) use ( $table ) {
+			if ( 0 === stripos( ltrim( $query ), 'INSERT' ) && false !== strpos( $query, $table ) ) {
+				return "INSERT INTO {$table}_missing ( x ) VALUES ( 1 )";
+			}
+			return $query;
+		};
+		add_filter( 'query', $break_insert );
+
+		$result = Used_Nonces::claim( Crypto::generate_nonce() );
+
+		remove_filter( 'query', $break_insert );
+
+		$this->assertNull( $result, 'A claim that could not be recorded reports no state, so the caller retries rather than guesses.' );
+	}
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Makes the hub's webhook processing idempotent: each incoming delivery is handled at most once.

Every delivery a node sends to the hub carries a single-use nonce. This adds a hub-side store, `Hub\Used_Nonces`, that records the nonce of each delivery the hub processes. The webhook claims a delivery's nonce before processing it. A delivery whose nonce is already on record is acknowledged and skipped, so a repeated delivery has no further effect.

Two copies of the same delivery cannot both be processed, even when they arrive at once, and the record persists durably in the database. If processing fails, the claim is released so the node's retry can process the delivery again. The table is created automatically — on activation, and on first use for a hub updated in place — so no manual migration is needed.

Reference: NPPM-3145

### How to test the changes in this Pull Request:

There is no UI to exercise; the behavior is covered by the `hub-webhook` test group, which also runs in CI. To run it locally from `plugins/newspack-network/`:

```
n test-php --group hub-webhook
```

Four tests cover the behavior this change enforces: a repeated delivery is acknowledged without being processed again, a distinct delivery is still processed, and the nonce store records, recognizes, and validates a nonce correctly. They fail against the pre-change code.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

### Release risk: Elevated

| Signal | Reading |
| --- | --- |
| Cross-repo contract | None. Hub-side only, and backward-compatible: an updated hub still accepts deliveries from un-updated nodes. |
| Surface type | The webhook handler that every node-to-hub delivery flows through, and a new database table. |
| Publisher exposure | All sites acting as a network hub. |
| Change shape | An additive guard plus a new table; no change to the wire format or to what nodes send. |

This rating is driven by the shared node-to-hub delivery path and a new table on every hub, and lowered by full test coverage and backward compatibility. A persistent failure on this path would exhaust the retries for individual deliveries, but would not stop the delivery pipeline as a whole.
