### PR TITLE
fix(salesforce): escape values interpolated into SOQL queries

### DIFF
--- a/plugins/newspack-plugin/includes/class-salesforce.php
+++ b/plugins/newspack-plugin/includes/class-salesforce.php
@@ -1050,6 +1050,19 @@ class Salesforce {
 	}
 
 	/**
+	 * Escape a value for interpolation into a single-quoted SOQL string literal.
+	 *
+	 * Backslashes are escaped before single quotes so the backslashes added by
+	 * the quote escaping aren't themselves re-escaped.
+	 *
+	 * @param string $value Value to escape.
+	 * @return string Escaped value.
+	 */
+	private static function escape_soql( $value ) {
+		return str_replace( [ '\\', "'" ], [ '\\\\', "\\'" ], (string) $value );
+	}
+
+	/**
 	 * Look up existing Contact records by email address.
 	 *
 	 * @param string $email Email address of the contact.
@@ -1057,7 +1070,7 @@ class Salesforce {
 	 */
 	private static function get_contacts_by_email( $email ) {
 		$query    = [
-			'q' => "SELECT Id, FirstName, LastName, Description FROM Contact WHERE Email = '" . $email . "'",
+			'q' => "SELECT Id, FirstName, LastName, Description FROM Contact WHERE Email = '" . self::escape_soql( $email ) . "'",
 		];
 		$endpoint = '/services/data/v48.0/query?' . http_build_query( $query );
 		$response = self::build_request( $endpoint );
@@ -1098,7 +1111,7 @@ class Salesforce {
 		if ( is_array( $opportunities ) ) {
 			$opportunities = array_map(
 				function( $opportunity_id ) {
-					return "'$opportunity_id'";
+					return "'" . self::escape_soql( $opportunity_id ) . "'";
 				},
 				$opportunities
 			);
@@ -1106,7 +1119,7 @@ class Salesforce {
 
 		$opportunity_ids = is_array( $opportunities ) && ! empty( $opportunities ) ? implode( ',', $opportunities ) : false;
 
-		$name        = $order_item['Name'];
+		$name        = self::escape_soql( $order_item['Name'] );
 		$amount      = $order_item['Amount'];
 		$description = $order_item['Description'];
 		$close_date  = $order_item['CloseDate'];

--- a/plugins/newspack-plugin/tests/unit-tests/salesforce-soql-escaping.php
+++ b/plugins/newspack-plugin/tests/unit-tests/salesforce-soql-escaping.php
@@ -1,0 +1,187 @@
+<?php
+/**
+ * Tests escaping of values interpolated into Salesforce SOQL queries.
+ *
+ * @package Newspack\Tests
+ */
+
+use Newspack\Salesforce;
+
+require_once __DIR__ . '/../mocks/wc-mocks.php';
+
+/**
+ * Tests escaping of values interpolated into Salesforce SOQL queries.
+ *
+ * Emails and product names originate from reader input, so a stray apostrophe
+ * must not be able to terminate the SOQL string literal it lands in.
+ */
+class Newspack_Test_Salesforce_Soql_Escaping extends WP_UnitTestCase {
+	/**
+	 * URLs of intercepted Salesforce API requests.
+	 *
+	 * @var array
+	 */
+	private $requested_urls = [];
+
+	public function set_up() { // phpcs:ignore Squiz.Commenting.FunctionComment.Missing
+		parent::set_up();
+		global $orders_database;
+		$orders_database      = [];
+		$this->requested_urls = [];
+		update_option( Salesforce::SALESFORCE_INSTANCE_URL, 'https://newspack.my.salesforce.com' );
+		update_option( Salesforce::SALESFORCE_ACCESS_TOKEN, 'test-access-token' );
+		add_filter( 'pre_http_request', [ $this, 'intercept_request' ], 10, 3 );
+	}
+
+	/**
+	 * Intercept outgoing Salesforce API requests, recording the URL and
+	 * returning an empty successful query response.
+	 *
+	 * @param false|array $preempt     Whether to preempt the request.
+	 * @param array       $parsed_args Request arguments.
+	 * @param string      $url         Request URL.
+	 * @return array Mocked HTTP response.
+	 */
+	public function intercept_request( $preempt, $parsed_args, $url ) {
+		$this->requested_urls[] = $url;
+		return [
+			'headers'  => [],
+			'body'     => wp_json_encode(
+				[
+					'totalSize' => 0,
+					'records'   => [],
+				]
+			),
+			'response' => [
+				'code'    => 200,
+				'message' => 'OK',
+			],
+		];
+	}
+
+	/**
+	 * Get the SOQL query sent in the last intercepted request.
+	 *
+	 * @return string The value of the `q` query param.
+	 */
+	private function get_last_soql_query() {
+		$this->assertNotEmpty( $this->requested_urls, 'A Salesforce API request was made.' );
+		wp_parse_str( (string) wp_parse_url( end( $this->requested_urls ), PHP_URL_QUERY ), $params );
+		return $params['q'] ?? '';
+	}
+
+	/**
+	 * Call a private static method on the Salesforce class.
+	 *
+	 * @param string $method  Method name.
+	 * @param mixed  ...$args Method arguments.
+	 * @return mixed Method return value.
+	 */
+	private static function call_salesforce( $method, ...$args ) {
+		$reflection = new ReflectionMethod( Salesforce::class, $method );
+		$reflection->setAccessible( true );
+		return $reflection->invoke( null, ...$args );
+	}
+
+	/**
+	 * Build an order item for the given product name, backed by a mock order.
+	 *
+	 * @param string $name Product (line item) name.
+	 * @return array The order id and the parsed order item.
+	 */
+	private function create_order_item( $name ) {
+		$order = wc_create_order( [ 'status' => 'pending' ] );
+		return [
+			$order->get_id(),
+			[
+				'Amount'      => '25.00',
+				'CloseDate'   => '2026-08-25',
+				'Description' => 'WooCommerce Order Number: ' . $order->get_id(),
+				'Name'        => $name,
+				'StageName'   => 'Closed Won',
+			],
+		];
+	}
+
+	/**
+	 * An apostrophe in an email must not terminate the SOQL string literal.
+	 */
+	public function test_contact_query_escapes_apostrophe_in_email() {
+		self::call_salesforce( 'get_contacts_by_email', "o'brien@example.com" );
+
+		$this->assertSame(
+			"SELECT Id, FirstName, LastName, Description FROM Contact WHERE Email = 'o\\'brien@example.com'",
+			$this->get_last_soql_query()
+		);
+	}
+
+	/**
+	 * A backslash in an email must not escape the closing quote of the literal.
+	 */
+	public function test_contact_query_escapes_backslash_in_email() {
+		self::call_salesforce( 'get_contacts_by_email', 'trailing\\' );
+
+		$this->assertSame(
+			"SELECT Id, FirstName, LastName, Description FROM Contact WHERE Email = 'trailing\\\\'",
+			$this->get_last_soql_query()
+		);
+	}
+
+	/**
+	 * Backslashes are escaped before quotes: a `\'` sequence becomes `\\\'`,
+	 * not `\\\\'` (which would leave the quote unescaped).
+	 */
+	public function test_contact_query_escapes_backslash_before_quote() {
+		self::call_salesforce( 'get_contacts_by_email', "evil\\'@example.com" );
+
+		$this->assertSame(
+			"SELECT Id, FirstName, LastName, Description FROM Contact WHERE Email = 'evil\\\\\\'@example.com'",
+			$this->get_last_soql_query()
+		);
+	}
+
+	/**
+	 * An apostrophe in a product name must not terminate the SOQL string literal.
+	 */
+	public function test_opportunity_query_escapes_apostrophe_in_product_name() {
+		list( $order_id, $order_item ) = $this->create_order_item( "Season's Pass" );
+		self::call_salesforce( 'get_opportunity_by_order_id', $order_id, $order_item );
+
+		$this->assertSame(
+			"SELECT Id, Description FROM Opportunity WHERE Name = 'Season\\'s Pass' AND Amount = 25.00 AND CloseDate = 2026-08-25",
+			$this->get_last_soql_query()
+		);
+	}
+
+	/**
+	 * A backslash in a product name must not escape the closing quote of the literal.
+	 */
+	public function test_opportunity_query_escapes_backslash_in_product_name() {
+		list( $order_id, $order_item ) = $this->create_order_item( 'Wildcard \\ Pass' );
+		self::call_salesforce( 'get_opportunity_by_order_id', $order_id, $order_item );
+
+		$this->assertSame(
+			"SELECT Id, Description FROM Opportunity WHERE Name = 'Wildcard \\\\ Pass' AND Amount = 25.00 AND CloseDate = 2026-08-25",
+			$this->get_last_soql_query()
+		);
+	}
+
+	/**
+	 * Opportunity ids stored in order meta are escaped in the IN (...) clause.
+	 */
+	public function test_opportunity_query_escapes_stored_opportunity_ids() {
+		list( , $order_item ) = $this->create_order_item( 'Donation' );
+		$order                = wc_create_order(
+			[
+				'status' => 'pending',
+				'meta'   => [ 'newspack_salesforce_opportunities' => [ "006'ABC" ] ],
+			]
+		);
+		self::call_salesforce( 'get_opportunity_by_order_id', $order->get_id(), $order_item );
+
+		$this->assertSame(
+			"SELECT Id, Description FROM Opportunity WHERE Id IN ('006\\'ABC')",
+			$this->get_last_soql_query()
+		);
+	}
+}

--- a/plugins/newspack-plugin/tests/unit-tests/salesforce-soql-escaping.php
+++ b/plugins/newspack-plugin/tests/unit-tests/salesforce-soql-escaping.php
@@ -16,6 +16,8 @@ require_once __DIR__ . '/../mocks/wc-mocks.php';
  * must not be able to terminate the SOQL string literal it lands in.
  */
 class Newspack_Test_Salesforce_Soql_Escaping extends WP_UnitTestCase {
+	const INSTANCE_URL = 'https://newspack.my.salesforce.com';
+
 	/**
 	 * URLs of intercepted Salesforce API requests.
 	 *
@@ -28,21 +30,26 @@ class Newspack_Test_Salesforce_Soql_Escaping extends WP_UnitTestCase {
 		global $orders_database;
 		$orders_database      = [];
 		$this->requested_urls = [];
-		update_option( Salesforce::SALESFORCE_INSTANCE_URL, 'https://newspack.my.salesforce.com' );
+		update_option( Salesforce::SALESFORCE_INSTANCE_URL, self::INSTANCE_URL );
 		update_option( Salesforce::SALESFORCE_ACCESS_TOKEN, 'test-access-token' );
+		// WP_UnitTestCase restores the hook state after each test, so the filter can't outlive this test case.
 		add_filter( 'pre_http_request', [ $this, 'intercept_request' ], 10, 3 );
 	}
 
 	/**
 	 * Intercept outgoing Salesforce API requests, recording the URL and
-	 * returning an empty successful query response.
+	 * returning an empty successful query response. Requests to any other
+	 * host pass through untouched.
 	 *
 	 * @param false|array $preempt     Whether to preempt the request.
 	 * @param array       $parsed_args Request arguments.
 	 * @param string      $url         Request URL.
-	 * @return array Mocked HTTP response.
+	 * @return false|array Mocked HTTP response for Salesforce requests, $preempt otherwise.
 	 */
 	public function intercept_request( $preempt, $parsed_args, $url ) {
+		if ( 0 !== strpos( $url, self::INSTANCE_URL ) ) {
+			return $preempt;
+		}
 		$this->requested_urls[] = $url;
 		return [
 			'headers'  => [],


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

The Salesforce sync interpolates reader-controlled values directly into SOQL string literals: the contact lookup uses the billing email, and the duplicate-opportunity lookup uses the order's line-item name. An apostrophe in either value (a product named `Season's Pass`) terminates the literal early, so Salesforce rejects the query and the lookup fails instead of matching — and crafted values can alter the query logic.

This adds an `escape_soql()` helper that escapes backslashes and single quotes per Salesforce's SOQL quoting rules, and applies it to every value interpolated into a quoted SOQL literal: the contact email, the line-item name, and the stored opportunity ids in the `IN (...)` lookup. Unit tests cover apostrophes, backslashes, and escape ordering in emails and product names.

### How to test the changes in this Pull Request:

1. Connect a site to Salesforce and enable the order sync (requires a Salesforce org with API access).
2. Create a WooCommerce product whose name contains an apostrophe, e.g. `Season's Pass`.
3. Complete an order for it. The order syncs: a Contact and an Opportunity are created in Salesforce.
4. Re-sync the same order. The existing Opportunity is updated, not duplicated — the duplicate lookup now succeeds.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

`Amount` and `CloseDate` in the opportunity lookup are unquoted number/date literals sourced from WooCommerce internals, so the string escaping deliberately leaves them alone.
