### PR TITLE
fix(network): bound memory in data-backfill so long ranges finish

### DIFF
--- a/plugins/newspack-network/includes/cli/backfillers/class-abstract-backfiller.php
+++ b/plugins/newspack-network/includes/cli/backfillers/class-abstract-backfiller.php
@@ -94,7 +94,10 @@ abstract class Abstract_Backfiller {
 	/**
 	 * Gets the events to be processed
 	 *
-	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 * Iterated once by process_events(), so an implementation may return an array or
+	 * yield — whichever suits the size of the set it is drawing from.
+	 *
+	 * @return iterable<\Newspack_Network\Incoming_Events\Abstract_Incoming_Event> The events.
 	 */
 	abstract public function get_events();
 
@@ -117,6 +120,7 @@ abstract class Abstract_Backfiller {
 	public function process_events() {
 		$events    = $this->get_events();
 		$processed = 0;
+		$can_clear = function_exists( 'WP_CLI\Utils\wp_clear_object_cache' );
 
 		foreach ( $events as $event ) {
 
@@ -127,7 +131,7 @@ abstract class Abstract_Backfiller {
 			// rather than the cache the whole site is sharing — which is what
 			// wp_cache_flush() would do.
 			++$processed;
-			if ( 0 === $processed % self::CLEAR_CACHE_EVERY && function_exists( 'WP_CLI\Utils\wp_clear_object_cache' ) ) {
+			if ( $can_clear && 0 === $processed % self::CLEAR_CACHE_EVERY ) {
 				\WP_CLI\Utils\wp_clear_object_cache();
 			}
 

--- a/plugins/newspack-network/includes/cli/backfillers/class-abstract-backfiller.php
+++ b/plugins/newspack-network/includes/cli/backfillers/class-abstract-backfiller.php
@@ -17,6 +17,22 @@ use WP_CLI;
 abstract class Abstract_Backfiller {
 
 	/**
+	 * How often, in events, to drop WordPress's in-process object cache.
+	 *
+	 * Bounds the memory a backfill uses so it no longer scales with the length of the
+	 * range being backfilled.
+	 */
+	const CLEAR_CACHE_EVERY = 100;
+
+	/**
+	 * How many records to load per batch when a backfiller queries in batches.
+	 *
+	 * Sized so a batch is comfortably small on a site with a heavy plugin set, while
+	 * still amortising the query overhead across a useful number of records.
+	 */
+	const BATCH_SIZE = 500;
+
+	/**
 	 * Whether to run the backfiller in live mode.
 	 *
 	 * @var bool
@@ -99,9 +115,21 @@ abstract class Abstract_Backfiller {
 	 * Process the events.
 	 */
 	public function process_events() {
-		$events = $this->get_events();
+		$events    = $this->get_events();
+		$processed = 0;
 
 		foreach ( $events as $event ) {
+
+			// Every event read populates the object cache, which never shrinks, so a
+			// long enough backfill exhausts the memory limit no matter how little each
+			// event costs. WP-CLI's helper empties the in-process cache and the query
+			// log without flushing a persistent backend, so this frees our own memory
+			// rather than the cache the whole site is sharing — which is what
+			// wp_cache_flush() would do.
+			++$processed;
+			if ( 0 === $processed % self::CLEAR_CACHE_EVERY && function_exists( 'WP_CLI\Utils\wp_clear_object_cache' ) ) {
+				\WP_CLI\Utils\wp_clear_object_cache();
+			}
 
 			if ( Site_Role::is_node() ) {
 				$requests = $this->find_webhook_requests( $event->get_action_name(), $event->get_timestamp(), $event->get_data() );

--- a/plugins/newspack-network/includes/cli/backfillers/class-reader-registered.php
+++ b/plugins/newspack-network/includes/cli/backfillers/class-reader-registered.php
@@ -28,15 +28,28 @@ class Reader_Registered extends Abstract_Backfiller {
 	/**
 	 * Gets the events to be processed
 	 *
-	 * @return \Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events An array of events.
+	 * Yields one event at a time rather than returning them all, and loads the users
+	 * behind them in batches. Building the full list up front meant a year's worth of
+	 * registrations on a busy site — tens of thousands of users and an event object
+	 * each — had to fit in memory before the first one could be processed, which on a
+	 * site with a heavy plugin set exhausts the memory limit. The caller only ever
+	 * iterates the result, so yielding costs nothing.
+	 *
+	 * The IDs are collected in one pass and the batches drawn from that list rather
+	 * than from repeated offset queries. An offset walks a result set that processing
+	 * could change underneath it, and every record after the change would be silently
+	 * skipped; a list of IDs captured up front cannot drift.
+	 *
+	 * @return \Generator|\Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events The events.
 	 */
 	public function get_events() {
 		$roles_to_sync = \Newspack_Network\Utils\Users::get_synced_user_roles();
 		if ( empty( $roles_to_sync ) ) {
 			WP_CLI::error( 'Incompatible Newspack plugin version or no roles to sync.' );
 		}
-		// Get all users registered between specified dates.
-		$users = get_users(
+		// Get the IDs of all users registered between specified dates. IDs only: the
+		// list is held for the whole run, and the user data is loaded a batch at a time.
+		$user_ids = get_users(
 			[
 				'role__in'   => $roles_to_sync,
 				'date_query' => [
@@ -45,7 +58,7 @@ class Reader_Registered extends Abstract_Backfiller {
 					'inclusive' => true,
 				],
 				'orderby'    => 'user_registered',
-				'fields'     => [ 'id', 'user_email', 'user_registered' ],
+				'fields'     => 'ID',
 				'number'     => -1,
 				'meta_query' => [ // phpcs:ignore WordPress.DB.SlowDBQuery.slow_db_query_meta_query
 					[
@@ -57,12 +70,10 @@ class Reader_Registered extends Abstract_Backfiller {
 		);
 
 		WP_CLI::line( '' );
-		WP_CLI::line( sprintf( 'Found %s user(s) eligible for sync.', count( $users ) ) );
+		WP_CLI::line( sprintf( 'Found %s user(s) eligible for sync.', count( $user_ids ) ) );
 		WP_CLI::line( '' );
 
-		$this->maybe_initialize_progress_bar( 'Processing users', count( $users ) );
-
-		$events = [];
+		$this->maybe_initialize_progress_bar( 'Processing users', count( $user_ids ) );
 
 		// Disregard any attached data when checking for duplicates of reader registrations.
 		// Only the email address and the date are relevant in this case.
@@ -76,24 +87,32 @@ class Reader_Registered extends Abstract_Backfiller {
 			}
 		);
 
-		foreach ( $users as $user ) {
-			$registration_method = get_user_meta( $user->ID, \Newspack\Reader_Activation::REGISTRATION_METHOD, true );
-			$user_data = [
-				'user_id'         => $user->ID,
-				'email'           => $user->user_email,
-				'user_registered' => $user->user_registered,
-				'first_name'      => get_user_meta( $user->ID, 'first_name', true ),
-				'last_name'       => get_user_meta( $user->ID, 'last_name', true ),
-				'meta_input'      => [
-					// 'current_page_url' is not saved, can't be backfilled.
-					'registration_method' => empty( $registration_method ) ? 'backfill-script' : $registration_method,
-				],
-			];
+		foreach ( array_chunk( $user_ids, self::BATCH_SIZE ) as $batch ) {
+			$users = get_users(
+				[
+					'include' => $batch,
+					'orderby' => 'include',
+					'fields'  => [ 'id', 'user_email', 'user_registered' ],
+					'number'  => -1,
+				]
+			);
 
-			$incoming_event = new \Newspack_Network\Incoming_Events\Reader_Registered( get_bloginfo( 'url' ), $user_data, strtotime( $user->user_registered ) );
-			$events[] = $incoming_event;
+			foreach ( $users as $user ) {
+				$registration_method = get_user_meta( $user->ID, \Newspack\Reader_Activation::REGISTRATION_METHOD, true );
+				$user_data = [
+					'user_id'         => $user->ID,
+					'email'           => $user->user_email,
+					'user_registered' => $user->user_registered,
+					'first_name'      => get_user_meta( $user->ID, 'first_name', true ),
+					'last_name'       => get_user_meta( $user->ID, 'last_name', true ),
+					'meta_input'      => [
+						// 'current_page_url' is not saved, can't be backfilled.
+						'registration_method' => empty( $registration_method ) ? 'backfill-script' : $registration_method,
+					],
+				];
+
+				yield new \Newspack_Network\Incoming_Events\Reader_Registered( get_bloginfo( 'url' ), $user_data, strtotime( $user->user_registered ) );
+			}
 		}
-
-		return $events;
 	}
 }

--- a/plugins/newspack-network/includes/cli/backfillers/class-reader-registered.php
+++ b/plugins/newspack-network/includes/cli/backfillers/class-reader-registered.php
@@ -40,7 +40,7 @@ class Reader_Registered extends Abstract_Backfiller {
 	 * could change underneath it, and every record after the change would be silently
 	 * skipped; a list of IDs captured up front cannot drift.
 	 *
-	 * @return \Generator|\Newspack_Network\Incoming_Events\Abstract_Incoming_Event[] $events The events.
+	 * @return \Generator<\Newspack_Network\Incoming_Events\Abstract_Incoming_Event> The events.
 	 */
 	public function get_events() {
 		$roles_to_sync = \Newspack_Network\Utils\Users::get_synced_user_roles();
@@ -87,7 +87,14 @@ class Reader_Registered extends Abstract_Backfiller {
 			}
 		);
 
-		foreach ( array_chunk( $user_ids, self::BATCH_SIZE ) as $batch ) {
+		// Sliced one batch at a time rather than array_chunk()ed up front: chunking
+		// copies the whole ID list into an array of arrays, which is a second full copy
+		// of it held for the length of the run.
+		$total = count( $user_ids );
+
+		for ( $offset = 0; $offset < $total; $offset += self::BATCH_SIZE ) {
+			$batch = array_slice( $user_ids, $offset, self::BATCH_SIZE );
+
 			$users = get_users(
 				[
 					'include' => $batch,


### PR DESCRIPTION
### All Submissions:

* [x] Have you followed the [Newspack Contributing guidelines](https://github.com/Automattic/newspack-workspace/blob/main/.github/CONTRIBUTING.md)?
* [x] Does your code follow the [WordPress coding standards](https://make.wordpress.org/core/handbook/best-practices/coding-standards/) and [VIP Go coding standards](https://vip.wordpress.com/documentation/vip-go/code-review-blockers-warnings-notices/)?
* [x] Have you checked to ensure there aren't other open [Pull Requests](../../pulls) for the same update/change?

### Changes proposed in this Pull Request:

Part of https://linear.app/a8c/issue/NPPM-2819/the-assembly-indy-week-and-cityview-migrations#comment-5139c4fa

`wp newspack-network data-backfill reader_registered` runs out of memory over a long date range. On a hub with roughly 11,000 eligible readers in range, it exhausted a 512 MB limit before processing a single event.

`Reader_Registered::get_events()` built every event object, and every user behind it, before the first one could be handled. The in-process object cache then grew for the length of the run, so the fatal surfaced wherever the last allocation happened rather than in this code.

Events are now yielded one at a time, and the users behind them load in batches drawn from an ID snapshot taken up front. Every backfiller also drops the in-process object cache each 100 events. Memory no longer scales with the length of the range.

On 6,002 readers, peak memory falls from 139.8 MB to 89.8 MB against an 87.8 MB baseline, with identical results.

### How to test the changes in this Pull Request:

1. On a Network hub site, run `wp user generate --count=6000 --role=subscriber`.
2. Run `wp newspack-network data-backfill reader_registered --start=<start> --end=<end>`, covering today. It reports the users found and finishes without a memory error.
3. Repeat step 2 on `main`. Peak memory is markedly higher for the same run.
4. Re-run step 2 with `--live`. The summary reports processed and duplicate counts, and rows land in the event log.
5. Run step 4 again unchanged. Every event now reports as a duplicate, and no rows are added.
6. Run step 2 with a range matching no readers. It reports 0 users found and exits cleanly.
7. On a node site, run step 2. Webhook requests are created as before.

### Other information:

* [x] Have you added an explanation of what your changes do and why you'd like us to include them?
* [ ] Have you written new tests for your changes, as applicable? No test suite covers the CLI backfillers; verified by the manual steps above.
* [x] Have you successfully run tests with your changes locally? PHPCS passes; behaviour verified against a 6,002-reader hub.

The other five backfillers share the unbounded query pattern this one had. `order_changed` and `donation_new` are the more pressing pair, since `wc_get_orders()` returns full order objects. They are left for a follow-up; the object-cache change here already applies to them.
