### PR TITLE
feat(content-gate): send IP-access page usage to GA4

### DIFF
--- a/plugins/newspack-plugin/includes/content-gate/class-ip-access-rule.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-ip-access-rule.php
@@ -512,13 +512,6 @@ class IP_Access_Rule {
 			return;
 		}
 
-		// Both legitimate flows set the bypass cookie before redirecting here,
-		// so a success param without it is a shared or hand-crafted URL — it
-		// must not inject a `connected` event into the publisher's data.
-		if ( 'success' === $result && ! self::is_cookie_set() ) {
-			return;
-		}
-
 		$payload = [
 			'action' => 'success' === $result ? 'connected' : 'not_verified',
 		];
@@ -528,6 +521,13 @@ class IP_Access_Rule {
 		$institution_id = isset( $_GET['institution-id'] ) ? absint( $_GET['institution-id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 		if ( $institution_id ) {
 			$payload['institution'] = 'Institution ' . $institution_id;
+		}
+		// Both legitimate flows set the bypass cookie before redirecting here,
+		// so a success param without it is a shared or hand-crafted URL — it
+		// must not inject a `connected` event into the publisher's data. The
+		// URL cleanup below still runs, so the params don't stick around.
+		if ( 'success' === $result && ! self::is_cookie_set() ) {
+			$payload = null;
 		}
 		?>
 		<script>
@@ -541,6 +541,9 @@ class IP_Access_Rule {
 					url.searchParams.delete( param );
 				} );
 				window.history.replaceState( window.history.state, '', url.toString() );
+			}
+			if ( ! payload ) {
+				return;
 			}
 			var tries = 0;
 			( function send() {

--- a/plugins/newspack-plugin/includes/content-gate/class-ip-access-rule.php
+++ b/plugins/newspack-plugin/includes/content-gate/class-ip-access-rule.php
@@ -74,6 +74,14 @@ class IP_Access_Rule {
 		add_action( 'init', [ __CLASS__, 'add_rewrite_rule' ] );
 		add_action( 'rest_api_init', [ __CLASS__, 'register_rest_route' ] );
 		add_action( 'template_redirect', [ __CLASS__, 'handle_redirect' ] );
+		// After third-party tag registration: Site Kit modules register their
+		// GA4/GTM snippet printing on template_redirect at priority 10, and the
+		// landing page renders and exits — at the default priority the
+		// publisher's analytics tag is never registered for it and the page
+		// sends no pageview. Only the rendering branch runs late; the
+		// query-param redirect in handle_redirect() emits no HTML and stays at
+		// the default priority so other redirect handlers can't pre-empt it.
+		add_action( 'template_redirect', [ __CLASS__, 'handle_landing_page' ], 100 );
 		add_action( 'template_redirect', [ __CLASS__, 'handle_result_notice' ] );
 	}
 
@@ -167,6 +175,7 @@ class IP_Access_Rule {
 		$institution_id = $request->get_param( 'institution_id' );
 		$valid          = false;
 		$inst_name      = '';
+		$matched_id     = 0;
 
 		if ( $institution_id ) {
 			$institutions = \Newspack\Institution::get_cached_institutions();
@@ -174,13 +183,15 @@ class IP_Access_Rule {
 				$user_id  = get_current_user_id();
 				$valid    = \Newspack\Institution::user_matches_institution( $user_id, $institutions[ $institution_id ], true );
 				$inst_name = get_the_title( $institution_id );
+				$matched_id = (int) $institution_id;
 			}
 		} else {
 			/** This filter is documented in handle_redirect(). */
 			$result = apply_filters( 'newspack_content_gate_check_ip', false );
 			$valid  = (bool) $result;
 			if ( is_int( $result ) ) {
-				$inst_name = get_the_title( $result );
+				$inst_name  = get_the_title( $result );
+				$matched_id = $result;
 			}
 		}
 
@@ -191,9 +202,13 @@ class IP_Access_Rule {
 		$data = [ 'valid' => $valid ];
 		// Only disclose the institution name to a visitor who actually matched it;
 		// otherwise an unauthenticated caller could enumerate every institution's
-		// name by iterating institution_id.
+		// name by iterating institution_id. The ID gets the same treatment for
+		// symmetry, and lets the destination page label its GA4 event.
 		if ( $valid && $inst_name ) {
 			$data['institution'] = $inst_name;
+		}
+		if ( $valid && $matched_id ) {
+			$data['institution_id'] = $matched_id;
 		}
 
 		return new \WP_REST_Response( $data );
@@ -321,50 +336,27 @@ class IP_Access_Rule {
 	}
 
 	/**
-	 * Handle the institutional access check.
+	 * Handle the query-param institutional access check.
 	 *
 	 * For `?institutional-access=1` or `?institutional-access` on any URL:
 	 * performs the IP check server-side, then redirects back to the same URL
-	 * with a result parameter.
-	 *
-	 * For the dedicated `/institutional-access` endpoint: renders a loading page
-	 * that performs the check via the REST API and redirects on completion.
+	 * with a result parameter. The dedicated `/institutional-access` endpoint
+	 * is handled by handle_landing_page() instead.
 	 */
 	public static function handle_redirect() {
 		if ( ! get_query_var( self::ENDPOINT ) && ! isset( $_GET[ self::ENDPOINT ] ) ) { // phpcs:ignore WordPress.Security.NonceVerification.Recommended
 			return;
 		}
+		if ( self::is_landing_page_request() ) {
+			return;
+		}
 
-		// Never cache this page.
+		// Never cache this response.
 		if ( function_exists( 'batcache_cancel' ) ) {
 			batcache_cancel();
 		}
 		nocache_headers();
 
-		// Check if this is the dedicated endpoint or a query param on a regular URL.
-		$slug = get_query_var( self::ENDPOINT . '-slug' );
-		$request_path = wp_parse_url( $_SERVER['REQUEST_URI'], PHP_URL_PATH ); // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
-		$is_dedicated = $slug || (bool) preg_match( '#^/?' . preg_quote( self::ENDPOINT, '#' ) . '/?$#', trim( $request_path, '/' ) );
-
-		if ( $is_dedicated ) {
-			$institution_id = null;
-			if ( $slug ) {
-				$posts = get_posts(
-					[
-						'post_type'      => \Newspack\Institution::POST_TYPE,
-						'name'           => sanitize_title( $slug ),
-						'posts_per_page' => 1,
-						'post_status'    => 'publish',
-						'fields'         => 'ids',
-					]
-				);
-				$institution_id = ! empty( $posts ) ? $posts[0] : null;
-			}
-			self::render_loading_page( $institution_id );
-			exit;
-		}
-
-		// Query param on a regular URL: server-side check and redirect.
 		/**
 		 * Filter whether the current IP is valid for content gate access.
 		 *
@@ -376,13 +368,89 @@ class IP_Access_Rule {
 			self::set_cookie();
 		}
 
-		$redirect_url = self::get_redirect_url();
-		$redirect_url = add_query_arg( self::RESULT_PARAM, $result ? 'success' : 'failure', $redirect_url );
-		if ( is_int( $result ) ) {
-			$redirect_url = add_query_arg( 'institution', rawurlencode( get_the_title( $result ) ), $redirect_url );
-		}
-		wp_safe_redirect( $redirect_url );
+		wp_safe_redirect( self::get_result_redirect_url( $result ) );
 		exit;
+	}
+
+	/**
+	 * Render the loading page on the dedicated `/institutional-access` endpoint.
+	 *
+	 * Hooked late on template_redirect (see init()) so third-party analytics
+	 * tags are registered before the page renders and exits.
+	 */
+	public static function handle_landing_page() {
+		if ( ! self::is_landing_page_request() ) {
+			return;
+		}
+
+		// Never cache this page.
+		if ( function_exists( 'batcache_cancel' ) ) {
+			batcache_cancel();
+		}
+		nocache_headers();
+
+		$institution_id = null;
+		$slug           = get_query_var( self::ENDPOINT . '-slug' );
+		if ( $slug ) {
+			$posts = get_posts(
+				[
+					'post_type'      => \Newspack\Institution::POST_TYPE,
+					'name'           => sanitize_title( $slug ),
+					'posts_per_page' => 1,
+					'post_status'    => 'publish',
+					'fields'         => 'ids',
+				]
+			);
+			$institution_id = ! empty( $posts ) ? $posts[0] : null;
+		}
+		self::render_loading_page( $institution_id );
+		exit;
+	}
+
+	/**
+	 * Whether the current request is for the dedicated landing page — the
+	 * rendered loading page — as opposed to the query-param flow on a regular
+	 * URL, which redirects without rendering anything. Public because the
+	 * Perfmatters integration vetoes JS delay on this request.
+	 *
+	 * @return bool
+	 */
+	public static function is_landing_page_request() {
+		// On the dedicated endpoint the query var comes from the rewrite rule;
+		// the query-param flow sets it through $_GET (which WP mirrors into the
+		// query var). Query var without the GET param therefore identifies the
+		// rendered landing page at any install depth, with no path parsing —
+		// a path check would misclassify subdirectory installs.
+		return (bool) get_query_var( self::ENDPOINT ) && ! isset( $_GET[ self::ENDPOINT ] ); // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+	}
+
+	/**
+	 * Build the query-param flow's post-check redirect URL: the current URL
+	 * without the endpoint param, carrying the result and, on a match, the
+	 * institution's name (for the snackbar) and ID (for the GA4 event).
+	 *
+	 * @param bool|int $result IP check result: institution post ID on a match, false otherwise.
+	 *
+	 * @return string The redirect URL.
+	 */
+	private static function get_result_redirect_url( $result ) {
+		$redirect_url = self::get_redirect_url();
+		if ( is_int( $result ) ) {
+			$redirect_url = add_query_arg(
+				[
+					'institution'    => rawurlencode( get_the_title( $result ) ),
+					'institution-id' => $result,
+				],
+				$redirect_url
+			);
+		} else {
+			// get_redirect_url() carries over the current query string, so a
+			// failed re-check must not inherit a previous success's institution
+			// params — the destination page would label its not_verified event
+			// with an institution the visitor did not match.
+			$redirect_url = remove_query_arg( [ 'institution', 'institution-id' ], $redirect_url );
+		}
+		return add_query_arg( self::RESULT_PARAM, $result ? 'success' : 'failure', $redirect_url );
 	}
 
 	/**
@@ -422,6 +490,71 @@ class IP_Access_Rule {
 				]
 			);
 		}
+
+		if ( in_array( $result, [ 'success', 'failure' ], true ) ) {
+			add_action( 'wp_footer', [ __CLASS__, 'print_result_event' ] );
+		}
+	}
+
+	/**
+	 * Print the GA4 event for a redirect-borne IP-check outcome.
+	 *
+	 * Fires np_institutional_access on the page the check redirected back to —
+	 * for both the query-param flow and the dedicated landing page's success
+	 * path. The landing page never fires `connected` itself, so a success is
+	 * counted exactly once. gtag is polled for because Perfmatters' JS delay
+	 * releases analytics scripts only on first user interaction, which typically
+	 * happens after this script runs.
+	 */
+	public static function print_result_event() {
+		$result = isset( $_GET[ self::RESULT_PARAM ] ) ? sanitize_text_field( wp_unslash( $_GET[ self::RESULT_PARAM ] ) ) : ''; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( ! in_array( $result, [ 'success', 'failure' ], true ) ) {
+			return;
+		}
+
+		// Both legitimate flows set the bypass cookie before redirecting here,
+		// so a success param without it is a shared or hand-crafted URL — it
+		// must not inject a `connected` event into the publisher's data.
+		if ( 'success' === $result && ! self::is_cookie_set() ) {
+			return;
+		}
+
+		$payload = [
+			'action' => 'success' === $result ? 'connected' : 'not_verified',
+		];
+		// The event param uses the same anonymized identifier as the GA4 `group`
+		// dimension, not the institution's display name (which the URL still
+		// carries for the snackbar).
+		$institution_id = isset( $_GET['institution-id'] ) ? absint( $_GET['institution-id'] ) : 0; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		if ( $institution_id ) {
+			$payload['institution'] = 'Institution ' . $institution_id;
+		}
+		?>
+		<script>
+		( function() {
+			var payload = <?php echo wp_json_encode( $payload ); ?>;
+			// Strip the result params so a reload, back-button return, or shared
+			// URL doesn't fire another event (or re-exempt the page from cache).
+			if ( window.history && window.history.replaceState && window.URL ) {
+				var url = new URL( window.location.href );
+				[ <?php echo wp_json_encode( self::RESULT_PARAM ); ?>, 'institution', 'institution-id' ].forEach( function( param ) {
+					url.searchParams.delete( param );
+				} );
+				window.history.replaceState( window.history.state, '', url.toString() );
+			}
+			var tries = 0;
+			( function send() {
+				if ( 'function' === typeof window.gtag ) {
+					window.gtag( 'event', 'np_institutional_access', payload );
+					return;
+				}
+				if ( tries++ < 60 ) {
+					setTimeout( send, 500 );
+				}
+			} )();
+		} )();
+		</script>
+		<?php
 	}
 
 	/**
@@ -568,10 +701,34 @@ class IP_Access_Rule {
 				var detailEl  = document.getElementById( 'ip-check-detail' );
 				var redirectUrl = <?php echo wp_json_encode( $redirect_url ); ?>;
 				var resultParam = <?php echo wp_json_encode( $result_param ); ?>;
+				var institutionLabel = <?php echo wp_json_encode( $institution_id ? 'Institution ' . $institution_id : '' ); ?>;
+
+				// Only the outcomes that never leave this page are reported here;
+				// a success redirects, and the destination page fires `connected`.
+				// gtag is polled for so a tag that loads after the outcome (JS
+				// delay, slow network) still records it; the page stays open on
+				// every outcome reported here, so late delivery is fine.
+				function sendEvent( action ) {
+					var payload = { action: action };
+					if ( institutionLabel ) {
+						payload.institution = institutionLabel;
+					}
+					var tries = 0;
+					( function send() {
+						if ( 'function' === typeof window.gtag ) {
+							window.gtag( 'event', 'np_institutional_access', payload );
+							return;
+						}
+						if ( tries++ < 60 ) {
+							setTimeout( send, 500 );
+						}
+					} )();
+				}
 
 				var controller = new AbortController();
 				var timer = setTimeout( function() {
 					controller.abort();
+					sendEvent( "timeout" );
 					showError(
 						<?php echo wp_json_encode( __( 'Verification timed out.', 'newspack-plugin' ) ); ?>,
 						<?php echo wp_json_encode( __( 'Please check your connection and try again.', 'newspack-plugin' ) ); ?>
@@ -597,20 +754,36 @@ class IP_Access_Rule {
 						setTimeout( function() {
 							var url = new URL( redirectUrl, location.origin );
 							url.searchParams.set( resultParam, 'success' );
+							// redirectUrl comes from redirect_to/referer, so never
+							// let institution params ride through from it — only
+							// the REST response labels this verification.
+							url.searchParams.delete( 'institution' );
+							url.searchParams.delete( 'institution-id' );
 							if ( data.institution ) {
 								url.searchParams.set( 'institution', data.institution );
+							}
+							if ( data.institution_id ) {
+								url.searchParams.set( 'institution-id', data.institution_id );
 							}
 							location.href = url.toString();
 						}, 1500 );
 					} else {
+						sendEvent( "not_verified" );
 						showError(
 							<?php echo wp_json_encode( __( "We couldn't verify your location.", 'newspack-plugin' ) ); ?>,
 							<?php echo wp_json_encode( __( "Make sure you're on your organization's network and try again.", 'newspack-plugin' ) ); ?>
 						);
 					}
 				} )
-				.catch( function() {
+				.catch( function( err ) {
 					clearTimeout( timer );
+					// An abort is the timeout firing: its event and message are
+					// already handled above, and the generic copy must not
+					// overwrite the timeout copy the visitor is reading.
+					if ( err && 'AbortError' === err.name ) {
+						return;
+					}
+					sendEvent( "error" );
 					showError(
 						<?php echo wp_json_encode( __( 'Verification failed.', 'newspack-plugin' ) ); ?>,
 						<?php echo wp_json_encode( __( 'An error occurred. Please try again.', 'newspack-plugin' ) ); ?>

--- a/plugins/newspack-plugin/includes/plugins/class-perfmatters.php
+++ b/plugins/newspack-plugin/includes/plugins/class-perfmatters.php
@@ -436,6 +436,14 @@ class Perfmatters {
 		if ( Lite_Site::is_lite_site_request() ) {
 			return false;
 		}
+		// The IP-access landing page auto-redirects with no user interaction, so
+		// delayed analytics would never execute and the visit would go unrecorded.
+		// Like the lite-site veto above, this holds even under
+		// NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS: it is a functional requirement of
+		// the page, not a configuration default.
+		if ( class_exists( 'Newspack\Content_Gate\IP_Access_Rule' ) && Content_Gate\IP_Access_Rule::is_landing_page_request() ) {
+			return false;
+		}
 		return $delay_js;
 	}
 

--- a/plugins/newspack-plugin/includes/plugins/class-perfmatters.php
+++ b/plugins/newspack-plugin/includes/plugins/class-perfmatters.php
@@ -441,7 +441,9 @@ class Perfmatters {
 		// Like the lite-site veto above, this holds even under
 		// NEWSPACK_IGNORE_PERFMATTERS_DEFAULTS: it is a functional requirement of
 		// the page, not a configuration default.
-		if ( class_exists( 'Newspack\Content_Gate\IP_Access_Rule' ) && Content_Gate\IP_Access_Rule::is_landing_page_request() ) {
+		// No autoload: the class self-initializes on load, and it is only ever
+		// loaded deliberately, when content gates are enabled.
+		if ( class_exists( 'Newspack\Content_Gate\IP_Access_Rule', false ) && Content_Gate\IP_Access_Rule::is_landing_page_request() ) {
 			return false;
 		}
 		return $delay_js;

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -1231,11 +1231,14 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 		$this->assertNotFalse( has_action( 'wp_footer', [ IP_Access_Rule::class, 'print_result_event' ] ) );
 
 		// Without the bypass cookie the success param is a shared or
-		// hand-crafted URL, and no event may be injected from it.
+		// hand-crafted URL: no event may be injected from it, but the URL
+		// cleanup still runs so the params don't survive reloads.
 		unset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 		ob_start();
 		IP_Access_Rule::print_result_event();
-		$this->assertSame( '', ob_get_clean() );
+		$gated_script = ob_get_clean();
+		$this->assertStringContainsString( 'var payload = null', $gated_script, 'No connected event without the bypass cookie.' );
+		$this->assertStringContainsString( 'replaceState', $gated_script, 'URL cleanup runs even when the event is withheld.' );
 
 		$_COOKIE[ IP_Access_Rule::COOKIE_NAME ] = '1'; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
 		ob_start();

--- a/plugins/newspack-plugin/tests/unit-tests/content-gate/class-ip-access-rule.php
+++ b/plugins/newspack-plugin/tests/unit-tests/content-gate/class-ip-access-rule.php
@@ -1031,4 +1031,233 @@ class Newspack_Test_IP_Access_Rule extends WP_UnitTestCase {
 		$this->assertSame( [ '0.0.0.0/0' ], $mixed['valid'], 'Leading-zero mask bits are canonicalized.' );
 		$this->assertSame( [ 'not-an-ip', '2001:db8::/32' ], $mixed['invalid'], 'Invalid entries are surfaced in their trimmed original form.' );
 	}
+
+	/**
+	 * Site Kit modules register their GA4/GTM tag printing on template_redirect at
+	 * priority 10. The landing page renders and exits, so it must run after them —
+	 * at priority 10 the page exits before the publisher's tag is registered and
+	 * sends no pageview to the publisher's property. The query-param redirect
+	 * emits no HTML and stays at the default priority, so other redirect handlers
+	 * on template_redirect can't pre-empt the check.
+	 */
+	public function test_landing_page_renders_after_third_party_tag_registration() {
+		$handle_landing_page_priority = has_action( 'template_redirect', [ IP_Access_Rule::class, 'handle_landing_page' ] );
+		$this->assertNotFalse( $handle_landing_page_priority );
+		$this->assertGreaterThan( 10, $handle_landing_page_priority );
+
+		$handle_redirect_priority = has_action( 'template_redirect', [ IP_Access_Rule::class, 'handle_redirect' ] );
+		$this->assertSame( 10, $handle_redirect_priority );
+	}
+
+	/**
+	 * The landing-page request check is true only for the dedicated endpoint
+	 * (the rendered loading page), not for the query-param flow on a regular URL
+	 * and not for unrelated requests. Perfmatters JS delay is vetoed based on it.
+	 */
+	public function test_landing_page_request_detection() {
+		$original_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$original_get = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		// Dedicated endpoint with an institution slug.
+		set_query_var( IP_Access_Rule::ENDPOINT, '1' );
+		set_query_var( IP_Access_Rule::ENDPOINT . '-slug', 'test-university' );
+		$_SERVER['REQUEST_URI'] = '/institutional-access/test-university/';
+		$this->assertTrue( IP_Access_Rule::is_landing_page_request() );
+
+		// Dedicated generic endpoint.
+		set_query_var( IP_Access_Rule::ENDPOINT . '-slug', '' );
+		$_SERVER['REQUEST_URI'] = '/institutional-access/';
+		$this->assertTrue( IP_Access_Rule::is_landing_page_request() );
+
+		// Subdirectory install: the path carries the home path prefix, but the
+		// classification must not depend on the path at all.
+		$_SERVER['REQUEST_URI'] = '/blog/institutional-access/';
+		$this->assertTrue( IP_Access_Rule::is_landing_page_request() );
+
+		// Query-param flow on a regular URL: redirects, never renders the page.
+		// WP mirrors the registered query var from $_GET, so both are set.
+		$_GET                   = [ IP_Access_Rule::ENDPOINT => '1' ];
+		$_SERVER['REQUEST_URI'] = '/some-article/?institutional-access=1';
+		$this->assertFalse( IP_Access_Rule::is_landing_page_request() );
+		set_query_var( IP_Access_Rule::ENDPOINT, '' );
+
+		// Unrelated request.
+		$_GET                   = [];
+		$_SERVER['REQUEST_URI'] = '/some-article/';
+		$this->assertFalse( IP_Access_Rule::is_landing_page_request() );
+
+		if ( null === $original_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $original_uri;
+		}
+		$_GET = $original_get;
+	}
+
+	/**
+	 * The loading page fires a np_institutional_access GA4 event for the outcomes
+	 * that never leave the page (not_verified, timeout, error), labeled with the
+	 * anonymized institution identifier used by the GA4 `group` dimension.
+	 */
+	public function test_loading_page_outputs_outcome_events() {
+		$inst_id = \Newspack\Institution::create(
+			'Events Test University',
+			'',
+			[ 'ip_range' => '192.168.1.0/24' ]
+		);
+		$this->assertIsInt( $inst_id );
+
+		ob_start();
+		IP_Access_Rule::render_loading_page( $inst_id );
+		$html = ob_get_clean();
+
+		$this->assertStringContainsString( 'np_institutional_access', $html );
+		$this->assertMatchesRegularExpression( '/sendEvent\(\s*["\']not_verified["\']\s*\)/', $html );
+		$this->assertMatchesRegularExpression( '/sendEvent\(\s*["\']timeout["\']\s*\)/', $html );
+		$this->assertMatchesRegularExpression( '/sendEvent\(\s*["\']error["\']\s*\)/', $html );
+		$this->assertDoesNotMatchRegularExpression(
+			'/sendEvent\(\s*["\']connected["\']/',
+			$html,
+			'A success redirects and the destination page fires `connected` — firing it here too would double-count every verification.'
+		);
+		$this->assertStringContainsString( 'Institution ' . $inst_id, $html );
+
+		wp_delete_post( $inst_id, true );
+	}
+
+	/**
+	 * The REST check response carries the matched institution's ID, so the landing
+	 * page can label the destination-page GA4 event without disclosing anything a
+	 * non-matching visitor could not already see.
+	 */
+	public function test_rest_response_includes_institution_id() {
+		$original_addr = isset( $_SERVER['REMOTE_ADDR'] ) ? $_SERVER['REMOTE_ADDR'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput, WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+
+		$inst_id = \Newspack\Institution::create(
+			'REST ID Test Library',
+			'',
+			[ 'ip_range' => '192.168.1.0/24' ]
+		);
+		$this->assertIsInt( $inst_id );
+		delete_transient( \Newspack\Institution::TRANSIENT_KEY );
+
+		$_SERVER['REMOTE_ADDR'] = '192.168.1.50'; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+
+		$request = new WP_REST_Request( 'GET', '/' . NEWSPACK_API_NAMESPACE . IP_Access_Rule::REST_ROUTE );
+		$request->set_param( 'institution_id', $inst_id );
+		$response = @rest_do_request( $request ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- nocache_headers cannot send headers in tests.
+		$data     = $response->get_data();
+
+		$this->assertTrue( $data['valid'] );
+		$this->assertSame( $inst_id, $data['institution_id'] );
+
+		// A non-matching visitor gets no institution_id, mirroring the name rule.
+		$_SERVER['REMOTE_ADDR'] = '10.0.0.1'; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		$response               = @rest_do_request( $request ); // phpcs:ignore WordPress.PHP.NoSilencedErrors.Discouraged -- nocache_headers cannot send headers in tests.
+		$this->assertArrayNotHasKey( 'institution_id', $response->get_data() );
+
+		if ( null === $original_addr ) {
+			unset( $_SERVER['REMOTE_ADDR'] ); // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		} else {
+			$_SERVER['REMOTE_ADDR'] = $original_addr; // phpcs:ignore WordPressVIPMinimum.Variables.ServerVariables.UserControlledHeaders, WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__REMOTE_ADDR__
+		}
+		wp_delete_post( $inst_id, true );
+	}
+
+	/**
+	 * The query-param flow's redirect URL carries the matched institution's ID, so
+	 * the destination page can label its GA4 event.
+	 */
+	public function test_result_redirect_url_includes_institution_id() {
+		$original_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+		$original_get = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+
+		$inst_id = \Newspack\Institution::create(
+			'Redirect Test University',
+			'',
+			[ 'ip_range' => '192.168.1.0/24' ]
+		);
+		$this->assertIsInt( $inst_id );
+
+		$_SERVER['REQUEST_URI'] = '/some-article/?institutional-access=1';
+		$_GET                   = [ IP_Access_Rule::ENDPOINT => '1' ];
+
+		$get_result_redirect_url_method = new ReflectionMethod( IP_Access_Rule::class, 'get_result_redirect_url' );
+		$get_result_redirect_url_method->setAccessible( true );
+
+		$success_url = $get_result_redirect_url_method->invoke( null, $inst_id );
+		$this->assertStringContainsString( IP_Access_Rule::RESULT_PARAM . '=success', $success_url );
+		$this->assertStringContainsString( 'institution-id=' . $inst_id, $success_url );
+
+		// A failed re-check on a URL still carrying a previous success's
+		// institution params must not pass them through — the destination page
+		// would label its not_verified event with an institution the visitor
+		// did not match.
+		$_GET = [
+			IP_Access_Rule::ENDPOINT => '1',
+			'institution'            => 'Stale University',
+			'institution-id'         => '123',
+		];
+		$failure_url = $get_result_redirect_url_method->invoke( null, false );
+		$this->assertStringContainsString( IP_Access_Rule::RESULT_PARAM . '=failure', $failure_url );
+		$this->assertStringNotContainsString( 'institution-id', $failure_url );
+		$this->assertStringNotContainsString( 'Stale', $failure_url );
+
+		if ( null === $original_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $original_uri;
+		}
+		$_GET = $original_get;
+		wp_delete_post( $inst_id, true );
+	}
+
+	/**
+	 * The destination page fires the redirect-borne outcome as a GA4 event: the
+	 * result notice handler registers a footer printer whose script sends
+	 * np_institutional_access with the action and institution from the URL params.
+	 * Redirect outcomes fire only here — the loading page does not also send a
+	 * `connected` event, so a success is never double-counted.
+	 */
+	public function test_result_notice_prints_ga_event() {
+		$original_get    = $_GET; // phpcs:ignore WordPress.Security.NonceVerification.Recommended
+		$original_cookie = $_COOKIE; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+
+		$_GET = [
+			IP_Access_Rule::RESULT_PARAM => 'success',
+			'institution-id'             => '37',
+		];
+		IP_Access_Rule::handle_result_notice();
+		$this->assertNotFalse( has_action( 'wp_footer', [ IP_Access_Rule::class, 'print_result_event' ] ) );
+
+		// Without the bypass cookie the success param is a shared or
+		// hand-crafted URL, and no event may be injected from it.
+		unset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		ob_start();
+		IP_Access_Rule::print_result_event();
+		$this->assertSame( '', ob_get_clean() );
+
+		$_COOKIE[ IP_Access_Rule::COOKIE_NAME ] = '1'; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		ob_start();
+		IP_Access_Rule::print_result_event();
+		$success_script = ob_get_clean();
+		$this->assertStringContainsString( 'np_institutional_access', $success_script );
+		$this->assertStringContainsString( '"connected"', $success_script );
+		$this->assertStringContainsString( 'Institution 37', $success_script );
+		$this->assertStringContainsString( 'replaceState', $success_script, 'The result params must be stripped from the URL, or a reload or shared link fires another event.' );
+
+		// A failure sets no cookie, so its event is not cookie-gated.
+		unset( $_COOKIE[ IP_Access_Rule::COOKIE_NAME ] ); // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+		$_GET = [
+			IP_Access_Rule::RESULT_PARAM => 'failure',
+		];
+		ob_start();
+		IP_Access_Rule::print_result_event();
+		$failure_script = ob_get_clean();
+		$this->assertStringContainsString( '"not_verified"', $failure_script );
+		$this->assertStringNotContainsString( 'Institution ', $failure_script );
+
+		$_GET    = $original_get;
+		$_COOKIE = $original_cookie; // phpcs:ignore WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___COOKIE
+	}
 }

--- a/plugins/newspack-plugin/tests/unit-tests/perfmatters.php
+++ b/plugins/newspack-plugin/tests/unit-tests/perfmatters.php
@@ -214,6 +214,33 @@ class Newspack_Test_Perfmatters extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Perfmatters "Delay JavaScript" executes scripts on first user interaction,
+	 * and the IP-access landing page auto-redirects with no interaction — a
+	 * delayed gtag never runs there, so no pageview or event is ever sent. The
+	 * delay is vetoed on that request; everywhere else the configured value
+	 * passes through.
+	 */
+	public function test_delay_js_vetoed_on_ip_access_landing_page() {
+		$original_uri = isset( $_SERVER['REQUEST_URI'] ) ? $_SERVER['REQUEST_URI'] : null; // phpcs:ignore WordPress.Security.ValidatedSanitizedInput
+
+		$_SERVER['REQUEST_URI'] = '/some-article/';
+		$this->assertTrue( Perfmatters::should_delay_js( true ), 'The configured value passes through on a regular request.' );
+
+		set_query_var( \Newspack\Content_Gate\IP_Access_Rule::ENDPOINT, '1' );
+		set_query_var( \Newspack\Content_Gate\IP_Access_Rule::ENDPOINT . '-slug', 'test-university' );
+		$_SERVER['REQUEST_URI'] = '/institutional-access/test-university/';
+		$this->assertFalse( Perfmatters::should_delay_js( true ), 'JS delay is vetoed on the landing page request.' );
+
+		set_query_var( \Newspack\Content_Gate\IP_Access_Rule::ENDPOINT, '' );
+		set_query_var( \Newspack\Content_Gate\IP_Access_Rule::ENDPOINT . '-slug', '' );
+		if ( null === $original_uri ) {
+			unset( $_SERVER['REQUEST_URI'] );
+		} else {
+			$_SERVER['REQUEST_URI'] = $original_uri;
+		}
+	}
+
+	/**
 	 * A saved option that already carries the manually-applied workaround entry
 	 * doesn't end up with duplicates after the defaults merge.
 	 */


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

IP-access landing pages send no usage data to the publisher's GA4: Site Kit registers its GA4/GTM tag on `template_redirect` at priority 10, and the landing page rendered and exited at the same hook and priority, before the tag printed; and Perfmatters' "Delay JavaScript" releases scripts on first interaction, which never happens on a page that auto-redirects.

This PR renders the landing page at priority 100 (the query-param redirect flow stays at 10), vetoes Perfmatters JS delay on that request, and adds a `np_institutional_access` GA4 event: `connected` fires once on the destination page (cookie-gated, and the result params are stripped via `history.replaceState` so reloads and shared URLs stay silent), while `not_verified`, `timeout`, and `error` fire on the landing page. Events carry an `institution` param in the `group` dimension's anonymized `Institution {id}` vocabulary. Per-institution pageview counts come from the page path; site-wide access attribution already exists via the `group` and `access_source` dimensions.

Closes NPPD-2197.

![Landing page verifying access](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/27/jhxe38c5-step-1-landing-page-verifying-spinner.png)

### How to test the changes in this Pull Request:

1. Add `define( 'NEWSPACK_CONTENT_GATES', true );` to `wp-config.php`.
2. In Audience > Content Gates > Institutions, create an institution with IP range `0.0.0.0/0`.
3. Visit `/institutional-access/<institution-slug>/`. Expected: a verifying spinner, then a redirect with a "Connected to…" snackbar.
4. Within 30 seconds, run `window.gtag = console.log` in the browser console. Expected: it logs `event np_institutional_access` with action `connected` and `Institution <id>`.
5. Reload the page. Expected: the result URL params are gone and no second event logs.
6. Open `/<any-path>/?institutional-access-result=success&institution-id=7` in a private window. Expected: no event logs (no bypass cookie).
7. Set the institution's IP range to `203.0.113.0/24` and revisit its landing page. Expected: an error state, and the console stub logs action `not_verified`.
8. With Site Kit Analytics connected, view the landing page source. Expected: the Site Kit gtag snippet is present.

![Destination page with Connected snackbar](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/27/zggi4k61-step-2-destination-page-connected-snackbar.png)

![Landing page not-verified error state](https://newspack-verification-artifacts.s3.us-east-2.amazonaws.com/pr-embeds/2026/08/27/x9l9v0ci-step-3-landing-page-not-verified-error.png)

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [x] Have you written new tests for your changes, as applicable?
* [x] Have you successfully run tests with your changes locally?

The landing-page request check no longer parses the request path, which also fixes a redirect loop on the generic endpoint of subdirectory installs. The `institution` event param is deliberately not registered as a GA4 custom dimension (the 50-dimension cap); it stays available in the raw export, and per-institution landing traffic is readable from the page path.

