### PR TITLE
fix(content-gate): invalidate block-visibility caches on gate writes

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-block-visibility.php
@@ -23,6 +23,13 @@ class Block_Visibility {
 		add_filter( 'render_block', [ __CLASS__, 'filter_render_block' ], 10, 2 );
 		add_action( 'enqueue_block_editor_assets', [ __CLASS__, 'enqueue_block_editor_assets' ] );
 		add_filter( 'register_block_type_args', [ __CLASS__, 'register_block_type_args' ], 10, 2 );
+
+		// Keep the per-request caches honest across writes (see $active_gates_cache).
+		add_action( 'save_post', [ __CLASS__, 'flush_caches' ] );
+		add_action( 'deleted_post', [ __CLASS__, 'flush_caches' ] );
+		add_action( 'added_post_meta', [ __CLASS__, 'flush_caches' ] );
+		add_action( 'updated_post_meta', [ __CLASS__, 'flush_caches' ] );
+		add_action( 'deleted_post_meta', [ __CLASS__, 'flush_caches' ] );
 	}
 
 	/**
@@ -478,22 +485,11 @@ class Block_Visibility {
 	 * The blog id is in the key because gate ids are per-site post ids, so a
 	 * switch_to_blog() mid-request would otherwise answer for the wrong site.
 	 *
-	 * Not flushed when a gate is written, and neither stale answer is safe. A stale
-	 * false returns early from is_hidden_for_user() and renders a block whose gates
-	 * have just become active. A stale true reaches compute_gate_rules_match(), which
-	 * passes through when no gate is active -- and under visibility "hidden" that
-	 * pass-through inverts into withholding a block that should have rendered.
-	 *
-	 * What bounds this is the write window, not the direction. A stale entry takes one
-	 * request that reads a gate set, changes the publish status of a gate in it, then
-	 * reads that same set again. Neither reader writes gates -- filter_render_block()
-	 * renders, strip_hidden() strips for the excerpt -- so it takes a caller outside
-	 * this file interleaving a gate write between two reads, and none is known to. The
-	 * stale true additionally needs the second read to miss $rules_match_cache, which
-	 * happens across user ids: filter_render_block() uses the current reader, while
-	 * strip_hidden() always uses 0. Anything that closes that window needs an
-	 * invalidation hook here, the way Content_Gate flushes its own cache on save_post
-	 * and the post-meta writes.
+	 * Dropped by flush_caches() on every post and post-meta write, so an entry cannot
+	 * outlive a change to the gates it answers for. It needs that: neither stale answer
+	 * is safe. A stale false renders a block whose gates have just become active, and a
+	 * stale true reaches the pass-through in compute_gate_rules_match(), which under
+	 * visibility "hidden" inverts into withholding a block that should have rendered.
 	 *
 	 * @var bool[]
 	 */
