### PR TITLE
ci(release): escalate post-release sync failures to a PR

### DIFF
--- a/.github/scripts/post-release.sh
+++ b/.github/scripts/post-release.sh
@@ -41,9 +41,6 @@ LATEST_VERSION_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "release
 # forward unchanged — so it cannot distinguish a bot escalation from a finished
 # one. A branch name survives amends.
 ESCALATION_BRANCH_PREFIX="post-release/conflicts"
-# The identity `Configure git` in release.yml gives this job. A PR whose head
-# commit is still authored by it is one nobody has started resolving.
-BOT_EMAIL="newspack-release-bot@users.noreply.github.com"
 
 # Restore workspace:* for any internal monorepo dep
 # (newspack-{scripts,components,colors,icons}) in every plugin/theme
@@ -64,8 +61,12 @@ BOT_EMAIL="newspack-release-bot@users.noreply.github.com"
 # release.yml — the alpha branch tip is then a chore[skip ci], same as today,
 # and the team's normal promotion merge commit later (without [skip ci]) is
 # what fires release.yml.
-restore_workspace_deps_and_commit() {
-  local branch="$1"
+#
+# Split in two: stage_workspace_deps_restore does the rewrite and staging,
+# restore_workspace_deps_and_commit wraps it in a commit. The escalation path
+# needs the staging without the commit, because its branch has to carry exactly
+# one commit for the `git commit --amend --no-edit` in the PR body to work.
+stage_workspace_deps_restore() {
   node -e '
     const fs = require("fs"), path = require("path");
     const WS_PACKAGES = ["newspack-scripts", "newspack-components", "newspack-colors", "newspack-icons"];
@@ -104,6 +105,11 @@ restore_workspace_deps_and_commit() {
   ' | while IFS= read -r -d "" f; do
     git add -- "$f"
   done
+}
+
+restore_workspace_deps_and_commit() {
+  local branch="$1"
+  stage_workspace_deps_restore
   if [ -n "$(git status --porcelain)" ]; then
     git commit -m "chore(release): restore workspace:* deps after release [skip ci]"
     echo "[post-release] Restored workspace:* deps on $branch."
@@ -149,24 +155,39 @@ attribute_conflicts() {
 }
 
 # Close open escalation PRs for $1 that nobody has started resolving, pointing
-# them at the new one ($2 = its URL). Each release produces a *different*
-# conflict set rather than re-presenting one unresolved conflict, so a stale
-# escalation PR describes a merge that no longer exists. Only bot-tipped PRs are
-# closed: once a human has pushed a resolution commit, the PR is theirs and
-# closing it would discard their work.
+# them at the new one ($2 = its URL). $3 is this run's own bot identity, used to
+# tell an untouched escalation from one someone is working on. Each release
+# produces a *different* conflict set rather than re-presenting one unresolved
+# conflict, so a stale escalation PR describes a merge that no longer exists.
+# Once a human has pushed a resolution commit the PR is theirs, and closing it
+# would discard their work.
+#
+# The test is the head commit's **committer**, not its author. The resolution
+# recipe in the PR body ends in `git commit --amend --no-edit`, and amending
+# rewrites the committer while carrying the original author forward — so an
+# author check would still read as the bot and close the very PR a person had
+# just finished. Anything unresolvable (a missing head, an API error) skips the
+# PR: leaving a stale escalation open costs noise, closing a live one costs work.
 supersede_escalations() {
-  local target="$1" new_url="$2"
+  local target="$1" new_url="$2" bot_identity="$3"
   local new_number="${2##*/}"
-  local prs n
-  prs=$(TARGET="$target" BOT_EMAIL="$BOT_EMAIL" PREFIX="$ESCALATION_BRANCH_PREFIX" \
+  local prs n head_sha committer
+  prs=$(TARGET="$target" PREFIX="$ESCALATION_BRANCH_PREFIX" \
     gh pr list --base "$target" --state open --limit 100 \
-      --json number,headRefName,commits \
+      --json number,headRefName \
       --jq '.[]
             | select(.headRefName | startswith(env.PREFIX + "/" + env.TARGET + "-"))
-            | select((.commits[-1].authors[0].email // "") == env.BOT_EMAIL)
             | .number' 2>/dev/null) || prs=""
   for n in $prs; do
     [ "$n" = "$new_number" ] && continue
+    head_sha=$(gh pr view "$n" --json headRefOid --jq '.headRefOid' 2>/dev/null) || head_sha=""
+    [ -z "$head_sha" ] && continue
+    # {owner}/{repo} is resolved by gh from the checkout's remote, so this needs
+    # no GITHUB_REPOSITORY.
+    committer=$(gh api "repos/{owner}/{repo}/commits/$head_sha" --jq '.commit.committer.email' 2>/dev/null) || committer=""
+    if [ -z "$committer" ] || [ "$committer" != "$bot_identity" ]; then
+      continue
+    fi
     gh pr comment "$n" --body "Superseded by $new_url. Each release conflicts on a different set of files, so this one describes a merge that no longer exists." > /dev/null 2>&1 || true
     if gh pr close "$n" > /dev/null 2>&1; then
       echo "[post-release] Superseded escalation PR #$n."
@@ -188,30 +209,53 @@ supersede_escalations() {
 # back-merge.
 #
 # $1 = target branch. $2 = the commit to restore the local branch to when done,
-# captured before the merge. Prints the PR URL on stdout, empty if escalation
-# could not complete; everything else goes to stderr so it cannot contaminate
-# that value.
+# captured before the merge. $3 = the newline-separated conflicting paths the
+# caller captured. Prints the PR URL on stdout, empty if escalation could not
+# complete; everything else goes to stderr so it cannot contaminate that value.
 #
 # Always returns 0 and always leaves the tree clean on $2: this runs on the
 # already-failed path, and an escalation hiccup must not preempt the Slack alert
 # or strand the second sync target.
 escalate_conflict() {
-  local target="$1" saved="$2"
-  local url="" marker_files="" body="" branch=""
+  local target="$1" saved="$2" conflicts="$3"
+  local url="" marker_files="" body="" branch="" bot_identity="" err_file=""
   branch="$ESCALATION_BRANCH_PREFIX/${target}-$(date -u +%Y%m%d-%H%M%S)"
 
-  # Staging is what resolves the unmerged index entries — git refuses to commit
-  # while any path is still unmerged — so the markers land in the tree verbatim,
-  # which is the point. `-u` and not `-A`: -A would also sweep in any untracked
-  # file sitting in the workspace, and the `git reset --hard` below then deletes
-  # it, so an unrelated stray file would be both published on the escalation
-  # branch and destroyed locally.
-  if ! git add -u >&2 || ! git commit -q -m "chore(release): merge in release $LATEST_VERSION_TAG" >&2; then
+  # Staging is what resolves the unmerged index entries, since git refuses to
+  # commit while any path is still unmerged, and it puts the markers in the tree
+  # verbatim, which is the point. Scoped to the conflicting paths rather than
+  # `-u` or `-A`: either of those would also sweep up unrelated work sitting in
+  # the workspace, and the `git reset --hard` below then destroys it locally
+  # after publishing it on the escalation branch. `-A` within the pathspec so a
+  # modify/delete conflict resolved as a deletion still stages.
+  if ! printf '%s\n' "$conflicts" | git add -A --pathspec-from-file=- >&2; then
+    echo "[post-release] Could not stage the conflicted paths; skipping escalation." >&2
+    git merge --abort > /dev/null 2>&1 || true
+    git reset --hard "$saved" >&2 || true
+    return 0
+  fi
+
+  # Fold the workspace:* restore into this same commit. Every other merge in
+  # this script pairs one with the other, and a back-merge that skips it carries
+  # the release's concretized internal versions into the target, where
+  # `pnpm install --frozen-lockfile` rejects them. It has to be *this* commit,
+  # not a second one, because the PR body's `git commit --amend --no-edit`
+  # only reaches the tip. Guarded: a package.json that is itself conflicted
+  # won't parse, and that must not preempt the alert.
+  if ! stage_workspace_deps_restore >&2; then
+    echo "[post-release] Could not restore workspace:* on the escalation branch; the resolver has to run it." >&2
+  fi
+
+  if ! git commit -q -m "chore(release): merge in release $LATEST_VERSION_TAG" >&2; then
     echo "[post-release] Could not commit the conflicted tree; skipping escalation." >&2
     git merge --abort > /dev/null 2>&1 || true
     git reset --hard "$saved" >&2 || true
     return 0
   fi
+  # Taken from the commit this run just made rather than hardcoded, so the
+  # supersede check can never drift out of step with the identity `Configure
+  # git` sets in release.yml.
+  bot_identity=$(git log -1 --format='%ce') || bot_identity=""
 
   # --cached, not HEAD: searching a rev prefixes every result with "HEAD:",
   # which the PR body then presents as paths that don't exist. The index is
@@ -237,7 +281,7 @@ To resolve:
 \`\`\`
 gh pr checkout $branch
 # resolve the conflict markers
-git add -A
+git add -u
 git commit --amend --no-edit
 git push --force-with-lease
 \`\`\`
@@ -252,22 +296,23 @@ ${marker_files:-(none — the conflict is structural, e.g. delete/modify)}
 EOF
 )
 
+  # stderr goes to a file, never into $url. gh writes advisory lines there on a
+  # *successful* create (an untracked file left in the tree draws "uncommitted
+  # changes"), and folding them in would leave the URL behind a warning, fail
+  # the prefix match below, and report a PR that exists as missing.
+  err_file=$(mktemp 2>/dev/null) || err_file=""
   url=$(gh pr create --draft --base "$target" --head "$branch" \
     --title "Post-release sync conflict: release into $target" \
-    --body "$body" 2>&1) || url=""
-  # gh writes diagnostics to the same stream on failure, so accept only
-  # something that is actually a URL.
-  case "$url" in
-    https://*) ;;
-    *)
-      [ -n "$url" ] && echo "[post-release] gh pr create failed: $url" >&2
-      url=""
-      ;;
-  esac
+    --body "$body" 2>"${err_file:-/dev/null}") || url=""
+  url=$(printf '%s\n' "$url" | grep -m1 '^https://' || true)
+  if [ -z "$url" ] && [ -n "$err_file" ]; then
+    echo "[post-release] gh pr create failed: $(tr '\n' ' ' < "$err_file")" >&2
+  fi
+  [ -n "$err_file" ] && rm -f "$err_file"
 
   if [ -n "$url" ]; then
     echo "[post-release] Opened escalation PR $url for $target." >&2
-    supersede_escalations "$target" "$url" >&2
+    supersede_escalations "$target" "$url" "$bot_identity" >&2
   else
     echo "[post-release] Conflict pushed to $branch, but no PR was opened." >&2
   fi
@@ -412,7 +457,7 @@ else
     # change the merge base and blame the wrong commits.
     attributed=$(attribute_conflicts "$conflicts")
     echo "[post-release] Post-release merge to alpha failed."
-    pr_url=$(escalate_conflict alpha "$saved")
+    pr_url=$(escalate_conflict alpha "$saved" "$conflicts")
     notify_slack alpha "$attributed" "$pr_url"
     sync_failed=1
   fi
@@ -433,7 +478,7 @@ else
   # See the alpha branch above: attribution must precede the escalation commit.
   attributed=$(attribute_conflicts "$conflicts")
   echo "[post-release] Post-release merge to $DEFAULT_BRANCH failed."
-  pr_url=$(escalate_conflict "$DEFAULT_BRANCH" "$saved")
+  pr_url=$(escalate_conflict "$DEFAULT_BRANCH" "$saved" "$conflicts")
   notify_slack "$DEFAULT_BRANCH" "$attributed" "$pr_url"
   sync_failed=1
 fi

--- a/.github/scripts/post-release.sh
+++ b/.github/scripts/post-release.sh
@@ -8,7 +8,13 @@
 #   - restore `workspace:*` for any internal workspace dep that the release
 #     concretized (see restore_workspace_deps below);
 #   - merge `release` back into the repository's default branch so they stay in
-#     sync (then restore workspace:* there too), notifying Slack on conflict.
+#     sync (then restore workspace:* there too).
+#
+# A merge that conflicts is not discarded: the conflicted tree is committed to a
+# `post-release/conflicts/<target>-<timestamp>` branch and opened as a draft PR,
+# and the Slack alert links to it. Conflicts here are fresh each release rather
+# than one recurring conflict, so escalations are timestamped and older
+# untouched ones are closed as superseded. The job still exits non-zero.
 #
 # This lives in the monorepo (not packages/scripts, which mirrors the legacy
 # newspack-scripts repo and is overwritten by the daily sync) and targets the
@@ -27,6 +33,17 @@ DEFAULT_BRANCH=${DEFAULT_BRANCH:-main}
 # carries the merge info used to decide whether the release came from alpha.
 SECOND_TO_LAST_COMMIT_MSG=$(git log -n 1 --skip 1 --pretty=format:"%s")
 LATEST_VERSION_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "release")
+
+# Branch prefix for escalation PRs (see escalate_conflict). Supersede keys on
+# this prefix rather than on the commit subject: the subject is deliberately the
+# same conventional `chore(release): merge in release <tag>` form every other
+# back-merge uses, and a reviewer's `commit --amend --no-edit` carries it
+# forward unchanged — so it cannot distinguish a bot escalation from a finished
+# one. A branch name survives amends.
+ESCALATION_BRANCH_PREFIX="post-release/conflicts"
+# The identity `Configure git` in release.yml gives this job. A PR whose head
+# commit is still authored by it is one nobody has started resolving.
+BOT_EMAIL="newspack-release-bot@users.noreply.github.com"
 
 # Restore workspace:* for any internal monorepo dep
 # (newspack-{scripts,components,colors,icons}) in every plugin/theme
@@ -131,14 +148,145 @@ attribute_conflicts() {
   done <<< "$files"
 }
 
+# Close open escalation PRs for $1 that nobody has started resolving, pointing
+# them at the new one ($2 = its URL). Each release produces a *different*
+# conflict set rather than re-presenting one unresolved conflict, so a stale
+# escalation PR describes a merge that no longer exists. Only bot-tipped PRs are
+# closed: once a human has pushed a resolution commit, the PR is theirs and
+# closing it would discard their work.
+supersede_escalations() {
+  local target="$1" new_url="$2"
+  local new_number="${2##*/}"
+  local prs n
+  prs=$(TARGET="$target" BOT_EMAIL="$BOT_EMAIL" PREFIX="$ESCALATION_BRANCH_PREFIX" \
+    gh pr list --base "$target" --state open --limit 100 \
+      --json number,headRefName,commits \
+      --jq '.[]
+            | select(.headRefName | startswith(env.PREFIX + "/" + env.TARGET + "-"))
+            | select((.commits[-1].authors[0].email // "") == env.BOT_EMAIL)
+            | .number' 2>/dev/null) || prs=""
+  for n in $prs; do
+    [ "$n" = "$new_number" ] && continue
+    gh pr comment "$n" --body "Superseded by $new_url. Each release conflicts on a different set of files, so this one describes a merge that no longer exists." > /dev/null 2>&1 || true
+    if gh pr close "$n" > /dev/null 2>&1; then
+      echo "[post-release] Superseded escalation PR #$n."
+    else
+      echo "[post-release] Could not close superseded escalation PR #$n."
+    fi
+  done
+}
+
+# Push a conflicted merge to a branch and open a draft PR, instead of throwing
+# the conflicted tree away.
+#
+# Why: this used to be `git merge --abort`, which left the resolution with
+# nowhere to happen on GitHub. Every reconciliation then landed as a direct push
+# to alpha/main with no PR and a bare "Merge branch 'release'" subject —
+# unreviewed, and not greppable alongside the bot's back-merges. Committing the
+# conflict here gives the resolution a reviewable home, and the conventional
+# subject means `commit --amend --no-edit` leaves it matching every other
+# back-merge.
+#
+# $1 = target branch. $2 = the commit to restore the local branch to when done,
+# captured before the merge. Prints the PR URL on stdout, empty if escalation
+# could not complete; everything else goes to stderr so it cannot contaminate
+# that value.
+#
+# Always returns 0 and always leaves the tree clean on $2: this runs on the
+# already-failed path, and an escalation hiccup must not preempt the Slack alert
+# or strand the second sync target.
+escalate_conflict() {
+  local target="$1" saved="$2"
+  local url="" marker_files="" body="" branch=""
+  branch="$ESCALATION_BRANCH_PREFIX/${target}-$(date -u +%Y%m%d-%H%M%S)"
+
+  # Staging is what resolves the unmerged index entries — git refuses to commit
+  # while any path is still unmerged — so the markers land in the tree verbatim,
+  # which is the point. `-u` and not `-A`: -A would also sweep in any untracked
+  # file sitting in the workspace, and the `git reset --hard` below then deletes
+  # it, so an unrelated stray file would be both published on the escalation
+  # branch and destroyed locally.
+  if ! git add -u >&2 || ! git commit -q -m "chore(release): merge in release $LATEST_VERSION_TAG" >&2; then
+    echo "[post-release] Could not commit the conflicted tree; skipping escalation." >&2
+    git merge --abort > /dev/null 2>&1 || true
+    git reset --hard "$saved" >&2 || true
+    return 0
+  fi
+
+  # --cached, not HEAD: searching a rev prefixes every result with "HEAD:",
+  # which the PR body then presents as paths that don't exist. The index is
+  # identical to the commit we just made.
+  marker_files=$(git grep --cached -lE '^<<<<<<< |^>>>>>>> ' 2>/dev/null | head -50 || true)
+
+  if ! git push origin "HEAD:refs/heads/$branch" >&2; then
+    echo "[post-release] Could not push $branch; skipping escalation." >&2
+    git reset --hard "$saved" >&2 || true
+    return 0
+  fi
+
+  body=$(cat <<EOF
+The post-release sync could not merge \`release\` into \`$target\`, so the conflicted merge is pushed here for a person to finish.
+
+- Release: \`$LATEST_VERSION_TAG\`
+- Build: ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}
+
+**CI on this branch will be red, and that is expected** — the tree still carries conflict markers. It goes green once they are resolved.
+
+To resolve:
+
+\`\`\`
+gh pr checkout $branch
+# resolve the conflict markers
+git add -A
+git commit --amend --no-edit
+git push --force-with-lease
+\`\`\`
+
+Then mark this PR ready for review and **merge it — do not squash**. \`$target\` has to genuinely contain \`release\`, or the next release reproduces this conflict.
+
+Files with conflict markers:
+
+\`\`\`
+${marker_files:-(none — the conflict is structural, e.g. delete/modify)}
+\`\`\`
+EOF
+)
+
+  url=$(gh pr create --draft --base "$target" --head "$branch" \
+    --title "Post-release sync conflict: release into $target" \
+    --body "$body" 2>&1) || url=""
+  # gh writes diagnostics to the same stream on failure, so accept only
+  # something that is actually a URL.
+  case "$url" in
+    https://*) ;;
+    *)
+      [ -n "$url" ] && echo "[post-release] gh pr create failed: $url" >&2
+      url=""
+      ;;
+  esac
+
+  if [ -n "$url" ]; then
+    echo "[post-release] Opened escalation PR $url for $target." >&2
+    supersede_escalations "$target" "$url" >&2
+  else
+    echo "[post-release] Conflict pushed to $branch, but no PR was opened." >&2
+  fi
+
+  git reset --hard "$saved" >&2 || true
+  printf '%s' "$url"
+}
+
 # Notify Slack about a failed post-release merge into $1, if Slack is configured.
 # $2 (optional) is a newline-separated list of "<file><TAB><PR><TAB><author>"
 # rows (see attribute_conflicts); when present the files are named in the message
 # — with the incoming PR/author — so readers can tell what needs reconciling and
 # who to ping without opening the build log.
+# $3 (optional) is the escalation PR URL from escalate_conflict; when present it
+# is linked last, so the alert routes straight to where the fix goes.
 notify_slack() {
   local target="$1"
   local conflicts="${2:-}"
+  local pr_url="${3:-}"
   if [ -z "${SLACK_CHANNEL_ID:-}" ] || [ -z "${SLACK_AUTH_TOKEN:-}" ]; then
     echo "[post-release] Missing Slack channel ID and/or token. Cannot notify."
     return
@@ -158,7 +306,7 @@ notify_slack() {
   # only sees *exported* vars; forwarding it explicitly (like TARGET/CONFLICTS)
   # decouples delivery from how the workflow happens to set it. The GITHUB_* vars
   # node reads are always exported by the Actions runtime, so they stay ambient.
-  payload=$(TARGET="$target" CONFLICTS="$conflicts" SLACK_CHANNEL_ID="$SLACK_CHANNEL_ID" node -e '
+  payload=$(TARGET="$target" CONFLICTS="$conflicts" PR_URL="$pr_url" SLACK_CHANNEL_ID="$SLACK_CHANNEL_ID" node -e '
     const MAX_FILES = 10;
     const MAX_TEXT = 2900;
     const items = (process.env.CONFLICTS || "")
@@ -171,7 +319,12 @@ notify_slack() {
       });
     const header = `⚠️ Post-release merge to \`${process.env.TARGET}\` failed for: \`${process.env.GITHUB_REPOSITORY}\`.`;
     const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
-    const footer = `\nCheck <${runUrl}|the build> for details.`;
+    // The PR link rides in the footer, not the body: the trim below only ever
+    // slices body, so the two links a reader needs can never be cut.
+    const prLink = process.env.PR_URL
+      ? `\n<${process.env.PR_URL}|Open the resolution PR>`
+      : "";
+    const footer = `\nCheck <${runUrl}|the build> for details.${prLink}`;
     let body = "";
     if (items.length) {
       const shown = items.slice(0, MAX_FILES);
@@ -209,7 +362,9 @@ notify_slack() {
     # hand-rolled alert (fixed text, no variable conflict list → no JSON-escaping
     # hazard) so the team is still notified the merge failed.
     echo "[post-release] Slack payload build failed; sending minimal fallback alert."
-    payload="{\"channel\":\"$SLACK_CHANNEL_ID\",\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"⚠️ Post-release merge to \`$target\` failed for: \`$GITHUB_REPOSITORY\`. Check <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|the build> for details.\"}}]}"
+    local fallback_pr=""
+    [ -n "$pr_url" ] && fallback_pr=" Resolution PR: $pr_url"
+    payload="{\"channel\":\"$SLACK_CHANNEL_ID\",\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"⚠️ Post-release merge to \`$target\` failed for: \`$GITHUB_REPOSITORY\`. Check <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|the build> for details.$fallback_pr\"}}]}"
   }
   if [ -z "$payload" ]; then
     echo "[post-release] Empty Slack payload; skipping notification."
@@ -230,6 +385,10 @@ sync_failed=0
 
 git pull origin release
 git checkout alpha
+# Captured before each merge so escalate_conflict can put the branch back
+# exactly where it was after committing the conflicted tree away to its own
+# branch. The two targets are independent and both can fail in one run.
+saved=$(git rev-parse HEAD)
 
 if echo "$SECOND_TO_LAST_COMMIT_MSG" | grep -q '^Merge .*alpha'; then
   echo "[post-release] Release came from the alpha branch. Resetting alpha onto release."
@@ -243,30 +402,39 @@ else
     restore_workspace_deps_and_commit alpha
     git push origin alpha
   else
-    # Capture the conflicting paths before --abort clears the unmerged state.
+    # Capture the conflicting paths while the index still has unmerged entries;
+    # the escalation commit below stages them and clears that state.
     # core.quotePath=false keeps non-ASCII paths literal (not octal-escaped &
     # double-quoted), so attribution lookups match and the alert shows real names.
     conflicts=$(git -c core.quotePath=false diff --name-only --diff-filter=U)
-    git merge --abort
+    # Attribute before escalating: attribute_conflicts resolves `git merge-base
+    # HEAD release`, and the escalation commit moves HEAD, which would silently
+    # change the merge base and blame the wrong commits.
+    attributed=$(attribute_conflicts "$conflicts")
     echo "[post-release] Post-release merge to alpha failed."
-    notify_slack alpha "$(attribute_conflicts "$conflicts")"
+    pr_url=$(escalate_conflict alpha "$saved")
+    notify_slack alpha "$attributed" "$pr_url"
     sync_failed=1
   fi
 fi
 
 echo "[post-release] Merging release into $DEFAULT_BRANCH."
 git checkout "$DEFAULT_BRANCH"
+saved=$(git rev-parse HEAD)
 if git merge --no-ff release -m "chore(release): merge in release $LATEST_VERSION_TAG"; then
   restore_workspace_deps_and_commit "$DEFAULT_BRANCH"
   git push origin "$DEFAULT_BRANCH"
 else
-  # Capture the conflicting paths before --abort clears the unmerged state.
+  # Capture the conflicting paths while the index still has unmerged entries;
+  # the escalation commit below stages them and clears that state.
   # core.quotePath=false keeps non-ASCII paths literal (not octal-escaped &
   # double-quoted), so attribution lookups match and the alert shows real names.
   conflicts=$(git -c core.quotePath=false diff --name-only --diff-filter=U)
-  git merge --abort
+  # See the alpha branch above: attribution must precede the escalation commit.
+  attributed=$(attribute_conflicts "$conflicts")
   echo "[post-release] Post-release merge to $DEFAULT_BRANCH failed."
-  notify_slack "$DEFAULT_BRANCH" "$(attribute_conflicts "$conflicts")"
+  pr_url=$(escalate_conflict "$DEFAULT_BRANCH" "$saved")
+  notify_slack "$DEFAULT_BRANCH" "$attributed" "$pr_url"
   sync_failed=1
 fi
 

--- a/.github/scripts/post-release.sh
+++ b/.github/scripts/post-release.sh
@@ -187,6 +187,11 @@ supersede_bot_prs() {
   local stem="$1" target="$2" new_url="$3" bot_identity="$4" reason="$5"
   local new_number="${3##*/}"
   local prs n head_sha committer
+  # --limit 100 is not pagination-shy: every run closes every escalation PR it
+  # matches, so the steady state is one open per target. Passing 100 means the
+  # closing has failed on that many consecutive conflicted syncs, and the
+  # truncation is then the least of the problems — reaching this ceiling is a
+  # signal worth noticing, not a case worth paginating for.
   prs=$(STEM="$stem" \
     gh pr list --base "$target" --state open --limit 100 \
       --json number,headRefName,isCrossRepository \

--- a/.github/scripts/post-release.sh
+++ b/.github/scripts/post-release.sh
@@ -168,14 +168,22 @@ attribute_conflicts() {
 # author check would still read as the bot and close the very PR a person had
 # just finished. Anything unresolvable (a missing head, an API error) skips the
 # PR: leaving a stale escalation open costs noise, closing a live one costs work.
+#
+# Cross-repository heads are excluded first, because neither of the other two
+# tests authenticates anything. This repo is public and takes PRs from forks; a
+# fork names its own head branch and writes its own commit identity, so a fork
+# PR can present both the escalation branch prefix and the bot's committer email
+# and have this job comment on and close it. Escalation branches are always
+# pushed to this repo, so nothing real is lost by ignoring the rest.
 supersede_escalations() {
   local target="$1" new_url="$2" bot_identity="$3"
   local new_number="${2##*/}"
   local prs n head_sha committer
   prs=$(TARGET="$target" PREFIX="$ESCALATION_BRANCH_PREFIX" \
     gh pr list --base "$target" --state open --limit 100 \
-      --json number,headRefName \
+      --json number,headRefName,isCrossRepository \
       --jq '.[]
+            | select(.isCrossRepository | not)
             | select(.headRefName | startswith(env.PREFIX + "/" + env.TARGET + "-"))
             | .number' 2>/dev/null) || prs=""
   for n in $prs; do

--- a/.github/scripts/post-release.sh
+++ b/.github/scripts/post-release.sh
@@ -41,6 +41,11 @@ LATEST_VERSION_TAG=$(git describe --tags --abbrev=0 2>/dev/null || echo "release
 # forward unchanged — so it cannot distinguish a bot escalation from a finished
 # one. A branch name survives amends.
 ESCALATION_BRANCH_PREFIX="post-release/conflicts"
+# Branch stem for the other escalation: a merge that succeeded and could not be
+# published. Separate from the conflicts prefix because the two carry different
+# trees and ask the reviewer for different work — resolve markers there, approve
+# and merge here.
+SYNC_BRANCH_PREFIX="sync/release-to"
 
 # Restore workspace:* for any internal monorepo dep
 # (newspack-{scripts,components,colors,icons}) in every plugin/theme
@@ -154,13 +159,16 @@ attribute_conflicts() {
   done <<< "$files"
 }
 
-# Close open escalation PRs for $1 that nobody has started resolving, pointing
-# them at the new one ($2 = its URL). $3 is this run's own bot identity, used to
-# tell an untouched escalation from one someone is working on. Each release
-# produces a *different* conflict set rather than re-presenting one unresolved
-# conflict, so a stale escalation PR describes a merge that no longer exists.
-# Once a human has pushed a resolution commit the PR is theirs, and closing it
-# would discard their work.
+# Close open bot-opened PRs whose head branch starts with $1 and whose base is
+# $2, pointing them at the new one ($3 = its URL). $4 is this run's own bot
+# identity, used to tell an untouched PR from one someone is working on. $5 is
+# the sentence explaining why the old one is obsolete, which differs by kind.
+#
+# Shared by both escalation paths. Each release produces a *different* conflict
+# set rather than re-presenting one unresolved conflict, and each rejected push
+# carries a different commit range, so in both cases a stale PR describes work
+# that no longer exists. Once a human has pushed to it the PR is theirs, and
+# closing it would discard their work.
 #
 # The test is the head commit's **committer**, not its author. The resolution
 # recipe in the PR body ends in `git commit --amend --no-edit`, and amending
@@ -175,16 +183,16 @@ attribute_conflicts() {
 # PR can present both the escalation branch prefix and the bot's committer email
 # and have this job comment on and close it. Escalation branches are always
 # pushed to this repo, so nothing real is lost by ignoring the rest.
-supersede_escalations() {
-  local target="$1" new_url="$2" bot_identity="$3"
-  local new_number="${2##*/}"
+supersede_bot_prs() {
+  local stem="$1" target="$2" new_url="$3" bot_identity="$4" reason="$5"
+  local new_number="${3##*/}"
   local prs n head_sha committer
-  prs=$(TARGET="$target" PREFIX="$ESCALATION_BRANCH_PREFIX" \
+  prs=$(STEM="$stem" \
     gh pr list --base "$target" --state open --limit 100 \
       --json number,headRefName,isCrossRepository \
       --jq '.[]
             | select(.isCrossRepository | not)
-            | select(.headRefName | startswith(env.PREFIX + "/" + env.TARGET + "-"))
+            | select(.headRefName | startswith(env.STEM))
             | .number' 2>/dev/null) || prs=""
   for n in $prs; do
     [ "$n" = "$new_number" ] && continue
@@ -196,11 +204,11 @@ supersede_escalations() {
     if [ -z "$committer" ] || [ "$committer" != "$bot_identity" ]; then
       continue
     fi
-    gh pr comment "$n" --body "Superseded by $new_url. Each release conflicts on a different set of files, so this one describes a merge that no longer exists." > /dev/null 2>&1 || true
+    gh pr comment "$n" --body "Superseded by $new_url. $reason" > /dev/null 2>&1 || true
     if gh pr close "$n" > /dev/null 2>&1; then
-      echo "[post-release] Superseded escalation PR #$n."
+      echo "[post-release] Superseded PR #$n."
     else
-      echo "[post-release] Could not close superseded escalation PR #$n."
+      echo "[post-release] Could not close superseded PR #$n."
     fi
   done
 }
@@ -325,9 +333,90 @@ EOF
 
   if [ -n "$url" ]; then
     echo "[post-release] Opened escalation PR $url for $target." >&2
-    supersede_escalations "$target" "$url" "$bot_identity" >&2
+    supersede_bot_prs "$ESCALATION_BRANCH_PREFIX/$target-" "$target" "$url" "$bot_identity" \
+      "Each release conflicts on a different set of files, so this one describes a merge that no longer exists." >&2
   else
     echo "[post-release] Conflict pushed to $branch, but no PR was opened." >&2
+  fi
+
+  git reset --hard "$saved" >&2 || true
+  printf '%s' "$url"
+}
+
+# Turn a rejected push into a mergeable PR instead of ending the run.
+#
+# Why: when the push fails the merge has already succeeded, so the work exists —
+# but only in the runner's workspace, and it dies with it. `set -euo pipefail`
+# ends the script at the failed push, before notify_slack, so the failure
+# reaches nobody at all; it shows only as a red job on a workflow whose reds
+# have been routine. Five consecutive releases failed this way in August 2026
+# and the default branch fell fifteen commits behind before anyone noticed.
+#
+# Unlike the conflict path, the tree here is finished: no markers, nothing to
+# resolve. The PR is mergeable as-is and its CI is real signal rather than red
+# by construction, so it is opened ready rather than draft.
+#
+# $1 = target branch. $2 = the commit to restore the local branch to. $3 = the
+# rejected push output, for the PR body. Prints the PR URL on stdout, empty if
+# escalation could not complete; everything else goes to stderr.
+#
+# Always returns 0 and always leaves the tree clean on $2, for the same reason
+# the conflict path does: this is the already-failed path, and a hiccup here
+# must not preempt the Slack alert or strand the rest of the run.
+escalate_push_rejection() {
+  local target="$1" saved="$2" push_output="$3"
+  local url="" body="" branch="" bot_identity="" err_file="" range="" count=""
+
+  bot_identity=$(git log -1 --format='%ce') || bot_identity=""
+  branch="$SYNC_BRANCH_PREFIX-${target}-$(date -u +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)"
+  count=$(git rev-list --count "$saved..HEAD" 2>/dev/null) || count="?"
+  range="$(git rev-parse --short "$saved")..$(git rev-parse --short HEAD)"
+
+  # Never quote a remote URL's credentials back into a public PR body. Nothing
+  # in a scope rejection carries one today, but this text is machine-generated
+  # from a stream that can contain a remote URL, and the PR body is the point
+  # where it would become public.
+  push_output=$(printf '%s' "$push_output" | sed -E 's#(https?://)[^/[:space:]@]+@#\1***@#g')
+
+  if ! git push origin "HEAD:refs/heads/$branch" >&2; then
+    echo "[post-release] Could not push $branch either; skipping escalation." >&2
+    git reset --hard "$saved" >&2 || true
+    return 0
+  fi
+
+  body=$(cat <<EOF
+The post-release sync merged \`release\` into \`$target\` cleanly, but could not push it. The finished merge is here instead.
+
+- Release: \`$LATEST_VERSION_TAG\`
+- Commits: $count ($range)
+- Build: ${GITHUB_SERVER_URL:-https://github.com}/${GITHUB_REPOSITORY:-}/actions/runs/${GITHUB_RUN_ID:-}
+
+Nothing needs resolving — this is the same tree the sync built. Review and **merge it, and do not squash**. \`$target\` has to genuinely contain \`release\`, or the next release reproduces this.
+
+What the push said:
+
+\`\`\`
+$push_output
+\`\`\`
+EOF
+)
+
+  err_file=$(mktemp 2>/dev/null) || err_file=""
+  url=$(gh pr create --base "$target" --head "$branch" \
+    --title "Post-release sync: release into $target" \
+    --body "$body" 2>"${err_file:-/dev/null}") || url=""
+  url=$(printf '%s\n' "$url" | grep -m1 '^https://' || true)
+  if [ -z "$url" ] && [ -n "$err_file" ]; then
+    echo "[post-release] gh pr create failed: $(tr '\n' ' ' < "$err_file")" >&2
+  fi
+  [ -n "$err_file" ] && rm -f "$err_file"
+
+  if [ -n "$url" ]; then
+    echo "[post-release] Opened sync PR $url for $target." >&2
+    supersede_bot_prs "$SYNC_BRANCH_PREFIX-$target-" "$target" "$url" "$bot_identity" \
+      "Each rejected push carries a different commit range, so this one describes a merge that no longer exists." >&2
+  else
+    echo "[post-release] Merge pushed to $branch, but no PR was opened." >&2
   fi
 
   git reset --hard "$saved" >&2 || true
@@ -339,12 +428,17 @@ EOF
 # rows (see attribute_conflicts); when present the files are named in the message
 # — with the incoming PR/author — so readers can tell what needs reconciling and
 # who to ping without opening the build log.
-# $3 (optional) is the escalation PR URL from escalate_conflict; when present it
-# is linked last, so the alert routes straight to where the fix goes.
+# $3 (optional) is the escalation PR URL; when present it is linked last, so the
+# alert routes straight to where the fix goes.
+# $4 (optional) is the kind of failure — "merge" (the default) or "push". They
+# need different words: a rejected push means the merge succeeded and only
+# publishing it failed, and telling a reader the merge failed would send them
+# looking for a conflict that does not exist.
 notify_slack() {
   local target="$1"
   local conflicts="${2:-}"
   local pr_url="${3:-}"
+  local kind="${4:-merge}"
   if [ -z "${SLACK_CHANNEL_ID:-}" ] || [ -z "${SLACK_AUTH_TOKEN:-}" ]; then
     echo "[post-release] Missing Slack channel ID and/or token. Cannot notify."
     return
@@ -364,7 +458,7 @@ notify_slack() {
   # only sees *exported* vars; forwarding it explicitly (like TARGET/CONFLICTS)
   # decouples delivery from how the workflow happens to set it. The GITHUB_* vars
   # node reads are always exported by the Actions runtime, so they stay ambient.
-  payload=$(TARGET="$target" CONFLICTS="$conflicts" PR_URL="$pr_url" SLACK_CHANNEL_ID="$SLACK_CHANNEL_ID" node -e '
+  payload=$(TARGET="$target" CONFLICTS="$conflicts" PR_URL="$pr_url" KIND="$kind" SLACK_CHANNEL_ID="$SLACK_CHANNEL_ID" node -e '
     const MAX_FILES = 10;
     const MAX_TEXT = 2900;
     const items = (process.env.CONFLICTS || "")
@@ -375,7 +469,10 @@ notify_slack() {
         const [file, pr, author] = line.split("\t");
         return { file, pr: pr || "", author: author || "" };
       });
-    const header = `⚠️ Post-release merge to \`${process.env.TARGET}\` failed for: \`${process.env.GITHUB_REPOSITORY}\`.`;
+    const what = process.env.KIND === "push"
+      ? `push to \`${process.env.TARGET}\` was rejected`
+      : `merge to \`${process.env.TARGET}\` failed`;
+    const header = `⚠️ Post-release ${what} for: \`${process.env.GITHUB_REPOSITORY}\`.`;
     const runUrl = `${process.env.GITHUB_SERVER_URL}/${process.env.GITHUB_REPOSITORY}/actions/runs/${process.env.GITHUB_RUN_ID}`;
     // The PR link rides in the footer, not the body: the trim below only ever
     // slices body, so the two links a reader needs can never be cut.
@@ -420,9 +517,10 @@ notify_slack() {
     # hand-rolled alert (fixed text, no variable conflict list → no JSON-escaping
     # hazard) so the team is still notified the merge failed.
     echo "[post-release] Slack payload build failed; sending minimal fallback alert."
-    local fallback_pr=""
+    local fallback_pr="" fallback_what="merge to \`$target\` failed"
     [ -n "$pr_url" ] && fallback_pr=" Resolution PR: $pr_url"
-    payload="{\"channel\":\"$SLACK_CHANNEL_ID\",\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"⚠️ Post-release merge to \`$target\` failed for: \`$GITHUB_REPOSITORY\`. Check <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|the build> for details.$fallback_pr\"}}]}"
+    [ "$kind" = "push" ] && fallback_what="push to \`$target\` was rejected"
+    payload="{\"channel\":\"$SLACK_CHANNEL_ID\",\"blocks\":[{\"type\":\"section\",\"text\":{\"type\":\"mrkdwn\",\"text\":\"⚠️ Post-release $fallback_what for: \`$GITHUB_REPOSITORY\`. Check <$GITHUB_SERVER_URL/$GITHUB_REPOSITORY/actions/runs/$GITHUB_RUN_ID|the build> for details.$fallback_pr\"}}]}"
   }
   if [ -z "$payload" ]; then
     echo "[post-release] Empty Slack payload; skipping notification."
@@ -481,7 +579,15 @@ git checkout "$DEFAULT_BRANCH"
 saved=$(git rev-parse HEAD)
 if git merge --no-ff release -m "chore(release): merge in release $LATEST_VERSION_TAG"; then
   restore_workspace_deps_and_commit "$DEFAULT_BRANCH"
-  git push origin "$DEFAULT_BRANCH"
+  # Captured rather than left to `set -e`, which would end the run here with the
+  # finished merge existing only in this workspace and nothing said to anyone.
+  if ! push_output=$(git push origin "$DEFAULT_BRANCH" 2>&1); then
+    echo "[post-release] Push to $DEFAULT_BRANCH was rejected."
+    printf '%s\n' "$push_output" >&2
+    pr_url=$(escalate_push_rejection "$DEFAULT_BRANCH" "$saved" "$push_output")
+    notify_slack "$DEFAULT_BRANCH" "" "$pr_url" push
+    sync_failed=1
+  fi
 else
   # Capture the conflicting paths while the index still has unmerged entries;
   # the escalation commit below stages them and clears that state.

--- a/.github/scripts/post-release.sh
+++ b/.github/scripts/post-release.sh
@@ -219,7 +219,6 @@ supersede_escalations() {
 escalate_conflict() {
   local target="$1" saved="$2" conflicts="$3"
   local url="" marker_files="" body="" branch="" bot_identity="" err_file=""
-  branch="$ESCALATION_BRANCH_PREFIX/${target}-$(date -u +%Y%m%d-%H%M%S)"
 
   # Staging is what resolves the unmerged index entries, since git refuses to
   # commit while any path is still unmerged, and it puts the markers in the tree
@@ -256,6 +255,12 @@ escalate_conflict() {
   # supersede check can never drift out of step with the identity `Configure
   # git` sets in release.yml.
   bot_identity=$(git log -1 --format='%ce') || bot_identity=""
+  # Named after the commit as well as the clock. The timestamp alone resolves to
+  # one second, and two escalations for the same target inside that second
+  # produce the same branch name — the second push is then rejected as a
+  # non-fast-forward and that escalation is lost, having already reported the
+  # conflict. The commit SHA makes the name unique whatever the clock says.
+  branch="$ESCALATION_BRANCH_PREFIX/${target}-$(date -u +%Y%m%d-%H%M%S)-$(git rev-parse --short HEAD)"
 
   # --cached, not HEAD: searching a rev prefixes every result with "HEAD:",
   # which the PR body then presents as paths that don't exist. The index is

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -383,6 +383,11 @@ jobs:
         env:
           SLACK_CHANNEL_ID: ${{ secrets.SLACK_CHANNEL_ID }}
           SLACK_AUTH_TOKEN: ${{ secrets.SLACK_AUTH_TOKEN }}
+          # For the `gh` calls that open and supersede a conflict-escalation PR.
+          # git alone works here because actions/checkout persists this same
+          # credential, but gh reads the environment, so without this it is
+          # unauthenticated and every escalation silently no-ops.
+          GH_TOKEN: ${{ secrets.GH_TOKEN }}
         run: ./.github/scripts/post-release.sh
 
   # WP.org deploys are plugin-specific and only run on the release branch.

--- a/bin/tests/test-post-release-escalation.sh
+++ b/bin/tests/test-post-release-escalation.sh
@@ -34,6 +34,11 @@ BOT_EMAIL="newspack-release-bot@users.noreply.github.com"
 
 [ -f "$SUT" ] || { echo "FAIL: $SUT not found"; exit 1; }
 command -v node > /dev/null || { echo "FAIL: node is required (post-release.sh uses it)"; exit 1; }
+# The gh stub applies the caller's --jq with real jq rather than reimplementing
+# the filter. That is the difference between testing the script's jq and testing
+# the stub's idea of it -- a hand-rolled filter silently stopped matching when a
+# second escalation kind arrived with a different branch stem.
+command -v jq > /dev/null || { echo "FAIL: jq is required (the gh stub applies --jq with it)"; exit 1; }
 
 WORK=$(mktemp -d -t post-release-XXXXXX)
 trap 'rm -rf "$WORK"' EXIT
@@ -79,6 +84,15 @@ setup_fixture() { # setup_fixture <case-name>; echoes the case root
 #!/usr/bin/env bash
 set -uo pipefail
 [ "${GH_STUB_FAIL:-0}" = "1" ] && { echo "stubbed gh failure" >&2; exit 4; }
+
+# Apply whatever --jq the caller passed, with real jq, so the script's own
+# filters are what get exercised rather than a reimplementation of them.
+jq_expr=""; prev=""
+for a in "$@"; do [ "$prev" = "--jq" ] && jq_expr="$a"; prev="$a"; done
+emit() {
+  if [ -n "$jq_expr" ]; then printf '%s' "$1" | jq -r "$jq_expr"; else printf '%s\n' "$1"; fi
+}
+
 case "${1:-} ${2:-}" in
   "pr create")
     # Real gh writes advisory lines to stderr on a *successful* create; the
@@ -89,9 +103,10 @@ case "${1:-} ${2:-}" in
     head=""; base=""
     while [ $# -gt 0 ]; do
       case "$1" in
-        --head) head="$2" ;;
-        --base) base="$2" ;;
-        --body) printf '%s' "$2" > "$CASE_ROOT/state/body-$n.md" ;;
+        --head)  head="$2" ;;
+        --base)  base="$2" ;;
+        --draft) echo "$n" >> "$CASE_ROOT/state/drafts" ;;
+        --body)  printf '%s' "$2" > "$CASE_ROOT/state/body-$n.md" ;;
       esac
       shift
     done
@@ -101,25 +116,26 @@ case "${1:-} ${2:-}" in
   "pr list")
     base=""; prev=""
     for a in "$@"; do [ "$prev" = "--base" ] && base="$a"; prev="$a"; done
+    json="["; sep=""
     while IFS=$'\t' read -r n head b; do
       [ "$b" = "$base" ] || continue
       grep -qx "$n" "$CASE_ROOT/state/closed" 2>/dev/null && continue
-      case "$head" in "post-release/conflicts/$base-"*) echo "$n" ;; esac
+      cross=false
+      grep -qx "$n" "$CASE_ROOT/state/cross-repo" 2>/dev/null && cross=true
+      json="$json$sep{\"number\":$n,\"headRefName\":\"$head\",\"isCrossRepository\":$cross}"
+      sep=","
     done < "$CASE_ROOT/state/open-prs" 2>/dev/null || true
+    emit "$json]"
     ;;
   "pr view")
     # Resolved live, so a force-push by a "human" is visible here the way it
     # would be to real gh.
     head=$(grep "^$3	" "$CASE_ROOT/state/open-prs" 2>/dev/null | tail -1 | cut -f2)
-    git -C "$CASE_ROOT/work" rev-parse "refs/remotes/origin/$head" 2>/dev/null
+    emit "{\"headRefOid\":\"$(git -C "$CASE_ROOT/work" rev-parse "refs/remotes/origin/$head" 2>/dev/null)\"}"
     ;;
   "api"*)
-    # Honour which field the caller asked for. Returning the committer no matter
-    # what would make the author-vs-committer case below pass against an author
-    # check too, which is the one thing it exists to catch.
-    fmt='%ce'
-    for a in "$@"; do case "$a" in *author*) fmt='%ae' ;; esac; done
-    git -C "$CASE_ROOT/work" log -1 --format="$fmt" "${2##*/}" 2>/dev/null
+    sha="${2##*/}"
+    emit "{\"commit\":{\"author\":{\"email\":\"$(git -C "$CASE_ROOT/work" log -1 --format=%ae "$sha" 2>/dev/null)\"},\"committer\":{\"email\":\"$(git -C "$CASE_ROOT/work" log -1 --format=%ce "$sha" 2>/dev/null)\"}}}"
     ;;
   "pr comment") echo "$3" >> "$CASE_ROOT/state/commented" ;;
   "pr close")   echo "$3" >> "$CASE_ROOT/state/closed" ;;
@@ -179,6 +195,37 @@ CURL
   echo "$root"
 }
 
+# Refuse pushes to one branch on the origin, which is what a ruleset or the
+# PAT workflow-scope restriction does. A pre-receive hook is the only faithful
+# way to get a rejected push out of a local remote: the merge still succeeds,
+# and only publishing it fails.
+refuse_pushes_to() { # refuse_pushes_to <case-root> <branch>
+  cat > "$1/origin.git/hooks/pre-receive" <<HOOK
+#!/usr/bin/env bash
+while read -r _ _ ref; do
+  if [ "\$ref" = "refs/heads/$2" ]; then
+    echo "remote: refusing to allow a Personal Access Token to create or update workflow .github/workflows/release.yml without workflow scope" >&2
+    exit 1
+  fi
+done
+exit 0
+HOOK
+  chmod +x "$1/origin.git/hooks/pre-receive"
+}
+
+make_merge_clean() { # make_merge_clean <case-root>
+  (
+    cd "$1/work"
+    for b in alpha main; do
+      git checkout -q "$b"
+      git checkout -q release -- packages/components/src/wizard/index.js
+      git commit -qam "align $b"
+      git push -q origin "$b"
+    done
+    git checkout -q release
+  )
+}
+
 run_sut() { # run_sut <case-root> [env assignments...]; echoes the exit code
   local root="$1"; shift
   local rc=0
@@ -207,6 +254,8 @@ check "one for alpha too" 1 "$([ -n "$(esc_branch "$R" alpha)" ] && echo 1 || ec
 check "two draft PRs opened" 2 "$(wc -l < "$R/state/open-prs" | tr -d ' ')"
 check "gh stderr did not swallow the URL" 0 "$(grep -c 'no PR was opened' "$R/state/run.log")"
 check "the tip is a merge commit" 2 "$(git -C "$R/work" log -1 --format=%p "origin/$B" | wc -w | tr -d ' ')"
+check "the branch name carries the commit, not just the clock" 1 \
+  "$(echo "$B" | grep -cE 'main-[0-9]{8}-[0-9]{6}-[0-9a-f]{7,}$')"
 check "exactly one commit above the target (the amend recipe needs this)" \
   1 "$(git -C "$R/work" rev-list --count --first-parent "main..origin/$B")"
 check "subject matches every other back-merge" \
@@ -292,6 +341,78 @@ for b in alpha main; do
   check "$b was still restored" "$(git -C "$R/work" rev-parse "origin/$b")" "$(git -C "$R/work" rev-parse "$b")"
 done
 check "working tree still clean" "" "$(git -C "$R/work" status --porcelain)"
+
+# ---------------------------------------------------------------------------
+echo "case: a rejected push escalates to a mergeable sync PR"
+# ---------------------------------------------------------------------------
+R=$(setup_fixture push_rejected)
+make_merge_clean "$R"
+refuse_pushes_to "$R" main
+check "job fails" 1 "$(run_sut "$R")"
+check "the merge itself succeeded" 0 "$(grep -c 'merge to main failed' "$R/state/run.log")"
+check "the rejection is named for what it is" 1 \
+  "$(grep -c 'Push to main was rejected' "$R/state/run.log")"
+SB=$(git -C "$R/work" branch -r | grep -o "sync/release-to-main-[0-9a-f-]*" | tail -1)
+check "a sync branch was pushed instead" 1 "$([ -n "$SB" ] && echo 1 || echo 0)"
+check "its name carries the commit, not just the clock" 1 \
+  "$(echo "$SB" | grep -cE 'main-[0-9]{8}-[0-9]{6}-[0-9a-f]{7,}$')"
+check "it carries the finished merge, not markers" 0 \
+  "$(git -C "$R/work" show "origin/$SB:packages/components/src/wizard/index.js" | grep -c '^<<<<<<< ')"
+check "it genuinely contains release" 0 \
+  "$(git -C "$R/work" merge-base --is-ancestor origin/release "origin/$SB" && echo 0 || echo 1)"
+check "workspace:* is restored on it" 'workspace:*' \
+  "$(git -C "$R/work" show "origin/$SB:plugins/newspack-plugin/package.json" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).dependencies["newspack-components"]))')"
+check "the PR is ready, not draft" 0 "$([ -f "$R/state/drafts" ] && wc -l < "$R/state/drafts" | tr -d ' ' || echo 0)"
+check "main was restored locally" \
+  "$(git -C "$R/work" rev-parse origin/main)" "$(git -C "$R/work" rev-parse main)"
+check "working tree left clean" "" "$(git -C "$R/work" status --porcelain)"
+check "alpha, which was not refused, still went out" \
+  "$(git -C "$R/work" rev-parse alpha)" "$(git -C "$R/work" rev-parse origin/alpha)"
+check "Slack was told, once, about the push" 1 "$(grep -c 'push to .main. was rejected' "$R/state/slack.json")"
+check "...and never that the merge failed" 0 "$(grep -c 'merge to .main. failed' "$R/state/slack.json")"
+check "the alert links the sync PR" 1 "$(grep -c 'Open the resolution PR' "$R/state/slack.json")"
+check "the body quotes what the push said" 1 "$(grep -c 'without workflow scope' "$R/state/body-1.md")"
+check "and does not present it as a conflict" 0 "$(grep -c 'conflict markers' "$R/state/body-1.md")"
+
+# ---------------------------------------------------------------------------
+echo "case: a fork PR is never superseded, however it names its branch"
+# ---------------------------------------------------------------------------
+# A fork picks its own head branch name and writes its own commit identity, so
+# neither the branch stem nor the committer authenticates anything. Only the
+# cross-repository flag does.
+R=$(setup_fixture cross_repo)
+run_sut "$R" > /dev/null                       # PRs 1 (alpha) and 2 (main)
+# PR 2 satisfies every other test: the right base, an escalation branch stem,
+# and a head commit committed by the bot. Only the flag separates it, so the
+# case fails the moment the cross-repository filter is removed.
+echo 2 > "$R/state/cross-repo"
+(
+  cd "$R/work"
+  git checkout -q release
+  git commit -q --allow-empty -m "chore(release): next [skip ci]"
+  git push -q origin release
+)
+run_sut "$R" > /dev/null
+check "the impostor is left alone" 0 "$(grep -cx 2 "$R/state/closed" 2>/dev/null || true)"
+check "and is not commented on" 0 "$(grep -cx 2 "$R/state/commented" 2>/dev/null || true)"
+
+# ---------------------------------------------------------------------------
+echo "case: a later rejected push supersedes the earlier sync PR"
+# ---------------------------------------------------------------------------
+R=$(setup_fixture push_supersede)
+make_merge_clean "$R"
+refuse_pushes_to "$R" main
+run_sut "$R" > /dev/null                       # PR 1
+(
+  cd "$R/work"
+  git checkout -q release
+  git commit -q --allow-empty -m "chore(release): next [skip ci]"
+  git push -q origin release
+)
+run_sut "$R" > /dev/null                       # PR 2
+check "the earlier sync PR is superseded" 1 "$(grep -cx 1 "$R/state/closed")"
+check "the new one stays open" 0 "$(grep -cx 2 "$R/state/closed" || true)"
+check "it is told why before it closes" 1 "$(grep -cx 1 "$R/state/commented")"
 
 # ---------------------------------------------------------------------------
 if [ "$failures" -ne 0 ]; then

--- a/bin/tests/test-post-release-escalation.sh
+++ b/bin/tests/test-post-release-escalation.sh
@@ -153,10 +153,14 @@ CURL
   git -C "$root/origin.git" symbolic-ref HEAD refs/heads/main
 
   git init -q -b main "$root/seed"
+  # Identity is addressed to the fixture with -C, never with a bare `git config`
+  # after a cd. A bare one writes to whatever repo the cwd happens to be in, so a
+  # cd that is missing or wrong lands it in the real checkout, which then quietly
+  # authors real commits under it until someone reads a git log.
+  git -C "$root/seed" config user.email seed@example.com
+  git -C "$root/seed" config user.name seed
   (
     cd "$root/seed"
-    git config user.email seed@example.com
-    git config user.name seed
     mkdir -p packages/components/src/wizard plugins/newspack-plugin
     printf 'export const wizard = 1;\n' > packages/components/src/wizard/index.js
     printf '{"name":"p","dependencies":{"newspack-components":"workspace:*"}}\n' > plugins/newspack-plugin/package.json
@@ -181,13 +185,12 @@ CURL
   )
 
   git clone -q "$root/origin.git" "$root/work"
-  (
-    cd "$root/work"
-    git config user.name newspack-release-bot
-    git config user.email "$BOT_EMAIL"
-    git config pull.ff only
-    git checkout -q alpha && git checkout -q main && git checkout -q release
-  )
+  git -C "$root/work" config user.name newspack-release-bot
+  git -C "$root/work" config user.email "$BOT_EMAIL"
+  git -C "$root/work" config pull.ff only
+  git -C "$root/work" checkout -q alpha
+  git -C "$root/work" checkout -q main
+  git -C "$root/work" checkout -q release
   # Kept outside the work tree: an untracked file there is exactly what the
   # scoped staging protects, so the runner must not depend on one surviving.
   cp "$SUT" "$root/post-release.sh"

--- a/bin/tests/test-post-release-escalation.sh
+++ b/bin/tests/test-post-release-escalation.sh
@@ -1,0 +1,301 @@
+#!/usr/bin/env bash
+#
+# test-post-release-escalation.sh
+#
+# Self-proving spec for the conflict-escalation path in
+# .github/scripts/post-release.sh, exercised against a throwaway origin with gh
+# and curl stubbed, so nothing reaches GitHub or Slack.
+#
+# The path only runs on a push to `release`, so a PR can never exercise it: the
+# first time a change here is observed for real is during a release, on the
+# already-failed branch, where a mistake either strands `main` or destroys work.
+# That is what these cases stand in for.
+#
+# Two of them guard defects this code has actually had:
+#
+#   - Superseding must key on the head commit's *committer*, not its author.
+#     `git commit --amend --no-edit` — the last step of the recipe the
+#     escalation PR itself prints — rewrites the committer but carries the
+#     original author forward, so an author check reads a PR someone just
+#     finished as untouched and closes it.
+#   - The escalation commit must also restore `workspace:*`. Every other merge
+#     in the script pairs the two, and a back-merge that skips it carries the
+#     release's concretized internal versions into the target, where
+#     `pnpm install --frozen-lockfile` rejects them. It has to be that same
+#     commit: the amend recipe only reaches the tip.
+#
+# Run: bash bin/tests/test-post-release-escalation.sh
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+SUT="$SCRIPT_DIR/../../.github/scripts/post-release.sh"
+BOT_EMAIL="newspack-release-bot@users.noreply.github.com"
+
+[ -f "$SUT" ] || { echo "FAIL: $SUT not found"; exit 1; }
+command -v node > /dev/null || { echo "FAIL: node is required (post-release.sh uses it)"; exit 1; }
+
+WORK=$(mktemp -d -t post-release-XXXXXX)
+trap 'rm -rf "$WORK"' EXIT
+
+# Isolate from whatever git environment this happens to run in. A global
+# commit.gpgsign or tag.gpgSign is enough to fail every commit here for reasons
+# that have nothing to do with the code under test, and husky's core.hooksPath
+# would run the workspace's hooks against these scratch repos.
+#
+# Scrubbing the whole GIT_* namespace, not just pointing the two config files at
+# scratch: GIT_CONFIG_GLOBAL and GIT_CONFIG_SYSTEM neutralise config *files*,
+# and several variables override those per process. Measured against this spec
+# before the scrub — GIT_CONFIG_COUNT/KEY/VALUE injected a user.email straight
+# past GIT_CONFIG_GLOBAL, GIT_TEMPLATE_DIR seeded a failing hook into every
+# scratch repo, and GIT_COMMITTER_EMAIL broke the one case that distinguishes a
+# committer from an author. GIT_DIR and GIT_WORK_TREE are the sharp end of the
+# same class: they aim git at a repo this spec never created.
+for _git_var in $(compgen -v | grep '^GIT_'); do unset "$_git_var"; done
+unset _git_var
+export GIT_CONFIG_GLOBAL="$WORK/gitconfig"
+export GIT_CONFIG_SYSTEM=/dev/null
+export HUSKY=0
+: > "$GIT_CONFIG_GLOBAL"
+
+failures=0
+pass() { echo "  ok   $1"; }
+fail() { echo "  FAIL $1"; failures=$((failures + 1)); }
+check() { # check <label> <expected> <actual>
+  if [ "$2" = "$3" ]; then pass "$1"; else fail "$1 (expected '$2', got '$3')"; fi
+}
+
+# ---------------------------------------------------------------------------
+# Fixture: a bare origin with main/alpha/release, where a hotfix on `release`
+# and unrelated work on both targets touch the same line of the same file --
+# the shape of the 2026-08-20 sync failure. `release` also carries a
+# concretized workspace dep, the way semantic-release leaves one.
+# ---------------------------------------------------------------------------
+setup_fixture() { # setup_fixture <case-name>; echoes the case root
+  local root="$WORK/$1"
+  mkdir -p "$root/bin" "$root/state"
+
+  cat > "$root/bin/gh" <<'GH'
+#!/usr/bin/env bash
+set -uo pipefail
+[ "${GH_STUB_FAIL:-0}" = "1" ] && { echo "stubbed gh failure" >&2; exit 4; }
+case "${1:-} ${2:-}" in
+  "pr create")
+    # Real gh writes advisory lines to stderr on a *successful* create; the
+    # script must not fold them into the URL it captures.
+    echo "Warning: 1 uncommitted change" >&2
+    n=$(( $(cat "$CASE_ROOT/state/counter" 2>/dev/null || echo 0) + 1 ))
+    echo "$n" > "$CASE_ROOT/state/counter"
+    head=""; base=""
+    while [ $# -gt 0 ]; do
+      case "$1" in
+        --head) head="$2" ;;
+        --base) base="$2" ;;
+        --body) printf '%s' "$2" > "$CASE_ROOT/state/body-$n.md" ;;
+      esac
+      shift
+    done
+    printf '%s\t%s\t%s\n' "$n" "$head" "$base" >> "$CASE_ROOT/state/open-prs"
+    echo "https://github.com/acme/repo/pull/$n"
+    ;;
+  "pr list")
+    base=""; prev=""
+    for a in "$@"; do [ "$prev" = "--base" ] && base="$a"; prev="$a"; done
+    while IFS=$'\t' read -r n head b; do
+      [ "$b" = "$base" ] || continue
+      grep -qx "$n" "$CASE_ROOT/state/closed" 2>/dev/null && continue
+      case "$head" in "post-release/conflicts/$base-"*) echo "$n" ;; esac
+    done < "$CASE_ROOT/state/open-prs" 2>/dev/null || true
+    ;;
+  "pr view")
+    # Resolved live, so a force-push by a "human" is visible here the way it
+    # would be to real gh.
+    head=$(grep "^$3	" "$CASE_ROOT/state/open-prs" 2>/dev/null | tail -1 | cut -f2)
+    git -C "$CASE_ROOT/work" rev-parse "refs/remotes/origin/$head" 2>/dev/null
+    ;;
+  "api"*)
+    # Honour which field the caller asked for. Returning the committer no matter
+    # what would make the author-vs-committer case below pass against an author
+    # check too, which is the one thing it exists to catch.
+    fmt='%ce'
+    for a in "$@"; do case "$a" in *author*) fmt='%ae' ;; esac; done
+    git -C "$CASE_ROOT/work" log -1 --format="$fmt" "${2##*/}" 2>/dev/null
+    ;;
+  "pr comment") echo "$3" >> "$CASE_ROOT/state/commented" ;;
+  "pr close")   echo "$3" >> "$CASE_ROOT/state/closed" ;;
+esac
+GH
+
+  cat > "$root/bin/curl" <<'CURL'
+#!/usr/bin/env bash
+prev=""
+for a in "$@"; do [ "$prev" = "--data" ] && printf '%s\n' "$a" >> "$CASE_ROOT/state/slack.json"; prev="$a"; done
+CURL
+  chmod +x "$root/bin/gh" "$root/bin/curl"
+
+  git init -q --bare "$root/origin.git"
+  git -C "$root/origin.git" symbolic-ref HEAD refs/heads/main
+
+  git init -q -b main "$root/seed"
+  (
+    cd "$root/seed"
+    git config user.email seed@example.com
+    git config user.name seed
+    mkdir -p packages/components/src/wizard plugins/newspack-plugin
+    printf 'export const wizard = 1;\n' > packages/components/src/wizard/index.js
+    printf '{"name":"p","dependencies":{"newspack-components":"workspace:*"}}\n' > plugins/newspack-plugin/package.json
+    git add -A && git commit -qm base
+    git branch alpha && git branch release
+
+    git checkout -q release
+    printf 'export const wizard = 2; // hotfix\n' > packages/components/src/wizard/index.js
+    printf '{"name":"p","dependencies":{"newspack-components":"3.4.5"}}\n' > plugins/newspack-plugin/package.json
+    git commit -qam "fix(wizard): refetch after the installer adds plugins (#893)"
+    git tag newspack-plugin@1.2.3
+    git commit -q --allow-empty -m "chore(release): 1.2.3 [skip ci]"
+
+    for b in main alpha; do
+      git checkout -q "$b"
+      printf 'export const wizard = 3; // %s\n' "$b" > packages/components/src/wizard/index.js
+      git commit -qam "feat(components): shared EmptyState component (#854)"
+    done
+    git checkout -q main
+    git remote add origin "$root/origin.git"
+    git push -q origin main alpha release --tags
+  )
+
+  git clone -q "$root/origin.git" "$root/work"
+  (
+    cd "$root/work"
+    git config user.name newspack-release-bot
+    git config user.email "$BOT_EMAIL"
+    git config pull.ff only
+    git checkout -q alpha && git checkout -q main && git checkout -q release
+  )
+  # Kept outside the work tree: an untracked file there is exactly what the
+  # scoped staging protects, so the runner must not depend on one surviving.
+  cp "$SUT" "$root/post-release.sh"
+  chmod +x "$root/post-release.sh"
+  echo "$root"
+}
+
+run_sut() { # run_sut <case-root> [env assignments...]; echoes the exit code
+  local root="$1"; shift
+  local rc=0
+  (
+    cd "$root/work"
+    export CASE_ROOT="$root"
+    export PATH="$root/bin:$PATH"
+    export SLACK_CHANNEL_ID=C123 SLACK_AUTH_TOKEN=tok
+    export GITHUB_SERVER_URL=https://github.com GITHUB_REPOSITORY=acme/repo GITHUB_RUN_ID=999
+    for kv in "$@"; do export "${kv?}"; done
+    "$root/post-release.sh"
+  ) > "$root/state/run.log" 2>&1 || rc=$?
+  echo "$rc"
+}
+
+esc_branch() { git -C "$1/work" branch -r | grep -o "post-release/conflicts/$2-[0-9a-f-]*" | tail -1; }
+
+# ---------------------------------------------------------------------------
+echo "case: a conflict escalates instead of being discarded"
+# ---------------------------------------------------------------------------
+R=$(setup_fixture escalates)
+check "job fails" 1 "$(run_sut "$R")"
+B=$(esc_branch "$R" main)
+check "an escalation branch for main was pushed" 1 "$([ -n "$B" ] && echo 1 || echo 0)"
+check "one for alpha too" 1 "$([ -n "$(esc_branch "$R" alpha)" ] && echo 1 || echo 0)"
+check "two draft PRs opened" 2 "$(wc -l < "$R/state/open-prs" | tr -d ' ')"
+check "gh stderr did not swallow the URL" 0 "$(grep -c 'no PR was opened' "$R/state/run.log")"
+check "the tip is a merge commit" 2 "$(git -C "$R/work" log -1 --format=%p "origin/$B" | wc -w | tr -d ' ')"
+check "exactly one commit above the target (the amend recipe needs this)" \
+  1 "$(git -C "$R/work" rev-list --count --first-parent "main..origin/$B")"
+check "subject matches every other back-merge" \
+  "chore(release): merge in release newspack-plugin@1.2.3" \
+  "$(git -C "$R/work" log -1 --format=%s "origin/$B")"
+check "conflict markers are on the branch" 1 \
+  "$(git -C "$R/work" show "origin/$B:packages/components/src/wizard/index.js" | grep -c '^<<<<<<< ')"
+check "workspace:* restored in that same commit" \
+  'workspace:*' \
+  "$(git -C "$R/work" show "origin/$B:plugins/newspack-plugin/package.json" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).dependencies["newspack-components"]))')"
+for b in alpha main; do
+  check "$b was restored to its pre-merge commit" \
+    "$(git -C "$R/work" rev-parse "origin/$b")" "$(git -C "$R/work" rev-parse "$b")"
+done
+check "working tree left clean" "" "$(git -C "$R/work" status --porcelain)"
+check "both targets alerted Slack" 2 "$(wc -l < "$R/state/slack.json" | tr -d ' ')"
+check "the alert links the escalation PR" 2 "$(grep -c 'Open the resolution PR' "$R/state/slack.json")"
+
+# ---------------------------------------------------------------------------
+echo "case: superseding spares a PR someone has resolved"
+# ---------------------------------------------------------------------------
+R=$(setup_fixture supersede)
+run_sut "$R" > /dev/null                       # PRs 1 (alpha) and 2 (main)
+AB=$(esc_branch "$R" alpha)
+(
+  cd "$R/work"
+  # Exactly the recipe the escalation PR body prints.
+  git checkout -q -B resolve "origin/$AB"
+  printf 'export const wizard = 4; // resolved\n' > packages/components/src/wizard/index.js
+  git add -u
+  git -c user.name=Human -c user.email=human@example.com commit -q --amend --no-edit
+  git push -q --force origin "HEAD:$AB"
+  git checkout -q main
+)
+check "the resolver's amend left the author as the bot" "$BOT_EMAIL" \
+  "$(git -C "$R/work" log -1 --format=%ae "origin/$AB")"
+check "...and moved the committer to the person" "human@example.com" \
+  "$(git -C "$R/work" log -1 --format=%ce "origin/$AB")"
+(
+  cd "$R/work"
+  git checkout -q release
+  git commit -q --allow-empty -m "chore(release): next [skip ci]"
+  git push -q origin release
+)
+run_sut "$R" > /dev/null                       # PRs 3 (alpha) and 4 (main)
+check "the untouched escalation is superseded" 1 "$(grep -cx 2 "$R/state/closed")"
+check "the resolved one survives" 0 "$(grep -cx 1 "$R/state/closed" || true)"
+check "a superseded PR is told why before it closes" 1 "$(grep -cx 2 "$R/state/commented")"
+check "the new escalations stay open" 0 "$(grep -cxE '3|4' "$R/state/closed" || true)"
+
+# ---------------------------------------------------------------------------
+echo "case: a clean merge is untouched by any of this"
+# ---------------------------------------------------------------------------
+R=$(setup_fixture clean)
+(
+  cd "$R/work"
+  for b in alpha main; do
+    git checkout -q "$b"
+    git checkout -q release -- packages/components/src/wizard/index.js
+    git commit -qam "align $b"
+    git push -q origin "$b"
+  done
+  git checkout -q release
+)
+check "job passes" 0 "$(run_sut "$R")"
+check "no escalation branch" 0 "$(git -C "$R/work" branch -r | grep -c post-release/conflicts)"
+check "no Slack alert" 0 "$([ -f "$R/state/slack.json" ] && wc -l < "$R/state/slack.json" | tr -d ' ' || echo 0)"
+for b in alpha main; do
+  check "$b was pushed" "$(git -C "$R/work" rev-parse "$b")" "$(git -C "$R/work" rev-parse "origin/$b")"
+  check "workspace:* restored on $b" 'workspace:*' \
+    "$(git -C "$R/work" show "$b:plugins/newspack-plugin/package.json" | node -e 'let s="";process.stdin.on("data",d=>s+=d).on("end",()=>process.stdout.write(JSON.parse(s).dependencies["newspack-components"]))')"
+done
+
+# ---------------------------------------------------------------------------
+echo "case: an escalation that cannot complete still alerts and still cleans up"
+# ---------------------------------------------------------------------------
+R=$(setup_fixture degraded)
+check "job still fails" 1 "$(run_sut "$R" GH_STUB_FAIL=1)"
+check "no PR was opened" 2 "$(grep -c 'no PR was opened' "$R/state/run.log")"
+check "Slack was still told about both targets" 2 "$(wc -l < "$R/state/slack.json" | tr -d ' ')"
+check "the alert carries no dead PR link" 0 "$(grep -c 'Open the resolution PR' "$R/state/slack.json" || true)"
+for b in alpha main; do
+  check "$b was still restored" "$(git -C "$R/work" rev-parse "origin/$b")" "$(git -C "$R/work" rev-parse "$b")"
+done
+check "working tree still clean" "" "$(git -C "$R/work" status --porcelain)"
+
+# ---------------------------------------------------------------------------
+if [ "$failures" -ne 0 ]; then
+  echo "$failures check(s) failed"
+  exit 1
+fi
+echo "all checks passed"


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)? Shell only, so PHPCS doesn't apply; `shellcheck` is clean at warning level.
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The post-release sync fails two ways, and both used to end with the work existing only inside a runner that then shut down.  This PR uses the failure information to generate a merge PR and surfaces it in the team notification.

**A merge that conflicts** was thrown away by `git merge --abort`, leaving the resolution nowhere to happen but someone's local clone. The two most recent reconciliations went in as direct pushes with no PR and a bare `Merge branch 'release'` subject: `b5d11514be` (alpha) and `4efcde93b4` (main), both on 2026-08-20.

**A merge that succeeds but can't be pushed** was quieter and worse. `set -euo pipefail` ended the script at the failed push, before the Slack alert, so the failure reached nobody—it showed only as a red job on a workflow whose reds were routine. Five consecutive releases failed that way and `main` fell fifteen commits behind before anyone noticed.

Both now become a pull request, and the job still exits non-zero either way.

* **Conflicts** go to `post-release/conflicts/<target>-<timestamp>-<sha>` as a **draft** PR carrying the conflicted tree and a resolution recipe. Its CI is red by construction, and the body says so, so a reviewer doesn't read the red as a second problem.
* **Rejected pushes** go to `sync/release-to-<target>-<timestamp>-<sha>` as a **ready** PR carrying the finished merge. Nothing needs resolving, so its CI is real signal.
* The Slack alert says which of the two happened and links the PR. A rejected push means the merge succeeded, and telling a reader it failed would send them looking for a conflict that doesn't exist.
* Older PRs of the same kind for the same target are closed as superseded when a new one opens—but only while nobody has touched them. The test is the head commit's **committer**, since the recipe's `git commit --amend --no-edit` preserves the author. Cross-repository heads are skipped: this repo takes fork PRs, and a fork controls both its branch name and its commit identity.
* The escalation commit also restores `workspace:*`, in that same commit. Every other merge here pairs the two, and a back-merge that skips it carries the release's concretized versions into the target.
* Attribution runs **before** the escalation commit, since `attribute_conflicts` resolves `git merge-base HEAD release` and committing moves `HEAD`.
* The workflow step gains `GH_TOKEN`. `git` works there only because `actions/checkout` persists the credential; `gh` reads the environment, so without it every escalation would quietly do nothing.

Most recent conflict: [run 32417050507](https://github.com/Automattic/newspack-workspace/actions/runs/32417050507), on `packages/components/src/wizard/index.js` for both targets after #893 landed on `release`.

Nothing here reduces how often either failure happens. It just makes the failures a little easier to fix. The durable solution is a question about where hotfixes are authored, and out of scope.

### How to test the changes in this Pull Request:

`Post-release branch sync` only runs on a push to `release`, using the copy of these files that lives on that branch, so this PR can't exercise the real thing. It's covered by a spec instead, which the existing **Shell specs** job picks up automatically.

1. Run `bash bin/tests/test-post-release-escalation.sh`. It builds a throwaway origin per case, stubs `gh` and `curl` so nothing reaches GitHub or Slack, and prints a line per check.
2. Read the seven cases: a conflict escalates; superseding spares a PR someone resolved; a fork PR is never superseded however it names its branch; a clean merge is untouched; an escalation that can't complete still alerts and still cleans up; a rejected push escalates to a mergeable sync PR; and a later rejected push supersedes the earlier one. The push cases use a `pre-receive` hook on the throwaway origin to refuse one ref, which is the only faithful way to get a rejected push out of a local remote.
3. Break something on purpose and watch it fail. Every guard was checked this way: keying supersede on the author, dropping the cross-repository filter, dropping the `workspace:*` restore, letting `set -e` kill the run on a bad push, calling the rejection a merge failure, opening the sync PR as a draft, and naming either branch on the clock alone. All eight are caught.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? `bin/tests/test-post-release-escalation.sh`—58 checks across seven cases, which the **Shell specs** job already runs on every PR.
* [x] Have you successfully run tests with your changes locally? The spec passes, and passes repeatedly—it was flaky until the branch-naming fix below, so it was run six consecutive times to confirm. `bash -n` and `shellcheck -S warning` are clean on both files.

<details>
<summary>Implementation notes</summary>

**Three functions, all in `.github/scripts/post-release.sh`.**

`escalate_conflict <target> <saved-sha> <conflicting-paths>` stages the conflicted tree, commits it, pushes the branch, opens the draft PR, supersedes older ones, then resets to `<saved-sha>`. It always returns 0 and always leaves a clean tree: this runs on the already-failed path, and an escalation hiccup must not preempt the Slack alert or strand the second sync target. The PR URL goes to stdout, everything else to stderr, so a diagnostic can't contaminate the value the caller captures.

`escalate_push_rejection <target> <saved-sha> <push-output>` is its sibling on the success branch. The merge is already committed and the tree is clean, so it only pushes, opens a ready PR, supersedes, and resets. The rejected push output goes into the body, run through `sed -E 's#(https?://)[^/[:space:]@]+@#\\1***@#g'` first—nothing in a scope rejection carries a credential today, but this is machine-generated text from a stream that can contain a remote URL, and the PR body is where it would become public.

`supersede_bot_prs <stem> <base> <url> <bot-identity> <reason>` is shared by both. It finds candidates by branch stem, then checks each one's head commit. Two things there are deliberate:

The branch prefix, not the commit subject, identifies an escalation. The subject is the same conventional form every back-merge uses, and an amend carries it forward, so it can't tell a bot escalation from a finished one.

The **committer** decides whether a PR is untouched, not the author. `git commit --amend --no-edit`—the last step of the recipe in every escalation PR body—rewrites the committer but carries the original author forward, so an author check reads a resolved PR as still the bot's and closes it. Verified locally: after that amend the author is `newspack-release-bot`, the committer is the person. Anything unresolvable (missing head, API error) skips the PR, since leaving a stale escalation open costs noise while closing a live one costs work.

**Staging is scoped to the conflicting paths.** Staging is what resolves the unmerged index entries, since git refuses to commit while any path is unmerged. Neither `-u` nor `-A` is right: both would also sweep up unrelated work in the workspace, publish it on the escalation branch, and then lose it to the `git reset --hard` that follows. The caller already captured the conflicting paths, so they are passed in and staged with `-A` limited to that pathspec, which also handles a modify/delete conflict resolved as a deletion.

**`gh pr create` stderr is kept out of the captured URL.** gh writes advisory lines there on a *successful* create, and folding them in would leave the URL behind a warning, fail the `https://` prefix check, and report a PR that exists as missing—losing the Slack link and the supersede pass with it.

**Draft PRs will show red CI, and that's accurate**—the branch carries conflict markers. Suppressing it with `[skip ci]` was rejected: `gh pr checkout` plus `commit --amend --no-edit` carries the message forward, so the *resolved* PR would merge having never run CI. The PR body says this so a reviewer doesn't read the red as a second problem.

**`post-release/conflicts/*` triggers no workflow on push.** `ci.yml` fires on `main`, `trunk`, `alpha`, `release`; `release.yml` on `release` and `alpha`. The draft PR does trigger `ci.yml` through `pull_request`, which is the intended signal, and it works because the checkout uses a PAT rather than `GITHUB_TOKEN`.

**Only `.github/scripts/post-release.sh` is edited.** The copy at `packages/scripts/scripts/github/post-release.sh` mirrors the legacy newspack-scripts repo and is overwritten by the daily sync.

**`notify_slack` takes the kind of failure.** Its header used to be fixed at *"merge to `X` failed"*. On the push path the merge succeeded and only publishing it failed, so that wording would send a reader hunting a conflict that isn't there. It now reads *"push to `X` was rejected"* for that case, in both the node payload and the hand-rolled fallback.

**Escalation branches are named after the commit as well as the clock.** The timestamp alone resolves to one second, and two escalations for the same target inside that second produce the same branch name—the second push is then rejected as a non-fast-forward and that escalation is lost, having already reported the conflict as escalated. Writing the spec is what surfaced this: it was reliably flaky at about one failure in three.

**The spec scrubs the inherited `GIT_*` environment before it runs.** Pointing `GIT_CONFIG_GLOBAL` and `GIT_CONFIG_SYSTEM` at scratch neutralises config *files*, which is not the same as isolating git: several variables override those per process, and two aim git at a repo the spec never created. Measured against the spec before the scrub, `GIT_CONFIG_COUNT`/`KEY_0`/`VALUE_0` injected a `user.email` straight past `GIT_CONFIG_GLOBAL`, `GIT_TEMPLATE_DIR` seeded a failing `pre-commit` into every scratch repo, and `GIT_COMMITTER_EMAIL` collapsed the author/committer distinction that the supersede case exists to test. Unsetting the whole namespace and re-exporting the two we want clears all of them, verified against `GIT_DIR`, `GIT_WORK_TREE`, `GIT_INDEX_FILE`, `GIT_AUTHOR_EMAIL`, and a `GIT_CONFIG_GLOBAL` hijack as well, with a decoy repo confirming no write-through.

**The `gh` stub in the spec applies the caller's `--jq` with real `jq`** rather than reimplementing the filter, which is why it needs `jq` alongside `node`. A hand-rolled filter tests the stub's idea of the script rather than the script: it silently stopped matching when a second escalation kind arrived with a different branch stem, and it made the author-versus-committer case pass against an author check. Running the real expression fixes both, and makes the cross-repository guard testable at all.

`PATH` is the remaining hole—the `gh` and `curl` stubs win by being prepended, but a hostile `git` or `node` earlier in `PATH` would own the run. Every spec in `bin/tests/` shares that.

**This is authored on `main` on purpose,** so the sync never has to carry a workflow file backwards. It goes live once `main` → `alpha` → `release` carries it, so a conflict before then still needs a hand-merge.

**One latent bug is deliberately left alone.** `restore_workspace_deps_and_commit` gates on `git status --porcelain`, which counts untracked files, so a stray untracked file makes it attempt an empty commit and `set -e` ends the run. It sits on the success path, is untouched by this change, and is unreachable in the runner today. Worth a separate PR.

</details>
