### PR TITLE
chore(newsletters): MailPoet integration exploration (do not merge)

### DIFF
--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters-settings.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters-settings.php
@@ -121,6 +121,25 @@ class Newspack_Newsletters_Settings {
 				'onboarding'        => false,
 			),
 			array(
+				'description' => esc_html__( 'Where newsletters are edited', 'newspack-newsletters' ),
+				'key'         => Newspack_Newsletters_Mailpoet_Campaigns::STRATEGY_OPTION,
+				'type'        => 'select',
+				'default'     => Newspack_Newsletters_Mailpoet_Campaigns::DEFAULT_STRATEGY,
+				'provider'    => 'mailpoet',
+				'options'     => array_map(
+					function ( $value, $label ) {
+						return [
+							'name'  => $label,
+							'value' => $value,
+						];
+					},
+					array_keys( Newspack_Newsletters_Mailpoet_Campaigns::get_strategies() ),
+					array_values( Newspack_Newsletters_Mailpoet_Campaigns::get_strategies() )
+				),
+				'help'        => esc_html__( 'Newsletters are always composed in Newspack and sent by MailPoet. This chooses which editor opens when a newsletter is edited from the MailPoet screen.', 'newspack-newsletters' ),
+				'onboarding'  => false,
+			),
+			array(
 				'description' => esc_html__( 'Constant Contact API Key', 'newspack-newsletters' ),
 				'key'         => 'newspack_newsletters_constant_contact_api_key',
 				'type'        => 'text',
@@ -213,7 +232,9 @@ class Newspack_Newsletters_Settings {
 				if ( ! empty( $item['provider'] ) && ! in_array( $item['provider'], $supported_providers, true ) ) {
 					return $acc;
 				}
-				if ( 'select' === $item['type'] && ! empty( $item['options'] ) ) {
+				// Only the provider dropdown lists providers. Other selects carry
+				// their own values, which would otherwise be filtered away here.
+				if ( 'newspack_newsletters_service_provider' === $item['key'] && 'select' === $item['type'] && ! empty( $item['options'] ) ) {
 					$item['options'] = array_values(
 						array_filter(
 							$item['options'],

--- a/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
+++ b/plugins/newspack-newsletters/includes/class-newspack-newsletters.php
@@ -143,6 +143,10 @@ final class Newspack_Newsletters {
 				'name'  => 'Active Campaign',
 				'class' => 'Newspack_Newsletters_Active_Campaign',
 			],
+			'mailpoet'         => [
+				'name'  => 'MailPoet',
+				'class' => 'Newspack_Newsletters_Mailpoet',
+			],
 		];
 
 		/**

--- a/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-admin.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-admin.php
@@ -1,0 +1,221 @@
+<?php
+/**
+ * Service Provider: MailPoet admin routing.
+ *
+ * Supports an authoring mode in which newsletters are composed in MailPoet's own
+ * UI rather than ours. Our menu stays registered — it still owns Newsletter Ads
+ * and Settings — but the entries that list or create newsletters point at
+ * MailPoet, and the matching screens redirect there for anyone arriving by
+ * bookmark or direct URL.
+ *
+ * Exploratory. See LEO-65.
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Routes newsletter listing and creation to MailPoet.
+ */
+class Newspack_Newsletters_Mailpoet_Admin {
+
+	/**
+	 * Option choosing where newsletters are authored.
+	 *
+	 * `newspack` keeps our editor and syncs to MailPoet. `mailpoet` hands
+	 * authoring over to MailPoet's UI.
+	 */
+	const AUTHORING_OPTION = 'newspack_newsletters_mailpoet_authoring';
+
+	/**
+	 * Query arg that reaches our newsletter list without being redirected.
+	 */
+	const BYPASS_ARG = 'newspack_past_newsletters';
+
+	/**
+	 * MailPoet's newsletter list page.
+	 */
+	const MAILPOET_LIST_PAGE = 'admin.php?page=mailpoet-newsletters';
+
+	/**
+	 * MailPoet's "new newsletter" route. A hash route on the list page.
+	 */
+	const MAILPOET_NEW_ROUTE = 'admin.php?page=mailpoet-newsletters#/new';
+
+	/**
+	 * Boot hooks.
+	 */
+	public static function init() {
+		add_action( 'admin_menu', [ __CLASS__, 'rewrite_menu' ], 999 );
+		add_action( 'current_screen', [ __CLASS__, 'maybe_redirect' ] );
+	}
+
+	/**
+	 * Whether MailPoet owns authoring.
+	 *
+	 * Requires MailPoet to be the active provider, so the mode is inert on a site
+	 * using any other ESP.
+	 *
+	 * @return boolean
+	 */
+	public static function is_mailpoet_authoring() {
+		if ( ! class_exists( 'Newspack_Newsletters' ) || 'mailpoet' !== Newspack_Newsletters::service_provider() ) {
+			return false;
+		}
+		$mode = get_option( self::AUTHORING_OPTION, 'newspack' );
+
+		/**
+		 * Filters where newsletters are authored when MailPoet is the provider.
+		 *
+		 * @param string $mode Either 'newspack' or 'mailpoet'.
+		 */
+		$mode = apply_filters( 'newspack_newsletters_mailpoet_authoring', $mode );
+
+		return 'mailpoet' === $mode;
+	}
+
+	/**
+	 * Our newsletter list, exempt from the redirect.
+	 *
+	 * Admin-relative, so it works as a submenu slug and WordPress can mark the
+	 * entry current when the screen is open.
+	 *
+	 * @return string
+	 */
+	public static function get_past_newsletters_slug() {
+		return sprintf(
+			'edit.php?post_type=%s&%s=1',
+			Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT,
+			self::BYPASS_ARG
+		);
+	}
+
+	/**
+	 * The absolute URL of our newsletter list, exempt from the redirect.
+	 *
+	 * @return string
+	 */
+	public static function get_past_newsletters_url() {
+		return admin_url( self::get_past_newsletters_slug() );
+	}
+
+	/**
+	 * Point the listing and creation entries at MailPoet, and add a way back to
+	 * newsletters authored before the handover.
+	 *
+	 * The parent menu slug is left alone so Newsletter Ads and Settings stay
+	 * parented to it. WordPress links a CPT's top-level menu to its first
+	 * submenu, so repointing that entry moves the menu itself without detaching
+	 * anything beneath it.
+	 *
+	 * @return void
+	 */
+	public static function rewrite_menu() {
+		if ( ! self::is_mailpoet_authoring() ) {
+			return;
+		}
+
+		global $submenu;
+		$parent = 'edit.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
+		if ( empty( $submenu[ $parent ] ) ) {
+			return;
+		}
+
+		$list_slug = $parent;
+		$new_slug  = 'post-new.php?post_type=' . Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT;
+		$has_past  = false;
+
+		foreach ( $submenu[ $parent ] as $index => $item ) {
+			if ( $list_slug === $item[2] ) {
+				$submenu[ $parent ][ $index ][2] = self::MAILPOET_LIST_PAGE; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			}
+			if ( $new_slug === $item[2] ) {
+				$submenu[ $parent ][ $index ][2] = self::MAILPOET_NEW_ROUTE; // phpcs:ignore WordPress.WP.GlobalVariablesOverride.Prohibited
+			}
+			if ( false !== strpos( (string) $item[2], self::BYPASS_ARG ) ) {
+				$has_past = true;
+			}
+		}
+
+		// TODO(LEO-65): show this only when there are newsletters to see, and
+		// settle on a better label than "Past newsletters".
+		if ( ! $has_past ) {
+			add_submenu_page(
+				$parent,
+				__( 'Past newsletters', 'newspack-newsletters' ),
+				__( 'Past newsletters', 'newspack-newsletters' ),
+				'edit_posts',
+				self::get_past_newsletters_slug()
+			);
+		}
+	}
+
+	/**
+	 * Send listing and creation screens to MailPoet.
+	 *
+	 * Covers bookmarks, direct URLs and "Add New" links elsewhere in wp-admin,
+	 * which the menu rewrite alone would miss. Mirrors the guards in
+	 * Admin_Shell_Legacy_Redirect: GET requests only, and never when `action`
+	 * carries a real value, so classic list-table flows keep working.
+	 *
+	 * @param \WP_Screen $screen Current screen.
+	 *
+	 * @return void
+	 */
+	public static function maybe_redirect( $screen ) {
+		if ( ! is_admin() || ! $screen instanceof \WP_Screen ) {
+			return;
+		}
+		if ( ! self::is_mailpoet_authoring() ) {
+			return;
+		}
+		if ( ! isset( $_SERVER['REQUEST_METHOD'] ) || 'GET' !== $_SERVER['REQUEST_METHOD'] ) {
+			return;
+		}
+		if ( Newspack_Newsletters::NEWSPACK_NEWSLETTERS_CPT !== $screen->post_type ) {
+			return;
+		}
+		// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only navigation check.
+		if ( isset( $_GET[ self::BYPASS_ARG ] ) ) {
+			return;
+		}
+		if ( self::has_real_get_action() ) {
+			return;
+		}
+
+		if ( 'edit' === $screen->base ) {
+			wp_safe_redirect( admin_url( self::MAILPOET_LIST_PAGE ) );
+			exit;
+		}
+		if ( 'post' === $screen->base && 'add' === $screen->action ) {
+			wp_safe_redirect( admin_url( self::MAILPOET_NEW_ROUTE ) );
+			exit;
+		}
+	}
+
+	/**
+	 * Whether `action` / `action2` carry a real value, rather than WP's `-1`
+	 * "no action selected" sentinel.
+	 *
+	 * @return boolean
+	 */
+	private static function has_real_get_action() {
+		foreach ( [ 'action', 'action2' ] as $key ) {
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended -- Read-only navigation check.
+			if ( ! isset( $_GET[ $key ] ) ) {
+				continue;
+			}
+			// phpcs:ignore WordPress.Security.NonceVerification.Recommended
+			$value = sanitize_text_field( wp_unslash( $_GET[ $key ] ) );
+			if ( '' !== $value && '-1' !== $value ) {
+				return true;
+			}
+		}
+		return false;
+	}
+}
+
+// Only registers hooks; every callback checks the active provider and mode
+// first, so this is inert unless MailPoet owns authoring.
+Newspack_Newsletters_Mailpoet_Admin::init();

--- a/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-campaigns.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-campaigns.php
@@ -1,0 +1,326 @@
+<?php
+/**
+ * Service Provider: MailPoet campaign sync.
+ *
+ * MailPoet has no campaign API, so this class drives its Doctrine entities
+ * directly through the plugin's DI container. All of that coupling lives here
+ * rather than in the provider, because none of it carries a compatibility
+ * promise and it is the first thing to check when MailPoet updates.
+ *
+ * Two ways to give MailPoet the newsletter body, selectable via the
+ * `newspack_newsletters_mailpoet_sync_strategy` filter:
+ *
+ * - `html` (default) — push the HTML our renderer already produced into a single
+ *   MailPoet text block. Works whichever renderer the site uses.
+ * - `wp_post` — attach our Newsletter post to the MailPoet newsletter, so
+ *   MailPoet renders our blocks itself through the shared WooCommerce email
+ *   editor engine. Needs the WC renderer enabled; see Email_Renderers\Feature_Flag.
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * Creates and updates MailPoet newsletters from Newspack newsletter posts.
+ */
+class Newspack_Newsletters_Mailpoet_Campaigns {
+
+	/**
+	 * Post meta holding the MailPoet newsletter ID for a Newspack newsletter.
+	 */
+	const CAMPAIGN_ID_META = 'mailpoet_newsletter_id';
+
+	/**
+	 * Whether MailPoet's entity layer is reachable.
+	 *
+	 * @return boolean
+	 */
+	public static function is_available() {
+		return class_exists( '\MailPoet\DI\ContainerWrapper' )
+			&& class_exists( '\MailPoet\Entities\NewsletterEntity' );
+	}
+
+	/**
+	 * Get the body strategy in use.
+	 *
+	 * @return string Either 'html' or 'wp_post'.
+	 */
+	public static function get_strategy() {
+		/**
+		 * Filters how the newsletter body reaches MailPoet.
+		 *
+		 * @param string $strategy Either 'html' (push rendered HTML) or 'wp_post'
+		 *                         (attach our post and let MailPoet render it).
+		 */
+		$strategy = apply_filters( 'newspack_newsletters_mailpoet_sync_strategy', 'html' );
+		return in_array( $strategy, [ 'html', 'wp_post' ], true ) ? $strategy : 'html';
+	}
+
+	/**
+	 * Get MailPoet's newsletters repository.
+	 *
+	 * @return \MailPoet\Newsletter\NewslettersRepository|WP_Error
+	 */
+	private static function get_repository() {
+		if ( ! self::is_available() ) {
+			return new WP_Error(
+				'newspack_newsletters_mailpoet_unavailable',
+				__( 'MailPoet is not available.', 'newspack-newsletters' )
+			);
+		}
+		try {
+			return \MailPoet\DI\ContainerWrapper::getInstance()->get( \MailPoet\Newsletter\NewslettersRepository::class );
+		} catch ( \Throwable $e ) {
+			return new WP_Error( 'newspack_newsletters_mailpoet_container_error', $e->getMessage() );
+		}
+	}
+
+	/**
+	 * Find a MailPoet newsletter by ID.
+	 *
+	 * @param int $newsletter_id MailPoet newsletter ID.
+	 *
+	 * @return \MailPoet\Entities\NewsletterEntity|null
+	 */
+	public static function find( $newsletter_id ) {
+		$repo = self::get_repository();
+		if ( is_wp_error( $repo ) || ! $newsletter_id ) {
+			return null;
+		}
+		try {
+			return $repo->findOneById( (int) $newsletter_id );
+		} catch ( \Throwable $e ) {
+			return null;
+		}
+	}
+
+	/**
+	 * Create or update the MailPoet newsletter for a Newspack newsletter post.
+	 *
+	 * @param \WP_Post $post The Newspack newsletter post.
+	 * @param array    $args {
+	 *     Campaign data.
+	 *
+	 *     @type string $subject      Email subject line.
+	 *     @type string $campaign_name Internal name shown in MailPoet.
+	 *     @type string $sender_name  Sender name.
+	 *     @type string $sender_email Sender email address.
+	 *     @type string $html         Rendered email HTML (used by the 'html' strategy).
+	 * }
+	 *
+	 * @return int|WP_Error MailPoet newsletter ID, or error.
+	 */
+	public static function upsert( $post, $args ) {
+		$repo = self::get_repository();
+		if ( is_wp_error( $repo ) ) {
+			return $repo;
+		}
+
+		$newsletter_id = (int) get_post_meta( $post->ID, self::CAMPAIGN_ID_META, true );
+		$newsletter    = self::find( $newsletter_id );
+		$is_new        = ! $newsletter instanceof \MailPoet\Entities\NewsletterEntity;
+
+		try {
+			if ( $is_new ) {
+				$newsletter = new \MailPoet\Entities\NewsletterEntity();
+				$newsletter->setType( \MailPoet\Entities\NewsletterEntity::TYPE_STANDARD );
+				$newsletter->setStatus( \MailPoet\Entities\NewsletterEntity::STATUS_DRAFT );
+				$newsletter->setHash( \MailPoet\Util\Security::generateHash( 12 ) );
+			}
+
+			// A newsletter MailPoet has already sent must not be rewritten.
+			if ( ! $is_new && \MailPoet\Entities\NewsletterEntity::STATUS_SENT === $newsletter->getStatus() ) {
+				return new WP_Error(
+					'newspack_newsletters_mailpoet_already_sent',
+					__( 'This newsletter has already been sent from MailPoet and can no longer be updated.', 'newspack-newsletters' )
+				);
+			}
+
+			$newsletter->setSubject( $args['subject'] );
+			if ( ! empty( $args['sender_name'] ) ) {
+				$newsletter->setSenderName( $args['sender_name'] );
+			}
+			if ( ! empty( $args['sender_email'] ) ) {
+				$newsletter->setSenderAddress( $args['sender_email'] );
+			}
+
+			$applied = self::apply_body( $newsletter, $post, $args );
+			if ( is_wp_error( $applied ) ) {
+				return $applied;
+			}
+
+			$repo->persist( $newsletter );
+			$repo->flush();
+		} catch ( \Throwable $e ) {
+			return new WP_Error( 'newspack_newsletters_mailpoet_sync_failed', $e->getMessage() );
+		}
+
+		$newsletter_id = (int) $newsletter->getId();
+		update_post_meta( $post->ID, self::CAMPAIGN_ID_META, $newsletter_id );
+		return $newsletter_id;
+	}
+
+	/**
+	 * Put the newsletter body onto the entity, per the active strategy.
+	 *
+	 * @param \MailPoet\Entities\NewsletterEntity $newsletter The MailPoet newsletter.
+	 * @param \WP_Post                            $post       The Newspack newsletter post.
+	 * @param array                               $args       Campaign data.
+	 *
+	 * @return true|WP_Error
+	 */
+	private static function apply_body( $newsletter, $post, $args ) {
+		if ( 'wp_post' === self::get_strategy() ) {
+			return self::attach_wp_post( $newsletter, $post );
+		}
+		$newsletter->setBody( self::build_html_body( $args['html'] ?? '' ) );
+		return true;
+	}
+
+	/**
+	 * Attach our Newsletter post to the MailPoet newsletter.
+	 *
+	 * MailPoet's renderer branches on the presence of a WP post and, when there
+	 * is one, renders it with the WooCommerce email editor engine — the same
+	 * engine our WC renderer path uses, so our blocks render through their own
+	 * email renderers.
+	 *
+	 * @param \MailPoet\Entities\NewsletterEntity $newsletter The MailPoet newsletter.
+	 * @param \WP_Post                            $post       The Newspack newsletter post.
+	 *
+	 * @return true|WP_Error
+	 */
+	private static function attach_wp_post( $newsletter, $post ) {
+		if ( ! class_exists( '\MailPoet\Entities\WpPostEntity' ) ) {
+			return new WP_Error(
+				'newspack_newsletters_mailpoet_no_wp_post_entity',
+				__( 'This version of MailPoet does not support post-backed emails.', 'newspack-newsletters' )
+			);
+		}
+		try {
+			$entity_manager = \MailPoet\DI\ContainerWrapper::getInstance()->get( \MailPoetVendor\Doctrine\ORM\EntityManager::class );
+			$newsletter->setWpPost( $entity_manager->getReference( \MailPoet\Entities\WpPostEntity::class, $post->ID ) );
+			// The body still has to be valid JSON for MailPoet's own screens,
+			// even though the renderer takes the post path.
+			$newsletter->setBody( [] );
+		} catch ( \Throwable $e ) {
+			return new WP_Error( 'newspack_newsletters_mailpoet_attach_failed', $e->getMessage() );
+		}
+		return true;
+	}
+
+	/**
+	 * Wrap rendered HTML in the minimal MailPoet body structure.
+	 *
+	 * MailPoet stores a block tree rather than HTML, and has no raw-HTML block.
+	 * A single text block is the closest fit: its content passes through the
+	 * renderer with markup, attributes and inline styles intact.
+	 *
+	 * @param string $html Rendered email HTML.
+	 *
+	 * @return array MailPoet body structure.
+	 */
+	private static function build_html_body( $html ) {
+		return [
+			'content'      => [
+				'type'         => 'container',
+				'columnLayout' => false,
+				'orientation'  => 'vertical',
+				'image'        => false,
+				'styles'       => [ 'block' => [ 'backgroundColor' => 'transparent' ] ],
+				'blocks'       => [
+					[
+						'type'        => 'container',
+						'orientation' => 'horizontal',
+						'image'       => false,
+						'styles'      => [ 'block' => [ 'backgroundColor' => 'transparent' ] ],
+						'blocks'      => [
+							[
+								'type'        => 'container',
+								'orientation' => 'vertical',
+								'image'       => false,
+								'styles'      => [ 'block' => [ 'backgroundColor' => 'transparent' ] ],
+								'blocks'      => [
+									[
+										'type' => 'text',
+										'text' => $html,
+									],
+								],
+							],
+						],
+					],
+				],
+			],
+			'globalStyles' => [
+				'text'    => [
+					'fontColor'  => '#000000',
+					'fontFamily' => 'Arial',
+					'fontSize'   => '16px',
+				],
+				'body'    => [ 'backgroundColor' => '#ffffff' ],
+				'link'    => [
+					'fontColor'      => '#21759b',
+					'textDecoration' => 'underline',
+				],
+				'wrapper' => [ 'backgroundColor' => '#ffffff' ],
+			],
+		];
+	}
+
+	/**
+	 * Delete the MailPoet newsletter for a Newspack newsletter post.
+	 *
+	 * @param int $post_id The Newspack newsletter post ID.
+	 *
+	 * @return true|WP_Error
+	 */
+	public static function delete_for_post( $post_id ) {
+		$repo = self::get_repository();
+		if ( is_wp_error( $repo ) ) {
+			return $repo;
+		}
+		$newsletter = self::find( get_post_meta( $post_id, self::CAMPAIGN_ID_META, true ) );
+		if ( ! $newsletter instanceof \MailPoet\Entities\NewsletterEntity ) {
+			return true;
+		}
+		try {
+			$repo->remove( $newsletter );
+			$repo->flush();
+		} catch ( \Throwable $e ) {
+			return new WP_Error( 'newspack_newsletters_mailpoet_delete_failed', $e->getMessage() );
+		}
+		delete_post_meta( $post_id, self::CAMPAIGN_ID_META );
+		return true;
+	}
+
+	/**
+	 * Get the MailPoet admin URL for editing a newsletter.
+	 *
+	 * @param int $newsletter_id MailPoet newsletter ID.
+	 *
+	 * @return string
+	 */
+	public static function get_edit_url( $newsletter_id ) {
+		return admin_url( 'admin.php?page=mailpoet-newsletter-editor&id=' . (int) $newsletter_id );
+	}
+
+	/**
+	 * Summarise a MailPoet newsletter for the Newspack editor.
+	 *
+	 * @param \MailPoet\Entities\NewsletterEntity $newsletter The MailPoet newsletter.
+	 *
+	 * @return array
+	 */
+	public static function to_array( $newsletter ) {
+		return [
+			'id'           => (int) $newsletter->getId(),
+			'subject'      => $newsletter->getSubject(),
+			'status'       => $newsletter->getStatus(),
+			'type'         => $newsletter->getType(),
+			'sender_name'  => $newsletter->getSenderName(),
+			'sender_email' => $newsletter->getSenderAddress(),
+			'wp_post_id'   => $newsletter->getWpPostId(),
+		];
+	}
+}

--- a/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-campaigns.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-campaigns.php
@@ -32,6 +32,39 @@ class Newspack_Newsletters_Mailpoet_Campaigns {
 	const CAMPAIGN_ID_META = 'mailpoet_newsletter_id';
 
 	/**
+	 * Post meta holding the mirrored `mailpoet_email` post ID, for the
+	 * `mailpoet_post` strategy.
+	 */
+	const MIRROR_POST_META = 'mailpoet_email_post_id';
+
+	/**
+	 * Option holding the chosen sync strategy.
+	 */
+	const STRATEGY_OPTION = 'newspack_newsletters_mailpoet_sync_strategy';
+
+	/**
+	 * MailPoet's post type for its block-based email editor.
+	 */
+	const MAILPOET_EMAIL_CPT = 'mailpoet_email';
+
+	/**
+	 * The default strategy.
+	 */
+	const DEFAULT_STRATEGY = 'mailpoet_post';
+
+	/**
+	 * Available strategies, with the labels shown in settings.
+	 *
+	 * @return array
+	 */
+	public static function get_strategies() {
+		return [
+			'mailpoet_post' => __( 'Edit in MailPoet — copies the newsletter into a MailPoet email', 'newspack-newsletters' ),
+			'wp_post'       => __( 'Edit in Newspack — MailPoet sends this newsletter directly', 'newspack-newsletters' ),
+		];
+	}
+
+	/**
 	 * Whether MailPoet's entity layer is reachable.
 	 *
 	 * @return boolean
@@ -44,17 +77,28 @@ class Newspack_Newsletters_Mailpoet_Campaigns {
 	/**
 	 * Get the body strategy in use.
 	 *
-	 * @return string Either 'html' or 'wp_post'.
+	 * Set in Newsletters settings when MailPoet is the provider. `html` is not
+	 * offered there — it leaves MailPoet with no attached post, which sends the
+	 * publisher into MailPoet's legacy page builder — but remains reachable
+	 * through the filter for a site without the WC renderer.
+	 *
+	 * @return string One of 'mailpoet_post', 'wp_post' or 'html'.
 	 */
 	public static function get_strategy() {
+		$strategy = get_option( self::STRATEGY_OPTION, self::DEFAULT_STRATEGY );
+
 		/**
 		 * Filters how the newsletter body reaches MailPoet.
 		 *
-		 * @param string $strategy Either 'html' (push rendered HTML) or 'wp_post'
-		 *                         (attach our post and let MailPoet render it).
+		 * @param string $strategy One of 'mailpoet_post' (mirror into a MailPoet
+		 *                         email post), 'wp_post' (attach our own post) or
+		 *                         'html' (push rendered HTML into a text block).
 		 */
-		$strategy = apply_filters( 'newspack_newsletters_mailpoet_sync_strategy', 'html' );
-		return in_array( $strategy, [ 'html', 'wp_post' ], true ) ? $strategy : 'html';
+		$strategy = apply_filters( 'newspack_newsletters_mailpoet_sync_strategy', $strategy );
+
+		return in_array( $strategy, [ 'mailpoet_post', 'wp_post', 'html' ], true )
+			? $strategy
+			: self::DEFAULT_STRATEGY;
 	}
 
 	/**
@@ -171,27 +215,95 @@ class Newspack_Newsletters_Mailpoet_Campaigns {
 	 * @return true|WP_Error
 	 */
 	private static function apply_body( $newsletter, $post, $args ) {
-		if ( 'wp_post' === self::get_strategy() ) {
-			return self::attach_wp_post( $newsletter, $post );
+		switch ( self::get_strategy() ) {
+			case 'mailpoet_post':
+				$mirror_id = self::sync_mirror_post( $post );
+				if ( is_wp_error( $mirror_id ) ) {
+					return $mirror_id;
+				}
+				return self::attach_post_id( $newsletter, $mirror_id );
+			case 'wp_post':
+				return self::attach_post_id( $newsletter, $post->ID );
+			default:
+				$newsletter->setBody( self::build_html_body( $args['html'] ?? '' ) );
+				return true;
 		}
-		$newsletter->setBody( self::build_html_body( $args['html'] ?? '' ) );
-		return true;
 	}
 
 	/**
-	 * Attach our Newsletter post to the MailPoet newsletter.
+	 * Create or update the `mailpoet_email` post mirroring a Newspack newsletter.
 	 *
-	 * MailPoet's renderer branches on the presence of a WP post and, when there
-	 * is one, renders it with the WooCommerce email editor engine — the same
-	 * engine our WC renderer path uses, so our blocks render through their own
-	 * email renderers.
+	 * MailPoet routes the edit link to whatever post a newsletter has attached, so
+	 * attaching one of its own post type is what makes its editor open on its own
+	 * screen. Our newsletter stays the source of truth and the mirror is rewritten
+	 * on every sync.
+	 *
+	 * The content written here is passed through
+	 * `newspack_newsletters_newsletter_content` first, which is what inserts
+	 * automatically placed ads. MailPoet never calls our renderers, so without
+	 * this the mirror would carry only manually inserted ad blocks.
+	 *
+	 * @param \WP_Post $post The Newspack newsletter post.
+	 *
+	 * @return int|WP_Error The mirror post ID.
+	 */
+	private static function sync_mirror_post( $post ) {
+		if ( ! post_type_exists( self::MAILPOET_EMAIL_CPT ) ) {
+			return new WP_Error(
+				'newspack_newsletters_mailpoet_no_email_cpt',
+				__( "MailPoet's email post type is unavailable. Its new email editor may need enabling.", 'newspack-newsletters' )
+			);
+		}
+
+		// Ads::$inserted_ads is process-global and the renderer will already have
+		// run in this request, marking each ad inserted. Without a reset the filter
+		// below drops every ad silently, exactly as a repeated render would.
+		if ( class_exists( '\Newspack_Newsletters\Ads' ) && method_exists( '\Newspack_Newsletters\Ads', 'reset_inserted_ads' ) ) {
+			\Newspack_Newsletters\Ads::reset_inserted_ads( $post->ID );
+		}
+
+		$content = (string) apply_filters( 'newspack_newsletters_newsletter_content', $post->post_content, $post );
+
+		$mirror_id = (int) get_post_meta( $post->ID, self::MIRROR_POST_META, true );
+		$mirror    = $mirror_id ? get_post( $mirror_id ) : null;
+
+		$postarr = [
+			'post_type'    => self::MAILPOET_EMAIL_CPT,
+			'post_status'  => 'draft',
+			'post_title'   => $post->post_title,
+			'post_content' => $content,
+		];
+
+		if ( $mirror instanceof \WP_Post && self::MAILPOET_EMAIL_CPT === $mirror->post_type ) {
+			$postarr['ID'] = $mirror->ID;
+			$result        = wp_update_post( $postarr, true );
+		} else {
+			// Either never mirrored, or the mirror was deleted in MailPoet.
+			$result = wp_insert_post( $postarr, true );
+		}
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		update_post_meta( $post->ID, self::MIRROR_POST_META, (int) $result );
+		return (int) $result;
+	}
+
+	/**
+	 * Point a MailPoet newsletter at a WordPress post.
+	 *
+	 * MailPoet's renderer branches on the presence of a post and, when there is
+	 * one, renders it with the WooCommerce email editor engine — the same engine
+	 * our WC renderer path uses, so our blocks render through their own email
+	 * renderers.
 	 *
 	 * @param \MailPoet\Entities\NewsletterEntity $newsletter The MailPoet newsletter.
-	 * @param \WP_Post                            $post       The Newspack newsletter post.
+	 * @param int                                 $post_id    Post to attach.
 	 *
 	 * @return true|WP_Error
 	 */
-	private static function attach_wp_post( $newsletter, $post ) {
+	private static function attach_post_id( $newsletter, $post_id ) {
 		if ( ! class_exists( '\MailPoet\Entities\WpPostEntity' ) ) {
 			return new WP_Error(
 				'newspack_newsletters_mailpoet_no_wp_post_entity',
@@ -200,7 +312,7 @@ class Newspack_Newsletters_Mailpoet_Campaigns {
 		}
 		try {
 			$entity_manager = \MailPoet\DI\ContainerWrapper::getInstance()->get( \MailPoetVendor\Doctrine\ORM\EntityManager::class );
-			$newsletter->setWpPost( $entity_manager->getReference( \MailPoet\Entities\WpPostEntity::class, $post->ID ) );
+			$newsletter->setWpPost( $entity_manager->getReference( \MailPoet\Entities\WpPostEntity::class, $post_id ) );
 			// The body still has to be valid JSON for MailPoet's own screens,
 			// even though the renderer takes the post path.
 			$newsletter->setBody( [] );
@@ -291,17 +403,34 @@ class Newspack_Newsletters_Mailpoet_Campaigns {
 			return new WP_Error( 'newspack_newsletters_mailpoet_delete_failed', $e->getMessage() );
 		}
 		delete_post_meta( $post_id, self::CAMPAIGN_ID_META );
+
+		// The mirror exists only to back the campaign, so it goes with it.
+		$mirror_id = (int) get_post_meta( $post_id, self::MIRROR_POST_META, true );
+		if ( $mirror_id && self::MAILPOET_EMAIL_CPT === get_post_type( $mirror_id ) ) {
+			wp_delete_post( $mirror_id, true );
+		}
+		delete_post_meta( $post_id, self::MIRROR_POST_META );
+
 		return true;
 	}
 
 	/**
-	 * Get the MailPoet admin URL for editing a newsletter.
+	 * Get the URL for editing a newsletter, matching where MailPoet itself sends
+	 * the publisher.
+	 *
+	 * MailPoet routes to the block editor for the attached post when a newsletter
+	 * has one, and to its legacy page builder otherwise.
 	 *
 	 * @param int $newsletter_id MailPoet newsletter ID.
 	 *
 	 * @return string
 	 */
 	public static function get_edit_url( $newsletter_id ) {
+		$newsletter = self::find( $newsletter_id );
+		$post_id    = $newsletter ? $newsletter->getWpPostId() : null;
+		if ( $post_id ) {
+			return admin_url( 'post.php?post=' . (int) $post_id . '&action=edit' );
+		}
 		return admin_url( 'admin.php?page=mailpoet-newsletter-editor&id=' . (int) $newsletter_id );
 	}
 

--- a/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-controller.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-controller.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * MailPoet ESP Service Controller.
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * API Controller for the Newspack MailPoet ESP service.
+ */
+class Newspack_Newsletters_Mailpoet_Controller extends Newspack_Newsletters_Service_Provider_Controller {
+
+	/**
+	 * Newspack_Newsletters_Mailpoet_Controller constructor.
+	 *
+	 * @param \Newspack_Newsletters_Mailpoet $mailpoet The service provider class.
+	 */
+	public function __construct( $mailpoet ) {
+		$this->service_provider = $mailpoet;
+		add_action( 'rest_api_init', [ $this, 'register_routes' ] );
+		parent::__construct( $mailpoet );
+	}
+
+	/**
+	 * Register API endpoints unique to MailPoet.
+	 *
+	 * MailPoet needs no credential or campaign routes: it is a local plugin, so
+	 * there is nothing to authorize, and composing is handled in its own UI.
+	 * Only the shared ESP routes are registered.
+	 */
+	public function register_routes() {
+		parent::register_routes();
+
+		\register_rest_route(
+			$this->service_provider::BASE_NAMESPACE . $this->service_provider->service,
+			'connection',
+			[
+				'methods'             => \WP_REST_Server::READABLE,
+				'callback'            => [ $this, 'api_connection' ],
+				'permission_callback' => [ 'Newspack_Newsletters', 'api_authoring_permissions_check' ],
+			]
+		);
+	}
+
+	/**
+	 * Report connection state.
+	 *
+	 * Also reports MailPoet's signup confirmation setting, which decides whether
+	 * readers synced from Newspack land subscribed or awaiting confirmation.
+	 *
+	 * @return WP_REST_Response|mixed
+	 */
+	public function api_connection() {
+		return self::get_api_response(
+			[
+				'connected'                   => $this->service_provider->has_api_credentials(),
+				'signup_confirmation_enabled' => $this->service_provider->is_signup_confirmation_enabled(),
+			]
+		);
+	}
+}

--- a/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-sdk.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-sdk.php
@@ -1,0 +1,460 @@
+<?php
+/**
+ * Service Provider: MailPoet SDK
+ *
+ * Thin wrapper over MailPoet's `MP('v1')` API. Every call into MailPoet goes
+ * through here so the provider itself stays free of MailPoet types, and so the
+ * one place we depend on MailPoet's surface is easy to audit when they change it.
+ *
+ * MailPoet's API throws on failure; this wrapper converts throwables into
+ * WP_Error so the provider can follow the ESP interface contract.
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+/**
+ * MailPoet SDK.
+ */
+class Newspack_Newsletters_Mailpoet_SDK {
+
+	/**
+	 * The MailPoet API version this wrapper targets.
+	 */
+	const API_VERSION = 'v1';
+
+	/**
+	 * Memoized API instance.
+	 *
+	 * @var \MailPoet\API\MP\v1\API|null
+	 */
+	private $api = null;
+
+	/**
+	 * Memoized map of Newspack metadata key => MailPoet custom field id (`cf_N`).
+	 *
+	 * @var array|null
+	 */
+	private $field_map = null;
+
+	/**
+	 * Whether MailPoet is installed and its API is reachable.
+	 *
+	 * @return boolean
+	 */
+	public static function is_available() {
+		return class_exists( '\MailPoet\API\API' );
+	}
+
+	/**
+	 * Get the MailPoet API instance.
+	 *
+	 * @return \MailPoet\API\MP\v1\API|WP_Error
+	 */
+	public function api() {
+		if ( $this->api ) {
+			return $this->api;
+		}
+		if ( ! self::is_available() ) {
+			return new WP_Error(
+				'newspack_newsletters_mailpoet_unavailable',
+				__( 'MailPoet is not installed or activated.', 'newspack-newsletters' )
+			);
+		}
+		try {
+			$this->api = \MailPoet\API\API::MP( self::API_VERSION );
+		} catch ( \Throwable $e ) {
+			return self::error( $e, 'newspack_newsletters_mailpoet_api_unavailable' );
+		}
+		return $this->api;
+	}
+
+	/**
+	 * Convert a throwable from MailPoet into a WP_Error.
+	 *
+	 * @param \Throwable $e    The throwable.
+	 * @param string     $code Error code to use.
+	 *
+	 * @return WP_Error
+	 */
+	private static function error( $e, $code = 'newspack_newsletters_mailpoet_error' ) {
+		return new WP_Error( $code, $e->getMessage() );
+	}
+
+	/**
+	 * Run a callable against the API, converting throwables to WP_Error.
+	 *
+	 * @param callable $fn   Receives the API instance.
+	 * @param string   $code Error code to use on failure.
+	 *
+	 * @return mixed|WP_Error
+	 */
+	private function call( callable $fn, $code = 'newspack_newsletters_mailpoet_error' ) {
+		$api = $this->api();
+		if ( is_wp_error( $api ) ) {
+			return $api;
+		}
+		try {
+			return $fn( $api );
+		} catch ( \Throwable $e ) {
+			return self::error( $e, $code );
+		}
+	}
+
+	// Lists.
+
+	/**
+	 * Get all MailPoet lists (segments).
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_lists() {
+		return $this->call(
+			function ( $api ) {
+				return $api->getLists();
+			},
+			'newspack_newsletters_mailpoet_get_lists_failed'
+		);
+	}
+
+	// Tags.
+
+	/**
+	 * Get all tags.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_tags() {
+		return $this->call(
+			function ( $api ) {
+				return $api->getTags();
+			},
+			'newspack_newsletters_mailpoet_get_tags_failed'
+		);
+	}
+
+	/**
+	 * Get a tag by ID or name.
+	 *
+	 * MailPoet throws when the tag is absent; callers that treat "missing" as a
+	 * normal outcome should check for WP_Error rather than relying on null.
+	 *
+	 * @param string|int $id_or_name Tag ID or name.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_tag( $id_or_name ) {
+		return $this->call(
+			function ( $api ) use ( $id_or_name ) {
+				return $api->getTag( $id_or_name );
+			},
+			'newspack_newsletters_mailpoet_tag_not_found'
+		);
+	}
+
+	/**
+	 * Create a tag.
+	 *
+	 * @param string $name Tag name.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function add_tag( $name ) {
+		return $this->call(
+			function ( $api ) use ( $name ) {
+				return $api->addTag( [ 'name' => $name ] );
+			},
+			'newspack_newsletters_mailpoet_add_tag_failed'
+		);
+	}
+
+	/**
+	 * Rename a tag.
+	 *
+	 * @param string|int $tag_id Tag ID.
+	 * @param string     $name   New name.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function update_tag( $tag_id, $name ) {
+		return $this->call(
+			function ( $api ) use ( $tag_id, $name ) {
+				return $api->updateTag(
+					[
+						'id'   => $tag_id,
+						'name' => $name,
+					]
+				);
+			},
+			'newspack_newsletters_mailpoet_update_tag_failed'
+		);
+	}
+
+	/**
+	 * Add a tag to a subscriber.
+	 *
+	 * @param string     $email      Subscriber email.
+	 * @param string|int $id_or_name Tag ID or name.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function tag_subscriber( $email, $id_or_name ) {
+		return $this->call(
+			function ( $api ) use ( $email, $id_or_name ) {
+				return $api->tagSubscriber( $email, $id_or_name );
+			},
+			'newspack_newsletters_mailpoet_tag_subscriber_failed'
+		);
+	}
+
+	/**
+	 * Remove a tag from a subscriber.
+	 *
+	 * @param string     $email      Subscriber email.
+	 * @param string|int $id_or_name Tag ID or name.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function untag_subscriber( $email, $id_or_name ) {
+		return $this->call(
+			function ( $api ) use ( $email, $id_or_name ) {
+				return $api->untagSubscriber( $email, $id_or_name );
+			},
+			'newspack_newsletters_mailpoet_untag_subscriber_failed'
+		);
+	}
+
+	// Subscribers.
+
+	/**
+	 * Get a subscriber by email.
+	 *
+	 * The returned array carries `subscriptions` (per-list status) and `tags` in
+	 * one payload, so callers needing lists, tags and profile data can share a
+	 * single fetch.
+	 *
+	 * @param string $email Subscriber email.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_subscriber( $email ) {
+		return $this->call(
+			function ( $api ) use ( $email ) {
+				return $api->getSubscriber( $email );
+			},
+			'newspack_newsletters_mailpoet_subscriber_not_found'
+		);
+	}
+
+	/**
+	 * Add a subscriber, optionally subscribing them to lists.
+	 *
+	 * Note that MailPoet decides the resulting subscriber status itself: with
+	 * signup confirmation enabled (its default) a subscriber added here lands as
+	 * `unconfirmed` regardless of the status requested, and cannot be promoted
+	 * afterwards through the public API. That is MailPoet's double opt-in, and it
+	 * is equivalent to Mailchimp's `pending`.
+	 *
+	 * @param array $subscriber Subscriber data (`email`, `first_name`, `last_name`, custom fields).
+	 * @param array $list_ids   List IDs to subscribe to.
+	 * @param array $options    MailPoet options (`send_confirmation_email`, `schedule_welcome_email`).
+	 *
+	 * @return array|WP_Error
+	 */
+	public function add_subscriber( $subscriber, $list_ids = [], $options = [] ) {
+		$options = wp_parse_args(
+			$options,
+			[
+				'send_confirmation_email' => false,
+				'schedule_welcome_email'  => false,
+			]
+		);
+		return $this->call(
+			function ( $api ) use ( $subscriber, $list_ids, $options ) {
+				return $api->addSubscriber( $subscriber, $list_ids, $options );
+			},
+			'newspack_newsletters_mailpoet_add_subscriber_failed'
+		);
+	}
+
+	/**
+	 * Update a subscriber.
+	 *
+	 * @param string $email      Subscriber email.
+	 * @param array  $subscriber Fields to update.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function update_subscriber( $email, $subscriber ) {
+		return $this->call(
+			function ( $api ) use ( $email, $subscriber ) {
+				return $api->updateSubscriber( $email, $subscriber );
+			},
+			'newspack_newsletters_mailpoet_update_subscriber_failed'
+		);
+	}
+
+	/**
+	 * Subscribe a subscriber to lists.
+	 *
+	 * @param string|int $subscriber_id Subscriber ID.
+	 * @param array      $list_ids      List IDs.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function subscribe_to_lists( $subscriber_id, $list_ids ) {
+		return $this->call(
+			function ( $api ) use ( $subscriber_id, $list_ids ) {
+				return $api->subscribeToLists(
+					$subscriber_id,
+					$list_ids,
+					[
+						'send_confirmation_email' => false,
+						'schedule_welcome_email'  => false,
+					]
+				);
+			},
+			'newspack_newsletters_mailpoet_subscribe_failed'
+		);
+	}
+
+	/**
+	 * Unsubscribe a subscriber from lists.
+	 *
+	 * @param string|int $subscriber_id Subscriber ID.
+	 * @param array      $list_ids      List IDs.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function unsubscribe_from_lists( $subscriber_id, $list_ids ) {
+		return $this->call(
+			function ( $api ) use ( $subscriber_id, $list_ids ) {
+				return $api->unsubscribeFromLists( $subscriber_id, $list_ids );
+			},
+			'newspack_newsletters_mailpoet_unsubscribe_failed'
+		);
+	}
+
+	/**
+	 * Count subscribers, optionally filtered.
+	 *
+	 * @param array $filter MailPoet filter args.
+	 *
+	 * @return int|WP_Error
+	 */
+	public function get_subscribers_count( $filter = [] ) {
+		return $this->call(
+			function ( $api ) use ( $filter ) {
+				return $api->getSubscribersCount( $filter );
+			},
+			'newspack_newsletters_mailpoet_count_failed'
+		);
+	}
+
+	// Custom fields (contact metadata).
+
+	/**
+	 * Get MailPoet's subscriber fields, both built-in and custom.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_subscriber_fields() {
+		return $this->call(
+			function ( $api ) {
+				return $api->getSubscriberFields();
+			},
+			'newspack_newsletters_mailpoet_get_fields_failed'
+		);
+	}
+
+	/**
+	 * Map Newspack metadata keys onto MailPoet custom field IDs, creating any
+	 * field that doesn't exist yet.
+	 *
+	 * MailPoet silently discards writes to an undeclared field, so metadata must
+	 * be resolved to a real `cf_N` id before `update_subscriber()` is called.
+	 *
+	 * @param array $keys Newspack metadata keys (used as the MailPoet field name).
+	 *
+	 * @return array|WP_Error Map of metadata key => `cf_N` id.
+	 */
+	public function resolve_field_ids( $keys ) {
+		if ( empty( $keys ) ) {
+			return [];
+		}
+
+		if ( null === $this->field_map ) {
+			$fields = $this->get_subscriber_fields();
+			if ( is_wp_error( $fields ) ) {
+				return $fields;
+			}
+			$this->field_map = [];
+			foreach ( $fields as $field ) {
+				if ( isset( $field['name'], $field['id'] ) ) {
+					$this->field_map[ $field['name'] ] = $field['id'];
+				}
+			}
+		}
+
+		$map = [];
+		foreach ( $keys as $key ) {
+			if ( isset( $this->field_map[ $key ] ) ) {
+				$map[ $key ] = $this->field_map[ $key ];
+				continue;
+			}
+			$created = $this->add_subscriber_field( $key );
+			if ( is_wp_error( $created ) ) {
+				// A field we can't create is metadata we can't sync; skip it rather.
+				// than failing the whole contact update.
+				continue;
+			}
+			$this->field_map[ $key ] = $created['id'];
+			$map[ $key ]             = $created['id'];
+		}
+		return $map;
+	}
+
+	/**
+	 * Create a custom subscriber field.
+	 *
+	 * @param string $name Field name.
+	 * @param string $type Field type.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function add_subscriber_field( $name, $type = 'text' ) {
+		return $this->call(
+			function ( $api ) use ( $name, $type ) {
+				return $api->addSubscriberField(
+					[
+						'name' => $name,
+						'type' => $type,
+					]
+				);
+			},
+			'newspack_newsletters_mailpoet_add_field_failed'
+		);
+	}
+
+	/**
+	 * Whether MailPoet's signup confirmation (double opt-in) is enabled.
+	 *
+	 * This is a MailPoet-owned, site-wide setting that also governs MailPoet's own
+	 * signup forms. It decides the status a subscriber added through the API
+	 * receives, so surfaces that explain reader status need to read it.
+	 *
+	 * @return boolean
+	 */
+	public function is_signup_confirmation_enabled() {
+		if ( ! class_exists( '\MailPoet\Settings\SettingsController' ) ) {
+			return true;
+		}
+		try {
+			$settings = \MailPoet\Settings\SettingsController::getInstance();
+			return (bool) $settings->get( 'signup_confirmation.enabled' );
+		} catch ( \Throwable $e ) {
+			return true;
+		}
+	}
+}

--- a/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet.php
@@ -64,6 +64,12 @@ final class Newspack_Newsletters_Mailpoet extends \Newspack_Newsletters_Service_
 		$this->service    = 'mailpoet';
 		$this->controller = new Newspack_Newsletters_Mailpoet_Controller( $this );
 
+		// The base class hooks updated_post_meta for its own `is_public` handling
+		// only, so the campaign sync and cleanup are wired here as the other
+		// providers do.
+		add_action( 'updated_post_meta', [ $this, 'save' ], 10, 4 );
+		add_action( 'wp_trash_post', [ $this, 'trash' ], 10, 1 );
+
 		parent::__construct( $this );
 	}
 
@@ -643,12 +649,49 @@ final class Newspack_Newsletters_Mailpoet extends \Newspack_Newsletters_Service_
 	/**
 	 * Retrieve a campaign.
 	 *
+	 * Creates the MailPoet newsletter on first call, mirroring the other
+	 * providers: the editor asks for campaign data as soon as a newsletter is
+	 * opened, and that is when the campaign should come into existence.
+	 *
 	 * @param integer $post_id Numeric ID of the Newsletter post.
 	 *
-	 * @return WP_Error
+	 * @return array|WP_Error
 	 */
 	public function retrieve( $post_id ) {
-		return $this->campaigns_not_supported();
+		if ( ! Newspack_Newsletters_Mailpoet_Campaigns::is_available() ) {
+			return new WP_Error(
+				'newspack_newsletters_mailpoet_unavailable',
+				__( 'MailPoet is not available.', 'newspack-newsletters' )
+			);
+		}
+
+		$newsletter_id = (int) get_post_meta( $post_id, Newspack_Newsletters_Mailpoet_Campaigns::CAMPAIGN_ID_META, true );
+		$newsletter    = Newspack_Newsletters_Mailpoet_Campaigns::find( $newsletter_id );
+
+		if ( ! $newsletter ) {
+			// Either never synced, or the newsletter was deleted in MailPoet. Drop
+			// the stale ID so the sync creates a fresh one rather than failing.
+			delete_post_meta( $post_id, Newspack_Newsletters_Mailpoet_Campaigns::CAMPAIGN_ID_META );
+			$synced = $this->sync( get_post( $post_id ) );
+			if ( is_wp_error( $synced ) ) {
+				return $synced;
+			}
+			$newsletter_id = (int) get_post_meta( $post_id, Newspack_Newsletters_Mailpoet_Campaigns::CAMPAIGN_ID_META, true );
+			$newsletter    = Newspack_Newsletters_Mailpoet_Campaigns::find( $newsletter_id );
+		}
+
+		if ( ! $newsletter ) {
+			return new WP_Error(
+				'newspack_newsletters_mailpoet_campaign_not_found',
+				__( 'Could not find or create the MailPoet newsletter.', 'newspack-newsletters' )
+			);
+		}
+
+		return [
+			'campaign'    => Newspack_Newsletters_Mailpoet_Campaigns::to_array( $newsletter ),
+			'campaign_id' => $newsletter_id,
+			'link'        => Newspack_Newsletters_Mailpoet_Campaigns::get_edit_url( $newsletter_id ),
+		];
 	}
 
 	/**
@@ -664,21 +707,59 @@ final class Newspack_Newsletters_Mailpoet extends \Newspack_Newsletters_Service_
 	}
 
 	/**
-	 * Synchronize a post with its ESP campaign.
+	 * Synchronize a post with its MailPoet newsletter.
+	 *
+	 * Creates the MailPoet newsletter on first sync and updates it thereafter,
+	 * so a newsletter composed in the Newspack editor shows up in MailPoet as a
+	 * draft ready to send.
 	 *
 	 * @param WP_Post $post Post to synchronize.
 	 *
-	 * @return WP_Error
+	 * @return int|WP_Error MailPoet newsletter ID on success.
 	 */
 	public function sync( $post ) {
-		return $this->campaigns_not_supported();
+		$transient_name = $this->get_transient_name( $post->ID );
+		delete_transient( $transient_name );
+
+		if ( ! Newspack_Newsletters_Mailpoet_Campaigns::is_available() ) {
+			return new WP_Error(
+				'newspack_newsletters_mailpoet_unavailable',
+				__( 'MailPoet is not available.', 'newspack-newsletters' )
+			);
+		}
+
+		if ( empty( $post->post_title ) ) {
+			$error = new WP_Error(
+				'newspack_newsletters_mailpoet_no_subject',
+				__( 'The newsletter subject cannot be empty.', 'newspack-newsletters' )
+			);
+			set_transient( $transient_name, $error->get_error_message(), 45 );
+			return $error;
+		}
+
+		$result = Newspack_Newsletters_Mailpoet_Campaigns::upsert(
+			$post,
+			[
+				'subject'       => $post->post_title,
+				'campaign_name' => $this->get_campaign_name( $post ),
+				'sender_name'   => get_post_meta( $post->ID, 'senderName', true ),
+				'sender_email'  => get_post_meta( $post->ID, 'senderEmail', true ),
+				'html'          => get_post_meta( $post->ID, Newspack_Newsletters::EMAIL_HTML_META, true ),
+			]
+		);
+
+		if ( is_wp_error( $result ) ) {
+			set_transient( $transient_name, 'MailPoet sync error: ' . $result->get_error_message(), 45 );
+		}
+
+		return $result;
 	}
 
 	/**
-	 * Update the ESP campaign after the email HTML post meta is saved.
+	 * Update the MailPoet newsletter after the email HTML post meta is saved.
 	 *
-	 * Required by Newspack_Newsletters_WP_Hookable_Interface. A no-op while
-	 * MailPoet owns composing: there is no campaign of ours to keep in step.
+	 * Guards mirror the other providers: skip autosaves, only react to the email
+	 * HTML meta, never sync a layout post, and never sync a trashed one.
 	 *
 	 * @param int   $meta_id  Numeric ID of the meta field being updated.
 	 * @param int   $post_id  The post ID for the meta field being updated.
@@ -687,7 +768,23 @@ final class Newspack_Newsletters_Mailpoet extends \Newspack_Newsletters_Service_
 	 * @return void
 	 */
 	public function save( $meta_id, $post_id, $meta_key ) {
-		// Nothing to sync; MailPoet composes and stores its own newsletters.
+		if ( defined( 'DOING_AUTOSAVE' ) && DOING_AUTOSAVE ) {
+			return;
+		}
+		if ( Newspack_Newsletters::EMAIL_HTML_META !== $meta_key ) {
+			return;
+		}
+		if ( $this->is_layout_post( $post_id ) ) {
+			return;
+		}
+		if ( ! Newspack_Newsletters_Editor::is_editing_email( $post_id ) ) {
+			return;
+		}
+		$post = get_post( $post_id );
+		if ( ! $post || 'trash' === $post->post_status ) {
+			return;
+		}
+		$this->sync( $post );
 	}
 
 	/**
@@ -706,17 +803,14 @@ final class Newspack_Newsletters_Mailpoet extends \Newspack_Newsletters_Service_
 	}
 
 	/**
-	 * Clean up the ESP campaign after a Newsletter post is deleted.
-	 *
-	 * Required by Newspack_Newsletters_WP_Hookable_Interface. A no-op: MailPoet
-	 * owns the lifecycle of its own newsletters.
+	 * Clean up the MailPoet newsletter after a Newsletter post is deleted.
 	 *
 	 * @param string $post_id Numeric ID of the campaign.
 	 *
 	 * @return void
 	 */
 	public function trash( $post_id ) {
-		// Nothing to clean up on MailPoet's side.
+		Newspack_Newsletters_Mailpoet_Campaigns::delete_for_post( $post_id );
 	}
 
 	// Reporting.

--- a/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet.php
+++ b/plugins/newspack-newsletters/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet.php
@@ -1,0 +1,740 @@
+<?php
+/**
+ * Service Provider: MailPoet Implementation
+ *
+ * MailPoet runs inside WordPress rather than behind a remote API, so this
+ * provider differs from the others in two structural ways:
+ *
+ * - There are no credentials. Connection means "the plugin is active".
+ * - Composing and sending are MailPoet's, not ours. The campaign methods on the
+ *   ESP interface are stubbed here; each exploratory branch replaces them with
+ *   its own approach. See LEO-65.
+ *
+ * @package Newspack
+ */
+
+defined( 'ABSPATH' ) || exit;
+
+use Newspack\Newsletters\Send_Lists;
+use Newspack\Newsletters\Send_List;
+
+/**
+ * Main Newspack Newsletters Class for the MailPoet ESP.
+ */
+final class Newspack_Newsletters_Mailpoet extends \Newspack_Newsletters_Service_Provider {
+
+	/**
+	 * Provider name.
+	 *
+	 * @var string
+	 */
+	public $name = 'MailPoet';
+
+	/**
+	 * Cached SDK instance.
+	 *
+	 * @var Newspack_Newsletters_Mailpoet_SDK|null
+	 */
+	private $sdk = null;
+
+	/**
+	 * Memoized contact payloads, keyed by email.
+	 *
+	 * MailPoet returns lists, tags and profile data in one call, so several
+	 * interface methods can share a fetch within a request.
+	 *
+	 * @var array
+	 */
+	private $contact_data = [];
+
+	/**
+	 * Whether the provider supports tag-based local Subscription Lists.
+	 *
+	 * Left at the base class default. MailPoet has tags, but local lists are not
+	 * part of this integration; see LEO-65.
+	 *
+	 * @var boolean
+	 */
+	public static $support_local_lists = false;
+
+	/**
+	 * Class constructor.
+	 */
+	public function __construct() {
+		$this->service    = 'mailpoet';
+		$this->controller = new Newspack_Newsletters_Mailpoet_Controller( $this );
+
+		parent::__construct( $this );
+	}
+
+	/**
+	 * Get the SDK wrapper.
+	 *
+	 * @return Newspack_Newsletters_Mailpoet_SDK
+	 */
+	public function get_sdk() {
+		if ( ! $this->sdk ) {
+			$this->sdk = new Newspack_Newsletters_Mailpoet_SDK();
+		}
+		return $this->sdk;
+	}
+
+	// Connection.
+	//
+	// MailPoet is a local plugin, so there is no key to store. The credential.
+	// methods exist to satisfy the ESP interface and report connection state.
+
+	/**
+	 * Get API credentials for the service provider.
+	 *
+	 * @return array Always empty; MailPoet needs no credentials.
+	 */
+	public function api_credentials() {
+		return [];
+	}
+
+	/**
+	 * Set the API credentials for the service provider.
+	 *
+	 * @param object $credentials API credentials.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function set_api_credentials( $credentials ) {
+		return true;
+	}
+
+	/**
+	 * Check if the provider has all necessary credentials set.
+	 *
+	 * Connection here means MailPoet is installed and its API is reachable.
+	 *
+	 * @return boolean
+	 */
+	public function has_api_credentials() {
+		return Newspack_Newsletters_Mailpoet_SDK::is_available();
+	}
+
+	/**
+	 * Whether MailPoet's signup confirmation (double opt-in) is on.
+	 *
+	 * MailPoet decides subscriber status from this site-wide setting and ignores
+	 * the status we request, so admin surfaces explaining reader status need it.
+	 * A contact added while this is enabled lands as `unconfirmed`, MailPoet's
+	 * equivalent of Mailchimp's `pending`.
+	 *
+	 * @return boolean
+	 */
+	public function is_signup_confirmation_enabled() {
+		return $this->get_sdk()->is_signup_confirmation_enabled();
+	}
+
+	// Labels.
+
+	/**
+	 * Get the provider-specific labels.
+	 *
+	 * @param mixed $context The context in which the labels are being applied.
+	 *
+	 * @return array
+	 */
+	public static function get_labels( $context = '' ) {
+		return array_merge(
+			parent::get_labels(),
+			[
+				'name'    => 'MailPoet',
+				'list'    => __( 'list', 'newspack-newsletters' ),
+				'lists'   => __( 'lists', 'newspack-newsletters' ),
+				'sublist' => __( 'tag', 'newspack-newsletters' ),
+				'List'    => __( 'List', 'newspack-newsletters' ),
+				'Lists'   => __( 'Lists', 'newspack-newsletters' ),
+				'Sublist' => __( 'Tag', 'newspack-newsletters' ),
+			]
+		);
+	}
+
+	/**
+	 * Get configuration for conditional tag support.
+	 *
+	 * MailPoet's shortcodes are not conditional in the sense the newsletter
+	 * editor means, so this reports no support.
+	 *
+	 * @return array
+	 */
+	public static function get_conditional_tag_support() {
+		return [
+			'support_url' => 'https://kb.mailpoet.com/article/215-personalize-your-newsletter-with-shortcodes',
+			'example'     => [
+				'before' => '',
+				'after'  => '',
+			],
+		];
+	}
+
+	// Lists.
+
+	/**
+	 * List the ESP's contact lists.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_lists() {
+		$lists = $this->get_sdk()->get_lists();
+		if ( is_wp_error( $lists ) ) {
+			return $lists;
+		}
+		return array_map(
+			function ( $list ) {
+				return [
+					'id'          => (string) $list['id'],
+					'name'        => $list['name'],
+					'description' => $list['description'] ?? '',
+				];
+			},
+			$lists
+		);
+	}
+
+	/**
+	 * Get the ESP's available lists and sublists as Send_List items.
+	 *
+	 * MailPoet lists map to top-level lists and MailPoet tags to sublists.
+	 *
+	 * @param array   $args     Search args. See Send_Lists::get_default_args().
+	 * @param boolean $to_array Whether to convert Send_List objects to arrays.
+	 *
+	 * @return Send_List[]|array|WP_Error
+	 */
+	public function get_send_lists( $args = [], $to_array = false ) {
+		$lists = $this->get_lists();
+		if ( is_wp_error( $lists ) ) {
+			return $lists;
+		}
+
+		$send_lists = array_map(
+			function ( $list ) {
+				return new Send_List(
+					[
+						'provider'    => $this->service,
+						'type'        => 'list',
+						'id'          => $list['id'],
+						'name'        => $list['name'],
+						'entity_type' => 'list',
+						'edit_link'   => admin_url( 'admin.php?page=mailpoet-lists' ),
+					]
+				);
+			},
+			$lists
+		);
+
+		$tags = $this->get_sdk()->get_tags();
+		if ( is_wp_error( $tags ) ) {
+			return $tags;
+		}
+		$send_tags = array_map(
+			function ( $tag ) {
+				return new Send_List(
+					[
+						'provider'    => $this->service,
+						'type'        => 'sublist',
+						'id'          => (string) $tag['id'],
+						'name'        => $tag['name'],
+						'entity_type' => 'tag',
+						'edit_link'   => admin_url( 'admin.php?page=mailpoet-subscribers' ),
+					]
+				);
+			},
+			$tags
+		);
+
+		$filtered = array_merge( $send_lists, $send_tags );
+
+		if ( ! empty( $args['ids'] ) ) {
+			$ids      = is_array( $args['ids'] ) ? $args['ids'] : [ $args['ids'] ];
+			$filtered = array_values(
+				array_filter(
+					$filtered,
+					function ( $list ) use ( $ids ) {
+						return Send_Lists::matches_id( $ids, $list->get_id() );
+					}
+				)
+			);
+		}
+
+		if ( ! empty( $args['search'] ) ) {
+			$search   = is_array( $args['search'] ) ? $args['search'] : [ $args['search'] ];
+			$filtered = array_values(
+				array_filter(
+					$filtered,
+					function ( $list ) use ( $search ) {
+						return Send_Lists::matches_search(
+							$search,
+							[
+								$list->get_id(),
+								$list->get_name(),
+								$list->get_entity_type(),
+							]
+						);
+					}
+				)
+			);
+		}
+
+		if ( ! empty( $args['limit'] ) ) {
+			$filtered = array_slice( $filtered, 0, $args['limit'] );
+		}
+
+		if ( $to_array ) {
+			$filtered = array_map(
+				function ( $list ) {
+					return $list->to_array();
+				},
+				$filtered
+			);
+		}
+
+		return $filtered;
+	}
+
+	// Contacts.
+
+	/**
+	 * Add a contact to a list, or update an existing contact.
+	 *
+	 * MailPoet decides the resulting subscriber status from its own signup
+	 * confirmation setting; see is_signup_confirmation_enabled().
+	 *
+	 * @param array  $contact Contact data: `email`, optional `name` and `metadata`.
+	 * @param string $list_id List to add the contact to.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function add_contact( $contact, $list_id = false ) {
+		if ( empty( $contact['email'] ) ) {
+			return new WP_Error(
+				'newspack_newsletters_mailpoet_invalid_contact',
+				__( 'A contact email address is required.', 'newspack-newsletters' )
+			);
+		}
+
+		$sdk      = $this->get_sdk();
+		$email    = $contact['email'];
+		$list_ids = $list_id ? [ $list_id ] : [];
+		$existing = $sdk->get_subscriber( $email );
+		$payload  = $this->build_subscriber_payload( $contact );
+
+		if ( is_wp_error( $existing ) ) {
+			// Treat any lookup failure as "not present" and create. MailPoet throws.
+			// rather than returning null for an unknown subscriber.
+			$payload['email'] = $email;
+			$result           = $sdk->add_subscriber( $payload, $list_ids );
+		} else {
+			$result = $sdk->update_subscriber( $email, $payload );
+			if ( ! is_wp_error( $result ) && ! empty( $list_ids ) ) {
+				$subscribed = $sdk->subscribe_to_lists( $existing['id'], $list_ids );
+				if ( is_wp_error( $subscribed ) ) {
+					return $subscribed;
+				}
+			}
+		}
+
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+
+		unset( $this->contact_data[ $email ] );
+		return $result;
+	}
+
+	/**
+	 * Build a MailPoet subscriber payload from Newspack contact data.
+	 *
+	 * Newspack metadata keys are resolved to MailPoet custom field IDs, creating
+	 * fields as needed — MailPoet silently drops writes to undeclared fields.
+	 *
+	 * @param array $contact Contact data.
+	 *
+	 * @return array
+	 */
+	private function build_subscriber_payload( $contact ) {
+		$payload = [];
+
+		if ( ! empty( $contact['name'] ) ) {
+			$name                  = explode( ' ', $contact['name'], 2 );
+			$payload['first_name'] = $name[0];
+			$payload['last_name']  = $name[1] ?? '';
+		}
+
+		if ( ! empty( $contact['metadata'] ) && is_array( $contact['metadata'] ) ) {
+			$metadata = array_filter(
+				$contact['metadata'],
+				function ( $value ) {
+					return is_scalar( $value );
+				}
+			);
+			if ( ! empty( $metadata ) ) {
+				$field_ids = $this->get_sdk()->resolve_field_ids( array_keys( $metadata ) );
+				if ( ! is_wp_error( $field_ids ) ) {
+					foreach ( $field_ids as $key => $field_id ) {
+						$payload[ $field_id ] = (string) $metadata[ $key ];
+					}
+				}
+			}
+		}
+
+		return $payload;
+	}
+
+	/**
+	 * Get contact data by email.
+	 *
+	 * @param string $email          Email address.
+	 * @param bool   $return_details Whether to return the full payload.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_contact_data( $email, $return_details = false ) {
+		if ( isset( $this->contact_data[ $email ] ) ) {
+			return $this->contact_data[ $email ];
+		}
+		$subscriber = $this->get_sdk()->get_subscriber( $email );
+		if ( is_wp_error( $subscriber ) ) {
+			return new WP_Error(
+				'newspack_newsletters_mailpoet_contact_not_found',
+				__( 'Contact not found.', 'newspack-newsletters' )
+			);
+		}
+		$this->contact_data[ $email ] = $subscriber;
+		return $subscriber;
+	}
+
+	/**
+	 * Get the lists a contact is subscribed to.
+	 *
+	 * Mirrors the Mailchimp provider, which reports only lists with a
+	 * `subscribed` status. A contact awaiting double opt-in reports no lists,
+	 * because MailPoet will not mail them until they confirm.
+	 *
+	 * @param string $email The contact email.
+	 *
+	 * @return string[]
+	 */
+	public function get_contact_lists( $email ) {
+		$contact = $this->get_contact_data( $email );
+		if ( is_wp_error( $contact ) ) {
+			return [];
+		}
+		// A subscriber who has not confirmed is not mailable, whatever the.
+		// per-list subscription says.
+		if ( 'subscribed' !== ( $contact['status'] ?? '' ) ) {
+			return [];
+		}
+		$lists = [];
+		foreach ( $contact['subscriptions'] ?? [] as $subscription ) {
+			if ( 'subscribed' === ( $subscription['status'] ?? '' ) ) {
+				$lists[] = (string) $subscription['segment_id'];
+			}
+		}
+		return $lists;
+	}
+
+	/**
+	 * Update a contact's list subscriptions.
+	 *
+	 * @param string   $email           Contact email address.
+	 * @param string[] $lists_to_add    List IDs to subscribe to.
+	 * @param string[] $lists_to_remove List IDs to remove from.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function update_contact_lists( $email, $lists_to_add = [], $lists_to_remove = [] ) {
+		$contact = $this->get_contact_data( $email );
+		if ( is_wp_error( $contact ) ) {
+			return $contact;
+		}
+		$sdk = $this->get_sdk();
+
+		if ( ! empty( $lists_to_add ) ) {
+			$result = $sdk->subscribe_to_lists( $contact['id'], $lists_to_add );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+		if ( ! empty( $lists_to_remove ) ) {
+			$result = $sdk->unsubscribe_from_lists( $contact['id'], $lists_to_remove );
+			if ( is_wp_error( $result ) ) {
+				return $result;
+			}
+		}
+
+		unset( $this->contact_data[ $email ] );
+		return true;
+	}
+
+	// Tags.
+
+	/**
+	 * Retrieve a tag ID from its name.
+	 *
+	 * @param string  $tag_name            The tag name.
+	 * @param boolean $create_if_not_found Whether to create the tag if absent.
+	 * @param string  $list_id             Unused; MailPoet tags are global.
+	 *
+	 * @return int|WP_Error
+	 */
+	public function get_tag_id( $tag_name, $create_if_not_found = true, $list_id = null ) {
+		$tag = $this->get_sdk()->get_tag( $tag_name );
+		if ( ! is_wp_error( $tag ) && ! empty( $tag['id'] ) ) {
+			return (int) $tag['id'];
+		}
+		if ( ! $create_if_not_found ) {
+			return new WP_Error(
+				'newspack_newsletters_mailpoet_tag_not_found',
+				__( 'Tag not found.', 'newspack-newsletters' )
+			);
+		}
+		$created = $this->create_tag( $tag_name );
+		if ( is_wp_error( $created ) ) {
+			return $created;
+		}
+		return (int) $created['id'];
+	}
+
+	/**
+	 * Retrieve a tag name from its ID.
+	 *
+	 * @param int    $tag_id  The tag ID.
+	 * @param string $list_id Unused; MailPoet tags are global.
+	 *
+	 * @return string|WP_Error
+	 */
+	public function get_tag_by_id( $tag_id, $list_id = null ) {
+		$tag = $this->get_sdk()->get_tag( $tag_id );
+		if ( is_wp_error( $tag ) ) {
+			return $tag;
+		}
+		return $tag['name'];
+	}
+
+	/**
+	 * Create a tag.
+	 *
+	 * @param string $tag     The tag name.
+	 * @param string $list_id Unused; MailPoet tags are global.
+	 *
+	 * @return array|WP_Error Tag representation with `id` and `name`.
+	 */
+	public function create_tag( $tag, $list_id = null ) {
+		$created = $this->get_sdk()->add_tag( $tag );
+		if ( is_wp_error( $created ) ) {
+			return $created;
+		}
+		return [
+			'id'   => (int) $created['id'],
+			'name' => $created['name'],
+		];
+	}
+
+	/**
+	 * Rename a tag.
+	 *
+	 * @param string|int $tag_id  The tag ID.
+	 * @param string     $tag     The new tag name.
+	 * @param string     $list_id Unused; MailPoet tags are global.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function update_tag( $tag_id, $tag, $list_id = null ) {
+		$updated = $this->get_sdk()->update_tag( $tag_id, $tag );
+		if ( is_wp_error( $updated ) ) {
+			return $updated;
+		}
+		return [
+			'id'   => (int) $updated['id'],
+			'name' => $updated['name'],
+		];
+	}
+
+	/**
+	 * Add a tag to a contact.
+	 *
+	 * @param string     $email   The contact email.
+	 * @param string|int $tag     The tag ID or name.
+	 * @param string     $list_id Unused; MailPoet tags are global.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function add_tag_to_contact( $email, $tag, $list_id = null ) {
+		$result = $this->get_sdk()->tag_subscriber( $email, $tag );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		unset( $this->contact_data[ $email ] );
+		return true;
+	}
+
+	/**
+	 * Remove a tag from a contact.
+	 *
+	 * @param string     $email   The contact email.
+	 * @param string|int $tag     The tag ID or name.
+	 * @param string     $list_id Unused; MailPoet tags are global.
+	 *
+	 * @return true|WP_Error
+	 */
+	public function remove_tag_from_contact( $email, $tag, $list_id = null ) {
+		$result = $this->get_sdk()->untag_subscriber( $email, $tag );
+		if ( is_wp_error( $result ) ) {
+			return $result;
+		}
+		unset( $this->contact_data[ $email ] );
+		return true;
+	}
+
+	/**
+	 * Get the IDs of the tags associated with a contact.
+	 *
+	 * @param string $email The contact email.
+	 *
+	 * @return array|WP_Error
+	 */
+	public function get_contact_tags_ids( $email ) {
+		$contact = $this->get_contact_data( $email );
+		if ( is_wp_error( $contact ) ) {
+			return $contact;
+		}
+		return array_map(
+			function ( $tag ) {
+				return (int) $tag['tag_id'];
+			},
+			$contact['tags'] ?? []
+		);
+	}
+
+	// Campaigns.
+	//
+	// MailPoet exposes no campaign API. Composing and sending are the subject of.
+	// the architecture spikes on LEO-65; each branch replaces these.
+
+	/**
+	 * Error returned by the unimplemented campaign methods.
+	 *
+	 * @return WP_Error
+	 */
+	private function campaigns_not_supported() {
+		return new WP_Error(
+			'newspack_newsletters_mailpoet_campaigns_unsupported',
+			__( 'Composing and sending newsletters is handled by MailPoet.', 'newspack-newsletters' )
+		);
+	}
+
+	/**
+	 * Set the list for a campaign.
+	 *
+	 * @param string $post_id Campaign ID.
+	 * @param string $list_id List ID.
+	 *
+	 * @return WP_Error
+	 */
+	public function list( $post_id, $list_id ) {
+		return $this->campaigns_not_supported();
+	}
+
+	/**
+	 * Retrieve a campaign.
+	 *
+	 * @param integer $post_id Numeric ID of the Newsletter post.
+	 *
+	 * @return WP_Error
+	 */
+	public function retrieve( $post_id ) {
+		return $this->campaigns_not_supported();
+	}
+
+	/**
+	 * Send a test email.
+	 *
+	 * @param integer $post_id Numeric ID of the Newsletter post.
+	 * @param array   $emails  Array of email addresses.
+	 *
+	 * @return WP_Error
+	 */
+	public function test( $post_id, $emails ) {
+		return $this->campaigns_not_supported();
+	}
+
+	/**
+	 * Synchronize a post with its ESP campaign.
+	 *
+	 * @param WP_Post $post Post to synchronize.
+	 *
+	 * @return WP_Error
+	 */
+	public function sync( $post ) {
+		return $this->campaigns_not_supported();
+	}
+
+	/**
+	 * Update the ESP campaign after the email HTML post meta is saved.
+	 *
+	 * Required by Newspack_Newsletters_WP_Hookable_Interface. A no-op while
+	 * MailPoet owns composing: there is no campaign of ours to keep in step.
+	 *
+	 * @param int   $meta_id  Numeric ID of the meta field being updated.
+	 * @param int   $post_id  The post ID for the meta field being updated.
+	 * @param mixed $meta_key The meta key being updated.
+	 *
+	 * @return void
+	 */
+	public function save( $meta_id, $post_id, $meta_key ) {
+		// Nothing to sync; MailPoet composes and stores its own newsletters.
+	}
+
+	/**
+	 * Send a campaign.
+	 *
+	 * Required by Newspack_Newsletters_WP_Hookable_Interface, and reached from
+	 * the base class on publish. Returning an error keeps a stray publish from
+	 * looking like a successful send.
+	 *
+	 * @param \WP_Post $post Post to send.
+	 *
+	 * @return WP_Error
+	 */
+	public function send( $post ) {
+		return $this->campaigns_not_supported();
+	}
+
+	/**
+	 * Clean up the ESP campaign after a Newsletter post is deleted.
+	 *
+	 * Required by Newspack_Newsletters_WP_Hookable_Interface. A no-op: MailPoet
+	 * owns the lifecycle of its own newsletters.
+	 *
+	 * @param string $post_id Numeric ID of the campaign.
+	 *
+	 * @return void
+	 */
+	public function trash( $post_id ) {
+		// Nothing to clean up on MailPoet's side.
+	}
+
+	// Reporting.
+
+	/**
+	 * Get the usage report for yesterday.
+	 *
+	 * MailPoet's public API exposes only a subscriber count. The remaining
+	 * figures live in its `mailpoet_statistics_*` tables, which carry no
+	 * compatibility promise, so the report is deliberately left for follow-up
+	 * work rather than reaching into them here. See LEO-65.
+	 *
+	 * @return WP_Error
+	 */
+	public function get_usage_report() {
+		return new WP_Error(
+			'newspack_newsletters_mailpoet_usage_report_unsupported',
+			__( 'Usage reports are not yet available for MailPoet.', 'newspack-newsletters' )
+		);
+	}
+}

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -81,6 +81,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/act
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-usage-reports.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-sdk.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-campaigns.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-admin.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/class-newspack-newsletters-letterhead.php';

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -80,6 +80,7 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/act
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-usage-reports.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-sdk.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-campaigns.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/class-newspack-newsletters-letterhead.php';

--- a/plugins/newspack-newsletters/newspack-newsletters.php
+++ b/plugins/newspack-newsletters/newspack-newsletters.php
@@ -79,6 +79,9 @@ require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/con
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/active_campaign/class-newspack-newsletters-active-campaign-usage-reports.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-sdk.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet.php';
+require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/mailpoet/class-newspack-newsletters-mailpoet-controller.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/class-newspack-newsletters-letterhead.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/dtos/class-newspack-newsletters-letterhead-promotion-dto.php';
 require_once NEWSPACK_NEWSLETTERS_PLUGIN_FILE . '/includes/service-providers/letterhead/models/class-newspack-newsletters-letterhead-promotion.php';


### PR DESCRIPTION
> **Not for review or merge.** This branch documents an exploration into supporting MailPoet as a newsletter service provider. It exists so the findings and the working code behind them are recoverable later, not because it is ready to ship. Nothing here is finished, several pieces are deliberately stubbed, and at least one approach it contains was tried and set aside.

### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)? — PHPCS clean via `composer phpcs`.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

MailPoet runs inside WordPress rather than behind a remote API, which makes it a different shape of integration from every provider we have. This branch works out what that means in practice.

**What was established**

MailPoet's `MP('v1')` API covers the reader-data half of our ESP contract cleanly — lists, contacts, tags, and contact metadata all map. It has no campaign API at all, so composing and sending cannot work the way they do for Mailchimp or Constant Contact.

The more consequential finding is that **MailPoet and Newspack Newsletters already share an email rendering engine**. MailPoet registers a `mailpoet_email` post type into `woocommerce_email_editor_post_types`, and its renderer branches to `Automattic\WooCommerce\EmailEditor` whenever a newsletter has an attached WP post — the same package our WC renderer path uses. That shared surface is what makes the rest of this possible, and it was not something we knew going in.

**What is implemented**

- A MailPoet service provider: lists, contacts and tags are real; campaign methods and the usage report return documented `WP_Error`s.
- Campaign sync, so a newsletter composed in Newspack appears in MailPoet as a draft.
- A setting choosing which editor opens from MailPoet's screen, with the newsletter either mirrored into a `mailpoet_email` post or attached directly.
- An authoring mode that hands listing and creation to MailPoet's own UI while our menu stays registered and keeps Newsletter Ads and Settings.

**What this is not**

Send lists are not associated with synced campaigns, `test()` is unimplemented, usage reports are left for later, and the per-provider editor JS was never written — so the ESP sidebar is absent when MailPoet is the provider. Two-way sync was investigated and not built; the notes below say why.

Not for merge, so no issue is closed by it.

### How to test the changes in this Pull Request:

Requires MailPoet installed and its **experimental email editor** enabled, plus the WC renderer on our side. Both are off by default.

1. Create an isolated env with this branch and install MailPoet.
   ```bash
   n env create mailpoet --worktree newspack-newsletters:leo-65-spike-b-campaign-sync
   n env up mailpoet --build && n setup --env mailpoet --yes
   docker exec newspack_env_mailpoet sh -c "wp plugin install mailpoet --activate --allow-root"
   ```
2. Enable the WC renderer. `wp option update newspack_newsletters_use_woo_renderer 1`
3. Set MailPoet as the provider in **Newsletters → Settings**. It appears in the dropdown with no icon, because the shared components package doesn't know the slug yet.
4. Create a list in **MailPoet → Lists**. It appears under Subscription lists on the Newspack settings screen.
5. Compose and save a newsletter in the Newspack editor. A draft campaign with the same subject appears in **MailPoet → Emails**.
6. Switch **Where newsletters are edited** between the two options and re-save. With *Edit in MailPoet*, MailPoet's edit link opens its own editor; with *Edit in Newspack*, it opens ours.
7. Turn on MailPoet authoring. `wp option update newspack_newsletters_mailpoet_authoring mailpoet`
8. Open **Newsletters → All Newsletters**. It lands on MailPoet's Emails screen. **Add Newsletter** lands on MailPoet's create screen, and **Past newsletters** still reaches our list.

A recorded walkthrough of step 8 exists and can be attached on request.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them? — explained above, though inclusion is explicitly not being requested.
* [ ] Have you written new tests for your changes, as applicable? — no. Exploratory branch; verified by the manual steps above and by scripted checks run against a live MailPoet install.
* [x] Have you successfully run tests with your changes locally? — provider behaviour exercised end to end against MailPoet 5.35.1; PHPCS clean.

<details>
<summary>Technical notes, findings and dead ends</summary>

**The provider contract is larger than it looks.** `Newspack_Newsletters_ESP_API_Interface` declares 24 methods and the base class supplies 2. The base also implements `Newspack_Newsletters_WP_Hookable_Interface`, adding `save()`, `send()` and `trash()`. A provider must supply **25** methods, and nothing in the code marks which.

**MailPoet decides subscriber status, not the caller.** With signup confirmation on — its default — a subscriber added through the API lands `unconfirmed` regardless of the status requested, and `updateSubscriber` will not promote them afterwards. This is MailPoet's double opt-in, and it is the equivalent of Mailchimp's `pending`. `get_contact_lists()` therefore filters on the subscriber-level status, mirroring the Mailchimp provider, so a contact awaiting confirmation reports no lists.

**Contact metadata needs its custom field declared first.** MailPoet silently discards writes to an undeclared field, so `Newspack_Newsletters_Mailpoet_SDK::resolve_field_ids()` maps each Newspack metadata key to a `cf_N` id, creating fields as needed.

**No hard delete.** There is no `deleteSubscriber`. `delete_contact()` isn't in the ESP interface and newspack-plugin's integration layer already supports `account_deletion_handling = 'flag'`, so this is a configuration choice rather than a gap.

**Two body strategies were compared, and a third replaced them.** Pushing our rendered HTML into a MailPoet text block produces a nested email document — two `<html>`, `<head>` and `<body>` elements — because our renderer emits a complete document. Attaching a post produces one clean document at roughly half the size. The `html` strategy is retained behind `newspack_newsletters_mailpoet_sync_strategy` for sites without the WC renderer, but it is not offered in the UI.

**Automatically placed ads only survive the mirror strategy.** `Ads::filter_newsletter_content()` is hooked to `newspack_newsletters_newsletter_content`, which fires in exactly two places, both our renderers. MailPoet calls neither. Mirroring lets us apply the filter before writing the content; attaching our post directly does not, so auto-placed ads are absent from what readers receive. Manually inserted ad blocks work either way.

**`Ads::$inserted_ads` is process-global.** Applying the ad filter after a render in the same request drops every ad, because they are already marked inserted. `Renderer_Controller::render_wc()` guards this with `reset_inserted_ads()`; the mirror sync now does the same. Anything else applying that filter outside a render needs the same reset.

**Our blocks are absent from MailPoet's editor, and it is our doing.** `newspack-newsletters/ad` is registered globally and renders correctly inside a `mailpoet_email` post. What is missing is the editor half: `dist/editor.js` is enqueued only when `is_editing_newsletter()` is true, a hardcoded comparison against our CPT. `newspack_newsletters_email_editor_cpts` filters `is_editing_email()` but not the asset enqueues. Making our blocks work there is a separate piece of work covering `ad`, `posts-inserter` and `share`.

**Our core-block email renderers already apply to MailPoet-composed emails.** `Block_Renderer_Registry` hooks `block_type_metadata_settings` and `woocommerce_email_editor_render_start` with no post-type scoping, so `core/button`, `core/quote` and friends render through Newspack's overrides inside MailPoet's own emails whenever the WC renderer is on. That is currently an accident rather than a decision.

**Two-way sync was investigated and not built.** Edits made in MailPoet do not return to Newspack, and the next sync overwrites them. Two things block a clean fix: auto-inserted ad blocks are byte-identical to manual ones, so pulling content back would silently switch a newsletter from rotating ads to frozen ones (`should_render_ads()` disables auto-insertion once any ad block is present); and round-tripping through an editor where our blocks are unregistered risks importing whatever that editor does to them. Block registration is a prerequisite, not a follow-up.

**Latent bug fixed along the way.** `Newspack_Newsletters_Settings::get_settings_list()` filtered every `select` field's options against the supported-provider list, on the assumption that any select is the provider dropdown. Any provider-scoped select with its own values had them stripped. Now scoped to `newspack_newsletters_service_provider`.

**Unrelated environment issue worth recording.** `newspack-newsletters` does not activate cleanly via WP-CLI in a fresh isolated env: `Undefined constant "NEWSPACK_NEWSLETTERS_PLUGIN_FILE"`. It reproduces on a clean checkout, and is the mixed-autoloading order dependency the plugin's own AGENTS.md warns about — `Newspack_Newsletters` sits in the Jetpack autoload classmap, so another plugin's autoloader can load the class file ahead of the bootstrap that defines the constant. Writing `active_plugins` directly works around it.

Authored with Claude, driving a live MailPoet install in an isolated environment.

</details>