@@ -503,6 +499,25 @@ class Block_Visibility {
 	 * Reset the per-request caches. Used in unit tests only.
 	 */
 	public static function reset_cache_for_tests() {
+		self::flush_caches();
+	}
+
+	/**
+	 * Drop the per-request caches after a write that could change a gate.
+	 *
+	 * Hooked to every post and post-meta write rather than to gate-CPT writes alone,
+	 * matching Content_Gate::flush_gates_cache(): gate settings are persisted with bare
+	 * update_post_meta() calls, and the meta hooks carry a meta ID rather than a post
+	 * type, so telling a gate write from any other costs a lookup on every write. The
+	 * caches are plain arrays, so clearing them unconditionally is cheaper than that
+	 * check and costs at most a recompute on requests that write posts.
+	 *
+	 * All three go, not just the active-gate one. compute_gate_rules_match() reads gate
+	 * status and rule meta on the way to $rules_match_cache, and $strip_cache holds
+	 * output built from both, so clearing only the first would leave the answers it
+	 * feeds still cached.
+	 */
+	public static function flush_caches() {
 		self::$rules_match_cache  = [];
 		self::$strip_cache        = [];
 		self::$active_gates_cache = [];
@@ -552,7 +567,7 @@ class Block_Visibility {
 		// caller's list carries both -- they arrive from a block attribute in editor
 		// order. Normalizing first lets every block gated by the same set, however its
 		// author happened to arrange them, share one entry.
-		$ids = array_values( array_unique( array_map( 'intval', $gate_ids ) ) );
+		$ids = array_unique( array_map( 'intval', $gate_ids ) );
 		sort( $ids, SORT_NUMERIC );
 		$cache_key = get_current_blog_id() . ':' . implode( ',', $ids );
 		if ( isset( self::$active_gates_cache[ $cache_key ] ) ) {
@@ -560,7 +575,7 @@ class Block_Visibility {
 		}
 
 		$has_active = false;
-		foreach ( $gate_ids as $gate_id ) {
+		foreach ( $ids as $gate_id ) {
 			$gate = Content_Gate::get_gate( $gate_id );
 			if ( ! \is_wp_error( $gate ) && 'publish' === $gate['status'] ) {
 				$has_active = true;

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
@@ -1063,4 +1063,55 @@ class Newspack_Test_Block_Visibility extends WP_UnitTestCase {
 			'The same gate set in a different order must reuse the cached result.'
 		);
 	}
+
+	/**
+	 * A gate write drops the per-request caches, so the next read sees the new status.
+	 */
+	public function test_gate_write_flushes_active_gate_cache() {
+		$gate_id = $this->make_gate();
+		$fetches = 0;
+
+		$counter = function( $value, $object_id, $meta_key ) use ( &$fetches, $gate_id ) {
+			if ( 'gate_priority' === $meta_key && (int) $object_id === (int) $gate_id ) {
+				++$fetches;
+			}
+			return $value;
+		};
+		add_filter( 'get_post_metadata', $counter, 10, 3 );
+
+		wp_set_current_user( 0 );
+		Block_Visibility::reset_cache_for_tests();
+
+		$block = $this->make_block(
+			'core/group',
+			[
+				'newspackAccessControlMode'    => 'gate',
+				'newspackAccessControlGateIds' => [ $gate_id ],
+			]
+		);
+
+		Block_Visibility::filter_render_block( '<div>members</div>', $block );
+		$after_first = $fetches;
+		Block_Visibility::filter_render_block( '<div>members</div>', $block );
+		$after_cached = $fetches;
+
+		// Snapshot after the write so the write's own meta reads cannot satisfy the
+		// assertion below -- only the render that follows it may.
+		wp_update_post(
+			[
+				'ID'          => $gate_id,
+				'post_status' => 'draft',
+			] 
+		);
+		$after_write = $fetches;
+
+		Block_Visibility::filter_render_block( '<div>members</div>', $block );
+		$after_reread = $fetches;
+
+		remove_filter( 'get_post_metadata', $counter, 10 );
+
+		$this->assertGreaterThan( 0, $after_first, 'The first render must reconstruct the gate.' );
+		$this->assertSame( $after_first, $after_cached, 'The second render must reuse the cached result.' );
+		$this->assertGreaterThan( $after_write, $after_reread, 'A gate write must drop the cache, so the next read reconstructs.' );
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-block-visibility.php
@@ -1101,7 +1101,7 @@ class Newspack_Test_Block_Visibility extends WP_UnitTestCase {
 			[
 				'ID'          => $gate_id,
 				'post_status' => 'draft',
-			] 
+			]
 		);
 		$after_write = $fetches;
 


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

`Block_Visibility` keeps three per-request caches — the active-gate check, rule evaluation, and stripped content — and drops none of them when a gate is written. `Content_Gate` flushes its own cache on five write hooks; this class never got the equivalent, so an entry can outlive the gates it answers for.

Neither stale answer is safe. A stale "no active gates" renders a block whose gates have just become active. A stale "has active gates" reaches the pass-through in `compute_gate_rules_match()`, which under `visibility: "hidden"` inverts into withholding a block that should have rendered.

**This is not a fix for an observed bug, and the body should not read like one.** Nobody has produced a request that reaches the stale state. It takes one request to read a gate set, change a gate's publish status, then read that same set again, and three attempts through the public API failed — `$rules_match_cache` is warmed on the same path, so the second read never reaches the code under test. The inversion itself is confirmed, by invoking the predicate directly with a forced stale entry. So: a proven code property, an unproven path to it.

**Alternatives.** Flushing only on gate-CPT writes is the obvious narrower option and was rejected for the reason `Content_Gate` already documents next door — gate settings are written with bare `update_post_meta()` calls, and the meta hooks carry a meta ID rather than a post type, so the check costs more than the flush it avoids. Flushing only the active-gate cache was rejected because the other two derive from it and would keep serving the stale answer. Leaving it documented is what #966 did, and it is the option this replaces: a hazard is invisible from the call site, and five `add_action` lines are cheaper than expecting each future reader to re-derive the window.

The docblock that #966 spent three paragraphs on collapses to five lines, which is most of the argument for doing this at all.

Out of scope: the cross-site concern in NPPM-3170.

Closes NPPM-3207 (https://linear.app/a8c/issue/NPPM-3207).

### How to test the changes in this Pull Request:

1. Delete the five `add_action` lines in `init()` and run `n test-php --filter test_gate_write_flushes` from `plugins/newspack-plugin`. It fails on the flush assertion — `Failed asserting that 2 is greater than 2` — not on setup. Restore and it passes. This is the check CI cannot perform.
2. Don't reach for an end-to-end check in an env; it cannot observe this. The caches are per-request statics, so a gate edit and a page reload are always separate requests and always see fresh state. The window only exists inside one request, which is why it is hard to reach and hard to demonstrate.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable? — one, verified by removing the hooks and watching it fail.
* [x] Have you successfully run tests with your changes locally? — full `newspack-plugin` suite, 3387 tests, 9 pre-existing skips; PHPCS clean against the root ruleset.
