### PR TITLE
fix(reader-activation): defer activity recording during prerender

### DIFF
--- a/plugins/newspack-plugin/src/content-gate/metering.js
+++ b/plugins/newspack-plugin/src/content-gate/metering.js
@@ -1,5 +1,7 @@
 /* globals newspack_metering_settings */
 
+import { whenActivated } from '../reader-activation/prerender.js';
+
 const settings = newspack_metering_settings;
 
 const storeKey = 'metering-' + settings.gate_id || 0;
@@ -87,7 +89,17 @@ function lockContent( ras ) {
 	}
 }
 
-function meter( ras ) {
+/**
+ * Apply the metering gate to the current page.
+ *
+ * The decision half — whether to lock the content — runs immediately, including
+ * during a prerender, so the page never activates and then changes under the
+ * reader. Only the recording half waits: an article the reader never opens must
+ * not spend one of their free reads.
+ *
+ * @param {Object} ras Reader Data Library object.
+ */
+export function meter( ras ) {
 	const data = getUserData( ras.store );
 	let locked = false;
 	// Lock content if reached limit, remove gate content if not.
@@ -106,11 +118,17 @@ function meter( ras ) {
 		if ( settings.article_view ) {
 			ras.dispatchActivity( settings.article_view.action, settings.article_view.data );
 		}
-		// Add current content to read content.
-		if ( ! data.content.includes( settings.post_id ) ) {
-			data.content.push( settings.post_id );
-			ras.store.set( storeKey, data );
-		}
+		// Add current content to read content. Re-read the stored data inside the
+		// deferred callback rather than reusing `data`: a prerendered page can sit
+		// idle for minutes, and writing back a snapshot taken before activation
+		// would drop reads the reader made in another tab meanwhile.
+		whenActivated( () => {
+			const current = getUserData( ras.store );
+			if ( ! current.content.includes( settings.post_id ) ) {
+				current.content.push( settings.post_id );
+				ras.store.set( storeKey, current );
+			}
+		} );
 	}
 }
 

--- a/plugins/newspack-plugin/src/content-gate/metering.test.js
+++ b/plugins/newspack-plugin/src/content-gate/metering.test.js
@@ -1,0 +1,111 @@
+/**
+ * Tests for the client-side metering gate.
+ *
+ * metering.js reads `newspack_metering_settings` at import time and pushes
+ * itself onto `window.newspackRAS`, so each test imports it fresh inside
+ * `jest.isolateModules()` with the globals already in place.
+ */
+
+/**
+ * Build a minimal stand-in for the Reader Data Library object metering uses.
+ *
+ * @return {Object} A `ras` with an in-memory store and a spied dispatchActivity.
+ */
+function createRAS() {
+	const data = {};
+	return {
+		store: {
+			get: key => data[ key ],
+			set: ( key, value ) => {
+				data[ key ] = value;
+			},
+		},
+		dispatchActivity: jest.fn(),
+		overlays: { get: () => [] },
+	};
+}
+
+/**
+ * The `month` expiration metering computes for right now. Stored data carrying a
+ * different expiration is treated as expired and its content list is cleared, so
+ * a test that primes the list has to match it.
+ *
+ * @return {number} Unix timestamp in seconds.
+ */
+function currentMonthExpiration() {
+	const date = new Date();
+	date.setHours( 0, 0, 0, 0 );
+	date.setMonth( date.getMonth() + 1 );
+	date.setDate( 1 );
+	return parseInt( date.getTime() / 1000, 10 );
+}
+
+function loadMeter( settings ) {
+	global.newspack_metering_settings = {
+		gate_id: 1,
+		post_id: 42,
+		count: 3,
+		period: 'month',
+		excerpt: '',
+		article_view: { action: 'article_view', data: { post_id: 42 } },
+		...settings,
+	};
+	let meter;
+	jest.isolateModules( () => {
+		( { meter } = require( './metering' ) );
+	} );
+	return meter;
+}
+
+describe( 'meter', () => {
+	beforeEach( () => {
+		window.newspackRAS = [];
+	} );
+
+	afterEach( () => {
+		delete global.newspack_metering_settings;
+		delete document.prerendering;
+		delete window.newspackRAS;
+	} );
+
+	it( 'should add the post to the metered content list on a normal page view', () => {
+		const ras = createRAS();
+		loadMeter()( ras );
+		expect( ras.store.get( 'metering-1' ).content ).toEqual( [ 42 ] );
+	} );
+
+	/**
+	 * A prerendered article the reader never opens must not spend one of their
+	 * free reads (NPPM-3134).
+	 */
+	it( 'should not add the post to the metered content list while prerendering', () => {
+		Object.defineProperty( document, 'prerendering', { value: true, configurable: true, writable: true } );
+		const ras = createRAS();
+		loadMeter()( ras );
+		expect( ras.store.get( 'metering-1' ).content ).toEqual( [] );
+	} );
+
+	it( 'should add the post to the metered content list once the prerender is activated', () => {
+		Object.defineProperty( document, 'prerendering', { value: true, configurable: true, writable: true } );
+		const ras = createRAS();
+		loadMeter()( ras );
+		document.prerendering = false;
+		document.dispatchEvent( new Event( 'prerenderingchange' ) );
+		expect( ras.store.get( 'metering-1' ).content ).toEqual( [ 42 ] );
+	} );
+
+	/**
+	 * The gating decision must NOT be deferred: a prerendered page that renders
+	 * unlocked and then locks itself on activation is worse than the bug.
+	 */
+	it( 'should lock content during prerender when the reader is over the limit', () => {
+		Object.defineProperty( document, 'prerendering', { value: true, configurable: true, writable: true } );
+		document.body.innerHTML = '<div class="entry-content">full article</div>';
+		const ras = createRAS();
+		ras.store.set( 'metering-1', { content: [ 1, 2, 3 ], expiration: currentMonthExpiration() } );
+		loadMeter()( ras );
+		expect( document.body.classList.contains( 'newspack-content-locked' ) ).toBe( true );
+		document.body.className = '';
+		document.body.innerHTML = '';
+	} );
+} );

--- a/plugins/newspack-plugin/src/reader-activation/index.js
+++ b/plugins/newspack-plugin/src/reader-activation/index.js
@@ -14,6 +14,7 @@ import setupEngagement from './engagement.js';
 import initSubscriptionTiersForm from './subscription-tiers-form.js';
 import { openAuthModal as _openAuthModal } from '../reader-activation-auth/auth-modal.js';
 import { getApiNonce, hydrateSession } from './session.js';
+import { whenActivated } from './prerender.js';
 
 /**
  * Reader Activation Library.
@@ -37,9 +38,15 @@ export { store };
  * @return {Object} Activity.
  */
 export function dispatchActivity( action, data, timestamp = 0 ) {
-	const activity = { action, data, timestamp: timestamp || Date.now() };
-	store.add( 'activity', activity );
-	emit( EVENTS.activity, activity );
+	// Stamp the time up front so a deferred activity keeps an explicitly passed
+	// timestamp. Without one it takes the activation time, which is when the
+	// reader actually saw the page.
+	const activity = { action, data, timestamp };
+	whenActivated( () => {
+		activity.timestamp = activity.timestamp || Date.now();
+		store.add( 'activity', activity );
+		emit( EVENTS.activity, activity );
+	} );
 	return activity;
 }
 
@@ -358,19 +365,27 @@ function pushActivities() {
 
 /**
  * Store the referrer.
+ *
+ * Exported only so that deferral can be unit-tested; it is not part of the
+ * public readerActivation API and is not attached to
+ * window.newspackReaderActivation. Do not depend on it from other bundles.
+ *
+ * @access private
  */
-function setReferrer() {
-	const normalize = hostname =>
-		hostname
-			.trim()
-			.toLowerCase()
-			.replace( /^www\./, '' );
-	const referrer = document.referrer ? normalize( new URL( document.referrer ).hostname ) : '';
-	if ( referrer && referrer !== normalize( window.location.hostname ) ) {
-		store.set( 'referrer', referrer );
-	} else {
-		store.set( 'referrer', '' );
-	}
+export function setReferrer() {
+	whenActivated( () => {
+		const normalize = hostname =>
+			hostname
+				.trim()
+				.toLowerCase()
+				.replace( /^www\./, '' );
+		const referrer = document.referrer ? normalize( new URL( document.referrer ).hostname ) : '';
+		if ( referrer && referrer !== normalize( window.location.hostname ) ) {
+			store.set( 'referrer', referrer );
+		} else {
+			store.set( 'referrer', '' );
+		}
+	} );
 }
 
 /**

--- a/plugins/newspack-plugin/src/reader-activation/index.test.js
+++ b/plugins/newspack-plugin/src/reader-activation/index.test.js
@@ -1,4 +1,14 @@
-import { store, dispatchActivity, getActivities, getUniqueActivitiesBy, setReaderEmail, setAuthenticated, getReader, register } from './index';
+import {
+	store,
+	dispatchActivity,
+	getActivities,
+	getUniqueActivitiesBy,
+	setReaderEmail,
+	setAuthenticated,
+	getReader,
+	register,
+	setReferrer,
+} from './index';
 import { on, off } from './events';
 
 describe( 'newspackReaderActivation', () => {
@@ -643,5 +653,104 @@ describe( 'register() transport options', () => {
 		expect( getReader().email ).not.toBe( 'limited@example.com' );
 		const failed = getActivities( 'reader_registration_failed' ).filter( a => a.data.email === 'limited@example.com' );
 		expect( failed ).toHaveLength( 1 );
+	} );
+} );
+
+/**
+ * A prerendered page is one the reader has not seen yet, so nothing it does may
+ * count as reader activity until the reader navigates to it (NPPM-3134).
+ *
+ * jsdom implements neither `document.prerendering` nor the `prerenderingchange`
+ * event, so both are simulated here.
+ */
+describe( 'dispatchActivity during prerender', () => {
+	function setPrerendering( prerendering ) {
+		Object.defineProperty( document, 'prerendering', {
+			value: prerendering,
+			configurable: true,
+			writable: true,
+		} );
+	}
+
+	function activate() {
+		document.prerendering = false;
+		document.dispatchEvent( new Event( 'prerenderingchange' ) );
+	}
+
+	// A prior describe block's afterEach deletes window.newspack_reader_data, so
+	// restore it here — store.add()'s bare reference throws a ReferenceError without it.
+	beforeEach( () => {
+		global.newspack_reader_data = {};
+	} );
+
+	afterEach( () => {
+		delete document.prerendering;
+		delete global.newspack_reader_data;
+	} );
+
+	it( 'should not record an activity while the document is prerendering', () => {
+		setPrerendering( true );
+		dispatchActivity( 'test-prerender-deferred', { test: 'test' } );
+		expect( getActivities( 'test-prerender-deferred' ) ).toEqual( [] );
+	} );
+
+	it( 'should not emit an activity event while the document is prerendering', () => {
+		setPrerendering( true );
+		const callback = jest.fn();
+		on( 'activity', callback );
+		dispatchActivity( 'test-prerender-no-emit', { test: 'test' } );
+		off( 'activity', callback );
+		expect( callback ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should record the activity once the prerendered document is activated', () => {
+		setPrerendering( true );
+		dispatchActivity( 'test-prerender-activated', { test: 'test' } );
+		activate();
+		expect( getActivities( 'test-prerender-activated' ) ).toHaveLength( 1 );
+	} );
+
+	it( 'should record an explicit timestamp rather than the activation time', () => {
+		setPrerendering( true );
+		dispatchActivity( 'test-prerender-timestamp', { test: 'test' }, 1234567890 );
+		activate();
+		expect( getActivities( 'test-prerender-timestamp' )[ 0 ].timestamp ).toBe( 1234567890 );
+	} );
+
+	it( 'should record immediately when the document is not prerendering', () => {
+		setPrerendering( false );
+		dispatchActivity( 'test-prerender-inactive', { test: 'test' } );
+		expect( getActivities( 'test-prerender-inactive' ) ).toHaveLength( 1 );
+	} );
+} );
+
+/**
+ * The stored referrer records where the reader entered the site from. A prerender
+ * of a same-site link resolves to an empty referrer, so recording it eagerly wipes
+ * a genuine external referrer for a page the reader never opened (NPPM-3134).
+ */
+describe( 'setReferrer during prerender', () => {
+	beforeEach( () => {
+		global.newspack_reader_data = {};
+		store.set( 'referrer', 'facebook.com' );
+	} );
+
+	afterEach( () => {
+		delete document.prerendering;
+		delete global.newspack_reader_data;
+	} );
+
+	it( 'should not overwrite the stored referrer while the document is prerendering', () => {
+		Object.defineProperty( document, 'prerendering', { value: true, configurable: true, writable: true } );
+		setReferrer();
+		expect( store.get( 'referrer' ) ).toBe( 'facebook.com' );
+	} );
+
+	it( 'should overwrite the stored referrer once the prerendered document is activated', () => {
+		Object.defineProperty( document, 'prerendering', { value: true, configurable: true, writable: true } );
+		setReferrer();
+		document.prerendering = false;
+		document.dispatchEvent( new Event( 'prerenderingchange' ) );
+		expect( store.get( 'referrer' ) ).toBe( '' );
 	} );
 } );

--- a/plugins/newspack-plugin/src/reader-activation/prerender.js
+++ b/plugins/newspack-plugin/src/reader-activation/prerender.js
@@ -1,0 +1,44 @@
+/**
+ * Defer reader-activity recording until a prerendered page is actually shown.
+ *
+ * Browsers can prerender a link the reader never clicks (Chrome's "Preload
+ * pages" setting, a CDN, or a site running speculative loading in `prerender`
+ * mode). Scripts run in that hidden document, so anything that records a visit
+ * runs too — inflating pageviews, spending prompt frequency caps and eating
+ * metered free reads for a page nobody opened (NPPM-3134).
+ *
+ * Only *recording* belongs behind this gate. Decisions that affect what the
+ * prerendered document displays — whether metering locks the content, which
+ * segment a prompt matches — must still run during prerender, or the page
+ * would activate and then visibly change under the reader.
+ *
+ * Kept deliberately in step with
+ * newspack-popups/src/view/utils/prerender.js, which needs the same gate for
+ * its pageview counters. The two are duplicated rather than shared because
+ * there is nowhere good to share them to: `packages/` is React components and
+ * build tooling, not view-layer utilities, and this is ~10 lines of
+ * dependency-free DOM code — the same call made for the preview-links pair (see
+ * the header of ../content-gate/preview-links.js). (Sharing would not create
+ * version coupling — workspace packages are bundled into each plugin's own
+ * dist/ at build time — so that is not the reason.) If you change one, change
+ * the other; the copies are identical today.
+ */
+
+/**
+ * Run a callback now, or once a prerendered document is activated.
+ *
+ * If the prerender is discarded because the reader never navigates, the
+ * callback never runs — which is the point.
+ *
+ * Browsers without the Speculation Rules API expose no `document.prerendering`,
+ * so the callback runs inline exactly as it did before.
+ *
+ * @param {Function} callback Callback to run.
+ */
+export function whenActivated( callback ) {
+	if ( ! document.prerendering ) {
+		callback();
+		return;
+	}
+	document.addEventListener( 'prerenderingchange', () => callback(), { once: true } );
+}

--- a/plugins/newspack-plugin/src/reader-activation/prerender.test.js
+++ b/plugins/newspack-plugin/src/reader-activation/prerender.test.js
@@ -1,0 +1,72 @@
+import { whenActivated } from './prerender';
+
+/**
+ * jsdom implements neither `document.prerendering` nor the `prerenderingchange`
+ * event, so both are simulated here. `prerendering` is defined as a configurable
+ * own property so each test can put the document into the state it needs and
+ * `activate()` can flip it the way a real activation does.
+ *
+ * @param {boolean|undefined} prerendering Initial value, or undefined to simulate
+ *                                         a browser without the Speculation Rules API.
+ * @return {Function} Activates the document, firing `prerenderingchange`.
+ */
+function mockPrerendering( prerendering ) {
+	if ( undefined === prerendering ) {
+		delete document.prerendering;
+		return () => {};
+	}
+	Object.defineProperty( document, 'prerendering', {
+		value: prerendering,
+		configurable: true,
+		writable: true,
+	} );
+	return () => {
+		document.prerendering = false;
+		document.dispatchEvent( new Event( 'prerenderingchange' ) );
+	};
+}
+
+describe( 'whenActivated', () => {
+	afterEach( () => {
+		delete document.prerendering;
+	} );
+
+	it( 'should run the callback immediately when the document is not prerendering', () => {
+		mockPrerendering( false );
+		const callback = jest.fn();
+		whenActivated( callback );
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should run the callback immediately when the browser has no prerendering support', () => {
+		mockPrerendering( undefined );
+		const callback = jest.fn();
+		whenActivated( callback );
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should not run the callback while the document is prerendering', () => {
+		mockPrerendering( true );
+		const callback = jest.fn();
+		whenActivated( callback );
+		expect( callback ).not.toHaveBeenCalled();
+	} );
+
+	it( 'should run the callback once the prerendered document is activated', () => {
+		const activate = mockPrerendering( true );
+		const callback = jest.fn();
+		whenActivated( callback );
+		activate();
+		expect( callback ).toHaveBeenCalledTimes( 1 );
+	} );
+
+	it( 'should run each deferred callback once, in the order it was deferred', () => {
+		const activate = mockPrerendering( true );
+		const calls = [];
+		whenActivated( () => calls.push( 'first' ) );
+		whenActivated( () => calls.push( 'second' ) );
+		activate();
+		document.dispatchEvent( new Event( 'prerenderingchange' ) );
+		expect( calls ).toEqual( [ 'first', 'second' ] );
+	} );
+} );

--- a/plugins/newspack-popups/src/view/segmentation.js
+++ b/plugins/newspack-popups/src/view/segmentation.js
@@ -11,6 +11,7 @@ import {
 	shouldPromptBeDisplayed,
 	syncMatchedSegments,
 } from './utils';
+import { whenActivated } from './utils/prerender';
 
 /**
  * Match reader to segments.
@@ -114,6 +115,13 @@ export const handleSegmentation = prompts => {
 		maybeDisplayPrompts();
 	} else {
 		window.newspackRAS = window.newspackRAS || [];
-		window.newspackRAS.push( maybeDisplayPrompts );
+		// Held for a prerendered page, in step with the pageview counter that
+		// frequency capping reads. Evaluating here would read a counter that has
+		// not been written yet: `logPageview` is queued ahead of this and defers
+		// its write the same way, and frequency arithmetic expects a count that
+		// already includes the current page. Since the queue drains in push
+		// order, both callbacks register their listeners in that order too, so
+		// the write still lands before this evaluation on activation (NPPM-3134).
+		window.newspackRAS.push( ras => whenActivated( () => maybeDisplayPrompts( ras ) ) );
 	}
 };

--- a/plugins/newspack-popups/src/view/segmentation.test.js
+++ b/plugins/newspack-popups/src/view/segmentation.test.js
@@ -1,0 +1,106 @@
+/**
+ * Prompt display depends on the pageview counter having been written for the
+ * current page: `logPageview` is pushed onto `newspackRAS` before
+ * `maybeDisplayPrompts`, and the queue drains synchronously in push order, so
+ * on an ordinary load the write always lands first.
+ *
+ * Deferring the write for a prerendered page has to defer the evaluation with
+ * it, or prompt display reads a counter that is not there yet (NPPM-3134).
+ */
+import { handleSegmentation } from './segmentation';
+import { logPageview } from './utils';
+
+/**
+ * A store faithful to reader-activation's: an unwritten key reads back as null,
+ * not undefined and not an empty object.
+ *
+ * @return {Object} A `ras` stand-in.
+ */
+function createRAS() {
+	const data = {};
+	return {
+		store: {
+			get: key => ( key in data ? data[ key ] : null ),
+			set: ( key, value ) => {
+				data[ key ] = value;
+			},
+		},
+		getActivities: () => [],
+		segments: { register: () => {}, setMatch: () => {} },
+	};
+}
+
+/**
+ * Drain the queue the way reader-activation's handlePush does: synchronously,
+ * in push order, invoking each callback with the `ras` object.
+ *
+ * @param {Object} ras The `ras` stand-in.
+ */
+function drainRAS( ras ) {
+	const queued = window.newspackRAS;
+	window.newspackRAS = [];
+	queued.forEach( arg => arg( ras ) );
+}
+
+function addPrompt() {
+	document.body.innerHTML = '<div id="id_123" class="newspack-popup hidden" data-frequency="0,0,0,month"></div>';
+	return [ ...document.querySelectorAll( '.newspack-popup' ) ];
+}
+
+function setPrerendering( prerendering ) {
+	Object.defineProperty( document, 'prerendering', {
+		value: prerendering,
+		configurable: true,
+		writable: true,
+	} );
+}
+
+function activate() {
+	document.prerendering = false;
+	document.dispatchEvent( new Event( 'prerenderingchange' ) );
+}
+
+describe( 'prompt display and the pageview counter', () => {
+	beforeEach( () => {
+		global.newspack_popups_view = { segments: {}, donor_landing_page: 0 };
+		window.newspackRAS = [];
+	} );
+
+	afterEach( () => {
+		delete global.newspack_popups_view;
+		delete document.prerendering;
+		delete window.newspackRAS;
+		document.body.innerHTML = '';
+	} );
+
+	it( 'should display the prompt on an ordinary page load', () => {
+		const ras = createRAS();
+		const prompts = addPrompt();
+		window.newspackRAS.push( logPageview );
+		handleSegmentation( prompts );
+		drainRAS( ras );
+		expect( prompts[ 0 ].classList.contains( 'hidden' ) ).toBe( false );
+	} );
+
+	it( 'should not evaluate prompts while the document is prerendering', () => {
+		setPrerendering( true );
+		const ras = createRAS();
+		const prompts = addPrompt();
+		window.newspackRAS.push( logPageview );
+		handleSegmentation( prompts );
+		expect( () => drainRAS( ras ) ).not.toThrow();
+		expect( prompts[ 0 ].classList.contains( 'hidden' ) ).toBe( true );
+	} );
+
+	it( 'should display the prompt once activated, counting the current page', () => {
+		setPrerendering( true );
+		const ras = createRAS();
+		const prompts = addPrompt();
+		window.newspackRAS.push( logPageview );
+		handleSegmentation( prompts );
+		drainRAS( ras );
+		activate();
+		expect( ras.store.get( 'pageviews' ).month.count ).toBe( 1 );
+		expect( prompts[ 0 ].classList.contains( 'hidden' ) ).toBe( false );
+	} );
+} );

--- a/plugins/newspack-popups/src/view/utils/index.js
+++ b/plugins/newspack-popups/src/view/utils/index.js
@@ -6,6 +6,7 @@ export * from './segments';
 
 import { getRawId } from './prompts';
 import { periods } from './segments';
+import { whenActivated } from './prerender';
 
 // The minimum continuous amount of time the prompt must be in the viewport before being considered visible.
 const MINIMUM_VISIBLE_TIME = 250;
@@ -83,9 +84,24 @@ export const handleSeen = ( prompt, ras ) => {
  *
  * @param {Object} ras Reader Data Library object.
  *
- * @return {Object} Total pageviews.
+ * @return {Object|undefined} Total pageviews, or undefined while prerendering.
  */
 export const logPageview = ras => {
+	let pageviews;
+	whenActivated( () => {
+		pageviews = countPageview( ras );
+	} );
+	return pageviews;
+};
+
+/**
+ * Increment the pageview counters and persist them.
+ *
+ * @param {Object} ras Reader Data Library object.
+ *
+ * @return {Object} Total pageviews.
+ */
+const countPageview = ras => {
 	const now = Date.now();
 	const pageviewTemplate = {
 		day: {

--- a/plugins/newspack-popups/src/view/utils/pageview.test.js
+++ b/plugins/newspack-popups/src/view/utils/pageview.test.js
@@ -1,0 +1,85 @@
+/**
+ * Tests for pageview logging.
+ *
+ * A browser can prerender a link the reader never clicks. Scripts run in that
+ * hidden document, so without a gate the visit is counted and the reader crosses
+ * "has read N articles" segment thresholds for pages they never opened
+ * (NPPM-3134).
+ */
+import { logPageview } from './index';
+
+/**
+ * Build a minimal stand-in for the Reader Data Library object.
+ *
+ * @return {Object} A `ras` with an in-memory store.
+ */
+function createRAS() {
+	const data = {};
+	return {
+		store: {
+			get: key => data[ key ],
+			set: ( key, value ) => {
+				data[ key ] = value;
+			},
+		},
+	};
+}
+
+function setPrerendering( prerendering ) {
+	Object.defineProperty( document, 'prerendering', {
+		value: prerendering,
+		configurable: true,
+		writable: true,
+	} );
+}
+
+function activate() {
+	document.prerendering = false;
+	document.dispatchEvent( new Event( 'prerenderingchange' ) );
+}
+
+describe( 'logPageview', () => {
+	beforeEach( () => {
+		global.newspack_popups_view = { donor_landing_page: 0 };
+	} );
+
+	afterEach( () => {
+		delete global.newspack_popups_view;
+		delete document.prerendering;
+		document.body.className = '';
+	} );
+
+	it( 'should increment the pageview counters on a normal page view', () => {
+		const ras = createRAS();
+		logPageview( ras );
+		expect( ras.store.get( 'pageviews' ).day.count ).toBe( 1 );
+	} );
+
+	it( 'should not increment the pageview counters while prerendering', () => {
+		setPrerendering( true );
+		const ras = createRAS();
+		logPageview( ras );
+		expect( ras.store.get( 'pageviews' ) ).toBeUndefined();
+	} );
+
+	it( 'should increment the pageview counters once the prerender is activated', () => {
+		setPrerendering( true );
+		const ras = createRAS();
+		logPageview( ras );
+		activate();
+		expect( ras.store.get( 'pageviews' ).day.count ).toBe( 1 );
+	} );
+
+	/**
+	 * Reaching the donor landing page marks the reader as a donor, which changes
+	 * which prompts they see. Prerendering that page is not reaching it.
+	 */
+	it( 'should not mark the reader as a donor while prerendering the donor landing page', () => {
+		setPrerendering( true );
+		global.newspack_popups_view = { donor_landing_page: 7 };
+		document.body.className = 'page-id-7';
+		const ras = createRAS();
+		logPageview( ras );
+		expect( ras.store.get( 'is_donor' ) ).toBeUndefined();
+	} );
+} );

--- a/plugins/newspack-popups/src/view/utils/prerender.js
+++ b/plugins/newspack-popups/src/view/utils/prerender.js
@@ -1,0 +1,44 @@
+/**
+ * Defer reader-activity recording until a prerendered page is actually shown.
+ *
+ * Browsers can prerender a link the reader never clicks (Chrome's "Preload
+ * pages" setting, a CDN, or a site running speculative loading in `prerender`
+ * mode). Scripts run in that hidden document, so anything that records a visit
+ * runs too — inflating pageviews and crossing segment thresholds for a page
+ * nobody opened (NPPM-3134).
+ *
+ * Only *recording* belongs behind this gate. Deciding which segment matches and
+ * whether a prompt should display must still run during prerender, or the page
+ * would activate and then visibly change under the reader.
+ *
+ * Kept deliberately in step with
+ * newspack-plugin/src/reader-activation/prerender.js, which gates the reader
+ * activity recorded on that side. The two are duplicated rather than shared
+ * because there is nowhere good to share them to: `packages/` is React
+ * components and build tooling, not view-layer utilities, and this is ~10 lines
+ * of dependency-free DOM code — the same call made for the preview-links pair
+ * (see the header of ./preview-links.js). (Sharing would not create version
+ * coupling — workspace packages are bundled into each plugin's own dist/ at
+ * build time — so that is not the reason.) If you change one, change the other;
+ * the copies are identical today. This one is covered through pageview.test.js,
+ * the other by its own prerender.test.js.
+ */
+
+/**
+ * Run a callback now, or once a prerendered document is activated.
+ *
+ * If the prerender is discarded because the reader never navigates, the
+ * callback never runs — which is the point.
+ *
+ * Browsers without the Speculation Rules API expose no `document.prerendering`,
+ * so the callback runs inline exactly as it did before.
+ *
+ * @param {Function} callback Callback to run.
+ */
+export function whenActivated( callback ) {
+	if ( ! document.prerendering ) {
+		callback();
+		return;
+	}
+	document.addEventListener( 'prerenderingchange', () => callback(), { once: true } );
+}


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

When a browser prerenders a page, reader-activation code runs in that hidden document and records the visit as though the reader had read it. A page nobody opened counts as a pageview, fires `prompt_seen`, and spends a metered free article. Segments drift upward, frequency caps get consumed, and a reader can reach the paywall having read nothing.

**Recording now waits until the reader actually sees the page.** Activity dispatch, the metered-content list, the pageview counters, and the stored referrer are all held while `document.prerendering` is true, then released on `prerenderingchange`. If the prerender is discarded, nothing is recorded at all.

Decisions still run during prerender. Metering locks or unlocks the content immediately, so a prerendered page never activates and then changes under the reader.

Prerender is not new in WordPress 7.1. It has been reachable since 6.8 through `wp_speculation_rules_configuration`, and a CDN, a performance plugin, or a reader's own Chrome preloading setting can prerender pages with no site-side rules at all.

Server-side metering for logged-in readers is out of scope here. NPPM-3134 traces it in code but never observed it, so it needs confirming before anyone sizes that work.

Closes NPPM-3134.

### How to test the changes in this Pull Request:

1. Set `WP_SPECULATIVE_LOADING_DEFAULT_MODE` to `prerender` and `WP_SPECULATIVE_LOADING_DEFAULT_EAGERNESS` to `eager` in `wp-config.php`. Both are required to reproduce.
2. Enable Reader Activation and a metered content gate. Metering must be on for the free-article steps.
3. Enable **Preload pages** at `chrome://settings/performance`. Prerendering does not happen under browser automation, so drive this by hand.
4. Browse logged out and clear site data. Reader activity starts empty.
5. Load a post that links to another post you have not visited. Do not click the link.
6. Open DevTools, then Application → Speculative loads. Wait for the target URL to reach **Ready** before continuing.
7. In the console, read `np_reader_1_activity` and filter for `article_view`. The never-visited post ID is absent.
8. Check `np_reader_1_pageviews` and the `metering-<gate_id>` key. Counts are unchanged and the post ID is absent.
9. Click the link. The post ID now appears in all three, and the article renders locked or unlocked per its metering state.
10. Arrive from an external referrer, then let a link prerender. `np_reader_1_referrer` keeps the external hostname.
11. Let a page with a prompt prerender without visiting it. No `prompt_seen` is recorded and the frequency cap is unspent.
12. Turn prerendering back off and browse normally. Activity, pageviews, prompts, and metering all record as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? 16 new unit tests across both plugins.
* [x] Have you successfully run tests with your changes locally? Both JS suites pass. The manual steps above have not been run yet, since prerendering does not happen under automation.

The gate is duplicated in `newspack-plugin` and `newspack-popups` rather than shared. `packages/` holds React components and build tooling, not view-layer utilities, and this is ~10 lines of dependency-free DOM code. Sharing would not create version coupling, since workspace packages are bundled into each plugin's own `dist/` at build time, so that is not the reason. Same call the `preview-links` pair already made; each copy points at the other.
