### PR TITLE
fix(salesforce): opportunity meta, HPOS sync status, refresh errors

### DIFF
--- a/plugins/newspack-plugin/includes/class-salesforce.php
+++ b/plugins/newspack-plugin/includes/class-salesforce.php
@@ -294,7 +294,22 @@ class Salesforce {
 	 * Register admin scripts for Salesforce functionality.
 	 */
 	public static function register_admin_scripts() {
-		if ( 'shop_order' !== get_current_screen()->id || 'shop_order' !== get_post_type() || ! Donations::is_platform_wc() || ! self::is_connected() ) {
+		$screen = get_current_screen();
+		if ( ! $screen || ! Donations::is_platform_wc() || ! self::is_connected() ) {
+			return;
+		}
+
+		$order_id = 0;
+		if ( 'shop_order' === $screen->id && 'shop_order' === get_post_type() ) {
+			// Classic post-based order editor.
+			$order_id = get_the_ID();
+		} elseif ( function_exists( 'wc_get_page_screen_id' ) && \wc_get_page_screen_id( 'shop_order' ) === $screen->id ) {
+			// HPOS order editor: orders aren't posts, so the edited order id comes from the
+			// query string. Its absence means the orders list, which shares this screen id.
+			$order_id = isset( $_GET['id'] ) ? absint( wp_unslash( $_GET['id'] ) ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		}
+
+		if ( ! $order_id ) {
 			return;
 		}
 
@@ -314,7 +329,7 @@ class Salesforce {
 			'newspack_salesforce_data',
 			[
 				'base_url'       => get_rest_url(),
-				'order_id'       => get_the_id(),
+				'order_id'       => $order_id,
 				'salesforce_url' => $settings['instance_url'],
 				'nonce'          => wp_create_nonce( 'wp_rest' ),
 			]
@@ -1277,7 +1292,7 @@ class Salesforce {
 	/**
 	 * Get a new Salesforce token using a valid refresh token.
 	 *
-	 * @return string The new access token.
+	 * @return string|WP_Error The new access token, or an error if one couldn't be granted.
 	 */
 	private static function refresh_salesforce_token() {
 		$settings = self::get_salesforce_settings();
@@ -1314,19 +1329,29 @@ class Salesforce {
 			]
 		);
 
-		$response_body = json_decode( $salesforce_response['body'] );
-
-		if ( ! empty( $response_body->access_token ) ) {
-
-			// Save tokens.
-			$update_response = self::set_salesforce_settings(
-				[
-					'access_token' => $response_body->access_token,
-				]
-			);
-
-			return $response_body->access_token;
+		if ( is_wp_error( $salesforce_response ) ) {
+			return $salesforce_response;
 		}
+
+		$response_body = json_decode( wp_remote_retrieve_body( $salesforce_response ) );
+
+		if ( empty( $response_body->access_token ) ) {
+			return new \WP_Error(
+				'newspack_salesforce_token_refresh_failed',
+				! empty( $response_body->error_description ) ?
+					$response_body->error_description :
+					__( 'Salesforce did not grant a new access token.', 'newspack' )
+			);
+		}
+
+		// Save the new token.
+		self::set_salesforce_settings(
+			[
+				'access_token' => $response_body->access_token,
+			]
+		);
+
+		return $response_body->access_token;
 	}
 
 	/**
@@ -1384,7 +1409,7 @@ class Salesforce {
 	}
 
 	/**
-	 * Save the synced opportunity IDs as post meta on the given order.
+	 * Save the synced opportunity IDs as order meta on the given order.
 	 *
 	 * @param int   $order_id Order ID.
 	 * @param array $opportunities Array of Opportunity IDs from Salesforce.
@@ -1394,7 +1419,12 @@ class Salesforce {
 		if ( ! $order ) {
 			return;
 		}
-		$order->update_meta_data( $order_id, 'newspack_salesforce_opportunities', $opportunities );
+		// An argument-shifted version of this call (Automattic/newspack-plugin#2711) wrote a
+		// junk row keyed by the order id, with the meta key as its value; scrub it on re-sync.
+		if ( 'newspack_salesforce_opportunities' === $order->get_meta( (string) $order_id, true ) ) {
+			$order->delete_meta_data( (string) $order_id );
+		}
+		$order->update_meta_data( 'newspack_salesforce_opportunities', $opportunities );
 		$order->save();
 	}
 }

--- a/plugins/newspack-plugin/tests/mocks/wc-mocks.php
+++ b/plugins/newspack-plugin/tests/mocks/wc-mocks.php
@@ -1620,6 +1620,21 @@ function wc_get_product( $product_id ) {
 	global $products_database;
 	return $products_database[ $product_id ] ?? false;
 }
+if ( ! function_exists( 'wc_get_page_screen_id' ) ) {
+	/**
+	 * Mirror of wc_get_page_screen_id() on an HPOS site, where order admin screens
+	 * live on the wc-orders page instead of the shop_order post screens. Modelling
+	 * the HPOS answer is the point: the legacy answer ('shop_order') is a screen id
+	 * code under test can, and does, check without this helper.
+	 *
+	 * @param string $for Name of the resource.
+	 * @return string Screen id.
+	 */
+	function wc_get_page_screen_id( $for ) {
+		$for = str_replace( '-', '_', $for );
+		return 'woocommerce_page_wc-orders' . ( 'shop_order' === $for ? '' : '--' . $for );
+	}
+}
 if ( ! function_exists( 'get_woocommerce_currency' ) ) {
 	function get_woocommerce_currency() {
 		return 'USD';

--- a/plugins/newspack-plugin/tests/unit-tests/salesforce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/salesforce.php
@@ -125,6 +125,34 @@ class Newspack_Test_Salesforce extends WP_UnitTestCase {
 	}
 
 	/**
+	 * A refresh response whose body isn't decodable JSON is reported as an error.
+	 * The suite promotes PHP warnings to failures, so this also pins that reading
+	 * fields off the failed decode stays warning-free.
+	 */
+	public function test_refresh_token_handles_undecodable_response_body() {
+		$this->connect_salesforce();
+		$filter = function() {
+			return [
+				'headers'  => [],
+				'body'     => 'Bad Gateway',
+				'response' => [
+					'code'    => 502,
+					'message' => 'Bad Gateway',
+				],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$result = self::call_private( 'refresh_salesforce_token' );
+
+		remove_filter( 'pre_http_request', $filter );
+
+		self::assertWPError( $result, 'An undecodable refresh response is reported as an error.' );
+	}
+
+	/**
 	 * A granted token is saved and returned.
 	 */
 	public function test_refresh_token_saves_and_returns_granted_token() {

--- a/plugins/newspack-plugin/tests/unit-tests/salesforce.php
+++ b/plugins/newspack-plugin/tests/unit-tests/salesforce.php
@@ -19,6 +19,222 @@ class Newspack_Test_Salesforce extends WP_UnitTestCase {
 		WC_Webhook::$registry = [];
 	}
 
+	public function tear_down() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		unset( $_GET['id'] );
+		$GLOBALS['current_screen'] = null;
+		// The admin-script tests enqueue into the process-global registry.
+		$GLOBALS['wp_scripts'] = null;
+		parent::tear_down();
+	}
+
+	/**
+	 * Invoke a private static Salesforce method.
+	 *
+	 * @param string $method  Method name.
+	 * @param mixed  ...$args Arguments to pass along.
+	 * @return mixed The method's return value.
+	 */
+	private static function call_private( $method, ...$args ) {
+		$reflection = new ReflectionMethod( Salesforce::class, $method );
+		$reflection->setAccessible( true );
+		return $reflection->invokeArgs( null, $args );
+	}
+
+	/**
+	 * Store the settings that make the Salesforce connection look established.
+	 */
+	private function connect_salesforce() {
+		update_option( Salesforce::SALESFORCE_CLIENT_ID, 'test-client-id' );
+		update_option( Salesforce::SALESFORCE_CLIENT_SECRET, 'test-client-secret' );
+		update_option( Salesforce::SALESFORCE_REFRESH_TOKEN, 'test-refresh-token' );
+		update_option( Salesforce::SALESFORCE_INSTANCE_URL, 'https://newspack-test.my.salesforce.com' );
+	}
+
+	/**
+	 * Opportunity ids are stored under the meta key the re-sync lookup reads back.
+	 */
+	public function test_save_opportunity_ids_stores_ids_under_meta_key() {
+		$order         = wc_create_order(
+			[
+				'status'      => 'processing',
+				'customer_id' => 1,
+			]
+		);
+		$opportunities = [ '0068d00000AAAAA', '0068d00000BBBBB' ];
+
+		self::call_private( 'save_opportunity_ids', $order->get_id(), $opportunities );
+
+		self::assertSame(
+			$opportunities,
+			wc_get_order( $order->get_id() )->get_meta( 'newspack_salesforce_opportunities' ),
+			'Opportunity ids are readable under the meta key the re-sync lookup uses.'
+		);
+	}
+
+	/**
+	 * A junk meta row keyed by the order id (written by the argument-shifted call
+	 * from Automattic/newspack-plugin#2711) is removed when the order re-syncs.
+	 */
+	public function test_save_opportunity_ids_scrubs_argument_shifted_row() {
+		$order = wc_create_order(
+			[
+				'status'      => 'processing',
+				'customer_id' => 1,
+			]
+		);
+		$order->update_meta_data( (string) $order->get_id(), 'newspack_salesforce_opportunities' );
+
+		self::call_private( 'save_opportunity_ids', $order->get_id(), [ '0068d00000AAAAA' ] );
+
+		self::assertFalse(
+			$order->meta_exists( (string) $order->get_id() ),
+			'The junk row keyed by the order id is removed on re-sync.'
+		);
+	}
+
+	/**
+	 * When Salesforce does not grant a new access token, the refresh returns an
+	 * error instead of null, so callers cannot mistake the failure for a token.
+	 */
+	public function test_refresh_token_returns_error_when_no_token_granted() {
+		$this->connect_salesforce();
+		$filter = function() {
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode(
+					[
+						'error'             => 'invalid_grant',
+						'error_description' => 'expired access/refresh token',
+					]
+				),
+				'response' => [
+					'code'    => 400,
+					'message' => 'Bad Request',
+				],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$result = self::call_private( 'refresh_salesforce_token' );
+
+		remove_filter( 'pre_http_request', $filter );
+
+		self::assertWPError( $result, 'A refresh that grants no token returns an error.' );
+	}
+
+	/**
+	 * A granted token is saved and returned.
+	 */
+	public function test_refresh_token_saves_and_returns_granted_token() {
+		$this->connect_salesforce();
+		$filter = function() {
+			return [
+				'headers'  => [],
+				'body'     => wp_json_encode( [ 'access_token' => 'new-access-token' ] ),
+				'response' => [
+					'code'    => 200,
+					'message' => 'OK',
+				],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+		add_filter( 'pre_http_request', $filter );
+
+		$result = self::call_private( 'refresh_salesforce_token' );
+
+		remove_filter( 'pre_http_request', $filter );
+
+		self::assertSame( 'new-access-token', $result, 'The granted token is returned.' );
+		self::assertSame( 'new-access-token', get_option( Salesforce::SALESFORCE_ACCESS_TOKEN ), 'The granted token is saved.' );
+	}
+
+	/**
+	 * When the access token is expired and the refresh fails, the request helper
+	 * returns the refresh error rather than retrying with an empty bearer token.
+	 */
+	public function test_build_request_propagates_failed_refresh() {
+		$this->connect_salesforce();
+		update_option( Salesforce::SALESFORCE_ACCESS_TOKEN, 'expired-token' );
+
+		$authorizations = [];
+		$filter         = function( $preempt, $args, $url ) use ( &$authorizations ) {
+			$authorizations[] = $args['headers']['Authorization'] ?? '';
+			if ( is_string( $url ) && false !== strpos( $url, 'login.salesforce.com' ) ) {
+				// The OAuth token endpoint refuses to grant a token.
+				return [
+					'headers'  => [],
+					'body'     => wp_json_encode( [ 'error' => 'invalid_grant' ] ),
+					'response' => [
+						'code'    => 400,
+						'message' => 'Bad Request',
+					],
+					'cookies'  => [],
+					'filename' => null,
+				];
+			}
+			// The instance API rejects the expired access token.
+			return [
+				'headers'  => [],
+				'body'     => '',
+				'response' => [
+					'code'    => 401,
+					'message' => 'Unauthorized',
+				],
+				'cookies'  => [],
+				'filename' => null,
+			];
+		};
+		add_filter( 'pre_http_request', $filter, 10, 3 );
+
+		$result = self::call_private( 'build_request', '/services/data/v48.0/query' );
+
+		remove_filter( 'pre_http_request', $filter );
+
+		self::assertWPError( $result, 'A failed token refresh becomes the request result.' );
+		self::assertNotContains( 'Bearer ', $authorizations, 'No request is sent with an empty bearer token.' );
+	}
+
+	/**
+	 * The sync-status script loads on the HPOS order editor, where orders are not
+	 * posts and the screen id is WooCommerce's orders page.
+	 */
+	public function test_admin_scripts_enqueue_on_hpos_order_editor() {
+		$this->connect_salesforce();
+		set_current_screen( 'woocommerce_page_wc-orders' );
+		$_GET['id'] = '123';
+
+		Salesforce::register_admin_scripts();
+
+		self::assertTrue(
+			wp_script_is( 'newspack-salesforce-sync-status', 'enqueued' ),
+			'The sync-status script is enqueued on the HPOS order editor.'
+		);
+		self::assertStringContainsString(
+			'"order_id":"123"',
+			wp_scripts()->get_data( 'newspack-salesforce-sync-status', 'data' ),
+			'The edited order id reaches the script without a post context.'
+		);
+	}
+
+	/**
+	 * The HPOS orders list shares the editor's screen id; with no order id in the
+	 * query string there is no order to report on, so the script stays out.
+	 */
+	public function test_admin_scripts_skip_hpos_orders_list() {
+		$this->connect_salesforce();
+		set_current_screen( 'woocommerce_page_wc-orders' );
+
+		Salesforce::register_admin_scripts();
+
+		self::assertFalse(
+			wp_script_is( 'newspack-salesforce-sync-status', 'enqueued' ),
+			'The sync-status script is not enqueued on the orders list.'
+		);
+	}
+
 	/**
 	 * Create a WooCommerce webhook and register it as the Salesforce sync webhook.
 	 *


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Three fixes to the legacy Salesforce order sync:

- Opportunity IDs now persist under the `newspack_salesforce_opportunities` order meta key. The previous call passed `WC_Data::update_meta_data()` arguments in the wrong order, so the IDs were never stored: every re-sync fell back to a fuzzy Name/Amount/CloseDate match (risking duplicate opportunities) and the order screen reported "Not synced". The shifted call left a junk meta row with no recoverable IDs; re-syncing an order scrubs it.
- The sync-status script now loads on the HPOS order editor. The screen guard only matched the classic `shop_order` screen, leaving the badge stuck on "Fetching…" on HPOS sites. The order ID comes from the query string there, since HPOS orders aren't posts.
- A failed token refresh returns an error instead of null, so requests surface the failure rather than retrying with an empty bearer token.

### How to test the changes in this Pull Request:

1. On a Salesforce-connected site with HPOS enabled, edit a paid WooCommerce order. The sync badge resolves instead of staying "Fetching…".
2. Run the "Sync order to Salesforce" order action twice. Salesforce holds a single opportunity, and the badge reports it synced.
3. Revoke the connected app's tokens in Salesforce, then run the sync action. The order note carries the Salesforce error.
4. Disable HPOS and edit the order again. The badge still resolves.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?
