### PR TITLE
don't insert popups unless the_content is running within the main query

### DIFF
--- a/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
+++ b/plugins/newspack-popups/includes/class-newspack-popups-inserter.php
@@ -562,6 +562,8 @@ final class Newspack_Popups_Inserter {
 			|| ! is_singular()
 			// If not in the loop, ignore.
 			|| ! in_the_loop()
+			// If not the main query, ignore.
+			|| ! is_main_query()
 			// Don't inject inline popups on paywalled posts.
 			// It doesn't make sense with a paywall message and also causes an infinite loop.
 			|| self::is_memberships_restricted()


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

This PR updates the **newspack-popups** plugin's logic for inserting popup content into post content via the `the_content` hook such that it will _not_ insert the popup if `the_content` is not being run in WordPress 'main query.' By adding the conditional function [`is_main_query()`](https://developer.wordpress.org/reference/functions/is_main_query/), we avoid adding content to secondary queries. This would, in many cases, be avoided through the existing code that checks the [`in_the_loop()`](https://developer.wordpress.org/reference/functions/in_the_loop/) conditional, but something can be in the loop but not the main query.

### How to test the changes in this Pull Request:

This tests before and after this change:

1. Add a popup that appears at the beginning of posts.
2. Add a template file that pulls in content from another post *while still inside the main loop of outputting content*. For example, this code pulls in the content of a page or post into the footer of another after that post is selected and saved to an ACF field:
    ```php
    <?php
    $bottom_of_page_embed_post_id = get_field( 'bottom_of_page_embed', 'option' );
    if ( ! empty( $bottom_of_page_embed_post_id ) ) :
      $post = get_post( $bottom_of_page_embed_post_id );
      setup_postdata( $post );
      ?>
      <div class="cmvg26-bottom-of-page-widget">
        <?php the_content(); ?>
      </div>
      <?php
      wp_reset_postdata();
    endif;
    ?>
    ```
3. Confirm that the popup you added in step 1 is appearing twice on the page—once at the top of the post, and once above the secondarily inserted post content.
4. Check out the changes in this PR.
5. Confirm that the popup you added in step 1 only appears once on the page, at the top of the post, and does *not* appear above the secondarily inserted post content.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable?
* [ ] Have you successfully run tests with your changes locally?
